### PR TITLE
Make hexctl lock recovery atomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Hexaemeron includes:
 - the [`imprimatur`](./plugins/hexaemeron/skills/imprimatur) three-tier prose lint and the [`vulgate`](./plugins/hexaemeron/skills/vulgate) voice mask, invokable on their own;
 - the Pashov Audit Group suite vendored verbatim (MIT; `LICENSE` and `NOTICE.md` in each skill directory);
 - Codex metadata for explicit or automatic invocation; and
-- 37 controller and contract tests, 56 lint tests, and a fuzz-audit log ([`audit/AUDIT.md`](./plugins/hexaemeron/audit/AUDIT.md)) covering the controller's own surfaces.
+- 42 controller and contract tests, 56 lint tests, and a fuzz-audit log ([`audit/AUDIT.md`](./plugins/hexaemeron/audit/AUDIT.md)) covering the controller's own surfaces.
 
 #### Day to day
 

--- a/plugins/hexaemeron/README.md
+++ b/plugins/hexaemeron/README.md
@@ -59,6 +59,11 @@ hexctl halt / resume        # put a stop itself on the ledger
 hexctl verify               # prove the chain and state were not edited
 ```
 
+Mutating commands hold a kernel lock for their whole run. A second writer is
+refused with the first process's details and a worktree command; `next`,
+`status`, and `verify` still answer. The operating system releases the lock if
+the holder crashes, so a stale metadata file never needs manual cleanup.
+
 The receipts are opinionated where the process is: the audit phase will not
 open without a resolved (or explicitly waived) security suite; it will not
 close with findings open unless a reasoned no-further-leads verdict is
@@ -119,7 +124,7 @@ path, so the warden and scribe always have their tools.
 python3 tests/run_tests.py
 ```
 
-Thirty-seven tests cover the controller and Fiat contract: phase ordering,
+Forty-two tests cover the controller and Fiat contract: phase ordering,
 audit gating and round caps, fixes evidence, prose skill enforcement,
-checkbox/issue-state rules, halt/resume, ledger tamper detection, and the
-Wildcat marketplace boundary.
+checkbox/issue-state rules, halt/resume, ledger tamper detection, concurrent
+writer exclusion, crash recovery, and the Wildcat marketplace boundary.

--- a/plugins/hexaemeron/skills/fiat/README.md
+++ b/plugins/hexaemeron/skills/fiat/README.md
@@ -33,6 +33,12 @@ Alias it as `hexctl` mentally; every command below means that invocation.
 State lives in `.hexaemeron/` beside a hash-chained ledger. The directory
 ships its own `.gitignore`, so git never sees it.
 
+Mutating commands hold a kernel lock for their whole run. If another writer is
+active, `hexctl` names it and prints a worktree command. Use another worktree;
+do not retry against the same state. `next`, `status`, and `verify` remain
+available while the writer runs, and a crashed process releases the lock
+without manual cleanup.
+
 ## Day to day
 
 **Developers.** A half-formed idea and a week to find out whether it

--- a/plugins/hexaemeron/skills/fiat/SKILL.md
+++ b/plugins/hexaemeron/skills/fiat/SKILL.md
@@ -33,6 +33,12 @@ Alias it as `hexctl` mentally; every command below means that invocation.
 State lives in `.hexaemeron/` beside a hash-chained ledger. The directory
 ships its own `.gitignore`, so git never sees it.
 
+Mutating commands hold a kernel lock for their whole run. If another writer is
+active, `hexctl` names it and prints a worktree command. Use another worktree;
+do not retry against the same state. `next`, `status`, and `verify` remain
+available while the writer runs, and a crashed process releases the lock
+without manual cleanup.
+
 ## Day to day
 
 **Developers.** A half-formed idea and a week to find out whether it

--- a/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
+++ b/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
@@ -18,11 +18,13 @@ human-facing goes to plain text or stderr.
 import argparse
 import contextlib
 import datetime
