### PR TITLE
Explain Probitas desk scores in the public ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,17 @@ Scored out of 10 for doing the job, not for reading the output. A marketer can q
 | Finance | 3 | 4 | 7 |
 | Legal | 1 | 4 | 4 |
 
-Five is the barrier. At or above it, the plugin's entry carries a worked example of what that role would use it for. Below it there is no example, because there is no honest one to give. These are engineering tools, and a 2 means we could not find a reason for that desk to open the plugin rather than read what it produced.
+Five is the barrier. At or above it, the plugin's entry carries a worked
+example of what that role would use it for. Below it there is no example,
+because there is no honest one to give. A low score means we could not find a
+reason for that desk to open the plugin rather than read what it produced.
+
+Probitas scores 9 for business development because the dossier is the job, 7
+for finance because the same record describes counterparty exposure, and 5 for
+security and audit because `verify` checks somebody else's document against
+its evidence. Its 4s for developers and legal reflect useful output rather
+than a strong reason for either desk to operate the plugin. Marketing has no
+credible operating case, so it scores 1.
 
 ## Install
 


### PR DESCRIPTION
## What changed

- Keeps the existing Hermes, Hexaemeron and Probitas score table intact.
- Moves the reasoning behind Probitas's 9, 7 and 5 scores beside that table.
- Replaces the stale description of all listed plugins as engineering tools.

## Why

PR #28 added Probitas to the public ranking, but its score rationale remained
in the private planning repository. The public README should own both the
numbers and the explanation.

## Checks

- Prose lint: 100/100.
- Root tests: 4 passed.
- Probitas tests: 234 passed.

Refs #29

<!-- wildcat-origin: shoggoth -->
