### PR TITLE
Make Hermes and Hexaemeron legible to local agents

### DIFF
--- a/.agents/skills/hermes/SKILL.md
+++ b/.agents/skills/hermes/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: hermes
+description: Optimise Solidity gas usage with a fail-closed Foundry loop that measures savings, reruns behaviour tests, checks storage layouts and method identifiers, and requires property evidence for state-sensitive unchecked arithmetic. Use for Solidity gas work, Forge snapshots, gas reports, storage packing, unchecked arithmetic, or any proposed EVM gas-saving change.
+---
+
+# Hermes portable entrypoint
+
+Read [the Hermes runtime contract](../../../plugins/hermes/AGENTS.md), then read
+[the canonical Hermes skill](../../../plugins/hermes/skills/hermes/SKILL.md) in
+full and follow it. Resolve every relative path from the canonical skill's
+directory. The canonical file is authoritative if this entrypoint and it ever
+disagree.

--- a/.agents/skills/hexaemeron/SKILL.md
+++ b/.agents/skills/hexaemeron/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: hexaemeron
+description: Route an explicit Hexaemeron delivery request or a request for its bundled Solidity audit, fuzzing, audit-readiness, or prose skills to the correct canonical instructions. Use when the user names Hexaemeron, Fiat, Fizz, Fizz Convert, Fizz Sync, X-Ray, Solidity Auditor, Imprimatur, or Vulgate. Never start the Fiat delivery loop unless the user explicitly asks to run, resume, or inspect it.
+---
+
+# Hexaemeron portable entrypoint
+
+Read [the Hexaemeron runtime contract](../../../plugins/hexaemeron/AGENTS.md).
+Use its selection table to choose the narrowest matching skill, then read that
+canonical `SKILL.md` in full and follow it.
+
+Invocation prefixes are aliases:
+
+- `/hexaemeron:fiat`, `$fiat`, and an explicit request to run Hexaemeron select
+  `fiat`.
+- `/hexaemeron:<name>`, `$<name>`, and a plain request naming a bundled skill
+  select that skill.
+
+Load more than one canonical skill only when the chosen workflow directs you
+to do so. The canonical skill and runtime contract are authoritative if this
+entrypoint disagrees with them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Instructions for local agents
+
+This repository distributes agent skills. Do not treat a skill as active merely
+because its files are present in context. Match the user's request against the
+portable entries under `.agents/skills/`, load the selected entry, and follow
+the canonical `SKILL.md` it names.
+
+## Repository map
+
+- Hermes is under `plugins/hermes/`. Read `plugins/hermes/AGENTS.md` before
+  running its skill or changing that plugin.
+- Hexaemeron is under `plugins/hexaemeron/`. Read
+  `plugins/hexaemeron/AGENTS.md` before running one of its skills or changing
+  that plugin.
+- `.claude-plugin/` and `.codex-plugin/` files install the same canonical skill
+  directories on their named hosts. They do not change the meaning of a skill.
+- `.agents/skills/` contains host-neutral entrypoints for agents that implement
+  the Agent Skills discovery convention.
+
+## Loading rules
+
+1. Read the selected `SKILL.md` in full before acting.
+2. Resolve paths relative to the directory containing that `SKILL.md`, unless
+   the file defines another base explicitly.
+3. Load linked references only when the selected skill directs you to them.
+4. Treat slash commands, dollar-prefixed names, and plugin-qualified names as
+   invocation aliases. They are not shell syntax.
+5. Keep the user's target repository separate from this distribution
+   repository. Run a skill's commands in the target named by the user.
+6. Obey the target repository's own instructions and permission rules before
+   any write or external side effect.
+
+## Checks for changes to this repository
+
+Run the checks that cover every changed area:
+
+```bash
+python3 -m unittest discover -s tests
+python3 plugins/hermes/skills/hermes/scripts/test_hermes.py
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 plugins/hexaemeron/skills/imprimatur/tests/run_tests.py
+```
+
+Validate every changed skill directory against the Agent Skills frontmatter
+rules. Keep `SKILL.md` names equal to their parent directory names and keep
+descriptions precise enough to select the skill without reading its body.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,31 @@ and Hexaemeron's entry skill as:
 
 See Anthropic's [skills](https://code.claude.com/docs/en/skills) and [plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces) documentation for the underlying format.
 