+import fcntl
 import hashlib
 import json
 import os
 import re
 import sys
+import time
 
 STATE_DIR_NAME = ".hexaemeron"
 STATE_FILE = "state.json"
@@ -134,13 +136,18 @@ def lock_path(base_dir: str) -> str:
     return os.path.join(state_root(base_dir), "lock")
 
 
-def holder_is_alive(pid: int) -> bool:
-    """Whether the process holding the lock still exists.
+def read_holder(descriptor: int) -> dict:
+    try:
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        data = os.read(descriptor, 4096)
+        return json.loads(data.decode("utf-8")) if data else {}
+    except (UnicodeDecodeError, ValueError, OSError):
+        return {}
 
-    `kill(pid, 0)` signals nothing and reports whether it could have. A
-    `PermissionError` means the process is alive and owned by somebody else,
-    which still counts as held.
-    """
+
+def holder_is_alive(pid) -> bool:
+    if not isinstance(pid, int):
+        return False
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -148,16 +155,19 @@ def holder_is_alive(pid: int) -> bool:
     except PermissionError:
         return True
     except OSError:
-        return True
+        return False
     return True
 
 
-def read_holder(path: str) -> dict:
-    try:
-        with open(path, "r", encoding="utf-8") as fh:
-            return json.load(fh)
-    except (ValueError, OSError):
-        return {}
+def read_live_holder(descriptor: int) -> dict:
+    """Wait briefly for a new owner to replace metadata left by a crash."""
+    holder = {}
+    for _ in range(50):
+        holder = read_holder(descriptor)
+        if holder_is_alive(holder.get("pid")):
+            break
+        time.sleep(0.002)
+    return holder
 
 
 @contextlib.contextmanager
@@ -169,10 +179,10 @@ def held_lock(base_dir: str, command: str):
     claiming the same parent, and `verify` reports the chain as broken
     afterwards. This turns that into a refusal beforehand.
 
-    `O_CREAT | O_EXCL` is the whole mechanism. Creating the file is atomic, so
-    exactly one process wins, with no dependency and nothing to configure. A
-    lock whose holder has died is broken and taken, because a crashed run
-    should not need a manual clean-up before the next one can start.
+    The kernel owns the exclusion. It releases the lock when a process exits,
+    including after a crash, so stale metadata never needs to be unlinked and
+    two contenders cannot both reclaim it. The file remains as an ignored
+    place to publish holder details for a refused writer.
     """
     root = state_root(base_dir)
     if not os.path.isdir(root):
@@ -185,33 +195,33 @@ def held_lock(base_dir: str, command: str):
         os.makedirs(root, exist_ok=True)
 
     path = lock_path(base_dir)
-    fd = None
-    while fd is None:
+    fd = os.open(
+        path,
+        os.O_CREAT | os.O_RDWR | getattr(os, "O_CLOEXEC", 0),
+        0o644,
+    )
+    acquired = False
+
+    try:
         try:
-            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
-        except FileExistsError:
-            holder = read_holder(path)
-            pid = holder.get("pid")
-            if not isinstance(pid, int) or not holder_is_alive(pid):
-                try:
-                    os.unlink(path)
-                except FileNotFoundError:
-                    pass
-                continue
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            acquired = True
+        except BlockingIOError:
+            holder = read_live_holder(fd)
             die(
                 "another hexctl is holding this run: pid {pid} running "
                 "`{cmd}` since {since}.\n"
                 "Two agents in one directory share one run and one ledger. "
                 "Give each its own working directory, for example "
                 "`git worktree add ../<name> main`, and run one there.".format(
-                    pid=pid,
+                    pid=holder.get("pid", "unknown"),
                     cmd=holder.get("command", "unknown"),
                     since=holder.get("ts", "unknown"),
                 ),
                 1,
             )
-
-    try:
+        os.ftruncate(fd, 0)
+        os.lseek(fd, 0, os.SEEK_SET)
         os.write(
             fd,
             json.dumps(
@@ -219,16 +229,18 @@ def held_lock(base_dir: str, command: str):
             ).encode()
             + b"\n",
         )
-        os.close(fd)
-        fd = None
+        os.fsync(fd)
         yield
     finally:
-        if fd is not None:
+        if acquired:
+            try:
+                os.ftruncate(fd, 0)
+                os.fsync(fd)
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+        else:
             os.close(fd)
-        try:
-            os.unlink(path)
-        except FileNotFoundError:
-            pass
 
 
 def save_state(base_dir: str, state: dict) -> None:

--- a/plugins/hexaemeron/tests/test_hexctl.py
+++ b/plugins/hexaemeron/tests/test_hexctl.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -15,8 +16,13 @@ class HexctlCase(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
         self.dir = self.tmp.name
+        self.processes = []
 
     def tearDown(self):
+        for process in self.processes:
+            if process.poll() is None:
+                process.terminate()
+                process.wait(timeout=5)
         self.tmp.cleanup()
 
     def run_ctl(self, *args, expect=0):
@@ -45,6 +51,67 @@ class HexctlCase(unittest.TestCase):
 
     def init(self, topic="test topic"):
         self.run_ctl("init", "--topic", topic)
+
+    def spawn_lock_holder(self, ready, release, command="cmd_record"):
+        program = """
+import importlib.util
+from pathlib import Path
+import sys
+import time
+
+spec = importlib.util.spec_from_file_location("hexctl_under_test", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+with module.held_lock(sys.argv[2], sys.argv[3]):
+    Path(sys.argv[4]).write_text("ready\\n", encoding="utf-8")
+    while not Path(sys.argv[5]).exists():
+        time.sleep(0.01)
+"""
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                program,
+                HEXCTL,
+                self.dir,
+                command,
+                ready,
+                release,
+            ],
+            cwd=self.dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.processes.append(process)
+        return process
+
+    def wait_for_file(self, path, process, timeout=5):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if os.path.exists(path):
+                return
+            if process.poll() is not None:
+                stdout, stderr = process.communicate()
+                self.fail(
+                    f"lock holder exited {process.returncode} before ready\n"
+                    f"stdout: {stdout}\nstderr: {stderr}"
+                )
+            time.sleep(0.01)
+        self.fail("lock holder did not become ready")
+
+    def start_lock_holder(self, name="holder", command="cmd_record"):
+        ready = os.path.join(self.dir, f"{name}.ready")
+        release = os.path.join(self.dir, f"{name}.release")
+        process = self.spawn_lock_holder(ready, release, command)
+        self.wait_for_file(ready, process)
+        return process, ready, release
+
+    def release_lock_holder(self, process, release):
+        with open(release, "w", encoding="utf-8") as handle:
+            handle.write("release\n")
+        stdout, stderr = process.communicate(timeout=5)
+        self.assertEqual(process.returncode, 0, (stdout, stderr))
 
     def to_steps(self, titles=("Scaffold", "Core")):
         self.init()
@@ -120,6 +187,81 @@ class TestLifecycle(HexctlCase):
         self.assertEqual(out["do"], "issue")
         self.assertEqual(out["step"], 1)
         self.assertEqual(out["title"], "Scaffold")
+
+
+class TestRunLock(HexctlCase):
+    def test_live_holder_refuses_a_second_writer_with_an_actionable_message(self):
+        self.init()
+        holder, _, release = self.start_lock_holder()
+        result = self.run_ctl("record", "key", '"value"', expect=1)
+        self.assertIn(f"pid {holder.pid}", result.stderr)
+        self.assertIn("`cmd_record`", result.stderr)
+        self.assertIn("git worktree add", result.stderr)
+        self.release_lock_holder(holder, release)
+
+    def test_read_only_commands_answer_while_a_writer_holds_the_run(self):
+        self.init()
+        holder, _, release = self.start_lock_holder()
+        for arguments in (("next",), ("status", "--json"), ("verify",)):
+            with self.subTest(command=arguments[0]):
+                self.run_ctl(*arguments)
+        self.release_lock_holder(holder, release)
+
+    def test_crashed_holder_needs_no_manual_cleanup(self):
+        self.init()
+        holder, _, _ = self.start_lock_holder()
+        holder.kill()
+        holder.communicate(timeout=5)
+        self.run_ctl("record", "after_crash", '"accepted"')
+
+    def test_normal_exit_clears_holder_metadata(self):
+        self.init()
+        holder, _, release = self.start_lock_holder()
+        self.release_lock_holder(holder, release)
+        path = os.path.join(self.dir, ".hexaemeron", "lock")
+        with open(path, "rb") as handle:
+            self.assertEqual(handle.read(), b"")
+
+    def test_two_contenders_after_a_crash_cannot_both_take_the_lock(self):
+        self.init()
+        stale, _, _ = self.start_lock_holder("stale")
+        stale.kill()
+        stale.communicate(timeout=5)
+
+        paths = []
+        contenders = []
+        for name in ("first", "second"):
+            ready = os.path.join(self.dir, f"{name}.ready")
+            release = os.path.join(self.dir, f"{name}.release")
+            contenders.append(self.spawn_lock_holder(ready, release))
+            paths.append((ready, release))
+
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            ready_indexes = [
+                index
+                for index, (ready, _) in enumerate(paths)
+                if os.path.exists(ready)
+            ]
+            exited_indexes = [
+                index
+                for index, process in enumerate(contenders)
+                if process.poll() is not None
+            ]
+            if len(ready_indexes) == 1 and len(exited_indexes) == 1:
+                break
+            time.sleep(0.01)
+        else:
+            self.fail("contenders did not resolve to one holder and one refusal")
+
+        winner = ready_indexes[0]
+        loser = exited_indexes[0]
+        self.assertNotEqual(winner, loser)
+        loser_out, loser_err = contenders[loser].communicate(timeout=5)
+        self.assertEqual(contenders[loser].returncode, 1, (loser_out, loser_err))
+        self.assertIn("another hexctl is holding this run", loser_err)
+        self.assertIn(f"pid {contenders[winner].pid}", loser_err)
+        self.release_lock_holder(contenders[winner], paths[winner][1])
 
 
 class TestStepGates(HexctlCase):


### PR DESCRIPTION
## What

Replace `hexctl`'s stale PID-file takeover with a kernel-held exclusive lock.

The previous recovery path could lose exclusion:

1. two writers read the same dead holder;
2. the first removes the stale file and acquires a new lock; and
3. the second removes that new live lock, then acquires its own.

The lock file now remains in `.hexaemeron/` as a place for holder metadata. The kernel owns exclusion and releases it when the process exits, including after a crash. A refused writer still gets the live PID, command, start time, and worktree instruction. Read-only commands do not take the lock.

## Tests

Five real-process cases cover:

- a live holder refusing another writer with actionable metadata;
- `next`, `status`, and `verify` while a writer holds the run;
- recovery after a killed holder without manual cleanup;
- holder metadata cleared on normal exit; and
- two simultaneous contenders after a crash resolving to one holder and one refusal.

The concurrency suite passed four consecutive runs. The full repository matrix also passed: root 5, Ariadne 310, Hermes 14, Hexaemeron 42, Imprimatur 56, both Lemma suites, Probitas 234, and Tabularium 91. The Goldfinch release rebuilt byte-identically, and the 363-file repository structure check passed.

Closes #43.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: https://github.com/wildcat-finance/skills/issues/43
Root-Issue-Successor: none-recorded
Root-Issue-Fiat-Required: 0
Root-Issue-Route: pr-only
Root-Issue-Classification-Source: live-contract
<!-- root-issue-analytics:v1:end -->