+### Local agents
+
+Agents that support the open Agent Skills convention can discover the two
+host-neutral entries under [`.agents/skills`](./.agents/skills). Point the
+agent at this repository and include that directory in its project skill
+search path. Keep the repository layout intact: each entry routes to the
+canonical plugin instructions instead of copying them.
+
+A file-reading agent without automatic skill discovery should begin with
+[`AGENTS.md`](./AGENTS.md). That file identifies the entrypoints, path rules,
+and plugin-specific runtime contracts. Named tools in vendored skills describe
+capabilities; the Hexaemeron contract maps them to file, shell, search,
+planning, question, and subagent operations available in a local runtime.
+
+Plain-text activation works alongside host syntax:
+
+```text
+Use Hermes to optimise gas in this Foundry repository.
+Use Hexaemeron Fiat to take "<topic>" through the delivery loop.
+Use Hexaemeron Fizz to generate a stateful fuzz suite.
+```
+
+Fiat remains explicit-only. Mentioning a similar delivery task does not start
+the controller unless the user names Hexaemeron or Fiat and asks to run it.
+
 ## Use
 
 Hermes needs Python 3, Git and [Foundry](https://getfoundry.sh/) available in the target repository. Start Codex from a clean Foundry worktree, then ask:
@@ -176,3 +201,7 @@ plugins/
 ```
 
 Codex and Claude Code load the same skill directory. The host manifests only handle discovery and installation; each plugin's instructions, harness and acceptance conditions stay shared. Target-repository instructions still apply. More will turn up here as they become useful enough to keep.
+
+Local agents load the same canonical directories through the two portable
+entries. The portable layer translates discovery and tool vocabulary; it does
+not weaken a skill's checks or invent receipts for work that did not run.

--- a/plugins/hermes/AGENTS.md
+++ b/plugins/hermes/AGENTS.md
@@ -1,0 +1,29 @@
+# Hermes runtime contract
+
+Hermes is one Agent Skill. Its canonical instructions are in
+`skills/hermes/SKILL.md`; read that file in full before working on Solidity gas
+usage. The `README.md` beside it is for repository browsing and is not the
+instruction source.
+
+## Capabilities and paths
+
+- The agent needs text-file read and write access plus a shell in the user's
+  target repository.
+- The target needs Git, Python 3, Foundry, and a clean working tree. If one is
+  absent, follow the refusal in `SKILL.md` rather than estimating a result.
+- Resolve `scripts/hermes.py` and `references/optimisation-catalogue.md` from
+  `skills/hermes/`, regardless of the current working directory.
+- Run the harness in the target Foundry repository. Do not use this plugin
+  checkout as the target unless the user explicitly names it.
+
+## Interpretation
+
+- `$hermes`, `/hermes:hermes`, and a plain request to use Hermes are equivalent
+  activation forms.
+- Shell snippets describe commands to execute, not text to paraphrase.
+- A non-zero harness exit is a rejected gate. Do not continue, weaken a check,
+  or report the candidate as accepted.
+- `result.json` with status `accepted` and exit code 0 is the only acceptance
+  signal. Report the evidence directory with the result.
+- Repository issue, branch, review, and approval rules still apply before
+  Hermes changes target source.

--- a/plugins/hexaemeron/AGENTS.md
+++ b/plugins/hexaemeron/AGENTS.md
@@ -1,0 +1,66 @@
+# Hexaemeron runtime contract
+
+Hexaemeron contains several Agent Skills. Select from this table, then read the
+chosen `SKILL.md` in full. Do not start `fiat` merely because another
+Hexaemeron skill matches a task.
+
+| Skill | Canonical instructions | Select when |
+| --- | --- | --- |
+| `fiat` | `skills/fiat/SKILL.md` | The user explicitly asks to start, resume, or report a Hexaemeron delivery run |
+| `fizz` | `skills/fizz/SKILL.md` | Generate a stateful Solidity fuzz suite |
+| `fizz-convert` | `skills/fizz/skills/fizz-convert/SKILL.md` | Turn pending `PROPERTIES.md` entries into Solidity assertions |
+| `fizz-sync` | `skills/fizz/skills/fizz-sync/SKILL.md` | Reconcile an existing Fizz harness with changed source |
+| `x-ray` | `skills/x-ray/SKILL.md` | Prepare a Solidity protocol for audit |
+| `solidity-auditor` | `skills/solidity-auditor/SKILL.md` | Audit Solidity source for security findings |
+| `imprimatur` | `skills/imprimatur/SKILL.md` | Lint shipped prose against the banned lexicon |
+| `vulgate` | `skills/vulgate/SKILL.md` | Rewrite prose in a plain human register without changing its content |
+
+## Translate tool names by capability
+
+Some canonical skills were written for hosts that name their tools. A local
+agent must map those names to equivalent capabilities:
+
+| Instruction term | Required capability |
+| --- | --- |
+| `Read` | Read the named file completely or at the stated range |
+| `Write` or `Edit` | Create or patch the named file |
+| `Bash` | Execute the command in a shell and inspect its exit status |
+| `Glob`, `Grep`, or `find` | Enumerate or search files with the stated pattern |
+| `ToolSearch` | Inspect the runtime's available tools before choosing one |
+| `AskUserQuestion` | Ask the stated question through structured UI or concise text |
+| `TodoWrite` | Maintain a durable plan with the same states and transitions |
+| `Agent` or `Task` | Run the supplied role prompt in an isolated agent context |
+| background or parallel calls | Start independent work concurrently and wait at the named barrier |
+
+Tool names describe capabilities, not mandatory API identifiers. Preserve the
+arguments, ordering, wait barriers, output files, and stop conditions when
+using an equivalent local tool.
+
+If the runtime cannot select the named model family, use its configured model
+and say that the requested family was unavailable. Omit unsupported model
+arguments. Never claim that Sonnet, Opus, or another model ran when it did not.
+
+If the runtime has no subagent facility, run each supplied role prompt
+separately and save each raw result before synthesis. Keep roles separate and
+finish every role named by the skill before crossing its wait barrier. Stop
+when the requested workflow depends on isolation that the runtime cannot
+preserve.
+
+## Resolve placeholders
+
+- `$SKILL_DIR` and `{SKILL_PATH}` mean the directory containing the active
+  `SKILL.md`, unless that file defines them differently.
+- `$PLUGIN_ROOT` means this `plugins/hexaemeron/` directory.
+- `{PROJECT_ROOT}` means the user's target repository, not this plugin
+  directory.
+- `{SUITE_DIR}` and `{META_DIR}` are relative to `{PROJECT_ROOT}` unless the
+  user supplied absolute paths.
+- Names such as `hexaemeron:fizz` and `/hexaemeron:fiat` are logical skill
+  aliases. Load the local canonical path from the table above.
+
+## Side effects and truthfulness
+
+Read the target repository's instructions before writing. Ask for any approval
+the runtime or repository requires. Preserve every fail-closed check in the
+canonical skill. If a command, audit role, lint, test, issue write, or push did
+not happen, state that plainly and do not create its receipt.

--- a/plugins/hexaemeron/skills/fiat/README.md
+++ b/plugins/hexaemeron/skills/fiat/README.md
@@ -3,9 +3,9 @@ name: fiat
 description: >
   Run the one-shot delivery loop: study, runbook, then per-step
   issue/implement/audit/prose/push until a working prototype exists.
-  Use only when a Wildcat contributor invokes /hexaemeron:fiat with a topic,
-  a bare /hexaemeron:fiat to resume, or /hexaemeron:fiat status for a report.
-  Do not invoke automatically.
+  Use only when a Wildcat contributor explicitly asks to start, run, resume,
+  or report a Hexaemeron or Fiat delivery, including /hexaemeron:fiat forms.
+  Do not infer activation from a similar task.
 metadata:
   version: "1.0.0"
 ---
@@ -151,11 +151,13 @@ whatever gate the repo runs.
 ## Delegation and context
 
 For long runs, hand research and implementation bulk to the bundled agents
-(`surveyor`, `mason`) via the Task tool, passing the controller path, the
-state directory, and the current directive verbatim. Keep the audit and
-prose phases in the main session when they depend on invoking other
-installed skills, since a subagent may not see them. After each `done push`,
-compact: the receipts carry everything a fresh context needs.
+(`surveyor`, `mason`) through the runtime's subagent mechanism, passing the
+controller path, the state directory, and the current directive verbatim. If
+the runtime has no subagent mechanism, perform the work in the main session
+and keep the controller receipt as the boundary. Keep the audit and prose
+phases in the main session when a delegated context cannot load the bundled
+skills. After each `done push`, compact if the runtime supports it: the
+receipts carry everything a fresh context needs.
 
 ## Stop conditions
 

--- a/plugins/hexaemeron/skills/fiat/SKILL.md
+++ b/plugins/hexaemeron/skills/fiat/SKILL.md
@@ -3,9 +3,9 @@ name: fiat
 description: >
   Run the one-shot delivery loop: study, runbook, then per-step
   issue/implement/audit/prose/push until a working prototype exists.
-  Use only when a Wildcat contributor invokes /hexaemeron:fiat with a topic,
-  a bare /hexaemeron:fiat to resume, or /hexaemeron:fiat status for a report.
-  Do not invoke automatically.
+  Use only when a Wildcat contributor explicitly asks to start, run, resume,
+  or report a Hexaemeron or Fiat delivery, including /hexaemeron:fiat forms.
+  Do not infer activation from a similar task.
 metadata:
   version: "1.0.0"
 ---
@@ -151,11 +151,13 @@ whatever gate the repo runs.
 ## Delegation and context
 
 For long runs, hand research and implementation bulk to the bundled agents
-(`surveyor`, `mason`) via the Task tool, passing the controller path, the
-state directory, and the current directive verbatim. Keep the audit and
-prose phases in the main session when they depend on invoking other
-installed skills, since a subagent may not see them. After each `done push`,
-compact: the receipts carry everything a fresh context needs.
+(`surveyor`, `mason`) through the runtime's subagent mechanism, passing the
+controller path, the state directory, and the current directive verbatim. If
+the runtime has no subagent mechanism, perform the work in the main session
+and keep the controller receipt as the boundary. Keep the audit and prose
+phases in the main session when a delegated context cannot load the bundled
+skills. After each `done push`, compact if the runtime supports it: the
+receipts carry everything a fresh context needs.
 
 ## Stop conditions
 

--- a/plugins/hexaemeron/skills/imprimatur/README.md
+++ b/plugins/hexaemeron/skills/imprimatur/README.md
@@ -1,7 +1,15 @@
 ---
 name: imprimatur
-version: 1.0.0
-description: Organisation-wide banned lexicon for AI writing tells. Blocks a hard list of banned words and phrases, gates technical terms of art on evidence, and catches the structural formulae that survive any wordlist. A mask over drafting: it strips the tells so shipped prose reads plainly, and is easier to grasp than the usual AI slop. Use when drafting, editing, or reviewing any prose that ships, when checking whether a draft reads as machine-written, or when the user names a term to ban.
+description: >-
+  Organisation-wide banned lexicon for AI writing tells. Blocks a hard list
+  of banned words and phrases, gates technical terms of art on evidence, and
+  catches the structural formulae that survive any wordlist. A mask over
+  drafting: it strips the tells so shipped prose reads plainly, and is easier
+  to grasp than the usual AI slop. Use when drafting, editing, or reviewing
+  any prose that ships, when checking whether a draft reads as
+  machine-written, or when the user names a term to ban.
+metadata:
+  version: "1.0.0"
 ---
 
 # Imprimatur

--- a/plugins/hexaemeron/skills/imprimatur/SKILL.md
+++ b/plugins/hexaemeron/skills/imprimatur/SKILL.md
@@ -1,7 +1,15 @@
 ---
 name: imprimatur
-version: 1.0.0
-description: Organisation-wide banned lexicon for AI writing tells. Blocks a hard list of banned words and phrases, gates technical terms of art on evidence, and catches the structural formulae that survive any wordlist. A mask over drafting: it strips the tells so shipped prose reads plainly, and is easier to grasp than the usual AI slop. Use when drafting, editing, or reviewing any prose that ships, when checking whether a draft reads as machine-written, or when the user names a term to ban.
+description: >-
+  Organisation-wide banned lexicon for AI writing tells. Blocks a hard list
+  of banned words and phrases, gates technical terms of art on evidence, and
+  catches the structural formulae that survive any wordlist. A mask over
+  drafting: it strips the tells so shipped prose reads plainly, and is easier
+  to grasp than the usual AI slop. Use when drafting, editing, or reviewing
+  any prose that ships, when checking whether a draft reads as
+  machine-written, or when the user names a term to ban.
+metadata:
+  version: "1.0.0"
 ---
 
 # Imprimatur

--- a/tests/test_portable_skills.py
+++ b/tests/test_portable_skills.py
@@ -1,0 +1,55 @@
+"""Checks for the host-neutral Agent Skills entrypoints."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class PortableSkillTests(unittest.TestCase):
+    def test_portable_entrypoints_exist_and_match_parent_name(self):
+        for name in ("hermes", "hexaemeron"):
+            path = ROOT / ".agents" / "skills" / name / "SKILL.md"
+            text = path.read_text(encoding="utf-8")
+            self.assertTrue(text.startswith("---\n"))
+            match = re.search(r"^name:\s*([^\n]+)$", text, re.MULTILINE)
+            self.assertIsNotNone(match)
+            self.assertEqual(match.group(1).strip(), name)
+            self.assertRegex(text, r"(?m)^description:\s*\S")
+
+    def test_portable_entrypoint_links_resolve(self):
+        for path in (ROOT / ".agents" / "skills").glob("*/SKILL.md"):
+            text = path.read_text(encoding="utf-8")
+            links = re.findall(r"\[[^]]+\]\(([^)]+)\)", text)
+            self.assertTrue(links, path)
+            for link in links:
+                self.assertTrue((path.parent / link).resolve().is_file(), link)
+
+    def test_plugin_runtime_contracts_point_to_canonical_skills(self):
+        hermes = ROOT / "plugins" / "hermes" / "skills" / "hermes" / "SKILL.md"
+        self.assertTrue(hermes.is_file())
+
+        hexa_root = ROOT / "plugins" / "hexaemeron"
+        contract = (hexa_root / "AGENTS.md").read_text(encoding="utf-8")
+        paths = re.findall(r"`(skills/[^`]+/SKILL\.md)`", contract)
+        self.assertEqual(len(paths), 8)
+        for relative in paths:
+            self.assertTrue((hexa_root / relative).is_file(), relative)
+
+    def test_skill_names_match_canonical_parent_directories(self):
+        skills = list((ROOT / "plugins" / "hermes" / "skills").glob("*/SKILL.md"))
+        skills += list((ROOT / "plugins" / "hexaemeron" / "skills").glob("*/SKILL.md"))
+        skills += list(
+            (ROOT / "plugins" / "hexaemeron" / "skills" / "fizz" / "skills").glob("*/SKILL.md")
+        )
+        for path in skills:
+            text = path.read_text(encoding="utf-8")
+            match = re.search(r"^name:\s*([^\n]+)$", text, re.MULTILINE)
+            self.assertIsNotNone(match, path)
+            self.assertEqual(match.group(1).strip(), path.parent.name, path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #25

<!-- wildcat-origin: shoggoth -->

## What changed

- Added standard `.agents/skills` entrypoints for Hermes and Hexaemeron.
- Added repository and plugin-local `AGENTS.md` contracts for skill loading,
  path resolution, target-repository separation, and side-effect rules.
- Added a Hexaemeron capability table covering Fiat, Fizz, Fizz Convert, Fizz
  Sync, X-Ray, Solidity Auditor, Imprimatur, and Vulgate.
- Mapped host-specific tool names to file, shell, search, planning, question,
  concurrency, and subagent capabilities available in local runtimes.
- Made Fiat's explicit activation rule accept plain language and added a
  main-session path for runtimes without subagents.
- Repaired Imprimatur's invalid YAML frontmatter and moved its version into
  the standard metadata map.
- Added tests that hold portable entrypoints, canonical paths, and skill names
  in place.

## Why

The canonical skill bodies were readable Markdown, but a local agent had no
standard discovery path and several Hexaemeron instructions assumed named
Claude or Codex tools. The new entrypoints and runtime contracts let a
file-reading agent select the right canonical skill and map its operations
without changing the workflow or weakening a check.

## Checks

- 11 Agent Skill directories pass `quick_validate.py`.
- 6 marketplace and plugin manifests parse as JSON.
- 4 portable-entrypoint tests pass.
- 14 Hermes harness tests pass.
- 32 Hexaemeron controller tests pass.
- 56 Imprimatur tests pass.
- Proscribed reports no defects in the changed Markdown.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: https://github.com/wildcat-finance/skills/issues/25
Root-Issue-Successor: none-recorded
Root-Issue-Fiat-Required: 0
Root-Issue-Route: pr-only
Root-Issue-Classification-Source: live-contract
<!-- root-issue-analytics:v1:end -->
