### PR TITLE
Publish Pandects

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -53,6 +53,18 @@
       "category": "Developer Tools"
     },
     {
+      "name": "pandects",
+      "source": {
+        "source": "local",
+        "path": "./plugins/pandects"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
       "name": "ariadne",
       "source": {
         "source": "local",

--- a/.agents/skills/pandects/SKILL.md
+++ b/.agents/skills/pandects/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: pandects
+description: Route a request about executable credit invariants to the canonical Pandects instructions. Use when the user names Pandects, asks which laws a lending or credit system should hold, or wants reviewed properties for a fuzzing campaign. Never use it to report a campaign under an engine that did not run.
+---
+
+# Pandects portable entrypoint
+
+Read [the Pandects runtime contract](../../../plugins/pandects/AGENTS.md). Use
+its selection table to choose the skill, then read that canonical `SKILL.md` in
+full and follow it.
+
+Invocation prefixes are aliases:
+
+- `/pandects:pandects`, `$pandects`, and a plain request for credit invariants
+  all select `pandects`.
+
+The corpus reaches no network and has no Solidity dependency to fetch. Running
+it against a target compiles and executes that target's code locally, so obey
+the target repository's own instructions first.
+
+The canonical skill and the runtime contract are authoritative if this
+entrypoint disagrees with them.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -93,6 +93,28 @@
       ]
     },
     {
+      "name": "pandects",
+      "displayName": "Pandects",
+      "source": "./plugins/pandects",
+      "description": "Executable laws for credit contracts, each proven against a contract built to break it.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Wildcat Labs",
+        "url": "https://wildcat.finance"
+      },
+      "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/pandects",
+      "repository": "https://github.com/wildcat-finance/skills",
+      "category": "Developer Tools",
+      "tags": [
+        "solidity",
+        "invariants",
+        "property-testing",
+        "fuzzing",
+        "credit",
+        "foundry"
+      ]
+    },
+    {
       "name": "ariadne",
       "displayName": "Ariadne",
       "source": "./plugins/ariadne",

--- a/.github/workflows/pandects.yml
+++ b/.github/workflows/pandects.yml
@@ -1,0 +1,57 @@
+name: pandects
+
+on:
+  push:
+    paths:
+      - "plugins/pandects/**"
+      - ".claude-plugin/**"
+      - ".agents/**"
+      - "AGENTS.md"
+      - "tests/**"
+      - ".github/workflows/pandects.yml"
+  pull_request:
+    paths:
+      - "plugins/pandects/**"
+      - ".claude-plugin/**"
+      - ".agents/**"
+      - "AGENTS.md"
+      - "tests/**"
+      - ".github/workflows/pandects.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  catalogue:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Portable entrypoints and repository contracts
+        run: python3 -m unittest discover -s tests -v
+
+      - name: Pandects catalogue suite
+        run: python3 -m unittest discover -s plugins/pandects/tests -t plugins/pandects -v
+
+      - name: Every law carries its six parts
+        run: python3 plugins/pandects/scripts/pandects.py check
+
+  corpus:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+      - name: Build with no dependency to fetch
+        run: forge build
+        working-directory: plugins/pandects
+      - name: Every law against every specimen
+        run: forge test -vv
+        working-directory: plugins/pandects

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,15 @@
 __pycache__/
-*.pyc
+*.py[cod]
+.DS_Store
+
+# Foundry build output inside plugins that carry Solidity
+plugins/*/out/
+plugins/*/cache/
+
+# Fuzzing and audit output
+plugins/*/crytic-export/
+plugins/*/corpus/
+plugins/*/search-record.json
+plugins/*/.medusa-artifact-hash
+plugins/*/slither.err
+plugins/*/slither_results.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ the canonical `SKILL.md` it names.
   that plugin.
 - Lemma is under `plugins/lemma/`. Read `plugins/lemma/AGENTS.md` before
   running its skill or changing that plugin.
+- Pandects is under `plugins/pandects/`. Read `plugins/pandects/AGENTS.md`
+  before running its skill or changing that plugin.
 - Probitas is under `plugins/probitas/`. Read `plugins/probitas/AGENTS.md`
   before running its skill or changing that plugin.
 - Tabularium is under `plugins/tabularium/`. Read
@@ -51,8 +53,16 @@ python3 plugins/hexaemeron/tests/run_tests.py
 python3 plugins/hexaemeron/skills/imprimatur/tests/run_tests.py
 python3 plugins/lemma/tests/test_markdown.py
 python3 plugins/lemma/tests/test_solidity.py
+python3 -m unittest discover -s plugins/pandects/tests -t plugins/pandects
 python3 -m unittest discover -s plugins/probitas/tests -t plugins/probitas
 python3 -m unittest discover -s plugins/tabularium/tests -t plugins/tabularium
+```
+
+Pandects also carries Solidity. From `plugins/pandects/`:
+
+```bash
+forge build
+forge test
 ```
 
 Validate every changed skill directory against the Agent Skills frontmatter

--- a/README.md
+++ b/README.md
@@ -126,6 +126,40 @@ lemmatisation.
 JSONL before it can enter a retrieval system. Lemma creates that file and
 rejects chunks that fail its schema checks.
 
+### Pandects
+
+[Pandects](./plugins/pandects) is a corpus of executable laws for credit
+contracts. Each law is a Solidity component with a deliberately broken
+contract it is proven to catch, a reduced counterexample, and a statement of
+the accounting model and observables it requires.
+
+The catalogue holds nine laws across conservation, accrual and withdrawal
+claims. Eight are exact. The path-independence law carries a bound derived from
+the rounding performed by linear accrual, and its tests assert the figures on
+both the sound reference and the compounding specimen.
+
+Pandects includes:
+
+- one-state and transition laws written against economic observables rather
+  than protocol-specific function names;
+- broken specimens and replayable counterexamples for every law;
+- observer, driver and differential adapters for Foundry, Echidna and Medusa;
+- a reduced Wildcat market model recording where three laws need narrower
+  applicability; and
+- a checker, catalogue renderer, search record and tests that keep each law's
+  six required parts together.
+
+#### Day to day
+
+**Security and audit.** A credit protocol arrives and its economic invariants
+have to be settled before a fuzz campaign can mean anything. Pandects supplies
+the laws, the assumptions behind them, and evidence that each catches the fault
+it names.
+
+**Developers.** A change touches accrual or a withdrawal queue. Run the
+applicable laws against the build and inspect the quantities behind any verdict
+that moved.
+
 ### Probitas
 
 [Probitas](./plugins/probitas) builds a sourced dossier on what a counterparty has done across on-chain lending venues.
@@ -433,6 +467,18 @@ plugins/
 │   ├── tests/
 │   └── skills/
 │       └── chunk/
+├── pandects/
+│   ├── .claude-plugin/plugin.json
+│   ├── .codex-plugin/plugin.json
+│   ├── adapters/
+│   ├── catalogue/
+│   ├── docs/
+│   ├── specimens/
+│   ├── src/
+│   ├── test/
+│   ├── tests/
+│   └── skills/
+│       └── pandects/
 ├── probitas/
 │   ├── .claude-plugin/plugin.json
 │   ├── .codex-plugin/plugin.json
@@ -475,9 +521,9 @@ of on-chain credit, shared laws for credit implementations, agents that can show
 their sources, a conformance suite for hooks and a way to replay chain state
 after the original infrastructure is gone. Carrying evidence with a release was
 the first of them, and `ariadne` above is the answer to it. Preserving the credit
-record was the next, and `tabularium` now has its first venue. Another protocol,
-auditor, researcher or agent builder should be able to use each one without
-needing to use Wildcat.
+record was the next, and `tabularium` now has its first venue. `pandects` now
+carries the shared credit laws. Another protocol, auditor, researcher or agent
+builder should be able to use each one without needing to use Wildcat.
 
 What remains, listed alphabetically:
 
@@ -486,7 +532,6 @@ What remains, listed alphabetically:
 | `berean` | A release manifest and evaluation corpus for agents that must support answers with exact documents and chain state |
 | `janus` | A conformance suite for what contract hooks may observe and change before and after a host action |
 | `lazarus` | Finite, verifiable historical-chain fixtures that can be replayed without the original RPC |
-| `pandects` | Executable laws for credit systems, each supplied with a broken specimen and a counterexample |
 
 These are tools we wanted and then needed. Their formats, datasets, properties,
 fixtures and tests become more useful when other teams can inspect, run and

--- a/plugins/pandects/.claude-plugin/plugin.json
+++ b/plugins/pandects/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "pandects",
+  "displayName": "Pandects",
+  "version": "0.1.0",
+  "description": "Executable laws for credit contracts: each one a Solidity component, a broken specimen it is proven to catch, a counterexample replayable without a fuzzer, and a statement of where it means anything.",
+  "author": {
+    "name": "Wildcat Labs",
+    "url": "https://wildcat.finance"
+  },
+  "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/pandects",
+  "repository": "https://github.com/wildcat-finance/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "solidity",
+    "invariants",
+    "property-testing",
+    "fuzzing",
+    "credit",
+    "foundry",
+    "echidna",
+    "wildcat"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/pandects/.codex-plugin/plugin.json
+++ b/plugins/pandects/.codex-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "pandects",
+  "version": "0.1.0",
+  "description": "Executable laws for credit contracts: each one a Solidity component, a broken specimen it is proven to catch, a counterexample replayable without a fuzzer, and a statement of where it means anything.",
+  "author": {
+    "name": "Wildcat Labs",
+    "url": "https://wildcat.finance"
+  },
+  "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/pandects",
+  "repository": "https://github.com/wildcat-finance/skills",
+  "keywords": [
+    "solidity",
+    "invariants",
+    "property-testing",
+    "fuzzing",
+    "credit",
+    "foundry",
+    "echidna",
+    "wildcat"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Pandects",
+    "shortDescription": "Executable laws for credit contracts, each proven against a contract built to break it.",
+    "longDescription": "A fuzzer searches a state space; it cannot decide which economic facts must survive that search. Generic token properties cover balances, approvals and round trips, while credit adds time, accrual, queues, changing terms, delinquency and claims that are neither liquid nor reducible to a token balance. Pandects is the reviewed corpus of those facts, in which a law is not a sentence: it is a Solidity component that executes, a deliberately broken contract it is proven to catch, a minimal counterexample replayable without a fuzzer, and an applicability contract saying which accounting model it means anything for. Laws read economic roles through an observables interface, so no law names an implementation. A law returns rather than reverts, because under fail_on_revert a revert carries no verdict. Nothing here is a fuzzer, a harness generator or a generic assertion library.",
+    "developerName": "Wildcat Labs",
+    "category": "Developer Tools",
+    "capabilities": [],
+    "defaultPrompt": "Use $pandects to check this credit protocol against the executable laws in the corpus."
+  }
+}

--- a/plugins/pandects/AGENTS.md
+++ b/plugins/pandects/AGENTS.md
@@ -1,0 +1,83 @@
+# Pandects runtime contract
+
+Pandects contains one Agent Skill. Select from this table, then read the chosen
+`SKILL.md` in full.
+
+| Skill | Canonical instructions | Select when |
+| --- | --- | --- |
+| `pandects` | `skills/pandects/SKILL.md` | Check a credit protocol against executable laws, or write a new law for the corpus |
+
+`skills/pandects/README.md` is a copy of that file, kept identical so the
+directory renders when browsed. Read either; a test fails if they diverge.
+
+## Translate tool names by capability
+
+The canonical skill was written for hosts that name their tools. A local agent
+must map those names to equivalent capabilities:
+
+| Instruction term | Required capability |
+| --- | --- |
+| `Read` | Read the named file completely or at the stated range |
+| `Write` or `Edit` | Create or patch the named file |
+| `Bash` | Execute the command in a shell and inspect its exit status |
+| `Glob`, `Grep`, or `find` | Enumerate or search files with the stated pattern |
+| `AskUserQuestion` | Ask the stated question through structured UI or concise text |
+
+Tool names describe capabilities, not mandatory API identifiers. Preserve the
+arguments, ordering, output files and exit codes when using an equivalent local
+tool. A non-zero exit from a check means the check failed; do not report a run
+as clean when it exited 1.
+
+## Resolve placeholders
+
+- `$SKILL_DIR` means the directory containing the active `SKILL.md`, unless
+  that file defines it differently.
+- `$PLUGIN_ROOT` means this `plugins/pandects/` directory.
+- The tool's own commands are relative to `$PLUGIN_ROOT`, so
+  `scripts/pandects.py` resolves there and not in the user's target repository.
+- Names such as `pandects:pandects` and `/pandects:pandects` are logical
+  aliases. Load the canonical path from the table above.
+
+## Network and side effects
+
+Nothing here reaches the network, and the Solidity has no dependency to fetch.
+`forge` compiles and runs the corpus locally; `pandects.py` reads the catalogue
+and prints.
+
+Running the corpus against a target compiles and executes that target's code in
+a local EVM. Treat a target repository as the user's, and obey its own
+instructions before writing anything into it.
+
+## What this skill must refuse
+
+These are properties of the tool rather than reminders, and a local agent must
+not route around them:
+
+- No law without its six parts. A component, a specimen it catches, a reduced
+  counterexample, an applicability contract, justified bounds, and an
+  identifier matching its catalogue entry. The checker enforces this; do not
+  add a law by editing the catalogue alone.
+- No implementation names in a law. Laws read `ICreditObservables`, and the
+  three that need a withdrawal queue read `IWithdrawalQueueObservables` on top
+  of it. A protocol's own names belong in the adapter that implements them.
+- No revert as a verdict. A law returns `(bool held, string detail)`, whether it
+  judges one state or a pair of observations, because a revert under
+  `fail_on_revert = false` carries no verdict at all.
+- No pair law held on a pair it cannot judge. A pair spanning real time is a
+  state of the world and the law holds; a pair nobody could have meant is a
+  mistake by whoever built it and the law refuses. Never the other way round.
+- No campaign reported under an engine that did not run. Name the engine, its
+  configuration and its seed, or report nothing. An engine that did not run is
+  absent from a search record; a value nobody could read is absent rather than
+  null; a campaign killed by its timeout is neither passed nor failed.
+- No pair law reported over a target nobody routed calls through. The observing
+  adapter does not offer them, and a driving adapter that recorded no call has
+  judged nothing however its properties read. `recordedCalls` is what tells the
+  two apart.
+- No tolerance without its arithmetic. An epsilon that made a test pass is the
+  thing being refused.
+- No claim that a law is true. The corpus says a law held under a search that
+  is described; it does not say the protocol is safe.
+
+If a lint, a test, a compile or a campaign did not run, say so plainly and do
+not describe its result.

--- a/plugins/pandects/LICENSE
+++ b/plugins/pandects/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Wildcat Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/pandects/README.md
+++ b/plugins/pandects/README.md
@@ -1,0 +1,306 @@
+# Pandects
+
+Executable laws for credit contracts.
+
+A fuzzer searches a state space. It cannot decide which economic facts must
+survive that search. Generic token property libraries cover balances, approvals
+and round trips; credit adds time, accrual, queues, changing terms,
+delinquency, partial repayment and claims that are neither liquid nor reducible
+to a token balance. Every audit rediscovers those facts in prose, implements a
+subset in a local harness, and the harness dies with the engagement.
+
+This is the corpus that survives it.
+
+## What a law is
+
+Six parts, and the checker refuses anything with fewer:
+
+1. **It executes.** A Solidity component, not a sentence.
+2. **It catches something.** A deliberately broken contract it is proven to
+   fail against.
+3. **It has been reduced.** A minimal counterexample, replayable without a
+   fuzzer.
+4. **It says where it applies.** Accounting model, assumptions, required
+   observables.
+5. **Its bounds are justified.** Exact, or a tolerance naming the arithmetic
+   that produces it.
+6. **It judges rather than reverts.** A law returns `(bool held, string
+   detail)`.
+
+Part 2 is the one that carries the weight. A property asserting `seen() >= 0`
+survives a stateful campaign of five hundred calls without complaint, and
+nothing in that passing run distinguishes it from a law. The specimen is not
+documentation; it is the only evidence that a law is a law.
+
+Part 6 follows from the harness. A campaign runs with `fail_on_revert = false`,
+because a credit system reverts constantly and correctly: a withdrawal past the
+queue, a borrow past the reserve, a repayment of more than is owed. Under that
+setting a revert carries no verdict, so a law using `require` to mean
+"violated" reports nothing and is counted as silence.
+
+## What is in the catalogue
+
+Nine laws in three families. Each says what it means, where it means it, and
+which contract it is proven to catch.
+
+| Law | Statement | Caught in |
+| --- | --- | --- |
+| `value-conserved` | Assets held plus debt owed equals lender claims plus accrued fees | `MintedClaims` |
+| `reserves-backed-by-claims` | Assets reserved never exceed the lender claims recorded | `OverReserved` |
+| `held-assets-partitioned` | Reserved assets plus borrowable assets never exceed assets held | `OverPromised` |
+| `debt-falls-only-against-payment` | Debt falls only against held assets rising by at least the fall | `DebtForgiven` |
+| `no-accrual-at-rest` | At equal observation times, debt rises only against held assets leaving | `AccruesAtRest` |
+| `path-independent` | One long step and the same span in equal small steps agree on debt | `CompoundsPerStep` |
+| `recorded-claim-never-shrinks` | A recorded claim keeps its owed amount and never loses payment made | `ClaimHaircut` |
+| `queue-order-preserved` | No claim is paid while an older claim is still owed something | `QueueJumped` |
+| `reserves-cover-payable` | Reserved assets cover everything owed on the claims declared payable | `PayableBeyondReserves` |
+
+Every one is independent of the others: a state or a transition can break any
+one while the rest hold, which is what makes a specimen per law possible at all.
+`test/Corpus.t.sol` and `test/Pairs.t.sol` assert that diagonal, so a law
+broader than its statement fails the suite rather than passing review.
+
+## Two shapes, because the facts have two shapes
+
+Conservation is a fact about one state: the sums agree or they do not, and no
+history is needed to say which. So a `Law` reads one target and judges what it
+finds.
+
+Accrual is not. Debt falling without payment cannot be violated by any single
+state, however wrong that state is, because the violation is in the transition.
+So a `PairLaw` judges two observations, where an `Observation` is a snapshot of
+everything a target reports. Three of them compare a system with its own past.
+The fourth compares two systems started identically and advanced over the same
+span by different routes, which is the only way to see interest that compounds
+when it should not.
+
+There is no third shape, and a law says in its applicability which kind of pair
+it means. Handed one it cannot judge, it follows one rule: a pair that spans
+real time is a state of the world, so hold and say why; a pair nobody could
+have meant is a mistake by whoever built it, so refuse and say why.
+
+## The one tolerance
+
+Eight of the nine laws are exact. `path-independent` is not, and its bound is
+derived rather than chosen: linear accrual on principal truncates once per
+step, so `n` small steps and one long step over the same span differ by at most
+`n - 1` units.
+
+At a hundred thousand borrowed over a year, the sound reference lands exactly
+one unit apart across two half-year steps, which is the bound. The compounding
+specimen lands two hundred and forty-nine away.
+`test/counterexamples/Accrual.t.sol` asserts all four figures, so the bound can
+be checked rather than believed.
+
+## Run it
+
+From this directory, `plugins/pandects`:
+
+```bash
+python3 scripts/pandects.py laws
+python3 scripts/pandects.py check
+python3 scripts/pandects.py run
+forge test
+```
+
+`laws` lists the catalogue with each law's applicability. `check` refuses a law
+missing any of its six parts, naming the part. `run` searches and writes down
+how. `forge test` runs the corpus: both diagonals, the counterexamples, the
+adapters, and a campaign over the sound reference.
+
+## Pointing it at your own protocol
+
+The specimen harnesses prove the laws catch what they claim to. `adapters/` is
+the other direction: the laws, and your address.
+
+```solidity
+import {CorpusObserver} from "pandects/adapters/CorpusBase.sol";
+
+CorpusObserver observer = new CorpusObserver(ICreditObservables(yourSystem));
+observer.coreHolds();   // conservation, whatever else is driving that contract
+observer.explainCore(); // and why, in the laws' own words
+```
+
+That is the observing form, and it offers the one-state laws only. A pair law
+needs the state as it was before the last call, and nothing observes a call it
+does not sit in front of. An observer offering them would report them holding
+forever, for the same reason a law that never fires reports holding.
+
+For those, extend `CorpusDriver` -- or `DrivenCorpusInvariants`,
+`DrivenCorpusEchidna`, `DrivenCorpusMedusa`, depending on the engine -- write
+your protocol's entry points, and put `records` on every one that changes
+state. The entry points are yours to write because they are yours to name: a
+base cannot proxy a surface it has never seen.
+
+Nothing catches a forgotten `records`. What it looks like is three succession
+laws holding and saying nothing, which reads exactly like a system behaving.
+So `recordedCalls` is public and `successionExercised` reads it: zero recorded
+calls means those laws searched nothing, whatever they reported. Read the two
+together or the first is worth nothing.
+
+Path independence is not in either adapter. It compares two systems advanced
+over the same span by different routes, and an adapter fronts one target;
+routing calls through it buys a past, not a second system.
+`PathIndependenceProbe` takes both, because only you can build two instances of
+your own system from the same start.
+
+| Adapter | Laws | Reach |
+| --- | --- | --- |
+| `CorpusObserver` | 5 one-state | any address |
+| `CorpusDriver` | 5 one-state, 3 succession | a target you front |
+| `PathIndependenceProbe` | 1 differential | two targets you built |
+
+`adapters/echidna/echidna.yaml` and `adapters/medusa/medusa.json` carry
+settings and leave the target empty, because the target is the only part that
+is yours.
+
+## Saying how it was searched
+
+A campaign result without its settings is an anecdote. `run` searches and
+writes down what it did:
+
+```bash
+python3 scripts/pandects.py run --out search-record.json
+```
+
+The record names the engine, the argv, the determinism class, the
+configuration read out of `foundry.toml` rather than restated, the sequence
+length, and a digest of the corpus that was searched. It is shaped as an
+`ariadne` command entry, so a result drops into a release statement without
+translation -- shaped as, not built by: the two plugins share no code and a
+test pins the shape from this side.
+
+Two things are absent rather than empty, and both are one rule. An engine that
+did not run has no entry, because a reader counting entries is counting
+searches. And what nobody could read -- a seed Foundry does not report, a
+version a binary would not give -- is absent rather than null, because null
+says there is nothing to find rather than asking you to go and find it. A
+campaign that was killed by the timeout is neither passed nor failed; it
+carries an outcome of its own.
+
+The corpus digest covers the catalogue, the law components and the specimens,
+with comments stripped and string literals kept. It moves when a law moves and
+holds still when somebody improves a docstring.
+
+## Running an engine over it
+
+`src/campaigns/Specimens.sol` carries one harness per specimen, each declaring
+both `echidna_` and `property_` prefixes because Echidna looks for the first
+and Medusa defaults to the second. A harness with only one of them is silent
+under the other engine.
+
+```bash
+echidna . --contract SoundCampaign --test-limit 20000
+medusa fuzz --compilation-target . --target-contracts SoundCampaign
+```
+
+Eight of the ten harnesses are expected to fail, and the expectation is the
+point: a campaign reporting every property holding against a contract built to
+break one has not searched hard enough. Replay a failing sequence and call
+`explain()` for the reason, in the law's own words.
+
+The ninth is the one worth knowing about. `CompoundsPerStepCampaign` passes
+every property under both engines, and the contract underneath it is broken.
+Its defect is path independence, which compares two systems advanced by
+different routes; a campaign drives one system along one route and can never
+see it. That is what a passing campaign is worth on its own.
+
+Exit codes: 0 success, 1 a check failed, 2 usage or validation error.
+
+## What a law may read
+
+`ICreditObservables`: the asset, total assets held, total debt, total lender
+claims, reserved and borrowable assets, accrued fees, and the time the
+observation describes. A target implements it, or a thin adapter does, and that
+adapter is the only place a protocol's own names appear.
+
+A system with a withdrawal queue also implements
+`IWithdrawalQueueObservables`, which adds the claim count, each claim's owed and
+paid amounts, and the bound through which the system declares claims payable.
+It is a separate interface rather than three more members on the core, because
+a system with no queue would have to implement all three and mean none of them,
+and an observable that means nothing is worse than an absent one: it reports
+zero, and zero reads like an answer. The three laws that need it say so in their
+applicability, and a target without it reverts on the read -- which is no
+verdict rather than a false one.
+
+A property written against one protocol's function names is a property about one
+codebase. The corpus exists because the same economic facts hold across
+codebases that share nothing else.
+
+## The demo, end to end
+
+From a clean checkout, in `plugins/pandects`. Nothing here reaches the network
+and there is no dependency to fetch.
+
+```bash
+python3 scripts/pandects.py laws
+python3 scripts/pandects.py check
+forge test
+python3 scripts/pandects.py run --out search-record.json
+```
+
+`laws` prints nine laws with their applicability. `check` reports every part
+present. `forge test` runs both diagonals, the counterexamples, the adapters and
+the Wildcat model. `run` searches and writes the record.
+
+Then watch a law fire against a contract built to break it:
+
+```bash
+echidna . --contract ClaimHaircutCampaign --test-limit 20000 --seed 20260816
+```
+
+`recorded_claim_never_shrinks` fails and nothing else does. Replay the sequence
+it prints and call `explain()` for the reason in the law's own words.
+
+And the case the corpus was built for -- laws written against no protocol in
+particular, pointed at a real design:
+
+```bash
+forge test --match-contract WildcatTest
+```
+
+`integrations/wildcat/` models a market with batched withdrawals, a reserve the
+borrower may not touch, delinquency and penalty accrual.
+[`APPLICABILITY.md`](./integrations/wildcat/APPLICABILITY.md) is the part worth
+reading. Six laws apply flatly. `queue-order-preserved` applies at batch
+granularity and says nothing per lender. `path-independent` holds while the
+market is solvent and stops holding once the penalty is running. And
+`recorded-claim-never-shrinks` does not hold over a batch that is still open,
+which Echidna found against the shipped adapter after that document had already
+claimed it did.
+
+None of those three is a yes or a no, which is what an applicability contract is
+for, and the third is the argument for pointing a corpus at a real design rather
+than only at contracts written to break it.
+
+## The documents
+
+- [The catalogue](./docs/catalogue.md), rendered for a reader. A test fails if
+  it and `catalogue/pandects.json` stop naming the same laws.
+- [Writing a law](./docs/writing-a-law.md), the six parts in the order somebody
+  adding one meets them.
+- [Applicability](./docs/applicability.md), the rules stated once: what a law
+  may read, the two shapes, what a pair law does with a pair it cannot judge,
+  and what a revert means.
+
+## Dependencies
+
+None. Foundry's invariant runner works on a bare contract, so there is no
+`lib/`, no submodule, and nothing to fetch at build or test time. The catalogue
+checker is standard-library Python on 3.9 through 3.13.
+
+## What this is not
+
+Not a fuzzer, not a harness generator, and not a generic assertion library.
+Echidna, Medusa and Foundry search; this says what to look for.
+[`fizz`](https://github.com/wildcat-finance/skills/tree/main/plugins/hexaemeron/skills/fizz)
+generates a harness for one repository and can select and adapt these laws;
+it stays useful where no public law describes the protocol.
+
+The corpus never says a protocol is safe. It says a law held under a search
+that is described.
+
+## Licence
+
+Apache-2.0. See [LICENSE](./LICENSE).

--- a/plugins/pandects/adapters/CorpusBase.sol
+++ b/plugins/pandects/adapters/CorpusBase.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ICreditObservables} from "../src/ICreditObservables.sol";
+import {Law} from "../src/Law.sol";
+import {Observation, Observe} from "../src/Observation.sol";
+import {PairLaw} from "../src/PairLaw.sol";
+import {ValueConserved} from "../src/laws/ValueConserved.sol";
+import {ReservesBackedByClaims} from "../src/laws/ReservesBackedByClaims.sol";
+import {HeldAssetsPartitioned} from "../src/laws/HeldAssetsPartitioned.sol";
+import {QueueOrderPreserved} from "../src/laws/QueueOrderPreserved.sol";
+import {ReservesCoverPayableClaims} from "../src/laws/ReservesCoverPayableClaims.sol";
+import {DebtFallsOnlyAgainstPayment} from "../src/laws/DebtFallsOnlyAgainstPayment.sol";
+import {NoAccrualAtRest} from "../src/laws/NoAccrualAtRest.sol";
+import {RecordedClaimNeverShrinks} from "../src/laws/RecordedClaimNeverShrinks.sol";
+
+/// @title The corpus, over a target somebody else supplies.
+/// @notice `src/campaigns/Specimens.sol` binds one harness to one specimen,
+/// which is what proving a law needs and no use to somebody who has a protocol.
+/// This is the other direction: the laws, and an address.
+///
+/// Two shapes come out of that, and the difference is a limit rather than a
+/// convenience. A one-state law reads a target and judges what it finds, so
+/// `CorpusObserver` can hold any address and ask. A pair law needs the state as
+/// it was before the last call, and nothing observes a call it does not sit in
+/// front of, so `CorpusDriver` gets the calls routed through it.
+///
+/// An observer that offered the pair laws would report them holding, always,
+/// for the same reason a law that never fires reports holding. That is what
+/// this corpus exists to refuse, so the observer does not offer them.
+///
+/// Neither offers `accrual/path-independent/v1`. It compares two systems
+/// advanced over the same span by different routes, and an adapter fronts one
+/// target; routing calls through it buys a past, not a second system. The
+/// probe in `adapters/foundry/PathIndependenceProbe.sol` takes both, because
+/// only the caller can build two instances of their own system from the same
+/// start.
+abstract contract CorpusBase {
+    Law internal immutable conserved = new ValueConserved();
+    Law internal immutable backed = new ReservesBackedByClaims();
+    Law internal immutable partitioned = new HeldAssetsPartitioned();
+    Law internal immutable ordered = new QueueOrderPreserved();
+    Law internal immutable covered = new ReservesCoverPayableClaims();
+
+    /// @notice The system under test, or an adapter over it.
+    function target() public view virtual returns (ICreditObservables);
+
+    // slither-disable-next-line unused-return
+    function judge(Law law) internal view returns (bool ok) {
+        (ok, ) = law.check(target());
+    }
+
+    /// @notice The one-state laws that need no withdrawal queue.
+    /// @dev Separated because a target with no queue reverts on the other two,
+    /// and a revert is no verdict. An integrator whose system has no queue asks
+    /// for these three and gets three answers rather than three reverts.
+    function coreHolds() public view returns (bool) {
+        return judge(conserved) && judge(backed) && judge(partitioned);
+    }
+
+    /// @notice The one-state laws that read the withdrawal queue.
+    /// @dev Reverts against a target that does not implement
+    /// `IWithdrawalQueueObservables`. That is the documented limit and not a
+    /// verdict: the state could not be observed.
+    function queueHolds() public view returns (bool) {
+        return judge(ordered) && judge(covered);
+    }
+
+    /// @notice Why the three laws that need no queue decided as they did.
+    /// @dev Separate from `explainOneState` for the same reason `coreHolds` is
+    /// separate from `queueHolds`. A target with no withdrawal queue reverts on
+    /// the last two reads, and a single five-part explanation would take the
+    /// three answers down with them: an integrator whose system has no queue
+    /// would be told nothing at all, including about the laws that were happy
+    /// to judge it.
+    function explainCore() public view returns (string[3] memory details) {
+        // slither-disable-start unused-return
+        (, details[0]) = conserved.check(target());
+        (, details[1]) = backed.check(target());
+        (, details[2]) = partitioned.check(target());
+        // slither-disable-end unused-return
+    }
+
+    /// @notice Why each one-state law decided as it did.
+    /// @dev Reverts against a target with no withdrawal queue. Use
+    /// `explainCore` there; it is the same three answers this would have given
+    /// before the queue reads took it down.
+    function explainOneState() public view returns (string[5] memory details) {
+        // slither-disable-start unused-return
+        (, details[0]) = conserved.check(target());
+        (, details[1]) = backed.check(target());
+        (, details[2]) = partitioned.check(target());
+        (, details[3]) = ordered.check(target());
+        (, details[4]) = covered.check(target());
+        // slither-disable-end unused-return
+    }
+}
+
+/// @title The corpus over a target nobody routes calls through.
+/// @notice Point it at an address and the one-state laws run, whatever else is
+/// driving that contract. This is the form to reach for when the system under
+/// test is already deployed, already driven by somebody else's harness, or
+/// simply not yours to front.
+///
+/// It offers no pair law, and that is the whole design. See `CorpusBase`.
+contract CorpusObserver is CorpusBase {
+    ICreditObservables internal immutable system;
+
+    constructor(ICreditObservables target_) {
+        system = target_;
+    }
+
+    function target() public view override returns (ICreditObservables) {
+        return system;
+    }
+}
+
+/// @title The corpus over a target whose calls come through here.
+/// @notice Extend this, write your protocol's entry points, and put `records`
+/// on every one that changes state. That modifier is the entire mechanism: it
+/// snapshots the system on the way in, so a pair law has a past to compare
+/// with.
+///
+/// The entry points are yours to write because they are yours to name. A base
+/// cannot proxy a surface it has never seen, and one that tried would need
+/// either an ABI it cannot know or a fallback that forwards calldata blindly --
+/// which would forward the call that breaks a law without ever recording the
+/// state before it.
+///
+/// A state-changing entry point without `records` is not an error the compiler
+/// can catch. It shows as pair laws that hold through the call and say nothing,
+/// which reads exactly like a system that is behaving.
+abstract contract CorpusDriver is CorpusBase {
+    PairLaw internal immutable falls = new DebtFallsOnlyAgainstPayment();
+    PairLaw internal immutable atRest = new NoAccrualAtRest();
+    PairLaw internal immutable shrinks = new RecordedClaimNeverShrinks();
+
+    /// @notice The system as it was immediately before the last recorded call.
+    Observation internal previous;
+
+    /// @notice How many calls this adapter has recorded a state for.
+    /// @dev Public because a pair law that was never given a past reports
+    /// holding, and nothing about that verdict distinguishes it from a law that
+    /// held. An integrator who forgets `records` on an entry point sees three
+    /// green properties and a system that was never judged.
+    ///
+    /// This is the number that tells them apart. Assert it is rising in your
+    /// own harness, or read it after a campaign: zero recorded calls means the
+    /// succession laws searched nothing, whatever they reported.
+    uint256 public recordedCalls;
+
+    modifier records() {
+        remember();
+        _;
+    }
+
+    /// @dev Field by field, and the queue entry by entry. A whole-struct
+    /// assignment from memory to storage needs the IR pipeline, and turning
+    /// that on would change how everybody consuming this corpus compiles.
+    function remember() internal {
+        Observation memory found = Observe.takeWithQueue(target());
+        recordedCalls++;
+        previous.totalAssets = found.totalAssets;
+        previous.totalDebt = found.totalDebt;
+        previous.totalLenderClaims = found.totalLenderClaims;
+        previous.reservedAssets = found.reservedAssets;
+        previous.borrowableAssets = found.borrowableAssets;
+        previous.accruedFees = found.accruedFees;
+        previous.observedAt = found.observedAt;
+        previous.payableThrough = found.payableThrough;
+        previous.queueObserved = true;
+        while (previous.queue.length > found.queue.length) {
+            previous.queue.pop();
+        }
+        for (uint256 i = 0; i < found.queue.length; i++) {
+            if (i < previous.queue.length) {
+                previous.queue[i] = found.queue[i];
+            } else {
+                previous.queue.push(found.queue[i]);
+            }
+        }
+    }
+
+    /// @dev Vacuously true before the first recorded call. An engine evaluates
+    /// properties against the starting state, where there is no past to compare
+    /// with, and a violation reported there would be a report about the harness.
+    // slither-disable-next-line unused-return
+    function judgePair(PairLaw law) internal view returns (bool ok) {
+        if (!previous.queueObserved) {
+            return true;
+        }
+        (ok, ) = law.check(previous, Observe.takeWithQueue(target()));
+    }
+
+    function successionHolds() public view returns (bool) {
+        return judgePair(falls) && judgePair(atRest) && judgePair(shrinks);
+    }
+
+    /// @notice Whether the succession laws have judged anything at all.
+    /// @dev `successionHolds` returning true means one of two things, and this
+    /// says which. Read them together or the first one is worth nothing.
+    function successionExercised() public view returns (bool) {
+        return recordedCalls > 0;
+    }
+
+    /// @notice Why each pair law decided as it did, across the last call.
+    function explainSuccession() public view returns (string[3] memory details) {
+        if (!previous.queueObserved) {
+            details[0] = "no call was recorded, so no transition was judged";
+            details[1] = details[0];
+            details[2] = details[0];
+            return details;
+        }
+        Observation memory now_ = Observe.takeWithQueue(target());
+        // slither-disable-start unused-return
+        (, details[0]) = falls.check(previous, now_);
+        (, details[1]) = atRest.check(previous, now_);
+        (, details[2]) = shrinks.check(previous, now_);
+        // slither-disable-end unused-return
+    }
+}

--- a/plugins/pandects/adapters/echidna/CorpusEchidna.sol
+++ b/plugins/pandects/adapters/echidna/CorpusEchidna.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {CorpusBase, CorpusDriver} from "../CorpusBase.sol";
+
+/// @title The corpus under the prefix Echidna reads.
+/// @notice The same laws the Foundry adapter asks about, asked through
+/// `echidna_`. The prefix is an engine's contract rather than a style choice,
+/// so it is answered here rather than argued with.
+///
+/// A property function returns only a boolean. When one fails, replay the
+/// sequence and call `explainOneState` or `explainSuccession` for the reason in
+/// the law's own words, rather than deriving it from a call trace.
+abstract contract CorpusEchidna is CorpusBase {
+    function hasWithdrawalQueue() public view virtual returns (bool) {
+        return true;
+    }
+
+    function echidna_value_conserved() external view returns (bool) {
+        return judge(conserved);
+    }
+
+    function echidna_reserves_backed() external view returns (bool) {
+        return judge(backed);
+    }
+
+    function echidna_held_partitioned() external view returns (bool) {
+        return judge(partitioned);
+    }
+
+    function echidna_queue_order_preserved() external view returns (bool) {
+        return !hasWithdrawalQueue() || judge(ordered);
+    }
+
+    function echidna_reserves_cover_payable() external view returns (bool) {
+        return !hasWithdrawalQueue() || judge(covered);
+    }
+}
+
+/// @title The same, plus the succession laws, for a target you front.
+/// @notice Extend this, write your protocol's entry points, and put `records`
+/// on every one that changes state. Echidna calls those entry points; the
+/// snapshot happens on the way in.
+abstract contract DrivenCorpusEchidna is CorpusEchidna, CorpusDriver {
+    function echidna_debt_falls_only_against_payment() external view returns (bool) {
+        return judgePair(falls);
+    }
+
+    function echidna_no_accrual_at_rest() external view returns (bool) {
+        return judgePair(atRest);
+    }
+
+    function echidna_recorded_claim_never_shrinks() external view returns (bool) {
+        return judgePair(shrinks);
+    }
+}

--- a/plugins/pandects/adapters/echidna/echidna.yaml
+++ b/plugins/pandects/adapters/echidna/echidna.yaml
@@ -1,0 +1,36 @@
+# Echidna, over an adapter you wrote.
+#
+# Point it at your own contract: the one extending `CorpusEchidna` or
+# `DrivenCorpusEchidna` and naming your system. This file carries the settings,
+# not the target, because the target is the only part that is yours.
+#
+#   echidna . --contract YourHarness --config adapters/echidna/echidna.yaml
+#
+# testMode is `property`, so Echidna reads functions prefixed `echidna_` and
+# nothing else. That prefix is the engine's contract, which is why the adapter
+# carries it rather than a name somebody preferred.
+testMode: property
+
+# A seed, so a campaign under Echidna can be reproduced. This is the single
+# difference from Medusa that reaches the search record: Echidna takes a seed
+# and reports the one it used, Medusa exposes none, and a record says which.
+# Change it deliberately; a run under a different seed is a different search.
+seed: 20260816
+
+# Twenty thousand transactions, sequences up to sixty-four calls. The sequence
+# length matters more than the count for a corpus like this: the pair laws judge
+# transitions, and a defect two calls deep is out of reach of a search that only
+# ever makes one.
+testLimit: 20000
+seqLen: 64
+
+# A credit system reverts constantly and correctly -- a withdrawal past the
+# queue, a borrow past the reserve, a repayment of more than is owed. A revert
+# is not a law failing, so reverts are allowed and counted rather than treated
+# as findings.
+checkAsserts: false
+
+# Shrinking is what turns a failure into something a person can read. Echidna
+# does this well and it is why the counterexamples in this corpus are as short
+# as they are.
+shrinkLimit: 5000

--- a/plugins/pandects/adapters/foundry/CorpusInvariants.sol
+++ b/plugins/pandects/adapters/foundry/CorpusInvariants.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {CorpusBase, CorpusDriver} from "../CorpusBase.sol";
+
+/// @title The one-state laws as Foundry invariants.
+/// @notice Written once and inherited by both adapters below, so the two differ
+/// in what they can reach rather than in which laws they ask about.
+///
+/// The three laws that need no withdrawal queue are separate from the two that
+/// do, because a target without one reverts on the read and a revert is no
+/// verdict. An integrator with no queue wants three answers, not three reverts,
+/// so `hasWithdrawalQueue` stands the other two down.
+abstract contract OneStateInvariants is CorpusBase {
+    /// @notice Whether the target implements `IWithdrawalQueueObservables`.
+    /// @dev True by default. A corpus that assumed the smaller interface would
+    /// quietly skip two laws for every system that does have a queue, and
+    /// quietly skipping is the failure this corpus is about.
+    function hasWithdrawalQueue() public view virtual returns (bool) {
+        return true;
+    }
+
+    function invariant_value_is_conserved() public view {
+        (bool held, string memory why) = conserved.check(target());
+        require(held, why);
+    }
+
+    function invariant_reserves_are_backed_by_claims() public view {
+        (bool held, string memory why) = backed.check(target());
+        require(held, why);
+    }
+
+    function invariant_held_assets_stay_partitioned() public view {
+        (bool held, string memory why) = partitioned.check(target());
+        require(held, why);
+    }
+
+    function invariant_the_queue_stays_in_order() public view {
+        if (!hasWithdrawalQueue()) {
+            return;
+        }
+        (bool held, string memory why) = ordered.check(target());
+        require(held, why);
+    }
+
+    function invariant_reserves_cover_what_is_payable() public view {
+        if (!hasWithdrawalQueue()) {
+            return;
+        }
+        (bool held, string memory why) = covered.check(target());
+        require(held, why);
+    }
+}
+
+/// @title The corpus over a target you do not front.
+/// @notice Extend this, create your system in `setUp`, and return it from
+/// `target()`. Foundry fuzzes what `setUp` creates, so the system is built
+/// there rather than handed in at construction.
+///
+/// One-state laws only. Nothing here sits in front of the calls, so there is no
+/// past to read, and a pair law offered from here would report holding for
+/// every target forever.
+abstract contract CorpusInvariants is OneStateInvariants {}
+
+/// @title The same, plus the succession laws, for a target you do front.
+/// @notice Extend this when the calls go through your harness. Write your
+/// protocol's entry points and put `records` on every one that changes state.
+///
+/// Foundry fuzzes the entry points you write, which is the point: the snapshot
+/// happens on the way in, so every call the fuzzer makes is one the succession
+/// laws get to judge.
+///
+/// A state-changing entry point without `records` is not an error the compiler
+/// can catch. It shows as pair laws holding through the call and saying
+/// nothing, which reads exactly like a system that is behaving.
+abstract contract DrivenCorpusInvariants is OneStateInvariants, CorpusDriver {
+    function invariant_debt_falls_only_against_payment() public view {
+        require(judgePair(falls), "debt fell further than held assets rose");
+    }
+
+    function invariant_no_accrual_at_rest() public view {
+        require(judgePair(atRest), "debt rose while time stood still");
+    }
+
+    function invariant_recorded_claims_never_shrink() public view {
+        require(judgePair(shrinks), "a recorded claim was written down");
+    }
+}

--- a/plugins/pandects/adapters/foundry/PathIndependenceProbe.sol
+++ b/plugins/pandects/adapters/foundry/PathIndependenceProbe.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ICreditObservables} from "../../src/ICreditObservables.sol";
+import {Observation, Observe} from "../../src/Observation.sol";
+import {AccrualPathIndependent} from "../../src/laws/AccrualPathIndependent.sol";
+
+/// @title The ninth law, which no campaign can carry.
+/// @notice `accrual/path-independent/v1` compares two systems started
+/// identically and advanced over the same span by different routes. An adapter
+/// fronts one target; routing calls through it buys a past to read, not a
+/// second system. So this is not an adapter and not a campaign property. It is
+/// a probe, and the caller supplies both systems, because only they can build
+/// two instances of their own from the same start.
+///
+/// Deploy it with the subdivision count the fine run actually used. Nothing in
+/// either observation reveals a mismatch, so a probe built for the wrong count
+/// compares against the wrong bound and gives no sign that it has. That hazard
+/// belongs to the law and is documented there; this contract is where a caller
+/// meets it.
+contract PathIndependenceProbe {
+    AccrualPathIndependent public immutable law;
+
+    constructor(uint256 subdivisions) {
+        law = new AccrualPathIndependent(subdivisions);
+    }
+
+    /// @notice The widest gap the law accepts, for the count it was built with.
+    function tolerance() external view returns (uint256) {
+        return law.tolerance();
+    }
+
+    /// @notice Judge two systems that should have reached the same moment.
+    /// @param coarse The system advanced once across the whole span.
+    /// @param fine The system advanced across the same span in equal steps.
+    /// @return held True when the two agree on debt within the bound.
+    /// @return detail What was compared, and what it decided.
+    function check(ICreditObservables coarse, ICreditObservables fine)
+        external
+        view
+        returns (bool held, string memory detail)
+    {
+        Observation memory a = Observe.take(coarse);
+        Observation memory b = Observe.take(fine);
+        return law.check(a, b);
+    }
+}

--- a/plugins/pandects/adapters/medusa/CorpusMedusa.sol
+++ b/plugins/pandects/adapters/medusa/CorpusMedusa.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {CorpusBase, CorpusDriver} from "../CorpusBase.sol";
+
+/// @title The corpus under the prefix Medusa defaults to.
+/// @notice The same laws the Echidna adapter asks about, asked through
+/// `property_`. Two files rather than one because the prefixes are fixed by the
+/// engines and a contract carrying both would answer every question twice; an
+/// integrator picks the engine they run.
+///
+/// The convention detector is answered here rather than obeyed: `property_` is
+/// what Medusa looks for, and a harness that renamed it to satisfy a linter
+/// would be a harness Medusa never calls.
+// slither-disable-start naming-convention
+abstract contract CorpusMedusa is CorpusBase {
+    function hasWithdrawalQueue() public view virtual returns (bool) {
+        return true;
+    }
+
+    function property_value_conserved() external view returns (bool) {
+        return judge(conserved);
+    }
+
+    function property_reserves_backed() external view returns (bool) {
+        return judge(backed);
+    }
+
+    function property_held_partitioned() external view returns (bool) {
+        return judge(partitioned);
+    }
+
+    function property_queue_order_preserved() external view returns (bool) {
+        return !hasWithdrawalQueue() || judge(ordered);
+    }
+
+    function property_reserves_cover_payable() external view returns (bool) {
+        return !hasWithdrawalQueue() || judge(covered);
+    }
+}
+
+/// @title The same, plus the succession laws, for a target you front.
+abstract contract DrivenCorpusMedusa is CorpusMedusa, CorpusDriver {
+    function property_debt_falls_only_against_payment() external view returns (bool) {
+        return judgePair(falls);
+    }
+
+    function property_no_accrual_at_rest() external view returns (bool) {
+        return judgePair(atRest);
+    }
+
+    function property_recorded_claim_never_shrinks() external view returns (bool) {
+        return judgePair(shrinks);
+    }
+}
+// slither-disable-end naming-convention

--- a/plugins/pandects/adapters/medusa/README.md
+++ b/plugins/pandects/adapters/medusa/README.md
@@ -1,0 +1,35 @@
+# Medusa, over an adapter you wrote
+
+`medusa.json` carries the settings and leaves `targetContracts` empty, because
+the target is the only part that is yours: the contract extending
+`CorpusMedusa` or `DrivenCorpusMedusa` and naming your system.
+
+Fill it in, or pass it on the command line and skip the file:
+
+```bash
+medusa fuzz --compilation-target . --target-contracts YourHarness --test-limit 20000
+```
+
+The settings match `adapters/echidna/echidna.yaml` wherever the two engines
+have the same knob: twenty thousand transactions, sequences up to sixty-four
+calls, assertion testing off and property testing on. `property_` is what
+Medusa reads by default, and it is why the adapter carries that prefix rather
+than a name somebody preferred.
+
+Two things differ, and both reach the search record.
+
+**Medusa exposes no seed.** Echidna takes one and reports the one it used, so a
+campaign under it can be reproduced call for call. A Medusa record therefore
+carries the engine, the configuration, the sequence length and the corpus
+digest, and says nothing about a seed -- rather than carrying a null, which
+would read as a run that had no seed instead of one nobody can read.
+
+**Medusa reports the sequence it found; Echidna shrinks it first.** Turning a
+Medusa failure into a deterministic replay is work that turning an Echidna one
+mostly is not.
+
+If a campaign exits before it starts -- `Failed to initialize the test chain`,
+or a target reported missing from the compilation artefacts -- clear
+`crytic-export/` and `.medusa-artifact-hash` and run again. An exit like that
+produces output with no failures in it, which reads exactly like a clean run
+and is not one.

--- a/plugins/pandects/adapters/medusa/medusa.json
+++ b/plugins/pandects/adapters/medusa/medusa.json
@@ -1,0 +1,19 @@
+{
+  "fuzzing": {
+    "workers": 6,
+    "testLimit": 20000,
+    "callSequenceLength": 64,
+    "corpusDirectory": "",
+    "targetContracts": [],
+    "testing": {
+      "stopOnFailedTest": false,
+      "assertionTesting": { "enabled": false },
+      "propertyTesting": { "enabled": true, "testPrefixes": ["property_"] },
+      "optimizationTesting": { "enabled": false }
+    }
+  },
+  "compilation": {
+    "platform": "crytic-compile",
+    "platformConfig": { "target": ".", "solcVersion": "", "exportDirectory": "", "args": [] }
+  }
+}

--- a/plugins/pandects/audit/AUDIT.md
+++ b/plugins/pandects/audit/AUDIT.md
@@ -1,0 +1,665 @@
+# Pandects audit log
+
+One section per round. A round with no findings is still a round and still gets
+written down.
+
+The suite for this run is the vendored Pashov set: `x-ray`, `solidity-auditor`
+and `fizz`, recorded on the run's ledger rather than waived, because this build
+ships Solidity. Each round says which of them ran, and where one did not, why.
+
+Echidna and Medusa were not installed when this log opened, and the step 1
+rounds below say so because it was true when they were written.
+
+They were installed on 2026-08-16, after step 1 closed and before step 2 began:
+Echidna 2.3.3, Medusa 1.5.1 and Slither 0.11.6, all from homebrew-core. Both
+fuzzers were proved against a contract written to break a law before either was
+relied on. Rounds from step 2 onwards therefore run campaigns, and each says
+which engine produced which result.
+
+## Step 1, round 1 -- 2026-08-16
+
+Reviewed: `src/ICreditObservables.sol`, `src/Law.sol`, and the Python that
+decides whether something is a law, against the risks listed in
+[`docs/design.md`](../docs/design.md).
+
+**How the suite ran.** `solidity-auditor` fans twelve specialist agents over
+the in-scope `.sol` files, excluding `test/` and `*.t.sol`. The in-scope set for
+this step is one interface and one abstract contract, neither of which has a
+single function body: there is no arithmetic, no state, no access control and
+no external call to audit. The review was therefore done directly rather than
+fanned out, and this line is here so nobody reads twelve agents into it.
+`x-ray` produces a pre-audit report over a protocol, and there is no protocol in
+this step for the same reason. `fizz` builds an invariant suite over a stateful
+system; the first stateful contracts arrive with the specimens in step 2, and
+its campaigns start there.
+
+What that leaves is the Python, which is where this step's decisions actually
+execute, and it is where the round found things.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R1-01 | medium | `scripts/pandects_lib/checker.py` | The revert check looked for `require` and `revert` and not `assert`. A law reaching for `assert(cond)` to mean "violated" reverts with a panic, which under `fail_on_revert = false` is as silent as any other revert, so the law reports nothing and the check that exists to catch exactly that missed it | fixed in this round: `assert` is scanned with the other two and the finding names which was used |
+| S1-R1-02 | medium | `scripts/pandects_lib/checker.py` | The check first matched the body of `check()` with a regex that depended on the closing brace sitting at four spaces. A law written on one line, or inside a library, or indented differently, produced no match at all, and the revert check then silently did not run. A check that stops checking without saying so is worse than no check | fixed in this round: the scan reads the whole component. A law component holds `id`, `statement` and `check` and nothing else, so no revert anywhere in it is legitimate and there is no body to find first |
+| S1-R1-03 | low | `scripts/pandects_lib/checker.py` | A component or specimen that was not UTF-8 raised out of the checker instead of being reported. `check_specimen` also called `.lower()` on the read result, so the same input crashed there twice over | fixed in this round: reading returns `None` and both call sites report it as a finding |
+| S1-R1-04 | low | `scripts/pandects_lib/checker.py` | `os.path.commonpath` raises on paths it cannot compare, which would have escaped as a traceback rather than a refusal to resolve | fixed in this round |
+
+Checked and found sound:
+
+- The word `require` inside a comment is no longer evidence, and a test asserts
+  it. Comments are stripped before the scan, so a law explaining what it does
+  not do is not accused of doing it.
+- `resolve` refuses a component path that leaves the plugin, including an
+  absolute one, so a catalogue cannot point the checker at `/etc/passwd`.
+- A law missing any part is a finding naming the part rather than a parse
+  error calling the file malformed. Walked all seven fields by hand.
+- `Law.check` is `view` and an override may only narrow that, so no law can
+  quietly become state-changing.
+
+Leads not pursued:
+
+- **A law calling a helper that reverts.** The scan reads one file. A component
+  that delegates to a library which reverts is not caught, and no regex over
+  one file would catch it. The specimen is what closes this: a law that reverts
+  where it should return fails against its own specimen in step 2, which is
+  evidence rather than a pattern match.
+- **Orphan scanning is limited to `src/laws/`.** A component filed elsewhere and
+  claimed by nobody is not reported. That is the documented location for law
+  components, and widening the scan would report every Solidity file in the
+  plugin.
+- **A target that consumes all gas in a view call** stalls a campaign rather
+  than failing it. That belongs to the harness adapter in step 4, which decides
+  what an unobservable state means.
+
+## Step 1, round 2 -- 2026-08-16
+
+Reviewed: the checker with round 1 applied, starting from the scan that round
+widened. Widening it introduced two ways to accuse an honest law, which is the
+cost of scanning a whole file instead of one function body and worth paying only
+once it is paid down.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R2-01 | medium | `scripts/pandects_lib/checker.py` | The pattern accepted any uppercase letter after the word, to catch `revert CustomError()`. A function named `revertHelper` matched it, so a law with an honestly named internal helper was reported as reverting to signal a violation | fixed in this round: the pattern takes the two real spellings, `revert(` and `revert` followed by whitespace and a capital, and nothing else |
+| S1-R2-02 | medium | `scripts/pandects_lib/checker.py` | The scan read string literals. A law whose `statement()` describes a system that requires collateral was accused of requiring it, which would have pushed authors to write worse sentences to get past a check | fixed in this round: string literals are removed before comments, so a `//` inside one is removed with the string rather than truncating the line |
+
+Checked and found sound:
+
+- Removing strings before comments is the right order, and the residual case is
+  a double quote inside a comment over-removing that comment. Comments are
+  being removed anyway, so the cost is nothing.
+- `require(`, `assert(`, `revert(` and `revert CustomError()` are all still
+  caught, asserted individually.
+
+Leads not pursued:
+
+- **Nothing yet proves a law fails its specimen.** The catalogue names one and
+  the checker confirms it exists and says it is deliberately broken. That it is
+  actually caught is a Solidity claim, and the diagonal in step 2's
+  `test/Corpus.t.sol` is what will make it. This is the corpus's central
+  discipline and it is worth saying that at the end of step 1 it is declared
+  rather than demonstrated.
+
+## Step 1, round 3 -- 2026-08-16
+
+Reviewed: the checker and the catalogue parser swept over malformed entries.
+Five law entries, each malformed differently: every field absent, every field
+the wrong type, empty and whitespace paths, absolute and traversing paths, and
+paths naming a directory where a file belongs. Then the parser over six
+documents that are not catalogues.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R3-01 | low | `scripts/pandects_lib/checker.py` | A path carrying an embedded null byte raised `ValueError` out of `realpath` rather than being reported. The same class as round 1's unreadable component: malformed input crashing the checker instead of being told to the reader | fixed in this round: a path the filesystem will not look at is a containment that cannot be established, so it is refused |
+
+Checked and found sound:
+
+- Every other malformed entry produces findings and renders them. Nothing in
+  the five raised after the fix.
+- The parser refuses six non-catalogues as `CatalogueError` and raises nothing
+  else.
+- A path naming a directory where a file belongs is reported as a missing
+  component rather than read.
+
+Leads not pursued: the specimen claim carried from round 2, which step 2 closes.
+
+## Step 1, round 4 -- 2026-08-16
+
+Reviewed: the step's whole diff with three rounds applied. Re-read
+`ICreditObservables.sol`, `Law.sol`, and the four Python modules end to end,
+re-ran the malformed sweep, and re-ran every suite: 53 catalogue and checker
+tests on Python 3.9 and 3.14, four Solidity tests under `forge 1.7.1`, and the
+repository's nine contract tests.
+
+No findings.
+
+Leads not pursued: the specimen claim, which step 2 closes with the diagonal in
+`test/Corpus.t.sol`.
+
+## Step 2, round 1 -- 2026-08-16
+
+The first round with the engines. Reviewed: three laws, four specimens, the
+diagonal and the counterexamples.
+
+**What ran.** Slither 0.11.6 over the corpus, 5 contracts and 102 detectors.
+A Foundry campaign over the sound reference, driving `deposit`, `borrow`, `repay`, `accrueFee` and `reserve` at the 64 runs and depth 64 that `foundry.toml` pins. Echidna 2.3.3 at 20,000
+transactions and seed 20260816 against four harnesses, and Medusa 1.5.1 at
+20,000 transactions against the same four. `x-ray` was not run as a procedure:
+it enumerates a protocol, builds a threat model from entry points and writes a
+readiness report, and the subject here is a nine-file property corpus with no
+protocol, no privileged role and no external integration. The review that
+procedure exists to produce was done directly and this line is here so nobody
+reads a report into it.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S2-R1-01 | high | `specimens/Sound.sol` | The sound reference is not sound. A Foundry campaign broke `reserves-backed-by-claims` against it and shrank the sequence to four calls: deposit, fee, reserve, fee. `accrueFee` reduced claims with no regard for what was already reserved, so a fee charged after a reservation dropped claims below reserved. In economic terms the protocol was taking its fee out of value already promised to a lender who had asked to leave. The law is right and the reference was wrong | fixed in this round: the fee is capped at claims that are not already reserved, and the reason is recorded on the function |
+| S2-R1-02 | medium | `src/campaigns/Specimens.sol` | The campaign harnesses were written under `test/`. crytic-compile skips `test/` when it builds a Foundry project, so Echidna could not see them at all and answered `Given contract not found`. A harness an engine cannot see is a campaign that quietly tests nothing, which is the failure this corpus exists to refuse, in its own tooling | fixed in this round: harnesses live under `src/campaigns/`, with the reason on the contract |
+| S2-R1-03 | low | `test/Corpus.t.sol` | A test function that reads and does not write was not marked `view`, which the compiler warned about. A warning nobody clears is a warning nobody reads | fixed in this round |
+
+**What the campaigns found, and what changed because of it.**
+
+Every engine reproduces the diagonal. Against the sound reference all three laws
+hold; against each broken specimen exactly its own law fails and the other two
+hold. Three independent searches agreeing is the evidence that the diagonal is a
+property of the laws rather than of the states somebody chose.
+
+Echidna reduced two of the three counterexamples. The hand-written sequences
+moved a hundred units where one was enough, so `deposit(1)` replaced
+`deposit(100)` for `value-conserved` and `deposit(1), reserve(1)` replaced the
+hundreds for `held-assets-partitioned`. The counterexample file said an engine
+finding something smaller meant the sequence was not minimal and would be
+replaced; it was, and it has been.
+
+Checked and found sound:
+
+- Slither reports nothing across 102 detectors.
+- The sound reference survives a Foundry campaign at 512 runs and depth 128,
+  three further campaigns at fresh seeds, Echidna at 20,000 transactions and
+  Medusa at 20,000.
+- Every harness declares both `echidna_` and `property_` prefixes. A harness
+  carrying one of them is silent under the other engine, which is the same
+  class of defect as S2-R1-02 and was designed out rather than found.
+
+Leads not pursued:
+
+- **Medusa reports no seed**, so its campaigns above are not reproducible call
+  for call. Echidna's are, and the seed is recorded. The search record in step 4
+  states this per engine rather than implying both are reproducible.
+- **The specimens bound their inputs by remainder**, so a fuzzer never explores
+  the arithmetic ceiling through them. The ceiling is covered instead by the
+  `Extreme` target in the diagonal, which asserts each law reports rather than
+  reverts there. Worth revisiting if a law is ever added whose defect lives near
+  the boundary.
+
+## Step 2, round 2 -- 2026-08-16
+
+Reviewed: the tree with round 1 applied, starting from what round 1's own fix
+changed about the reach of its tools.
+
+**What ran.** Slither over 14 contracts, which is the point of the first
+finding. Foundry, Echidna at 20,000 transactions and seed 20260816, and Medusa
+at 20,000, all four harnesses each.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S2-R2-01 | medium | `src/campaigns/Specimens.sol` | The harness discarded the detail every law builds. `Law` is written so that a reader who finds a failure later learns which quantities were compared and what they were, and the campaign entry points dropped exactly that, leaving an operator with a call sequence and no reason. Slither's `unused-return` is what pointed at it | fixed in this round: `explain()` returns each law's reason for the current state, so a replayed sequence gives up its reason instead of having to be worked out again. A property function may return only a boolean and emitting the string would make it non-view, so this is where it goes |
+| S2-R2-02 | low | `audit/AUDIT.md` | Round 1 recorded Slither over 5 contracts and no results. True when written, and stale within the same round: moving the harnesses out of `test/` so Echidna could see them also moved them into Slither's scope, and Slither was not run again afterwards. The clean result covered less than the sentence suggested | fixed in this round: Slither re-run over all 14 contracts, and the entry above records the count so the scope is legible |
+| S2-R2-03 | low | `specimens/Sound.sol` | `asset` was declared and never assigned, so every specimen reported that its quantities were denominated in the zero address. An observable that says nothing about itself while the interface promises it names the unit | fixed in this round: a named constant, with the reason that these specimens model units rather than a token |
+| S2-R2-04 | low | `src/campaigns/Specimens.sol` | Seven harness fields were mutable storage where they are set once. Cosmetic on its own, but a detector list with fourteen entries nobody intends to act on is a detector list nobody reads | fixed in this round: the fields are immutable, and the two detectors that remain by design are disabled at each site with the reason in the source rather than repository wide, so the next thing either catches is read rather than filtered out with them |
+
+Checked and found sound:
+
+- Slither reports nothing across 102 detectors and 14 contracts.
+- The diagonal survives every change: Sound clean under all three engines,
+  each broken specimen caught by its own law alone under Echidna and Medusa.
+- `explain()` returns the law's own sentence, asserted against the exact
+  string in `test/Explain.t.sol` rather than against a non-empty check.
+
+Leads not pursued:
+
+- **A law that reads one observable twice** could be fooled by a target
+  answering differently between the two calls. None of the three does, and each
+  reads every quantity once into a local. Worth a rule if a law ever needs two
+  reads of the same observable, and worth checking then rather than forbidding
+  now.
+- **The campaign harnesses ship under `src/`**, so a consumer of the corpus
+  receives them. They have to be there for crytic-compile to see them, and they
+  document how to point an engine at a specimen, so this is left deliberate
+  rather than hidden behind a build flag.
+
+## Step 2, round 3 -- 2026-08-16
+
+Reviewed: the step's whole diff with two rounds applied, and the one lead round
+2 left open.
+
+**The lead, settled.** No law reads the same observable twice. Each of the
+three assigns every quantity it needs into a local once, checked mechanically
+across all three components rather than by reading them. That closes the way a
+target could answer differently between two reads of the same getter and get a
+verdict neither answer deserved. It is left as a property the current laws have
+rather than a rule the checker enforces, because there is no law yet that needs
+two reads and a check written against a case nobody has met is a check nobody
+can calibrate.
+
+**What ran.** The full sweep: 55 catalogue and checker tests on Python 3.9 and
+3.14, the repository's 9, `pandects check` over three laws, 20 Solidity tests
+across five suites, Slither over 14 contracts, and the diagonal under Foundry,
+Echidna and Medusa.
+
+No findings.
+
+Leads not pursued: the two carried from round 2, both recorded there with their
+reasons.
+
+
+## Step 3, round 1 -- 2026-08-16
+
+Reviewed: the whole of the step's diff. Two new law shapes, a queue extension
+interface, six laws, six specimens, six counterexamples and the campaign
+harness that carries a snapshot between calls.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R1-01 | medium | src/laws/QueueOrderPreserved.sol, src/laws/ReservesCoverPayableClaims.sol, src/Observation.sol | Both queue laws and the snapshot helper traverse the whole queue with one external call per claim. Above some queue length the call runs out of gas and reverts, and the corpus counts a revert as no verdict -- so each law stops working, silently, at a size nobody has written down. | fixed in 2429718 |
+| S3-R1-02 | medium | src/laws/DebtFallsOnlyAgainstPayment.sol, src/laws/NoAccrualAtRest.sol, src/laws/RecordedClaimNeverShrinks.sol | The succession laws compare totals, so an offsetting movement inside one transition hides a violation. A write-off in the same call as a deposit of the same size leaves debt down and held assets up, and the payment law holds. | fixed in 2429718 |
+| S3-R1-03 | low | src/PairLaw.sol | Three laws each explain, in their own words, what they do with a pair they cannot judge, and two of them reach opposite conclusions. The rule behind that was written nowhere, so it read as inconsistency rather than as policy. | fixed in 2429718 |
+| S3-R1-04 | low | -- | A Medusa run was read as "none failed" when it had not run at all: stale crytic artefacts, and the engine exited on `Failed to initialize the test chain` before any campaign started. Caught by noticing that Medusa disagreed with Echidna on five specimens. The corpus's own rule is never to report a campaign under an engine that did not run, and this round nearly broke it. | fixed in 2429718 |
+
+**S3-R1-01, on why the fix is prose.** There is no partial answer available.
+Both properties are about the whole queue, and a law that read the first
+hundred claims and held would be reporting on part of a system as though it
+were the system. So the limit is stated where a reader meets it -- in each
+component and in the applicability the catalogue carries -- and a target that
+queues more than can be read in one call needs an adapter that pages rather
+than a law that guesses.
+
+**S3-R1-02, on the shape of the gap.** A law over aggregates cannot attribute
+movement to a cause, and attributing it needs per-transition detail the
+observables do not carry. The honest fix is the applicability: these laws mean
+what they say when the two observations bracket a single operation. That is how
+every harness in this repository uses them, including the campaign, which
+snapshots on the way into each entry point.
+
+**S3-R1-04, on what was actually wrong.** The first invocation passed a
+hand-written Medusa config; the engine's own crytic-compile step produced
+nothing and it exited before the chain came up. The output contained no
+failures because it contained no campaign. The run was redone with the
+invocation the README documents, `medusa fuzz --compilation-target .
+--target-contracts <name>`, after clearing `crytic-export` and the stale
+artefact hash, and every campaign then reported.
+
+**What ran.** 50 Solidity tests across eight suites under forge 1.7.1, 63
+catalogue and checker tests on Python 3.14, the repository's 9 contract tests,
+`pandects check` over nine laws, Slither 0.11.6 over 24 contracts, and both
+engines over all ten campaigns: Echidna 2.3.3 at 20,000 transactions with seed
+20260816, and Medusa 1.5.1 at 20,000.
+
+**The diagonal, under both engines.** Each broken specimen failed exactly its
+own property and nothing else, under Echidna and under Medusa, and the sound
+reference failed nothing under either.
+
+`CompoundsPerStep` passed every property under both engines, which is the
+expected result and the sharpest illustration in the corpus of why a passing
+campaign is not evidence. Its defect is path independence, which compares two
+systems advanced by different routes; a campaign drives one system along one
+route and can never see it. It is caught deterministically in
+`test/Pairs.t.sol` and reduced in `test/counterexamples/Accrual.t.sol`.
+
+Leads not pursued:
+
+- **A recorded claim has no identity, only an index.** The claim law compares
+  the queue positionally, so a system that dropped one claim and appended
+  another of the same size would keep its length and its amounts and go
+  uncaught. Giving `claimAt` an identifier would close it. Not done here,
+  because that is a new observable and no law in the corpus reads it: the
+  applicability already assumes a claim keeps its index, and inventing an
+  observable ahead of the law that needs it is how interfaces grow members
+  nobody can justify.
+- **Nothing says the clock never runs backwards.** `NoAccrualAtRest` holds
+  whenever the two observation times differ, in either direction, so a system
+  whose `observedAt` went down would slip past every accrual law. That is a
+  law, and a real one, but it is not one of the six this step was asked for.
+- **`slither_results.json` is tracked.** Generated output committed in an
+  earlier step, so every Slither run leaves a diff. Raised separately rather
+  than folded into this step.
+
+## Step 3, round 2 -- 2026-08-16
+
+Reviewed: the tree with round 1 applied, and the two areas round 1 did not
+reach -- what the path-independence law takes on trust, and what the reference
+can be driven into that no law describes.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R2-01 | medium | src/laws/AccrualPathIndependent.sol | The bound is `subdivisions - 1`, and `subdivisions` is fixed when the law is deployed. Nothing in either observation says how many steps the subdivided run actually took, so a law built for the wrong count silently compares against the wrong bound -- too generous and a compounding system passes, too tight and a correct one is reported as violated. | fixed in 0b7ae32 |
+| S3-R2-02 | low | src/laws/ReservesCoverPayableClaims.sol | The law reports a violation when more claims are declared payable than exist, which is marginally broader than its statement. The reason -- that the alternative reads past the end of the queue and reverts into silence -- was in nobody's head but mine. | fixed in 0b7ae32 |
+
+**S3-R2-01, and why the fix is a test rather than a guard.** There is no guard
+available. The count cannot be derived from the observations, so it is part of
+the question rather than part of the answer, and the honest response is to say
+so where it will be read and to show it going wrong.
+`test_a_bound_built_for_the_wrong_run_is_wrong_in_both_directions` builds the
+same compounding pair three times: caught by a law built for the two steps it
+took, passed by a law built for a thousand, and a correct system reported as
+violated by a law built for one. A hazard nobody has watched fail is a hazard
+people assume is handled.
+
+**What ran.** 51 Solidity tests across eight suites, 63 catalogue and checker
+tests, the repository's 9, `pandects check` over nine laws, Slither 0.11.6 over
+24 contracts, and both engines over the sound campaign and the three campaigns
+carrying pair laws: Echidna 2.3.3 at 20,000 transactions with seed 20260816,
+and Medusa 1.5.1 at 20,000. Scoped rather than swept, because this round's diff
+is comments, one catalogue assumption and one test, and claiming a full sweep
+that did not happen is the failure mode round 1 caught me in.
+
+Slither returned the same fifteen results as round 1: one uninitialized-state
+and three uninitialized-local, all of them Solidity's zero defaults for a
+storage array and three counters, and two calls-loop, which is the traversal
+round 1 documented rather than removed.
+
+Leads not pursued:
+
+- **The reference can record withdrawal claims summing beyond the pooled claim
+  total.** `reserve` caps each request at total lender claims rather than at
+  the claims not already spoken for, so two requests can each ask for the whole
+  pool. That is what `PayableBeyondReserves` is driven into, and capping at the
+  unspoken-for remainder would put that state out of reach of every operation
+  the reference has. It is also not obviously wrong: the model has no lender
+  identity, claims are pooled, and a request cannot be bounded by a share the
+  system does not track. The law it implies -- unpaid recorded claims never
+  exceed total lender claims -- needs per-lender accounting, which is a larger
+  model than this step.
+- **A full queue drops a withdrawal request silently.** `reserve` records
+  nothing once `MAX_CLAIMS` claims exist. The cap is a harness bound, so that
+  every observation stays affordable to copy, and it is documented as one. No
+  law says a request must become a claim, and a lost request is a real defect
+  shape; both are worth a later step and neither is this one.
+- Three carried from round 1, each recorded there with its reason: claims have
+  position but no identity, no law says the clock never runs backwards, and
+  `slither_results.json` is tracked.
+
+## Step 3, round 3 -- 2026-08-16
+
+Reviewed: the whole step with both rounds applied, and the three Slither
+categories neither earlier round had read line by line.
+
+**What ran.** The full sweep: 51 Solidity tests across eight suites under forge
+1.7.1, 63 catalogue and checker tests on Python 3.14, the repository's 9,
+`pandects check` over nine laws, Slither 0.11.6 over 24 contracts, and both
+engines over all ten campaigns -- Echidna 2.3.3 at 20,000 transactions with
+seed 20260816, and Medusa 1.5.1 at 20,000.
+
+**The diagonal, complete.** Eight broken specimens, each failing exactly its own
+property and no other, identically under Echidna and Medusa. The sound
+reference failed nothing under either. `CompoundsPerStep` passed everything
+under both, which is the documented expectation rather than a miss: its defect
+compares two systems and a campaign drives one.
+
+**The Slither results, settled.** Fifteen, unchanged across all three rounds and
+none of them a finding. Six `costly-loop` on `settle`, which writes three
+storage slots inside a loop that returns after the first claim it settles.
+Three `uninitialized-local` and one `uninitialized-state`, all of them
+Solidity's zero defaults for three counters and an empty storage array. Two
+`cache-array-length`, gas in a specimen written to be read. Two `calls-loop`,
+which is the queue traversal round 1 documented as a limit rather than removed.
+
+No findings.
+
+Leads not pursued: the five carried forward, each recorded in the round that
+found it -- claims have position but no identity; nothing says the clock never
+runs backwards; the reference can record claims summing past the pooled total;
+a full queue drops a request silently; and `slither_results.json` is tracked.
+
+## Step 4, round 1 -- 2026-08-16
+
+Reviewed: the whole of the step's diff. Two adapter shapes over a caller's
+target, the probe, both engine entry points, the search record and the corpus
+digest.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S4-R1-01 | high | adapters/CorpusBase.sol | A driving adapter whose entry points do not carry `records` reports all three succession laws holding, forever, and nothing about that verdict distinguishes it from three laws that held. The forgotten modifier is not something the compiler can catch, and the result of forgetting it is three green properties over a system nobody judged. | fixed in aa3df12 |
+| S4-R1-02 | medium | scripts/pandects_lib/run.py | A campaign killed by the timeout was reported as an engine that did not run. The engine ran, searched for as long as it was given and was killed; dropping it from the record hides a search that happened, and calling it passed would be worse. | fixed in aa3df12 |
+| S4-R1-03 | medium | scripts/pandects_lib/run.py | Settings were read from `[invariant]` only, and an absent or differently named section produced `"configuration": {}` -- a record saying the campaign ran under no settings, when what happened is that nobody could read them. Foundry accepts `[profile.default.invariant]` as well. | fixed in aa3df12 |
+
+**S4-R1-01, and why the fix is a counter.** There is nothing to enforce. A base
+cannot see whether an entry point somebody else wrote carries a modifier, and a
+fallback that forwarded calldata blindly would forward the call that breaks a
+law without recording the state before it. So the unexercised case is made
+visible instead: `recordedCalls` is public, `successionExercised` reads it, and
+`explainSuccession` returns "no call was recorded, so no transition was judged"
+rather than three empty strings. An integrator now has a number to assert on,
+and `successionHolds` means something only when read beside it.
+
+**S4-R1-03, on the shape of the mistake.** The record's entire purpose is
+describing the search. A configuration that describes a different search, or
+none, is worse than a record that refuses to be written, so it refuses.
+
+**What ran.** 59 Solidity tests across nine suites under forge 1.7.1, 90
+catalogue, checker and search-record tests on Python 3.14, the repository's 9,
+`pandects check` over nine laws, Slither 0.11.6 over 26 contracts, and both
+engines against both adapter forms.
+
+**The adapters, under both engines.** `ObservedQueueJumped` failed
+`queue_order_preserved` and nothing else, under Echidna and under Medusa,
+through an adapter that never saw the call that broke it -- which is the case
+for the observing form in one line. `DrivenClaimHaircut` failed
+`recorded_claim_never_shrinks` and nothing else, under both, which is the case
+for the driving one.
+
+Slither returned the same fifteen results as step 3 and nothing new for the
+adapters: the zero defaults, the queue traversal already documented, and gas in
+a specimen.
+
+Leads not pursued:
+
+- **The observer cannot tell a queue-less target from a broken one.**
+  `queueHolds` reverts against a system that does not implement the extension,
+  which is the documented limit, but an integrator meets it as a revert with no
+  explanation attached. A probe that answered "this target has no queue" would
+  need a call that cannot be distinguished from a target whose queue read
+  happens to revert, so there is nothing honest to return.
+- **`hasWithdrawalQueue` defaults to true.** A queue-less integrator who does
+  not override it gets two reverting invariants. The default is deliberate --
+  false would silently skip two laws for every system that does have a queue --
+  but it is a sharp edge and the prose is the only thing guarding it.
+- **The five carried from step 3**, each recorded in the round that found it.
+
+## Step 4, round 2 -- 2026-08-16
+
+Reviewed: the tree with round 1 applied, and the two places round 1 did not
+reach -- what an integrator without a withdrawal queue can actually get out of
+the adapters, and whether the record says "unknown" the same way twice.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S4-R2-01 | medium | adapters/CorpusBase.sol | `explainOneState` reads all five laws, so against a target with no withdrawal queue it reverts and takes the three answers down with the two reads that had none. An integrator whose system has no queue was told nothing at all, including about the laws that were happy to judge it. | fixed in cf9cf68 |
+| S4-R2-02 | low | scripts/pandects_lib/run.py | A seed nobody could read was absent from the record; an engine version nobody could read was present and null. Same reason, two spellings, in one document. | fixed in cf9cf68 |
+
+**S4-R2-01, and what the fix is not.** `explainOneState` still reverts, because
+reading a queue off a target that has none is exactly the documented limit and
+softening it would be inventing a verdict. What changed is that `explainCore`
+exists beside it, carrying the three reasons that had answers. `coreHolds` and
+`queueHolds` were already split this way; the explanation was not, and the split
+is only useful if it goes all the way through.
+
+**S4-R2-02, on why a low finding was worth fixing.** A record that spells
+"unknown" two ways has to be read twice, and the second reading is where
+somebody decides that null means the run had no seed. The rule is now one rule
+and a test walks the whole record asserting no field anywhere in it is null,
+rather than checking the two fields that prompted it.
+
+**What ran.** 60 Solidity tests across nine suites, 92 catalogue, checker and
+search-record tests, the repository's 9, `pandects check` over nine laws, and
+Echidna 2.3.3 against both adapter forms with the shipped configuration. Scoped
+rather than swept: this round's diff is one new function, one field rule and two
+tests.
+
+`ObservedQueueJumped` failed `queue_order_preserved` and nothing else;
+`DrivenClaimHaircut` failed `recorded_claim_never_shrinks` and nothing else.
+
+Leads not pursued:
+
+- **A counterexample changing does not change the corpus digest.** The digest
+  covers the catalogue, the law components and the specimens. That is
+  deliberate -- the criterion asks for a digest that moves when the corpus moves
+  and holds still when a test does -- but a counterexample is closer to a law
+  than a test is, and which side of the line it belongs on is a real question
+  rather than a settled one.
+- **The three carried from round 1**, and the five carried from step 3, each
+  recorded in the round that found it.
+
+## Step 4, round 3 -- 2026-08-16
+
+Reviewed: the whole step with both rounds applied, and whether the adapters
+disturbed anything the specimen campaigns already prove.
+
+**What ran.** The full sweep: 60 Solidity tests across nine suites under forge
+1.7.1, 92 catalogue, checker and search-record tests on Python 3.14, the
+repository's 9, `pandects check` over nine laws, Slither 0.11.6 over 26
+contracts, Echidna 2.3.3 against both adapter forms with the shipped
+configuration and against three specimen campaigns at seed 20260816, and Medusa
+1.5.1 against both adapter forms at 20,000.
+
+**The adapters.** `ObservedQueueJumped` failed `queue_order_preserved` and
+nothing else under both engines, through an adapter that never saw the call
+that broke it. `DrivenClaimHaircut` failed `recorded_claim_never_shrinks` and
+nothing else under both.
+
+**The specimen campaigns, unchanged.** `SoundCampaign` failed nothing,
+`PayableBeyondReserves` failed its own law alone, and `CompoundsPerStep` passed
+everything, which is still the documented expectation rather than a miss.
+
+**Slither.** Fifteen results, the same set as step 3 and nothing new for the
+adapters: zero defaults for a storage array and three counters, the queue
+traversal documented as a limit, and gas in a specimen.
+
+No findings.
+
+Leads not pursued: the one from round 2 about which side of the line a
+counterexample belongs on, the three carried from round 1, and the five carried
+from step 3. Each is recorded in the round that found it.
+
+## Step 5, round 1 -- 2026-08-16
+
+Reviewed: the whole of the step's diff. The Wildcat model, its applicability
+notes, the three documents, the drift check and the demo.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S5-R1-01 | medium | docs/catalogue.md | The document calls itself a rendering and there was no renderer. It was written once by a script that was not committed, and the drift test caught a stale document without offering any way to fix it: somebody adding a law was told the document was wrong and left to work out what it should have said. | fixed in ac37f14 |
+| S5-R1-02 | low | integrations/wildcat/APPLICABILITY.md | A law added to the catalogue could go unmentioned in the integration's notes, which is the one place the applicability question actually gets asked of a real design. Nothing checked. | fixed in ac37f14 |
+
+**S5-R1-01, and what it took to make the claim true.**
+`scripts/pandects_lib/render.py` is now the only thing that writes that file,
+`python3 scripts/pandects.py render` regenerates it, and a test compares the
+committed bytes with what the renderer produces. Drift is a one-line fix rather
+than a transcription exercise. The renderer also skips a family the catalogue
+declares and files nothing under, because a heading with nothing beneath it
+reads as a section somebody deleted.
+
+**What ran.** 71 Solidity tests across ten suites under forge 1.7.1, 104
+catalogue, checker, search-record and document tests on Python 3.14, the
+repository's 9, `pandects check` over nine laws, Slither 0.11.6 over 28
+contracts, and both engines against the Wildcat campaign: Echidna 2.3.3 with the
+shipped configuration and Medusa 1.5.1 at 20,000.
+
+**The finding the integration was for.** Echidna and Medusa both failed
+`recorded_claim_never_shrinks` against `WildcatMarketCampaign`, and both were
+right. A Wildcat batch accumulates while it is open, so the amount owed on it
+rises, and the law says a recorded claim keeps its amount. The applicability
+notes had already claimed the law held before either engine ran.
+
+That is recorded in the step rather than here, because it is a fact about the
+design rather than a defect in the work: an open batch is not a claim that has
+been recorded, it is one still being assembled, and the law starts applying when
+the batch closes. Both halves are asserted in `test/Wildcat.t.sol`. It is worth
+repeating in this log because it is the sharpest evidence in the whole run for
+why a corpus proven against contracts written to break it has not yet been
+tested.
+
+Slither returned twenty-one results, six more than step 4 and all of them the
+model's share of the same benign classes: zero defaults for two counters and two
+storage arrays, gas in loops that return after one iteration, and the queue
+traversal documented in step 3.
+
+Leads not pursued:
+
+- **Whether `claims/recorded-claim-never-shrinks/v1` should be relaxed.** Saying
+  a recorded claim is never written *down* would still catch the specimen it was
+  built for, and would hold over an open batch. It would also stop catching a
+  system that silently raises a claim nobody asked to raise, which conservation
+  does not see because moving claim into a batch moves no value. One design
+  should not settle a law on its own, and a second integration is the honest way
+  to decide.
+- **A fee can drop pooled claims below what is owed on open batches.**
+  `accrueFee` caps at claims less what is reserved, and reserved cannot exceed
+  what the market holds, so a delinquent market can take a fee that leaves it
+  promising more withdrawals than lenders are owed in total. No law covers it.
+  It is a real gap and a new law rather than a fix to this one.
+- **The nine carried from earlier steps**, each recorded in the round that found
+  it.
+
+## Step 5, round 2 -- 2026-08-16
+
+Reviewed: the tree with round 1 applied, and the one thing round 1's fix could
+not check about itself.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S5-R2-01 | medium | scripts/pandects_lib/render.py | The renderer hardcoded "Nine laws in three families" and looped over its own list of families rather than the catalogue's. A tenth law would produce a document that lies about its own count, and a law filed under a new family would vanish from the document entirely -- neither of which the drift test can see, because that test compares the document against this renderer and both would be wrong the same way. | fixed in 9eb1314 |
+| S5-R2-02 | low | .gitignore | The demo tells a reader to write `search-record.json` into the plugin, and nothing ignored it. Following the documented walkthrough left the repository dirty. | fixed in 9eb1314 |
+
+**S5-R2-01, and why round 1's fix could not have caught it.** Making the
+document a rendering closed the gap between the document and the renderer. It
+opened a new one between the renderer and the catalogue, and a test comparing
+the first pair is structurally blind to the second. The preamble now counts what
+it rendered, the headings come from the laws rather than from a vocabulary, and
+two tests assert both from outside: a one-law catalogue renders "One law in one
+family", and a law filed under a family the renderer has never heard of still
+appears under its own heading.
+
+**What ran.** 71 Solidity tests across ten suites, 106 catalogue, checker,
+search-record and document tests, the repository's 9, `pandects check` over nine
+laws, and `pandects render` reproducing the committed document byte for byte.
+Scoped rather than swept: this round's diff is one module, one ignore rule and
+three tests, none of it Solidity.
+
+Leads not pursued:
+
+- **`slither_results.json` is still tracked.** Raised in step 3, raised again
+  here, and still generated output sitting in the index. It is a two-line fix
+  that belongs to nobody's step.
+- Two carried from round 1, each recorded there with its reason: whether the
+  claim law should be relaxed, and the fee that can drop pooled claims below
+  what is owed on open batches.
+
+## Step 5, round 3 -- 2026-08-16
+
+Reviewed: the whole step with both rounds applied, and whether the integration
+disturbed anything the earlier steps prove.
+
+**What ran.** The full sweep: 71 Solidity tests across ten suites under forge
+1.7.1, 106 catalogue, checker, search-record and document tests on Python 3.14,
+the repository's 9, `pandects check` over nine laws, `pandects render`
+reproducing the committed document byte for byte, Slither 0.11.6 over 28
+contracts, Echidna 2.3.3 against the Wildcat campaign and three earlier
+harnesses with the shipped configuration, and Medusa 1.5.1 against the Wildcat
+campaign at 20,000.
+
+**The engines.** `WildcatMarketCampaign` failed `recorded_claim_never_shrinks`
+and nothing else, under both engines, which is the documented expectation and
+the finding this step exists for. `SoundCampaign` failed nothing.
+`DrivenClaimHaircut` and `ObservedQueueJumped` each failed their own law alone,
+unchanged from step 4.
+
+**Slither.** Twenty-one results, the same set as round 1 and none of them a
+finding: zero defaults for two counters and two storage arrays, gas in loops
+that return after one iteration, and the queue traversal documented in step 3.
+
+No findings.
+
+Leads not pursued: whether the claim law should be relaxed and the fee that can
+drop pooled claims below what is owed on open batches, both from round 1;
+`slither_results.json` still tracked, from round 2; and the nine carried from
+earlier steps. Each is recorded in the round that found it.

--- a/plugins/pandects/catalogue/pandects.json
+++ b/plugins/pandects/catalogue/pandects.json
@@ -1,0 +1,215 @@
+{
+  "version": "0.1.0",
+  "observables": "ICreditObservables",
+  "families": {
+    "conservation": "What the system holds, owes and has promised, held against each other.",
+    "accrual": "How debt and claims move with time.",
+    "claims": "What a recorded withdrawal claim is owed, and in what order."
+  },
+  "laws": [
+    {
+      "id": "conservation/value-conserved/v1",
+      "family": "conservation",
+      "statement": "Assets held plus debt owed equals lender claims plus accrued fees.",
+      "component": "src/laws/ValueConserved.sol",
+      "specimen": "specimens/MintedClaims.sol",
+      "counterexample": "test/counterexamples/Conservation.t.sol",
+      "applicability": {
+        "accounting_model": "a pooled lender claim denominated in one asset, where borrowers owe that same asset and fees accrue out of lender yield",
+        "assumes": [
+          "every quantity is denominated in the asset the system reports",
+          "a written-down debt is written down against claims in the same state transition",
+          "collateral posted by borrowers, if any, is not counted in assets held"
+        ],
+        "requires": [
+          "totalAssets",
+          "totalDebt",
+          "totalLenderClaims",
+          "accruedFees"
+        ]
+      },
+      "bounds": "exact"
+    },
+    {
+      "id": "conservation/reserves-backed-by-claims/v1",
+      "family": "conservation",
+      "statement": "Assets reserved never exceed the lender claims recorded.",
+      "component": "src/laws/ReservesBackedByClaims.sol",
+      "specimen": "specimens/OverReserved.sol",
+      "counterexample": "test/counterexamples/Conservation.t.sol",
+      "applicability": {
+        "accounting_model": "a system that earmarks held assets against recorded withdrawal claims",
+        "assumes": [
+          "a reservation is made against a claim that has been recorded",
+          "a system with no withdrawal queue reports zero reserved"
+        ],
+        "requires": [
+          "reservedAssets",
+          "totalLenderClaims"
+        ]
+      },
+      "bounds": "exact"
+    },
+    {
+      "id": "conservation/held-assets-partitioned/v1",
+      "family": "conservation",
+      "statement": "Reserved assets plus borrowable assets never exceed assets held.",
+      "component": "src/laws/HeldAssetsPartitioned.sol",
+      "specimen": "specimens/OverPromised.sol",
+      "counterexample": "test/counterexamples/Conservation.t.sol",
+      "applicability": {
+        "accounting_model": "a system where borrower liquidity and withdrawal reservations are drawn from the same held assets",
+        "assumes": [
+          "borrowable assets are what a borrower may take right now, not a credit limit",
+          "reserved assets are unavailable to the borrower"
+        ],
+        "requires": [
+          "reservedAssets",
+          "borrowableAssets",
+          "totalAssets"
+        ]
+      },
+      "bounds": "exact"
+    },
+    {
+      "id": "accrual/debt-falls-only-against-payment/v1",
+      "family": "accrual",
+      "statement": "Debt falls only against held assets rising by at least the fall.",
+      "component": "src/laws/DebtFallsOnlyAgainstPayment.sol",
+      "specimen": "specimens/DebtForgiven.sol",
+      "counterexample": "test/counterexamples/Accrual.t.sol",
+      "applicability": {
+        "accounting_model": "a pooled lender claim denominated in one asset, where borrowers owe that same asset and fees accrue out of lender yield",
+        "assumes": [
+          "the two observations are one system and its own past, in that order",
+          "assets a borrower repays are held by the system rather than forwarded",
+          "no third party settles debt outside the system's own accounting",
+          "the two observations bracket a single operation; an offsetting movement inside one batched transition would hide a violation from a law that compares totals"
+        ],
+        "requires": [
+          "totalDebt",
+          "totalAssets"
+        ]
+      },
+      "bounds": "exact"
+    },
+    {
+      "id": "accrual/no-accrual-at-rest/v1",
+      "family": "accrual",
+      "statement": "At equal observation times, debt rises only against held assets leaving.",
+      "component": "src/laws/NoAccrualAtRest.sol",
+      "specimen": "specimens/AccruesAtRest.sol",
+      "counterexample": "test/counterexamples/Accrual.t.sol",
+      "applicability": {
+        "accounting_model": "a pooled lender claim denominated in one asset, where borrowers owe that same asset and fees accrue out of lender yield",
+        "assumes": [
+          "the two observations are one system and its own past, in that order",
+          "observedAt advances only with real elapsed time, never per call",
+          "a borrowing removes from held assets what it adds to debt",
+          "the two observations bracket a single operation; an offsetting movement inside one batched transition would hide a violation from a law that compares totals"
+        ],
+        "requires": [
+          "totalDebt",
+          "totalAssets",
+          "observedAt"
+        ]
+      },
+      "bounds": "exact"
+    },
+    {
+      "id": "accrual/path-independent/v1",
+      "family": "accrual",
+      "statement": "One long step and the same span in equal small steps agree on debt, within one unit per step less one.",
+      "component": "src/laws/AccrualPathIndependent.sol",
+      "specimen": "specimens/CompoundsPerStep.sol",
+      "counterexample": "test/counterexamples/Accrual.t.sol",
+      "applicability": {
+        "accounting_model": "a pooled lender claim denominated in one asset, where borrowers owe that same asset and fees accrue out of lender yield, accruing linearly on principal rather than compounding",
+        "assumes": [
+          "the two observations are two systems, not one system and its past",
+          "both began from the same state and were advanced over the same span",
+          "the span divides evenly into the number of subdivisions",
+          "the rate did not change during the span",
+          "the law is deployed with the subdivision count the run actually used; nothing in either observation reveals a mismatch, and a mismatch silently changes the bound"
+        ],
+        "requires": [
+          "totalDebt",
+          "observedAt"
+        ]
+      },
+      "bounds": {
+        "tolerance": "one unit of the asset per subdivision, less one",
+        "arithmetic": "linear accrual on principal truncates once per step: the subdivided run accrues n*floor(x) where the single run accrues floor(n*x), and those differ by at most n-1"
+      }
+    },
+    {
+      "id": "claims/recorded-claim-never-shrinks/v1",
+      "family": "claims",
+      "statement": "A recorded claim keeps its owed amount and never loses payment already made.",
+      "component": "src/laws/RecordedClaimNeverShrinks.sol",
+      "specimen": "specimens/ClaimHaircut.sol",
+      "counterexample": "test/counterexamples/Claims.t.sol",
+      "applicability": {
+        "accounting_model": "a pooled lender claim denominated in one asset, with withdrawals recorded as an ordered queue of individual claims that keep their position once made",
+        "assumes": [
+          "the two observations are one system and its own past, in that order",
+          "a claim keeps its index once recorded, including after it is paid in full",
+          "both observations read the queue rather than the core observables alone",
+          "the two observations bracket a single operation; an offsetting movement inside one batched transition would hide a violation from a law that compares totals",
+          "the queue is short enough to read in one call; a law that runs out of gas traversing it reverts, and a revert is no verdict"
+        ],
+        "requires": [
+          "withdrawalQueue.claimCount",
+          "withdrawalQueue.claimAt"
+        ]
+      },
+      "bounds": "exact"
+    },
+    {
+      "id": "claims/queue-order-preserved/v1",
+      "family": "claims",
+      "statement": "No withdrawal claim is paid while an older claim is still owed something.",
+      "component": "src/laws/QueueOrderPreserved.sol",
+      "specimen": "specimens/QueueJumped.sol",
+      "counterexample": "test/counterexamples/Claims.t.sol",
+      "applicability": {
+        "accounting_model": "a pooled lender claim denominated in one asset, with withdrawals recorded as an ordered queue of individual claims that keep their position once made",
+        "assumes": [
+          "the queue is ordered oldest first",
+          "partial payment is recorded against the claim rather than held elsewhere",
+          "the system promises order, rather than paying pro rata",
+          "the queue is short enough to read in one call; a law that runs out of gas traversing it reverts, and a revert is no verdict"
+        ],
+        "requires": [
+          "withdrawalQueue.claimCount",
+          "withdrawalQueue.claimAt"
+        ]
+      },
+      "bounds": "exact"
+    },
+    {
+      "id": "claims/reserves-cover-payable/v1",
+      "family": "claims",
+      "statement": "Reserved assets cover everything still owed on the claims declared payable.",
+      "component": "src/laws/ReservesCoverPayableClaims.sol",
+      "specimen": "specimens/PayableBeyondReserves.sol",
+      "counterexample": "test/counterexamples/Claims.t.sol",
+      "applicability": {
+        "accounting_model": "a pooled lender claim denominated in one asset, with withdrawals recorded as an ordered queue of individual claims that keep their position once made",
+        "assumes": [
+          "payableThrough is what the system declares, not something derived from the reserves",
+          "reserved assets are held against the queue and against nothing else",
+          "a claim is never paid more than it is owed; no law in the corpus covers that yet",
+          "the queue is short enough to read in one call; a law that runs out of gas traversing it reverts, and a revert is no verdict"
+        ],
+        "requires": [
+          "reservedAssets",
+          "withdrawalQueue.claimCount",
+          "withdrawalQueue.claimAt",
+          "withdrawalQueue.payableThrough"
+        ]
+      },
+      "bounds": "exact"
+    }
+  ]
+}

--- a/plugins/pandects/docs/applicability.md
+++ b/plugins/pandects/docs/applicability.md
@@ -1,0 +1,91 @@
+# Applicability
+
+The rules a law obeys, stated once here rather than nine times in nine
+docstrings.
+
+## What a law may read
+
+`ICreditObservables` names economic roles: the asset, total assets held, total
+debt, total lender claims, reserved and borrowable assets, accrued fees, and
+the time the observation describes. A target implements it, or a thin adapter
+does, and that adapter is the only place a protocol's own names appear.
+
+`IWithdrawalQueueObservables` adds the claim count, each claim's owed and paid
+amounts, and the bound through which the system declares claims payable. It is
+separate because a system with no queue would implement three members and mean
+none of them, and an observable that means nothing is worse than an absent one:
+it reports zero, and zero reads like an answer.
+
+A law that named a protocol's own functions would be a law about one codebase.
+The corpus exists because the same economic facts hold across codebases that
+share nothing else.
+
+## The two shapes
+
+A `Law` judges one observed state. A `PairLaw` judges two observations.
+
+Nothing else. The shape follows from the fact: if a single state can violate
+it, it is a `Law`, and if the violation lives in a transition, it is a
+`PairLaw`.
+
+Three pair laws compare a system with its own past. One compares two systems
+advanced over the same span by different routes. A law says which in its
+applicability, because reading one the wrong way round is the mistake available
+to everyone.
+
+## A pair a law cannot judge
+
+Ask whose mistake the pair is.
+
+A pair that spans real time, or that shows a system somewhere the law says
+nothing about, is a state of the world. Hold, and say why.
+
+A pair nobody could have meant -- two runs that never reached the same moment,
+a queue law handed observations with no queue in them -- is a mistake by
+whoever built it. Refuse, and say why. Holding there would report a comparison
+nobody made.
+
+## What a revert means
+
+Nothing. Not a violation and not a pass.
+
+A campaign runs with `fail_on_revert = false`, because a credit system reverts
+constantly and correctly: a withdrawal past the queue, a borrow past the
+reserve, a repayment of more than is owed. Under that setting a revert carries
+no verdict.
+
+So a law returns `false` to mean violated and never reverts to mean it. The
+converse is a limit rather than a guarantee: if the target reverts on a read,
+the law reverts with it, the state could not be observed, and the harness
+counts a revert. What an unobservable state means is the adapter's decision.
+
+## What a bound means
+
+Exact, or a tolerance naming the arithmetic that produces it.
+
+The distinction is not pedantry. An epsilon chosen because it made a test pass
+will absorb the next real defect that lands under it, and nobody will be able
+to say whether it should have.
+
+## Applicability is a contract in two directions
+
+A law's applicability says what a design must provide for the law to mean
+anything. That is the direction it is usually read.
+
+The other direction is what `integrations/wildcat/` is for. Pointed at a real
+design, the same contract has to say which laws that design supports and under
+what conditions, and two of the answers there are not yes or no.
+
+`claims/queue-order-preserved/v1` is true of a Wildcat market at batch
+granularity and says nothing per lender, because a batch is paid pro rata and
+no lender in one is ahead of another. The law is right; the unit is the whole
+finding, and a corpus that let the two readings blur would be quietly wrong
+about somebody's protocol.
+
+`accrual/path-independent/v1` holds for a solvent market and stops holding once
+penalty accrual is running, because the grace timer advances when the market is
+poked. That is a condition, not a verdict, and the applicability note carries
+it.
+
+A law with no applicability contract is not in the corpus. A law whose contract
+says only "yes" has not met a real design.

--- a/plugins/pandects/docs/catalogue.md
+++ b/plugins/pandects/docs/catalogue.md
@@ -1,0 +1,199 @@
+# The catalogue
+
+Nine laws in three families, rendered for a reader. The catalogue itself is
+`catalogue/pandects.json`, and a test fails if this document and that file stop
+naming the same laws, so this is a rendering rather than a second source.
+
+Regenerate it with `python3 scripts/pandects.py render`. Editing it by hand is
+how a rendering becomes a second source.
+
+Every law here has six parts. It executes, it catches a contract written to
+break it, that failure has been reduced to a replay with no fuzzer in it, it
+says where it applies, its bounds are justified, and it judges rather than
+reverting. `python3 scripts/pandects.py check` refuses anything with fewer.
+
+## Conservation
+
+What the system holds, owes and has promised, held against each other.
+Every one of these is a fact about a single state: the sums agree or they do
+not, and no history is needed to say which.
+
+### `conservation/value-conserved/v1`
+
+> Assets held plus debt owed equals lender claims plus accrued fees.
+
+| | |
+| --- | --- |
+| Component | `src/laws/ValueConserved.sol` |
+| Specimen | `specimens/MintedClaims.sol` |
+| Counterexample | `test/counterexamples/Conservation.t.sol` |
+| Bounds | exact |
+| Reads | `totalAssets`, `totalDebt`, `totalLenderClaims`, `accruedFees` |
+
+Applies to a pooled lender claim denominated in one asset, where borrowers owe that same asset and fees accrue out of lender yield. Assuming:
+
+- every quantity is denominated in the asset the system reports
+- a written-down debt is written down against claims in the same state transition
+- collateral posted by borrowers, if any, is not counted in assets held
+
+### `conservation/reserves-backed-by-claims/v1`
+
+> Assets reserved never exceed the lender claims recorded.
+
+| | |
+| --- | --- |
+| Component | `src/laws/ReservesBackedByClaims.sol` |
+| Specimen | `specimens/OverReserved.sol` |
+| Counterexample | `test/counterexamples/Conservation.t.sol` |
+| Bounds | exact |
+| Reads | `reservedAssets`, `totalLenderClaims` |
+
+Applies to a system that earmarks held assets against recorded withdrawal claims. Assuming:
+
+- a reservation is made against a claim that has been recorded
+- a system with no withdrawal queue reports zero reserved
+
+### `conservation/held-assets-partitioned/v1`
+
+> Reserved assets plus borrowable assets never exceed assets held.
+
+| | |
+| --- | --- |
+| Component | `src/laws/HeldAssetsPartitioned.sol` |
+| Specimen | `specimens/OverPromised.sol` |
+| Counterexample | `test/counterexamples/Conservation.t.sol` |
+| Bounds | exact |
+| Reads | `reservedAssets`, `borrowableAssets`, `totalAssets` |
+
+Applies to a system where borrower liquidity and withdrawal reservations are drawn from the same held assets. Assuming:
+
+- borrowable assets are what a borrower may take right now, not a credit limit
+- reserved assets are unavailable to the borrower
+
+## Accrual
+
+How debt and claims move with time. None of these can be violated by any
+single state, however wrong that state is, because the violation is in the
+transition.
+
+### `accrual/debt-falls-only-against-payment/v1`
+
+> Debt falls only against held assets rising by at least the fall.
+
+| | |
+| --- | --- |
+| Component | `src/laws/DebtFallsOnlyAgainstPayment.sol` |
+| Specimen | `specimens/DebtForgiven.sol` |
+| Counterexample | `test/counterexamples/Accrual.t.sol` |
+| Bounds | exact |
+| Reads | `totalDebt`, `totalAssets` |
+
+Applies to a pooled lender claim denominated in one asset, where borrowers owe that same asset and fees accrue out of lender yield. Assuming:
+
+- the two observations are one system and its own past, in that order
+- assets a borrower repays are held by the system rather than forwarded
+- no third party settles debt outside the system's own accounting
+- the two observations bracket a single operation; an offsetting movement inside one batched transition would hide a violation from a law that compares totals
+
+### `accrual/no-accrual-at-rest/v1`
+
+> At equal observation times, debt rises only against held assets leaving.
+
+| | |
+| --- | --- |
+| Component | `src/laws/NoAccrualAtRest.sol` |
+| Specimen | `specimens/AccruesAtRest.sol` |
+| Counterexample | `test/counterexamples/Accrual.t.sol` |
+| Bounds | exact |
+| Reads | `totalDebt`, `totalAssets`, `observedAt` |
+
+Applies to a pooled lender claim denominated in one asset, where borrowers owe that same asset and fees accrue out of lender yield. Assuming:
+
+- the two observations are one system and its own past, in that order
+- observedAt advances only with real elapsed time, never per call
+- a borrowing removes from held assets what it adds to debt
+- the two observations bracket a single operation; an offsetting movement inside one batched transition would hide a violation from a law that compares totals
+
+### `accrual/path-independent/v1`
+
+> One long step and the same span in equal small steps agree on debt, within one unit per step less one.
+
+| | |
+| --- | --- |
+| Component | `src/laws/AccrualPathIndependent.sol` |
+| Specimen | `specimens/CompoundsPerStep.sol` |
+| Counterexample | `test/counterexamples/Accrual.t.sol` |
+| Bounds | one unit of the asset per subdivision, less one (linear accrual on principal truncates once per step: the subdivided run accrues n*floor(x) where the single run accrues floor(n*x), and those differ by at most n-1) |
+| Reads | `totalDebt`, `observedAt` |
+
+Applies to a pooled lender claim denominated in one asset, where borrowers owe that same asset and fees accrue out of lender yield, accruing linearly on principal rather than compounding. Assuming:
+
+- the two observations are two systems, not one system and its past
+- both began from the same state and were advanced over the same span
+- the span divides evenly into the number of subdivisions
+- the rate did not change during the span
+- the law is deployed with the subdivision count the run actually used; nothing in either observation reveals a mismatch, and a mismatch silently changes the bound
+
+## Claims
+
+What a recorded withdrawal claim is owed, and in what order. These need the
+withdrawal-queue extension, and a target without one reverts on the read
+rather than being reported as orderly.
+
+### `claims/recorded-claim-never-shrinks/v1`
+
+> A recorded claim keeps its owed amount and never loses payment already made.
+
+| | |
+| --- | --- |
+| Component | `src/laws/RecordedClaimNeverShrinks.sol` |
+| Specimen | `specimens/ClaimHaircut.sol` |
+| Counterexample | `test/counterexamples/Claims.t.sol` |
+| Bounds | exact |
+| Reads | `withdrawalQueue.claimCount`, `withdrawalQueue.claimAt` |
+
+Applies to a pooled lender claim denominated in one asset, with withdrawals recorded as an ordered queue of individual claims that keep their position once made. Assuming:
+
+- the two observations are one system and its own past, in that order
+- a claim keeps its index once recorded, including after it is paid in full
+- both observations read the queue rather than the core observables alone
+- the two observations bracket a single operation; an offsetting movement inside one batched transition would hide a violation from a law that compares totals
+- the queue is short enough to read in one call; a law that runs out of gas traversing it reverts, and a revert is no verdict
+
+### `claims/queue-order-preserved/v1`
+
+> No withdrawal claim is paid while an older claim is still owed something.
+
+| | |
+| --- | --- |
+| Component | `src/laws/QueueOrderPreserved.sol` |
+| Specimen | `specimens/QueueJumped.sol` |
+| Counterexample | `test/counterexamples/Claims.t.sol` |
+| Bounds | exact |
+| Reads | `withdrawalQueue.claimCount`, `withdrawalQueue.claimAt` |
+
+Applies to a pooled lender claim denominated in one asset, with withdrawals recorded as an ordered queue of individual claims that keep their position once made. Assuming:
+
+- the queue is ordered oldest first
+- partial payment is recorded against the claim rather than held elsewhere
+- the system promises order, rather than paying pro rata
+- the queue is short enough to read in one call; a law that runs out of gas traversing it reverts, and a revert is no verdict
+
+### `claims/reserves-cover-payable/v1`
+
+> Reserved assets cover everything still owed on the claims declared payable.
+
+| | |
+| --- | --- |
+| Component | `src/laws/ReservesCoverPayableClaims.sol` |
+| Specimen | `specimens/PayableBeyondReserves.sol` |
+| Counterexample | `test/counterexamples/Claims.t.sol` |
+| Bounds | exact |
+| Reads | `reservedAssets`, `withdrawalQueue.claimCount`, `withdrawalQueue.claimAt`, `withdrawalQueue.payableThrough` |
+
+Applies to a pooled lender claim denominated in one asset, with withdrawals recorded as an ordered queue of individual claims that keep their position once made. Assuming:
+
+- payableThrough is what the system declares, not something derived from the reserves
+- reserved assets are held against the queue and against nothing else
+- a claim is never paid more than it is owed; no law in the corpus covers that yet
+- the queue is short enough to read in one call; a law that runs out of gas traversing it reverts, and a revert is no verdict

--- a/plugins/pandects/docs/design.md
+++ b/plugins/pandects/docs/design.md
@@ -1,0 +1,255 @@
+# Design: pandects, executable laws for credit contracts
+
+The specification is `specs/pandects.md` in the repository this was built in. This study fixes the
+reading the runbook builds from, records the experiments that decided the
+architecture, and says where the spec left a choice open.
+
+## Problem statement
+
+A fuzzer searches a state space. It cannot decide which economic facts must
+survive that search. Generic token property libraries cover balances,
+approvals and round trips; credit adds time, accrual, queues, changing terms,
+delinquency, partial repayment and claims that are neither liquid nor
+reducible to a token balance. Every audit rediscovers those facts in prose,
+implements a subset in a local harness, and the harness dies with the
+engagement.
+
+`pandects` is the reviewed corpus that survives the engagement. A law is not a
+sentence about credit; it is a Solidity component that executes, a specimen it
+is proven to catch, a minimal counterexample, and a statement of where it means
+anything.
+
+The build is a plugin at `plugins/pandects/`, in the shape every plugin in this
+repository has.
+
+**Working prototype** means this runs offline:
+
+```bash
+forge test                       # every law, against every specimen
+python3 scripts/pandects.py laws # the catalogue, with applicability
+python3 scripts/pandects.py check # the six parts, enforced
+```
+
+with each law caught failing by the specimen written for it, each specimen
+caught by exactly one law, and a deterministic replay of every counterexample.
+A corpus whose laws have never failed is the thing this exists to prevent, so
+the demo is not "the laws pass" but "each law fails the specimen built to break
+it, and nothing else".
+
+## What the toolchain can actually do
+
+Three experiments, run before the design was fixed, because two of them changed
+it.
+
+**Foundry's invariant runner needs no forge-std.** A bare contract with
+`setUp()` and `invariant_*()` is fuzzed, shrunk and reported. A deliberately
+weak law (`total >= seen`) was caught by `add(0)` and shrunk to a single call
+on the first run. No library, no submodule, no network at test time. The
+corpus therefore takes no external Solidity dependency at all.
+
+**A tautology passes quietly.** `require(seen() >= 0)` survived 512 calls
+across 16 runs without complaint. Nothing in a passing campaign distinguishes a
+law that holds from a law that cannot fail. That is the whole argument for gate
+2, and it means the specimen is not a nicety: it is the only evidence that a law
+is a law.
+
+**A shrunk sequence replays deterministically.** The counterexample above
+converts to a plain test with no fuzzing, which is gate 6 satisfied by
+construction rather than by promise.
+
+**All three engines run here.** Echidna 2.3.3, Medusa 1.5.1 and Slither 0.11.6
+are installed, and both fuzzers were proved against a contract written to break
+one law: Echidna found it and shrank the sequence to `deposit(1002)`, Medusa
+found it and printed the call sequence and execution trace. Both compile a
+Foundry project through crytic-compile with no library present.
+
+Two differences between them shape the adapters. Echidna takes properties
+prefixed `echidna_`; Medusa defaults to `property_`. And Echidna shrinks a
+failing sequence to something close to minimal while Medusa reports the sequence
+it found, so converting a Medusa failure into a deterministic test is manual
+work that converting an Echidna one mostly is not.
+
+One of those differences reaches gate 7 directly. Echidna accepts `--seed` and
+reports the seed it used, so a campaign under it can be reproduced. Medusa
+exposes no seed at all. A search record for a Medusa run therefore states the
+engine, the configuration digest, the call sequence length and the corpus
+digest, and says the seed is unavailable rather than inventing one. That is the
+corpus's own absence discipline applied to the corpus.
+
+## Prior art
+
+**Outside.**
+
+- [crytic/properties](https://github.com/crytic/properties): reusable property
+  tests for ERC-20, ERC-4626 and others, written as abstract contracts the
+  target inherits, aimed at Echidna. The standards are covered; credit
+  economics are not. Contributions upstream are in scope where a law fits.
+- [Echidna](https://github.com/crytic/echidna) and
+  [Medusa](https://github.com/crytic/medusa): the engines, with corpus,
+  coverage and shrinking. Neither is replaced.
+- Foundry invariant testing: the engine available here, with `fail_on_revert`,
+  target selection and a printed fuzz seed.
+- [a16z/erc4626-tests](https://github.com/a16z/erc4626-tests) and OpenZeppelin's
+  ERC-4626 suites: property sets bound to one standard, useful as shape.
+- Certora, Halmos and Kontrol: formal verification. Out of scope. A law here
+  executes against a running state, and a proof obligation is a different
+  artefact.
+
+**In this repository.**
+
+- `plugins/hexaemeron/skills/fizz`: generates a stateful harness for one
+  repository. `pandects` supplies laws that fizz can select and adapt; fizz
+  stays useful where no public law describes the protocol.
+- `plugins/hexaemeron/skills/solidity-auditor`: looks for conservation,
+  state-transition, rounding and economic failures by reading. The corpus is
+  the executable form of what it looks for.
+- `plugins/ariadne`: carries the search record. Its `commands` block already
+  requires an engine, a determinism class and an output digest, which is gate 7
+  in a format that already exists. The run record this ships is shaped to drop
+  into an ariadne statement without translation.
+- `plugins/probitas`: the gates-after-the-fact discipline, and the precedent
+  for a Python checker that refuses a document missing its evidence.
+
+## Constraints and non-goals
+
+**Starting point.** `main` at `51157e3`, with `plugins/ariadne` and
+`plugins/probitas` shipped and nothing under `plugins/pandects/`.
+
+**Toolchain.** Solidity 0.8.28 through `forge 1.7.1`, with no external Solidity
+dependency. Python 3.9 through 3.13, standard library only, for the catalogue
+checker, matching the CI matrix the other plugins use.
+
+**Ruled out.** Replacing an engine, writing a harness generator, or shipping a
+generic assertion library. Formal proof obligations. Wildcat-shaped law
+presented as universal law.
+
+**Deferred past the prototype**, each a line in the shipped documents rather
+than a silence:
+
+- Seven of the ten property families in the spec. The prototype covers
+  conservation, accrual and withdrawal claims, which is the slice that proves
+  the shape and contains the laws Wildcat most needs.
+- Echidna and Medusa campaign results, for the reason above.
+- The property-to-bug index against public incidents.
+- The second example integration against a differently designed lender.
+
+## Design options
+
+**A. Laws as forge-std `Test` contracts.** Familiar and immediately runnable.
+Rejected: it drags a submodule the corpus does not otherwise need, and it binds
+a public law to one harness.
+
+**B. Laws as abstract contracts the target inherits**, as crytic/properties
+does. Rejected: it requires modifying and redeploying the system under test,
+which is hostile to the case that matters most, a system already deployed and
+being reviewed.
+
+**C. Laws as free-standing checkers over an observables interface.** Chosen.
+A law takes a view adapter describing economic roles and returns whether it
+held. The target implements the adapter, or a wrapper does, and the law never
+names an implementation. All three engines call functions, so one component
+works under each.
+
+**D. Laws as data, evaluated off-chain.** Rejected: gate 1 says every law
+executes, and an off-chain evaluator is one more engine to trust between the
+state and the verdict.
+
+### The shape that follows from C
+
+A law returns rather than reverts:
+
+```solidity
+function check(ICreditObservables target)
+    external view returns (bool held, string memory detail);
+```
+
+Returning is the decision worth arguing about. Under `fail_on_revert = false` a
+reverting law is indistinguishable from a target that reverted, so a law that
+reverts on the state it was meant to judge reports nothing and is counted as
+silence. A law that returns `false` with a detail string has an opinion that
+survives the harness.
+
+The catalogue is a JSON document carrying each law's identifier, statement,
+applicability, bounds and the specimen it catches. The Solidity component
+declares its own identifier, and a test ties the two together, so a law that
+exists in one and not the other fails the suite. That is the drift check
+`plugins/ariadne` already uses between its schema and its validator.
+
+## Risk register seed
+
+This run ships Solidity, so the audit suite runs in full. What it should look
+hardest at:
+
+1. **A law that cannot fail.** The thing the corpus exists to prevent, and
+   invisible in a passing campaign. Every law faces its specimen, and a law
+   that passes its own specimen is a failing test.
+2. **A law that reverts instead of judging.** Arithmetic inside the property,
+   an unchecked cast, a view that reverts on an edge state. Silence read as
+   assent.
+3. **A specimen caught by the wrong law.** If two laws catch one specimen, at
+   least one is broader than its statement claims.
+4. **Tolerance that hides a defect.** Gate 5: a bound must name the arithmetic
+   that produces it. An epsilon chosen because it made a test pass is the
+   thing being rejected.
+5. **Observables that lie.** The adapter is written by whoever runs the law.
+   Stale values, reentrant views, and a `totalAssets()` that counts what is
+   already promised elsewhere.
+6. **Specimens escaping into production.** They are deliberately broken credit
+   contracts. They need a licence header and a warning that survives copying.
+7. **Arithmetic in the law itself.** Overflow, truncation and ordering in the
+   comparison can mask the very defect being checked.
+8. **Unbounded work in a law.** A loop over a queue makes a campaign useless
+   long before it makes it wrong.
+9. **Cross-law interference.** Laws sharing a harness and a target must not
+   leave state behind for each other.
+10. **A search reported without its settings.** Gate 7: an engine, a
+    configuration, a seed and a corpus digest, or the result is an anecdote.
+
+## Glossary seeds
+
+- **Law.** An executable statement about credit that must survive every state
+  transition, with an identity, applicability and a specimen.
+- **Property component.** The Solidity contract implementing one law.
+- **Observables adapter.** The view interface a target implements so laws can
+  read economic roles without naming an implementation.
+- **Applicability contract.** The accounting model, trust assumptions and
+  features a law requires before it means anything.
+- **Specimen.** A deliberately broken credit implementation that a named law is
+  proven to catch.
+- **Counterexample.** The minimal failing sequence, replayable without a
+  fuzzer.
+- **Campaign.** One engine run against a harness, with its configuration.
+- **Search record.** Engine, configuration, seed, sequence length and corpus
+  digest, travelling with a result.
+- **Tolerance.** A permitted deviation, stated with the arithmetic that
+  produces it.
+
+## Recorded readings
+
+Where the spec left a choice, this is the reading taken.
+
+- **The name.** Raised as weak and reaffirmed by the user, so `pandects`
+  stands. The defect worth fixing is the Naming section, which glosses the
+  reference rather than carrying a story, and which invokes a compilation whose
+  emperor forbade commentary on it while this corpus ships an applicability
+  contract inviting exactly that. The prose pass rewrites the section around
+  the *Regulae Iuris*, the closing title of the Digest, where the rule is drawn
+  from the law rather than the law from the rule.
+- **First release scope.** Undercollateralised credit first, with each law's
+  applicability stating whether an overcollateralised analogue holds. Pairing
+  every law with its analogue is deferred; claiming neutrality without the
+  analogue is not.
+- **Versioning.** A law's identifier carries its economic statement's version.
+  An adapter interface change bumps the component, not the law.
+- **Specimen licensing.** Specimens ship under the plugin's licence with a
+  header naming them as deliberately broken, and the checker refuses a specimen
+  without one.
+
+## Sources
+
+- `specs/pandects.md`, and `specs/ariadne.md` for the search-record shape.
+- crytic/properties, Echidna and Medusa, at `github.com/crytic/`.
+- Foundry invariant testing, exercised locally at `forge 1.7.1` with
+  `solc 0.8.28`.
+- This repository: `plugins/ariadne` (drift check, run records),
+  `plugins/probitas` (gate checker), `plugins/hexaemeron/skills/fizz`.

--- a/plugins/pandects/docs/writing-a-law.md
+++ b/plugins/pandects/docs/writing-a-law.md
@@ -1,0 +1,101 @@
+# Writing a law
+
+Six parts, in the order you meet them. A law with fewer is refused by
+`python3 scripts/pandects.py check`, which names the missing part rather than
+the file.
+
+## 1. Decide what shape it is
+
+Ask whether a single state can violate it.
+
+Conservation can: the sums agree or they do not, and no history is needed. That
+is a `Law`, and it reads one target.
+
+Accrual cannot. Debt falling without payment is invisible in any one state,
+however wrong that state is, because the violation is in the transition. That
+is a `PairLaw`, and it judges two `Observation`s.
+
+Three of the pair laws compare a system with its own past. One compares two
+systems started identically and advanced over the same span by different
+routes. Say which you mean in the applicability, because reading a law the
+wrong way round is the mistake available to everybody who uses it.
+
+## 2. State it in terms a law may read
+
+`ICreditObservables`, and `IWithdrawalQueueObservables` if it needs a
+withdrawal queue. Nothing else, ever.
+
+This is where most first attempts fail, and the failure is not obvious. "Debt
+never decreases between repayments" cannot be checked: nothing a target reports
+says a repayment happened, so the law would need the harness to tell it, and a
+law that trusts the harness is a law about the harness. The observable form is
+that held assets rose by at least the fall, which is what a repayment looks
+like from outside and what a write-off does not.
+
+Check the statement against the sound reference before writing any Solidity.
+Two laws in the accrual family were written, checked, and found false of a
+correct system before a line of them existed.
+
+## 3. Write the component
+
+It returns `(bool held, string detail)` and never reverts to mean violated.
+
+The reason is the harness rather than taste. A campaign runs with
+`fail_on_revert = false`, because a credit system reverts constantly and
+correctly. Under that setting a revert carries no verdict, so a law using
+`require` to mean "violated" reports nothing and is counted as silence. The
+checker greps for `require`, `assert` and `revert` in a component and refuses
+it.
+
+Sums go in an `unchecked` block with the overflow reported as a violation. In
+0.8 an overflow reverts, and a law that overflowed would fall silent exactly
+where the numbers went furthest wrong.
+
+The detail is for the reader who finds the failure six months later. Name the
+quantities that were compared.
+
+## 4. Write the specimen
+
+A contract that breaks this law and no other, inheriting from `Sound` so the
+defect is the diff rather than a paragraph claiming there is one. Say
+"deliberately broken" in it; the checker looks for those words, because a
+broken credit contract that does not say so gets copied.
+
+The one-law-only part is the work. A specimen that breaks two laws proves
+neither, and the diagonal in `test/Corpus.t.sol` and `test/Pairs.t.sol` fails
+when it happens. Getting there usually means finding the compensating move that
+keeps every other law satisfied: the write-off specimen charges itself against
+accrued fees, so conservation holds across the transition that loses a
+borrower's debt.
+
+## 5. Reduce the failure
+
+A deterministic replay under `test/counterexamples/`, running with no fuzzer,
+no seed and no engine. Derive it by hand, then check it against the engines --
+two of the conservation counterexamples got smaller that way, because Echidna
+shrank sequences that had been written at a hundred units down to one.
+
+Assert the intermediate quantities, not just the verdict. A counterexample that
+only asserts the law fires stops being evidence the moment somebody changes the
+specimen.
+
+## 6. Say where it applies, and what it costs
+
+The applicability carries the accounting model, the assumptions and the
+observables required. Write the assumptions that would make the law false if
+they did not hold, not the ones that sound careful.
+
+Bounds are `exact` or an object naming the arithmetic that produces the
+tolerance. An epsilon chosen because it made a test pass is the thing being
+refused. The corpus has one tolerance, and it reads: linear accrual on
+principal truncates once per step, so `n` steps and one step over the same span
+differ by at most `n - 1`.
+
+## 7. File it
+
+Add the entry to `catalogue/pandects.json` and the rendering to
+`docs/catalogue.md`. A component in `src/laws/` that no entry claims is a
+finding, and so is a document that names a law the catalogue does not have.
+
+Then extend the campaign harness in `src/campaigns/Specimens.sol` so the
+specimen is reachable by Echidna and Medusa under both prefixes, and run both.

--- a/plugins/pandects/foundry.toml
+++ b/plugins/pandects/foundry.toml
@@ -1,0 +1,22 @@
+[profile.default]
+src = "src"
+test = "test"
+out = "out"
+libs = []
+solc_version = "0.8.28"
+evm_version = "cancun"
+optimizer = true
+optimizer_runs = 200
+build_info = true
+extra_output = ["storageLayout"]
+
+# A law returns rather than reverts, so a revert in the target is not a law
+# failing. Campaigns run with reverts allowed and counted.
+[invariant]
+runs = 64
+depth = 64
+fail_on_revert = false
+call_override = false
+
+[fuzz]
+runs = 256

--- a/plugins/pandects/integrations/wildcat/APPLICABILITY.md
+++ b/plugins/pandects/integrations/wildcat/APPLICABILITY.md
@@ -1,0 +1,116 @@
+# The corpus against a Wildcat market
+
+`WildcatMarketModel.sol` is a reduced model, not a reimplementation. It keeps
+the shape the corpus has to survive -- withdrawals pooled into batches, a
+reserve the borrower may not touch, delinquency, and a penalty rate on top of
+the base one -- and nothing in it should be mistaken for the market contracts.
+
+Nine laws. Six apply without qualification. Three do not, and those three are
+why this integration exists: until now, applicability described what a law
+needs, and here it has to describe what a design does and does not promise.
+
+One of the three was found by Echidna rather than by reading, against the
+shipped adapter, after this document had already claimed the law held. That is
+worth saying plainly, because it is the whole argument for pointing a corpus at
+a real design instead of at contracts written to break it.
+
+## The six
+
+| Law | Holds | Because |
+| --- | --- | --- |
+| `conservation/value-conserved/v1` | yes | Every operation moves value between two sides, including accrual, which raises debt and claims together |
+| `conservation/reserves-backed-by-claims/v1` | yes | A market cannot earmark more than lenders are owed |
+| `conservation/held-assets-partitioned/v1` | yes | Borrowable liquidity is derived, and the required reserve comes out of it before the borrower is offered anything |
+| `claims/reserves-cover-payable/v1` | yes | Payability is derived from what has actually been set aside, so a delinquent market declares fewer batches payable rather than lying about them |
+| `accrual/debt-falls-only-against-payment/v1` | yes | Debt falls only in `repay`, against assets arriving |
+| `accrual/no-accrual-at-rest/v1` | yes | Interest accrues in `advance` and nowhere else, and borrowing removes from held assets what it adds to debt |
+
+## Batch granularity, and what the ordering law means here
+
+`claims/queue-order-preserved/v1` holds, and reading it as a per-lender promise
+would be wrong.
+
+A Wildcat market pools every withdrawal request made in the same cycle into one
+batch, and pays a batch pro rata. So no lender inside a batch is ahead of any
+other, and none is paid in full while another waits. Batches are paid oldest
+first.
+
+The law says no claim is paid while an older claim is still owed something. At
+batch granularity that is exactly what the design guarantees, and the extension
+here exposes batches rather than lenders for that reason. At lender granularity
+it would be false, and trivially: a pro-rata payment leaves every lender in the
+batch partly paid.
+
+Neither reading is wrong about the design. One of them is wrong about the unit,
+and a corpus that let the two blur would be quietly wrong about somebody's
+protocol. `test_a_batch_paid_pro_rata_does_not_break_the_ordering` is the
+assertion that the pooled case does not read as a jump.
+
+## An open batch is not yet a recorded claim
+
+`claims/recorded-claim-never-shrinks/v1` does not hold over an open batch, and
+does hold over a closed one.
+
+The law says a recorded claim keeps its owed amount. A Wildcat batch
+accumulates while it is open: a second request in the same cycle joins the batch
+and the amount owed on it rises. Echidna found that against
+`WildcatMarketCampaign` within a few hundred calls, and the property is expected
+to fail there.
+
+Neither side is wrong. For a queue of individual claims, an amount that changes
+after the fact is precisely the defect the law was written for -- a lender was
+given a number and the number moved. For a batched design, an open batch is not
+a claim that has been recorded; it is a claim still being assembled. The law
+starts applying when the batch closes, which happens as soon as anything is paid
+out of it, and from that moment the amount is fixed.
+
+`test_an_open_batch_grows_and_the_claim_law_refuses_it` and
+`test_a_closed_batch_satisfies_the_claim_law` are the two halves, asserted
+rather than described.
+
+Whether the law should be relaxed to say a recorded claim is never written
+*down* -- which would still catch the specimen it was built for, and would hold
+over an open batch -- is a real question and not one this integration should
+answer on its own. It is recorded as a lead in `audit/AUDIT.md`.
+
+## Path independence, and the condition on it
+
+`accrual/path-independent/v1` holds while the market is solvent and stops
+holding once penalty accrual is running.
+
+Base interest is linear on principal. It never accrues on interest already
+accrued, so a span costs the same however it is cut up, to within the bound the
+law derives.
+
+The penalty is different. It runs only once the market has been delinquent for
+longer than the grace period, and the grace timer advances when the market is
+poked. A market that crosses into delinquency mid-span therefore owes a
+different penalty depending on how often somebody updated it: advanced once
+across a year from a fresh delinquency, it pays no penalty at all, because the
+grace was unspent at the moment the charge was computed. Advanced in two halves,
+it pays the penalty for the whole second half.
+
+That is path dependence in the plain sense, and it is not a defect in the design
+or in the law. It is a design the law does not describe once that rate is on.
+`test_a_penalised_market_is_not_path_independent` watches it happen rather than
+describing it, and `test_a_solvent_market_is_path_independent` holds the other
+half.
+
+## Delinquency arrives with the request
+
+Worth stating because it is the part a reader coming from a simpler model gets
+wrong. Borrowing cannot make a market delinquent: the required reserve is
+subtracted before the borrower is offered anything. What makes a market
+delinquent is a lender asking to leave a market whose liquidity has already gone
+out of the door, and no amount of care at borrow time prevents that.
+
+This is why the model bounds a withdrawal request by the lender's claims rather
+than by what the market holds. A model that refused the request would have no
+way to reach the situation the whole design is built around.
+
+## What is not modelled
+
+Per-lender accounting, so nothing here says anything about one lender's share of
+a batch. The scaling index, so amounts are in the asset throughout. Market
+expiry, borrower authorisation, the sentinel, and every access control. Each of
+those matters to a market and none of them changes what the laws read.

--- a/plugins/pandects/integrations/wildcat/WildcatMarketModel.sol
+++ b/plugins/pandects/integrations/wildcat/WildcatMarketModel.sol
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ICreditObservables} from "../../src/ICreditObservables.sol";
+import {IWithdrawalQueueObservables} from "../../src/IWithdrawalQueueObservables.sol";
+
+/// @title A reduced model of a Wildcat market.
+/// @notice Reduced, not faithful. This is a model written to be read, not a
+/// reimplementation, and nothing here should be mistaken for the market
+/// contracts. What it keeps is the shape the corpus has to survive: withdrawals
+/// pooled into batches rather than queued as individual claims, a reserve the
+/// borrower may not touch, delinquency, and a penalty rate that runs on top of
+/// the base one while a market is delinquent.
+///
+/// Four things about that shape matter to the laws.
+///
+/// **Withdrawals are batched.** A request joins the batch open in the current
+/// cycle. A batch is paid pro rata, so within one batch no lender is ahead of
+/// another; batches are paid oldest first. That is why the queue extension here
+/// exposes batches rather than lenders, and why the applicability note for
+/// `claims/queue-order-preserved/v1` says which unit it means. Read as a
+/// per-lender promise the law is false of this design. Read as a per-batch one
+/// it is exactly what the design guarantees.
+///
+/// **Liquidity is not all borrowable.** The borrower may take held assets less
+/// what is reserved against unpaid batches and less the required reserve on
+/// outstanding claims. A market that cannot cover both is delinquent.
+///
+/// **Base interest is linear on principal.** It accrues on what was borrowed
+/// and never on interest already accrued, so a span costs the same however it
+/// is cut up.
+///
+/// **Penalty interest is not.** It runs only while the market has been
+/// delinquent longer than the grace period, and the grace timer advances when
+/// the market is poked. A market that crosses into delinquency mid-span accrues
+/// a different penalty depending on how often somebody updated it, which is
+/// path dependence in the plain sense. `accrual/path-independent/v1` therefore
+/// holds here while the market is solvent and does not hold once penalty
+/// accrual is running -- a condition rather than a yes or a no, and the reason
+/// the applicability contract has a shape at all.
+contract WildcatMarketModel is ICreditObservables, IWithdrawalQueueObservables {
+    uint256 internal constant CEILING = 1e30;
+
+    /// @dev A tenth per 365 days, and the same again as penalty. Both are rates
+    /// on a duration rather than charges on a call.
+    uint256 internal constant BASE_RATE = 3_170_979_198;
+    uint256 internal constant PENALTY_RATE = 3_170_979_198;
+    uint256 internal constant RATE_SCALE = 1e18;
+
+    /// @dev What fraction of outstanding claims the borrower must leave behind,
+    /// in hundredths. Twenty per cent, which is a plausible figure and not a
+    /// claim about any real market.
+    uint256 internal constant RESERVE_RATIO = 20;
+
+    /// @dev How long a market may be delinquent before the penalty starts.
+    uint256 internal constant GRACE = 7 days;
+
+    /// @dev Bounded so a fuzzer spends its calls on sequences rather than on
+    /// overflow reverts, which carry no verdict.
+    uint256 internal constant MAX_STEP = 365 days;
+    uint256 internal constant MAX_BATCHES = 8;
+
+    address public constant asset =
+        address(uint160(uint256(keccak256("pandects.wildcat.model.asset"))));
+
+    uint256 internal clock;
+    uint256 internal held;
+    uint256 internal principal;
+    uint256 internal interest;
+    uint256 internal claims;
+    uint256 internal fees;
+
+    /// @dev How long this market has been short of its required liquidity.
+    uint256 internal delinquentFor;
+
+    uint256[] internal batchOwed;
+    uint256[] internal batchPaid;
+
+    function bounded(uint256 amount) internal pure returns (uint256) {
+        return amount % CEILING;
+    }
+
+    // -- the core observables -----------------------------------------------
+
+    function totalAssets() external view returns (uint256) {
+        return held;
+    }
+
+    function totalDebt() external view returns (uint256) {
+        return principal + interest;
+    }
+
+    function totalLenderClaims() external view returns (uint256) {
+        return claims;
+    }
+
+    function accruedFees() external view returns (uint256) {
+        return fees;
+    }
+
+    /// @notice Assets set aside against batches that have not been paid.
+    function reservedAssets() external view returns (uint256) {
+        return reserved();
+    }
+
+    /// @notice What the borrower may actually take.
+    /// @dev Held assets, less what is reserved against unpaid batches, less the
+    /// reserve the borrower must leave on outstanding claims. This is the
+    /// quantity a borrower cares about and the one a naive model gets wrong by
+    /// reporting everything not already spoken for.
+    function borrowableAssets() external view returns (uint256) {
+        uint256 spoken = reserved() + requiredReserve();
+        return held > spoken ? held - spoken : 0;
+    }
+
+    function observedAt() external view returns (uint256) {
+        return clock;
+    }
+
+    // -- the withdrawal batches ----------------------------------------------
+
+    /// @notice How many batches this market has opened.
+    /// @dev Batches, not lenders. A batch pools every request made in its cycle
+    /// and is paid pro rata, so there is no ordering inside one to report.
+    function claimCount() external view returns (uint256) {
+        return batchOwed.length;
+    }
+
+    function claimAt(uint256 index)
+        external
+        view
+        returns (uint256 owed, uint256 paid)
+    {
+        return (batchOwed[index], batchPaid[index]);
+    }
+
+    /// @notice How far down the batches this market can settle now.
+    function payableThrough() external view returns (uint256) {
+        return payableCount();
+    }
+
+    /// @dev The same answer, reachable from inside. `payBatch` uses this rather
+    /// than the observable so that a market which ever declared payability
+    /// differently would still pay in the order it actually can -- the
+    /// declaration is what a law checks, and code that read its own declaration
+    /// could never disagree with it.
+    function payableCount() internal view returns (uint256) {
+        uint256 covered = reserved();
+        uint256 through;
+        for (uint256 i = 0; i < batchOwed.length; i++) {
+            uint256 unpaid = batchOwed[i] - batchPaid[i];
+            if (unpaid > covered) {
+                break;
+            }
+            covered -= unpaid;
+            through++;
+        }
+        return through;
+    }
+
+    // -- what the market owes itself -----------------------------------------
+
+    function unpaidBatches() internal view returns (uint256) {
+        uint256 total;
+        for (uint256 i = 0; i < batchOwed.length; i++) {
+            total += batchOwed[i] - batchPaid[i];
+        }
+        return total;
+    }
+
+    function reserved() internal view returns (uint256) {
+        uint256 outstanding = unpaidBatches();
+        uint256 ceiling = claims < held ? claims : held;
+        return outstanding < ceiling ? outstanding : ceiling;
+    }
+
+    /// @notice The reserve the borrower must leave on claims not yet requested.
+    function requiredReserve() internal view returns (uint256) {
+        uint256 unrequested = claims > unpaidBatches() ? claims - unpaidBatches() : 0;
+        return (unrequested * RESERVE_RATIO) / 100;
+    }
+
+    /// @notice Whether the market is short of the liquidity it owes.
+    /// @dev Against what is owed on unpaid batches, not against what has been
+    /// set aside. Those differ exactly when the market is in trouble: `reserved`
+    /// cannot exceed what is held, because a market cannot earmark assets it
+    /// does not have, so comparing held against it would make delinquency
+    /// almost unreachable and the penalty rate decorative.
+    function delinquent() public view returns (bool) {
+        return held < unpaidBatches() + requiredReserve();
+    }
+
+    /// @notice Whether the penalty rate is running.
+    function penalised() public view returns (bool) {
+        return delinquentFor > GRACE;
+    }
+
+    // -- the operations -------------------------------------------------------
+
+    function deposit(uint256 amount) external {
+        uint256 value = bounded(amount);
+        held += value;
+        claims += value;
+    }
+
+    function borrow(uint256 amount) external {
+        uint256 spoken = reserved() + requiredReserve();
+        uint256 available = held > spoken ? held - spoken : 0;
+        uint256 value = bounded(amount);
+        if (value > available) {
+            value = available;
+        }
+        held -= value;
+        principal += value;
+    }
+
+    function repay(uint256 amount) external {
+        uint256 owed = principal + interest;
+        uint256 value = bounded(amount);
+        if (value > owed) {
+            value = owed;
+        }
+        if (value > interest) {
+            principal -= value - interest;
+            interest = 0;
+        } else {
+            interest -= value;
+        }
+        held += value;
+    }
+
+    /// @notice Move the clock and charge for the time.
+    /// @dev Two rates, and only one of them is path independent. The base rate
+    /// runs on principal for the whole step. The penalty runs only for the part
+    /// of the step after the grace period had already been exhausted, and
+    /// whether that is any of it depends on when this was last called.
+    function advance(uint256 elapsed) external {
+        uint256 step = elapsed % (MAX_STEP + 1);
+        uint256 accrued = (principal * BASE_RATE * step) / RATE_SCALE;
+
+        if (penalised()) {
+            accrued += (principal * PENALTY_RATE * step) / RATE_SCALE;
+        }
+
+        clock += step;
+        interest += accrued;
+        claims += accrued;
+
+        // Recomputed after the accrual, because accruing raises claims and can
+        // itself tip a market into delinquency.
+        if (delinquent()) {
+            delinquentFor += step;
+        } else {
+            delinquentFor = 0;
+        }
+    }
+
+    function accrueFee(uint256 amount) external {
+        uint256 spoken = reserved();
+        uint256 available = claims > spoken ? claims - spoken : 0;
+        uint256 value = bounded(amount);
+        if (value > available) {
+            value = available;
+        }
+        claims -= value;
+        fees += value;
+    }
+
+    /// @notice Request a withdrawal, joining the batch open in this cycle.
+    /// @dev Bounded by claims not already requested, and deliberately not by
+    /// what the market holds. A lender may ask to leave a market that cannot
+    /// pay them; that is the situation the whole design is built around, and a
+    /// model that refused the request would have no way to reach it.
+    function requestWithdrawal(uint256 amount) external {
+        uint256 requested = unpaidBatches();
+        uint256 ceiling = claims > requested ? claims - requested : 0;
+        uint256 value = bounded(amount);
+        if (value > ceiling) {
+            value = ceiling;
+        }
+        if (value == 0) {
+            return;
+        }
+        if (batchOwed.length == 0 || batchPaid[batchOwed.length - 1] > 0) {
+            if (batchOwed.length >= MAX_BATCHES) {
+                return;
+            }
+            batchOwed.push(value);
+            batchPaid.push(0);
+            return;
+        }
+        // The open batch is the newest one nobody has been paid from yet.
+        // Joining it is what makes this a batch rather than a queue.
+        batchOwed[batchOwed.length - 1] += value;
+    }
+
+    /// @notice Pay the oldest batch the market can settle.
+    /// @dev Pro rata within the batch is not modelled per lender, because the
+    /// laws read amounts rather than lenders. What matters here is that a
+    /// partial payment lands on the oldest unpaid batch and never on a newer
+    /// one, which is the promise `claims/queue-order-preserved/v1` checks.
+    function payBatch(uint256 amount) external {
+        uint256 through = payableCount();
+        for (uint256 i = 0; i < through; i++) {
+            uint256 unpaid = batchOwed[i] - batchPaid[i];
+            if (unpaid == 0) {
+                continue;
+            }
+            uint256 value = bounded(amount);
+            if (value > unpaid) {
+                value = unpaid;
+            }
+            if (value > held) {
+                value = held;
+            }
+            if (value > claims) {
+                value = claims;
+            }
+            batchPaid[i] += value;
+            held -= value;
+            claims -= value;
+            return;
+        }
+    }
+}

--- a/plugins/pandects/scripts/pandects.py
+++ b/plugins/pandects/scripts/pandects.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""pandects -- executable laws for credit contracts.
+
+Three subcommands:
+
+    laws   list the catalogue, with each law's applicability
+    check  refuse a law missing any of the six parts that make it one
+    run    search with an engine, and write down how it was searched
+    render write the catalogue out as the document readers are pointed at
+
+Exit codes: 0 success, 1 a check failed, 2 usage or validation error.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from pandects_lib import catalogue as catalogue_module  # noqa: E402
+from pandects_lib import checker  # noqa: E402
+from pandects_lib import render as render_module  # noqa: E402
+from pandects_lib import run as run_module  # noqa: E402
+
+PLUGIN_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CATALOGUE = os.path.join(PLUGIN_ROOT, "catalogue", "pandects.json")
+
+CHECK_FAILED = 1
+USAGE_ERROR = 2
+
+
+def load(path):
+    try:
+        return catalogue_module.load(path)
+    except catalogue_module.CatalogueError as error:
+        print("%s" % error, file=sys.stderr)
+        return None
+
+
+def cmd_laws(args):
+    found = load(args.catalogue)
+    if found is None:
+        return USAGE_ERROR
+
+    if args.json:
+        print(json.dumps(found.raw, indent=2))
+        return 0
+
+    if not found.laws:
+        print("catalogue %s: no laws yet" % found.version)
+        print("families declared: %s" % ", ".join(sorted(found.families)))
+        return 0
+
+    width = max(len(law.id) for law in found.laws)
+    for law in found.laws:
+        print("%s  %s" % (law.id.ljust(width), law.get("statement")))
+        applicability = law.get("applicability") or {}
+        print("%s  applies to: %s" % (" " * width, applicability.get("accounting_model")))
+    return 0
+
+
+def cmd_check(args):
+    found = load(args.catalogue)
+    if found is None:
+        return USAGE_ERROR
+
+    findings = checker.check(PLUGIN_ROOT, found)
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "laws": len(found.laws),
+                    "findings": [
+                        {"law": f.law, "part": f.part, "detail": f.detail}
+                        for f in findings
+                    ],
+                    "ok": not findings,
+                },
+                indent=2,
+            )
+        )
+        return CHECK_FAILED if findings else 0
+
+    for finding in findings:
+        print(finding.line())
+    if findings:
+        print("%d law(s) checked, %d finding(s)" % (len(found.laws), len(findings)))
+        return CHECK_FAILED
+    print("%d law(s) checked, every part present" % len(found.laws))
+    return 0
+
+
+def cmd_run(args):
+    found = load(args.catalogue)
+    if found is None:
+        return USAGE_ERROR
+
+    try:
+        record = run_module.search_record(
+            PLUGIN_ROOT, found, match=args.match, seed=args.seed
+        )
+    except run_module.RunError as error:
+        print("%s" % error, file=sys.stderr)
+        return USAGE_ERROR
+
+    body = json.dumps(record, indent=2)
+    if args.out:
+        try:
+            with open(args.out, "w") as handle:
+                handle.write(body + "\n")
+        except OSError as error:
+            print("cannot write %s: %s" % (args.out, error), file=sys.stderr)
+            return USAGE_ERROR
+    else:
+        print(body)
+
+    if not record["commands"]:
+        print("no engine ran; the record names none", file=sys.stderr)
+        return CHECK_FAILED
+    failed = [
+        c for c in record["commands"] if c["detail"].get("outcome") == "failed"
+    ]
+    if failed:
+        print(
+            "%d of %d campaign(s) reported a violation"
+            % (len(failed), len(record["commands"])),
+            file=sys.stderr,
+        )
+        return CHECK_FAILED
+    return 0
+
+
+def cmd_render(args):
+    found = load(args.catalogue)
+    if found is None:
+        return USAGE_ERROR
+
+    body = render_module.render(found)
+    if not args.out:
+        print(body, end="")
+        return 0
+    try:
+        with open(args.out, "w") as handle:
+            handle.write(body)
+    except OSError as error:
+        print("cannot write %s: %s" % (args.out, error), file=sys.stderr)
+        return USAGE_ERROR
+    return 0
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="pandects", description="Executable laws for credit contracts."
+    )
+    subcommands = parser.add_subparsers(dest="command")
+
+    listing = subcommands.add_parser("laws", help="list the catalogue")
+    listing.add_argument("--catalogue", default=CATALOGUE)
+    listing.add_argument("--json", action="store_true")
+    listing.set_defaults(handler=cmd_laws)
+
+    verify = subcommands.add_parser(
+        "check", help="refuse a law missing any of its six parts"
+    )
+    verify.add_argument("--catalogue", default=CATALOGUE)
+    verify.add_argument("--json", action="store_true")
+    verify.set_defaults(handler=cmd_check)
+
+    search = subcommands.add_parser(
+        "run", help="run a campaign and write the search record"
+    )
+    search.add_argument("--catalogue", default=CATALOGUE)
+    search.add_argument("--match", help="restrict the campaign to one contract")
+    search.add_argument(
+        "--seed", help="the seed the engine was given, when it takes one"
+    )
+    search.add_argument("--out", help="write the record here rather than to stdout")
+    search.set_defaults(handler=cmd_run)
+
+    document = subcommands.add_parser(
+        "render", help="write the catalogue out as a document"
+    )
+    document.add_argument("--catalogue", default=CATALOGUE)
+    document.add_argument(
+        "--out",
+        default=os.path.join(PLUGIN_ROOT, "docs", "catalogue.md"),
+        help="where to write it; the shipped document by default",
+    )
+    document.set_defaults(handler=cmd_render)
+
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not getattr(args, "handler", None):
+        parser.print_help()
+        return USAGE_ERROR
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/pandects/scripts/pandects_lib/__init__.py
+++ b/plugins/pandects/scripts/pandects_lib/__init__.py
@@ -1,0 +1,3 @@
+"""pandects: executable laws for credit contracts."""
+
+__all__ = ["catalogue", "checker", "safejson"]

--- a/plugins/pandects/scripts/pandects_lib/catalogue.py
+++ b/plugins/pandects/scripts/pandects_lib/catalogue.py
@@ -1,0 +1,123 @@
+"""The catalogue: what the corpus claims to contain.
+
+A law is six things, and the catalogue is where five of them are written down.
+The sixth is the Solidity, and `checker.py` is what ties the two together.
+
+Nothing here decides whether a law is true. It decides whether something is a
+law at all, which is a lower bar and the one worth enforcing mechanically: a
+sentence with a hopeful name is not a law, and neither is a component nobody
+can say the applicability of.
+"""
+
+from . import safejson
+
+REQUIRED_TOP = ("version", "observables", "families", "laws")
+
+REQUIRED_LAW = (
+    "id",
+    "family",
+    "statement",
+    "component",
+    "specimen",
+    "counterexample",
+    "applicability",
+    "bounds",
+)
+"""Every field a law may carry, and every one of them is required.
+
+Absence is checked by `checker.py` rather than here, so a law missing a part is
+told which part it is missing instead of being called a malformed file. Only
+`id` is enforced at parse time, because without it there is nothing to name in
+the message."""
+
+REQUIRED_APPLICABILITY = ("accounting_model", "assumes", "requires")
+"""Gate 3 of the specification, as fields. `assumes` and `requires` are lists so
+that an empty one is a claim of no assumptions rather than an oversight."""
+
+EXACT = "exact"
+
+
+class CatalogueError(ValueError):
+    """A catalogue that is not one."""
+
+
+class Law(object):
+    def __init__(self, raw, index):
+        self.raw = raw
+        self.index = index
+
+    @property
+    def id(self):
+        return self.raw.get("id")
+
+    @property
+    def label(self):
+        return self.id or "law %d" % (self.index + 1)
+
+    def __getitem__(self, key):
+        return self.raw[key]
+
+    def get(self, key, default=None):
+        return self.raw.get(key, default)
+
+
+class Catalogue(object):
+    def __init__(self, raw, path=None):
+        self.raw = raw
+        self.path = path
+        self.laws = [Law(entry, i) for i, entry in enumerate(raw["laws"])]
+
+    @property
+    def version(self):
+        return self.raw["version"]
+
+    @property
+    def families(self):
+        return self.raw["families"]
+
+    def law(self, identifier):
+        for entry in self.laws:
+            if entry.id == identifier:
+                return entry
+        return None
+
+
+def parse(raw, path=None):
+    """Validate the document's shape. Contents are `checker.py`'s business."""
+    if not isinstance(raw, dict):
+        raise CatalogueError("a catalogue is a JSON object")
+
+    missing = [field for field in REQUIRED_TOP if field not in raw]
+    if missing:
+        raise CatalogueError("catalogue has no %s" % ", ".join(missing))
+    if not isinstance(raw["families"], dict) or not raw["families"]:
+        raise CatalogueError("families must be a non-empty object")
+    if not isinstance(raw["laws"], list):
+        raise CatalogueError("laws must be an array")
+
+    seen = set()
+    for index, entry in enumerate(raw["laws"]):
+        label = "law %d" % (index + 1)
+        if not isinstance(entry, dict):
+            raise CatalogueError("%s is not an object" % label)
+        identifier = entry.get("id")
+        if not isinstance(identifier, str) or not identifier.strip():
+            raise CatalogueError("%s has no id" % label)
+        if identifier in seen:
+            raise CatalogueError("two laws share the id %r" % identifier)
+        seen.add(identifier)
+        unknown = sorted(set(entry) - set(REQUIRED_LAW))
+        if unknown:
+            raise CatalogueError(
+                "%s carries fields a law does not define: %s"
+                % (identifier, ", ".join(unknown))
+            )
+
+    return Catalogue(raw, path)
+
+
+def load(path):
+    try:
+        return parse(safejson.load_file(path), path)
+    except safejson.InputError as error:
+        raise CatalogueError("%s: %s" % (path, error))

--- a/plugins/pandects/scripts/pandects_lib/checker.py
+++ b/plugins/pandects/scripts/pandects_lib/checker.py
@@ -1,0 +1,300 @@
+"""The six parts, enforced.
+
+A law that has never failed may be a tautology or an unreachable check. That is
+the specification's gate 2, and it is not rhetoric: a property asserting
+`seen() >= 0` survived five hundred and twelve calls of a stateful campaign
+without complaint. Nothing in a passing run distinguishes a law that holds from
+a law that cannot fail, so the specimen is not documentation. It is the only
+evidence that a law is a law.
+
+These checks cannot tell whether a law is true either. They refuse the shapes
+that let something which is not a law be filed as one:
+
+1. It executes. A component exists, and its `id()` is this law's id.
+2. It catches something. A specimen exists and says it is deliberately broken.
+3. It has been reduced. A counterexample exists, replayable without a fuzzer.
+4. It says where it applies. Accounting model, assumptions, requirements.
+5. Its bounds are justified. Exact, or a tolerance naming the arithmetic that
+   produces it.
+6. It judges rather than reverts. A component that reverts to signal a failure
+   reports nothing under `fail_on_revert = false`.
+"""
+
+import os
+import re
+
+from .catalogue import EXACT, REQUIRED_APPLICABILITY
+
+ID_IN_SOLIDITY = re.compile(
+    r"function\s+id\s*\(\s*\)[^{]*\{[^}]*return\s+\"([^\"]+)\"", re.DOTALL
+)
+
+BROKEN_MARKER = "deliberately broken"
+
+REVERTS = re.compile(
+    r"(?<![\w.$])(require|assert|revert)\s*\(|(?<![\w.$])(revert)\s+[A-Z]"
+)
+"""`assert` belongs here with the other two. It reverts with a panic, which
+under `fail_on_revert = false` is as silent as any other revert, and a law
+reaching for it to mean "violated" is making the same mistake in a different
+word.
+
+The two alternatives are the two spellings and nothing else. `revert` followed
+by whitespace and a capital is a custom error; `revert(` is the plain form. A
+function called `revertHelper` is neither, and an earlier pattern that accepted
+any uppercase letter after the word flagged it."""
+
+STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
+LINE_COMMENT = re.compile(r"//[^\n]*")
+BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+
+class Finding(object):
+    def __init__(self, law, part, detail):
+        self.law = law
+        self.part = part
+        self.detail = detail
+
+    def line(self):
+        return "%s: %s -- %s" % (self.law, self.part, self.detail)
+
+
+def read(path):
+    """Read a component's source, or None when it is not text.
+
+    A component that is not UTF-8 is not a component. Returning rather than
+    raising keeps it a finding the reader is told about instead of a traceback
+    out of the checker.
+    """
+    try:
+        with open(path, "rb") as handle:
+            return handle.read().decode("utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def scannable(source):
+    """Source with string literals and comments removed.
+
+    Both are places a law legitimately writes the word `require` without doing
+    it: a comment saying what the law does not do, and a `statement()` whose
+    sentence describes a system that requires something. Strings go first, so a
+    `//` inside one is removed with the string rather than truncating the line.
+
+    A double quote inside a comment can confuse the string pass. The cost is a
+    comment being over-removed, which loses nothing, because comments are being
+    removed anyway.
+    """
+    return LINE_COMMENT.sub("", BLOCK_COMMENT.sub("", STRING.sub('""', source)))
+
+
+def resolve(root, relative):
+    """A catalogue path, resolved and confined to the plugin."""
+    if not isinstance(relative, str) or not relative.strip():
+        return None
+    try:
+        root = os.path.realpath(root)
+        target = os.path.realpath(os.path.join(root, relative))
+        shared = os.path.commonpath([root, target])
+    except (ValueError, OSError):
+        # A path the filesystem will not even look at: an embedded null byte,
+        # a name too long, or two paths that cannot be compared. Each is a
+        # containment this cannot establish, so it is not established.
+        return None
+    if shared != root:
+        return None
+    return target
+
+
+def check_component(root, law, findings):
+    path = resolve(root, law.get("component"))
+    if path is None or not os.path.isfile(path):
+        findings.append(
+            Finding(law.label, "executes", "no component at %r" % law.get("component"))
+        )
+        return
+    source = read(path)
+    if source is None:
+        findings.append(
+            Finding(
+                law.label, "executes", "%s is not readable text" % law.get("component")
+            )
+        )
+        return
+    declared = ID_IN_SOLIDITY.search(source)
+    if declared is None:
+        findings.append(
+            Finding(law.label, "executes", "%s declares no id()" % law.get("component"))
+        )
+        return
+    if declared.group(1) != law.id:
+        findings.append(
+            Finding(
+                law.label,
+                "executes",
+                "%s declares id %r, the catalogue says %r"
+                % (law.get("component"), declared.group(1), law.id),
+            )
+        )
+    # Scanned over the whole component rather than a parsed `check` body. A
+    # law component holds `id`, `statement` and `check` and nothing else, so
+    # there is no legitimate revert anywhere in it, and a regex that had to
+    # find the body first would stop checking whenever a law was formatted in
+    # a way the regex did not expect. A check that silently stops checking is
+    # worse than no check.
+    reverting = REVERTS.search(scannable(source))
+    if reverting:
+        findings.append(
+            Finding(
+                law.label,
+                "judges rather than reverts",
+                "uses %s; under fail_on_revert = false a revert carries no "
+                "verdict, so this reports nothing rather than a violation"
+                % (reverting.group(1) or reverting.group(2)),
+            )
+        )
+
+
+def check_specimen(root, law, findings):
+    path = resolve(root, law.get("specimen"))
+    if path is None or not os.path.isfile(path):
+        findings.append(
+            Finding(law.label, "catches", "no specimen at %r" % law.get("specimen"))
+        )
+        return
+    source = read(path)
+    if source is None:
+        findings.append(
+            Finding(
+                law.label, "catches", "%s is not readable text" % law.get("specimen")
+            )
+        )
+        return
+    if BROKEN_MARKER not in source.lower():
+        findings.append(
+            Finding(
+                law.label,
+                "catches",
+                "%s does not say it is %s; a broken credit contract that does "
+                "not say so gets copied" % (law.get("specimen"), BROKEN_MARKER),
+            )
+        )
+
+
+def check_counterexample(root, law, findings):
+    path = resolve(root, law.get("counterexample"))
+    if path is None or not os.path.isfile(path):
+        findings.append(
+            Finding(
+                law.label,
+                "has been reduced",
+                "no counterexample at %r" % law.get("counterexample"),
+            )
+        )
+
+
+def check_applicability(law, findings):
+    found = law.get("applicability")
+    if not isinstance(found, dict):
+        findings.append(
+            Finding(law.label, "says where it applies", "applicability is not an object")
+        )
+        return
+    missing = [f for f in REQUIRED_APPLICABILITY if f not in found]
+    if missing:
+        findings.append(
+            Finding(
+                law.label,
+                "says where it applies",
+                "applicability has no %s" % ", ".join(missing),
+            )
+        )
+        return
+    if not isinstance(found["accounting_model"], str) or not found["accounting_model"].strip():
+        findings.append(
+            Finding(law.label, "says where it applies", "accounting_model is empty")
+        )
+    for field in ("assumes", "requires"):
+        if not isinstance(found[field], list):
+            findings.append(
+                Finding(law.label, "says where it applies", "%s must be a list" % field)
+            )
+
+
+def check_bounds(law, findings):
+    found = law.get("bounds")
+    if found == EXACT:
+        return
+    if not isinstance(found, dict):
+        findings.append(
+            Finding(
+                law.label,
+                "bounds are justified",
+                'bounds must be "%s" or an object naming its arithmetic' % EXACT,
+            )
+        )
+        return
+    for field in ("tolerance", "arithmetic"):
+        value = found.get(field)
+        if not isinstance(value, str) or not value.strip():
+            findings.append(
+                Finding(
+                    law.label,
+                    "bounds are justified",
+                    "bounds has no %s; an epsilon chosen because it made a test "
+                    "pass is the thing being refused" % field,
+                )
+            )
+
+
+def check_family(catalogue, law, findings):
+    if law.get("family") not in catalogue.families:
+        findings.append(
+            Finding(
+                law.label,
+                "is filed",
+                "family %r is not one the catalogue declares" % law.get("family"),
+            )
+        )
+
+
+def check_statement(law, findings):
+    statement = law.get("statement")
+    if not isinstance(statement, str) or not statement.strip():
+        findings.append(Finding(law.label, "states itself", "statement is empty"))
+
+
+def orphans(root, catalogue, findings):
+    """Components on disk that no catalogue entry claims.
+
+    The reverse of a missing component, and the easier mistake to make: a law
+    written, compiled and never filed is a law nobody can find the applicability
+    of.
+    """
+    laws_dir = os.path.join(root, "src", "laws")
+    if not os.path.isdir(laws_dir):
+        return
+    claimed = {law.get("component") for law in catalogue.laws}
+    for name in sorted(os.listdir(laws_dir)):
+        if not name.endswith(".sol"):
+            continue
+        relative = os.path.join("src", "laws", name)
+        if relative not in claimed:
+            findings.append(
+                Finding(relative, "is filed", "on disk and in no catalogue entry")
+            )
+
+
+def check(root, catalogue):
+    """Every law, every part. Returns findings; an empty list is a pass."""
+    findings = []
+    for law in catalogue.laws:
+        check_statement(law, findings)
+        check_family(catalogue, law, findings)
+        check_component(root, law, findings)
+        check_specimen(root, law, findings)
+        check_counterexample(root, law, findings)
+        check_applicability(law, findings)
+        check_bounds(law, findings)
+    orphans(root, catalogue, findings)
+    return findings

--- a/plugins/pandects/scripts/pandects_lib/render.py
+++ b/plugins/pandects/scripts/pandects_lib/render.py
@@ -1,0 +1,127 @@
+"""The catalogue, rendered for a reader.
+
+`docs/catalogue.md` describes itself as a rendering rather than a second source.
+That was a claim about intent until this existed: the document was written once
+by hand and a test checked the two agreed, which catches drift and offers no way
+to fix it. A reader who added a law was told the document was wrong and left to
+work out what it should have said.
+
+So the rendering has a renderer, the renderer is the only thing that writes that
+file, and a test compares the committed bytes with what this produces. Drift is
+then a one-line fix rather than a transcription exercise.
+"""
+
+FAMILY_BLURB = {
+    "conservation": (
+        "What the system holds, owes and has promised, held against each other.\n"
+        "Every one of these is a fact about a single state: the sums agree or they do\n"
+        "not, and no history is needed to say which."
+    ),
+    "accrual": (
+        "How debt and claims move with time. None of these can be violated by any\n"
+        "single state, however wrong that state is, because the violation is in the\n"
+        "transition."
+    ),
+    "claims": (
+        "What a recorded withdrawal claim is owed, and in what order. These need the\n"
+        "withdrawal-queue extension, and a target without one reverts on the read\n"
+        "rather than being reported as orderly."
+    ),
+}
+
+#: Spelled out to twelve, past which the numeral reads better than the word. A
+#: corpus with more laws than this has a bigger problem than its preamble.
+WORDS = (
+    "No", "One", "Two", "Three", "Four", "Five", "Six",
+    "Seven", "Eight", "Nine", "Ten", "Eleven", "Twelve",
+)
+
+
+def counted(number, singular, plural, capitalised=False):
+    """A spelled-out count, capitalised only where a sentence starts."""
+    word = WORDS[number] if number < len(WORDS) else str(number)
+    if not capitalised:
+        word = word.lower() if word[0].isupper() and not word.isdigit() else word
+    return "%s %s" % (word, singular if number == 1 else plural)
+
+
+PREAMBLE = """# The catalogue
+
+%s in %s, rendered for a reader. The catalogue itself is
+`catalogue/pandects.json`, and a test fails if this document and that file stop
+naming the same laws, so this is a rendering rather than a second source.
+
+Regenerate it with `python3 scripts/pandects.py render`. Editing it by hand is
+how a rendering becomes a second source.
+
+Every law here has six parts. It executes, it catches a contract written to
+break it, that failure has been reduced to a replay with no fuzzer in it, it
+says where it applies, its bounds are justified, and it judges rather than
+reverting. `python3 scripts/pandects.py check` refuses anything with fewer.
+"""
+
+
+def bounds_text(bounds):
+    if bounds == "exact":
+        return "exact"
+    if not isinstance(bounds, dict):
+        return str(bounds)
+    return "%s (%s)" % (bounds.get("tolerance"), bounds.get("arithmetic"))
+
+
+def families_in(catalogue):
+    """Every family that has a law filed under it, in catalogue order.
+
+    Driven by the catalogue rather than by the blurbs above. A renderer that
+    looped over its own vocabulary would silently drop every law filed under a
+    family it had not been told about, and the drift test cannot see that: it
+    compares the document against this renderer, so both would be wrong the same
+    way.
+    """
+    seen = []
+    for law in catalogue.laws:
+        family = law.get("family")
+        if family is not None and family not in seen:
+            seen.append(family)
+    return seen
+
+
+def render(catalogue):
+    """The whole document, as a string ending in one newline."""
+    families = families_in(catalogue)
+    preamble = PREAMBLE % (
+        counted(len(catalogue.laws), "law", "laws", capitalised=True),
+        counted(len(families), "family", "families"),
+    )
+    lines = preamble.rstrip("\n").split("\n") + [""]
+
+    for family in families:
+        laws = [law for law in catalogue.laws if law.get("family") == family]
+        blurb = FAMILY_BLURB.get(family)
+        lines += ["## %s" % family.capitalize(), ""]
+        if blurb:
+            lines += [blurb, ""]
+        for law in laws:
+            applicability = law.get("applicability") or {}
+            lines += ["### `%s`" % law.id, "", "> %s" % law.get("statement"), ""]
+            lines += ["| | |", "| --- | --- |"]
+            lines += ["| Component | `%s` |" % law.get("component")]
+            lines += ["| Specimen | `%s` |" % law.get("specimen")]
+            lines += ["| Counterexample | `%s` |" % law.get("counterexample")]
+            lines += ["| Bounds | %s |" % bounds_text(law.get("bounds"))]
+            lines += [
+                "| Reads | %s |"
+                % ", ".join("`%s`" % name for name in applicability.get("requires", []))
+            ]
+            lines += [
+                "",
+                "Applies to %s. Assuming:" % applicability.get("accounting_model"),
+                "",
+            ]
+            lines += ["- %s" % assumption for assumption in applicability.get("assumes", [])]
+            lines += [""]
+
+    # A family the catalogue declares and files nothing under never appears,
+    # because the headings come from the laws rather than from the declarations.
+    # A heading with nothing beneath it reads as a section somebody deleted.
+    return "\n".join(lines).rstrip("\n") + "\n"

--- a/plugins/pandects/scripts/pandects_lib/run.py
+++ b/plugins/pandects/scripts/pandects_lib/run.py
@@ -1,0 +1,294 @@
+"""A campaign, and the record of how it was searched.
+
+A result without its settings is an anecdote. The corpus already refuses a
+tolerance that does not name its arithmetic; a campaign that does not name its
+engine, its configuration, its seed and the corpus it searched is the same
+refusal at a different scale, and this is where it is written down.
+
+The record is shaped as an `ariadne` command entry, so a campaign drops into a
+release statement without translation. Shaped as, not built by: the two plugins
+share no code, and `tests/test_search_record.py` pins the shape so a change on
+either side is a failing test rather than a document nobody can verify.
+
+An engine that did not run is absent. Not present with a null result, not
+present with zero findings -- absent, because a reader counting entries is
+counting engines that ran, and an empty result reads like a search that found
+nothing.
+"""
+
+import hashlib
+import json
+import os
+import subprocess
+
+#: The two classes ariadne's determinism gate allows.
+EXACT = "exact"
+NONDETERMINISTIC = "nondeterministic"
+
+#: Every field an ariadne command entry may carry, and nothing else.
+COMMAND_FIELDS = frozenset({"name", "argv", "determinism", "output_digest", "detail"})
+
+
+class RunError(Exception):
+    """A campaign that cannot be run, or a record that cannot be built."""
+
+
+def strip_comments(source):
+    """Source with comments removed and string literals left alone.
+
+    The corpus digest has to change when a law changes and hold still when
+    somebody rewrites a docstring, so comments come out. String literals stay
+    in, because a law's `statement()` and every `detail` it returns are string
+    literals, and those are the law.
+
+    Written as a scan rather than a regex because the two cases interleave: a
+    `//` inside a string is not a comment, and a quote inside a comment is not a
+    string. A regex that took either side first gets the other one wrong.
+    """
+    out = []
+    i, n = 0, len(source)
+    while i < n:
+        ch = source[i]
+        if ch in '"\'':
+            quote = ch
+            out.append(ch)
+            i += 1
+            while i < n:
+                out.append(source[i])
+                if source[i] == "\\":
+                    if i + 1 < n:
+                        out.append(source[i + 1])
+                        i += 2
+                        continue
+                elif source[i] == quote:
+                    i += 1
+                    break
+                i += 1
+            continue
+        if source.startswith("//", i):
+            while i < n and source[i] != "\n":
+                i += 1
+            continue
+        if source.startswith("/*", i):
+            end = source.find("*/", i + 2)
+            i = n if end == -1 else end + 2
+            continue
+        out.append(ch)
+        i += 1
+    lines = [line.rstrip() for line in "".join(out).split("\n")]
+    return "\n".join(line for line in lines if line)
+
+
+def digest_of(data):
+    return {"sha256": hashlib.sha256(data).hexdigest()}
+
+
+def corpus_digest(root, catalogue):
+    """One digest over the catalogue, its law components and its specimens.
+
+    Built from what the catalogue claims rather than from what is on disk, so a
+    file nobody has filed cannot change the digest and a filed file that has
+    gone missing raises rather than being skipped. `check` is what refuses an
+    unfiled component; this only has to be honest about what it hashed.
+    """
+    parts = [json.dumps(catalogue.raw, sort_keys=True, separators=(",", ":")).encode("utf-8")]
+    seen = set()
+    for law in catalogue.laws:
+        for field in ("component", "specimen"):
+            relative = law.get(field)
+            if not isinstance(relative, str) or relative in seen:
+                continue
+            seen.add(relative)
+            path = os.path.join(root, relative)
+            try:
+                with open(path, "rb") as handle:
+                    source = handle.read().decode("utf-8")
+            except (OSError, UnicodeDecodeError) as error:
+                raise RunError("cannot digest %s: %s" % (relative, error))
+            parts.append(relative.encode("utf-8"))
+            parts.append(strip_comments(source).encode("utf-8"))
+    return digest_of(b"\x00".join(parts))
+
+
+def command(name, argv, determinism, detail, output_digest=None):
+    """One ariadne command entry, refused if it is not one.
+
+    The checks here are the ones ariadne's determinism gate makes, made at the
+    point of writing rather than at the point of verifying. A record that fails
+    its own shape should never reach a statement.
+    """
+    if not isinstance(argv, list) or not argv or not all(isinstance(w, str) for w in argv):
+        raise RunError("%s: argv must be a non-empty list of strings" % name)
+    if determinism not in (EXACT, NONDETERMINISTIC):
+        raise RunError(
+            "%s: determinism must be %r or %r, not %r"
+            % (name, EXACT, NONDETERMINISTIC, determinism)
+        )
+    entry = {
+        "name": name,
+        "argv": list(argv),
+        "determinism": determinism,
+        "detail": detail,
+    }
+    if determinism == EXACT:
+        if not output_digest:
+            raise RunError(
+                "%s: an exact command needs an output digest; there would be "
+                "nothing to compare a replay against" % name
+            )
+        entry["output_digest"] = output_digest
+    elif output_digest is not None:
+        entry["output_digest"] = output_digest
+    unknown = sorted(set(entry) - COMMAND_FIELDS)
+    if unknown:
+        raise RunError("%s: unknown fields %s" % (name, ", ".join(unknown)))
+    return entry
+
+
+#: The section headings Foundry accepts for invariant settings. Both are in use
+#: in the wild, and a reader that knew only one would report an empty
+#: configuration for half the projects it met.
+INVARIANT_SECTIONS = ("invariant", "profile.default.invariant")
+
+
+def foundry_settings(root):
+    """The invariant settings the campaign actually ran under.
+
+    Read from `foundry.toml` rather than restated here, so a record cannot
+    describe a configuration nobody used.
+
+    An empty result is refused rather than returned. A record carrying
+    `"configuration": {}` says the campaign ran under no settings, when what
+    happened is that nobody could read them -- and the whole point of the record
+    is that a search which cannot be described is not reported as one.
+    """
+    path = os.path.join(root, "foundry.toml")
+    settings = {}
+    section = None
+    try:
+        with open(path) as handle:
+            for line in handle:
+                line = line.split("#", 1)[0].strip()
+                if line.startswith("[") and line.endswith("]"):
+                    section = line[1:-1].strip()
+                    continue
+                if section not in INVARIANT_SECTIONS or "=" not in line:
+                    continue
+                key, value = (part.strip() for part in line.split("=", 1))
+                settings[key] = value
+    except OSError as error:
+        raise RunError("cannot read foundry.toml: %s" % error)
+    if not settings:
+        raise RunError(
+            "foundry.toml declares no invariant settings under %s; a record "
+            "with an empty configuration would claim the campaign ran under "
+            "none" % " or ".join("[%s]" % s for s in INVARIANT_SECTIONS)
+        )
+    return settings
+
+
+def run_foundry(root, match=None, timeout=1800):
+    """Run the Foundry campaign and return what happened.
+
+    Returns None only when the engine is not there to run: no `forge` on the
+    path, or the operating system refusing to start it. That is what makes an
+    engine absent from a record rather than present and empty.
+
+    A timeout is not that. The engine ran, searched for as long as it was
+    given, and was killed; reporting it as absent would hide a campaign that
+    happened, and reporting it as passed would be worse. It comes back with an
+    outcome of its own.
+    """
+    argv = ["forge", "test"]
+    if match:
+        argv += ["--match-contract", match]
+    try:
+        finished = subprocess.run(
+            argv, cwd=root, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as expired:
+        return {
+            "argv": argv,
+            "returncode": None,
+            "timed_out_after": timeout,
+            "output": (expired.output or b"").decode("utf-8", "replace"),
+        }
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return {
+        "argv": argv,
+        "returncode": finished.returncode,
+        "output": finished.stdout.decode("utf-8", "replace"),
+    }
+
+
+def engine_version(argv, timeout=60):
+    try:
+        finished = subprocess.run(
+            argv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if finished.returncode != 0:
+        return None
+    return finished.stdout.decode("utf-8", "replace").strip().split("\n")[0]
+
+
+def outcome_of(result):
+    """What happened, in three words rather than two.
+
+    A campaign that was killed part way through neither passed nor failed. It
+    searched less than it was asked to, and a reader deciding whether to trust
+    the result needs that in the record rather than folded into either verdict.
+    """
+    if result.get("returncode") is None:
+        return "timed out"
+    return "passed" if result["returncode"] == 0 else "failed"
+
+
+def foundry_record(root, catalogue, result, seed=None):
+    """The command entry for a Foundry campaign that ran."""
+    settings = foundry_settings(root)
+    detail = {
+        "engine": "foundry",
+        "configuration": settings,
+        "sequence_length": settings.get("depth"),
+        "corpus_digest": corpus_digest(root, catalogue),
+        "laws_searched": len(catalogue.laws),
+        "outcome": outcome_of(result),
+    }
+    if result.get("timed_out_after") is not None:
+        detail["timed_out_after_seconds"] = result["timed_out_after"]
+    # Two fields, one rule: what nobody could read is absent, never null. A
+    # `"seed": null` says the run had no seed when what is true is that Foundry
+    # does not report the one it used, and an `"engine_version": null` says the
+    # same thing about a binary that would not answer. Absent asks a reader to
+    # go and find out; null tells them there is nothing to find.
+    version = engine_version(["forge", "--version"])
+    if version is not None:
+        detail["engine_version"] = version
+    if seed is not None:
+        detail["seed"] = seed
+    return command(
+        "fuzz campaign: foundry invariant",
+        result["argv"],
+        NONDETERMINISTIC,
+        detail,
+    )
+
+
+def search_record(root, catalogue, match=None, seed=None):
+    """Every engine that ran, and no entry for any that did not."""
+    commands = []
+    result = run_foundry(root, match=match)
+    if result is not None:
+        commands.append(foundry_record(root, catalogue, result, seed=seed))
+    return {
+        "corpus": {
+            "version": catalogue.version,
+            "laws": len(catalogue.laws),
+            "digest": corpus_digest(root, catalogue),
+        },
+        "commands": commands,
+    }

--- a/plugins/pandects/scripts/pandects_lib/safejson.py
+++ b/plugins/pandects/scripts/pandects_lib/safejson.py
@@ -1,0 +1,89 @@
+"""JSON parsing with the bounds a document read from disk should have.
+
+Deliberately duplicated rather than imported from a sibling plugin. Each plugin
+in this repository is distributed on its own, so a dependency between two of
+them is a dependency a user cannot satisfy by installing the one they wanted.
+Thirty lines is the price of that.
+
+Three things the standard parser does that a checker should not accept. It
+reads a file of any size. It recurses until the stack gives out, which surfaces
+as a crash rather than a refusal. And it keeps the last value for a repeated
+key, so a catalogue carrying two `laws` entries parses as one and two readers
+disagree about what it says.
+"""
+
+import json
+
+DEFAULT_MAX_BYTES = 4 * 1024 * 1024
+DEFAULT_MAX_DEPTH = 32
+
+OPENING = {0x7B, 0x5B}  # { [
+CLOSING = {0x7D, 0x5D}  # } ]
+QUOTE = 0x22
+BACKSLASH = 0x5C
+
+
+class InputError(ValueError):
+    """A document refused before it was parsed."""
+
+
+def check_depth(data, max_depth):
+    depth = 0
+    in_string = False
+    escaped = False
+    for byte in bytearray(data):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif byte == BACKSLASH:
+                escaped = True
+            elif byte == QUOTE:
+                in_string = False
+            continue
+        if byte == QUOTE:
+            in_string = True
+        elif byte in OPENING:
+            depth += 1
+            if depth > max_depth:
+                raise InputError(
+                    "nested deeper than %d levels; refused before parsing" % max_depth
+                )
+        elif byte in CLOSING:
+            depth -= 1
+
+
+def no_duplicate_keys(pairs):
+    seen = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise InputError(
+                "duplicate key %r; two readers of this document would disagree "
+                "about what it says" % key
+            )
+        seen.add(key)
+    return dict(pairs)
+
+
+def loads(data, max_bytes=DEFAULT_MAX_BYTES, max_depth=DEFAULT_MAX_DEPTH):
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+    if not isinstance(data, bytes):
+        raise InputError("expected bytes")
+    if len(data) > max_bytes:
+        raise InputError("%d bytes, over the %d byte cap" % (len(data), max_bytes))
+    check_depth(data, max_depth)
+    try:
+        return json.loads(data.decode("utf-8"), object_pairs_hook=no_duplicate_keys)
+    except UnicodeDecodeError as error:
+        raise InputError("not UTF-8: %s" % error)
+    except json.JSONDecodeError as error:
+        raise InputError("not valid JSON: %s" % error)
+
+
+def load_file(path, max_bytes=DEFAULT_MAX_BYTES, max_depth=DEFAULT_MAX_DEPTH):
+    import os
+
+    if not os.path.isfile(path):
+        raise InputError("%s is not a regular file" % path)
+    with open(path, "rb") as handle:
+        return loads(handle.read(max_bytes + 1), max_bytes, max_depth)

--- a/plugins/pandects/search-record.json
+++ b/plugins/pandects/search-record.json
@@ -1,0 +1,35 @@
+{
+  "corpus": {
+    "version": "0.1.0",
+    "laws": 9,
+    "digest": {
+      "sha256": "197a01e6dbf1feea13b2845e332ddc9d89b78bb0bb20936c9203f245b0b60efd"
+    }
+  },
+  "commands": [
+    {
+      "name": "fuzz campaign: foundry invariant",
+      "argv": [
+        "forge",
+        "test"
+      ],
+      "determinism": "nondeterministic",
+      "detail": {
+        "engine": "foundry",
+        "configuration": {
+          "runs": "64",
+          "depth": "64",
+          "fail_on_revert": "false",
+          "call_override": "false"
+        },
+        "sequence_length": "64",
+        "corpus_digest": {
+          "sha256": "197a01e6dbf1feea13b2845e332ddc9d89b78bb0bb20936c9203f245b0b60efd"
+        },
+        "laws_searched": 9,
+        "outcome": "passed",
+        "engine_version": "forge Version: 1.7.1"
+      }
+    }
+  ]
+}

--- a/plugins/pandects/skills/pandects/README.md
+++ b/plugins/pandects/skills/pandects/README.md
@@ -1,0 +1,233 @@
+---
+name: pandects
+description: >
+  Check a credit protocol against executable laws: conservation, accrual and
+  withdrawal claims, each one a Solidity component with a broken specimen it is
+  proven to catch. Use when someone asks which invariants a lending or credit
+  system should hold, wants properties for a fuzzing campaign, or hands over a
+  protocol and asks what could be checked mechanically. Do not use it to
+  generate a harness for one repository; that is fizz. Never report a campaign
+  under an engine that did not run.
+metadata:
+  version: "0.1.0"
+---
+
+# Pandects
+
+A fuzzer searches a state space. It cannot decide which economic facts must
+survive that search. Generic token property libraries cover balances, approvals
+and round trips; credit adds time, accrual, queues, changing terms,
+delinquency, partial repayment and claims that are neither liquid nor reducible
+to a token balance. Every audit rediscovers those facts in prose, implements a
+subset in a local harness, and the harness dies with the engagement.
+
+This is the corpus that survives it.
+
+`$SKILL_DIR` is the directory holding this file. The tool lives at
+`$SKILL_DIR/../../scripts/pandects.py`; resolve it from where you loaded this
+skill.
+
+## Day to day
+
+**Security and audit.** A credit protocol arrives and the invariants have to be
+worked out before anything can be fuzzed. The corpus states them, says which
+accounting model each one assumes, and ships the broken contract each is proven
+to catch, so a law that holds against your target is a law you can see working.
+
+**Developers.** A change touches accrual or the withdrawal queue and the
+question is what it might have broken. Point the corpus at the build and read
+which laws stopped holding, with the quantities that were compared.
+
+## What a law is
+
+Six parts. Anything with fewer is not a law, and the checker refuses it:
+
+1. **It executes.** A Solidity component, not a sentence.
+2. **It catches something.** A deliberately broken contract it is proven to
+   fail against. A law that has never failed may be a tautology; a property
+   asserting `seen() >= 0` survives a campaign of five hundred calls without
+   complaint, and nothing in that run distinguishes it from a real law.
+3. **It has been reduced.** A minimal counterexample, replayable without a
+   fuzzer.
+4. **It says where it applies.** The accounting model, the assumptions and the
+   observables it requires.
+5. **Its bounds are justified.** Exact, or a tolerance naming the arithmetic
+   that produces it. An epsilon chosen because it made a test pass is refused.
+6. **It judges rather than reverts.** A law returns `(bool held, string
+   detail)`.
+
+That last one is the decision worth knowing about. A campaign runs with
+`fail_on_revert = false`, because a credit system reverts constantly and
+correctly. Under that setting a revert carries no verdict, so a law using
+`require` to mean "violated" reports nothing and is counted as silence. Silence
+read as assent is what this exists to prevent.
+
+## Two shapes
+
+Conservation is a fact about one state, so a `Law` reads one target. Accrual is
+not: debt falling without payment cannot be violated by any single state,
+because the violation is in the transition. A `PairLaw` judges two
+`Observation`s instead, each a snapshot of everything a target reports.
+
+Three pair laws compare a system with its own past. One compares two systems
+started identically and advanced over the same span by different routes, which
+is the only way to see interest compounding when it should not. A law says
+which kind of pair it means in its applicability, and handed one it cannot
+judge it either holds or refuses on a single rule: a pair that spans real time
+is a state of the world, and a pair nobody could have meant is a mistake by
+whoever built it.
+
+## The commands
+
+```bash
+python3 scripts/pandects.py laws
+python3 scripts/pandects.py check
+python3 scripts/pandects.py run --out search-record.json
+python3 scripts/pandects.py render
+```
+
+`laws` lists the catalogue with each law's applicability. `check` refuses a law
+missing any of its six parts, naming the part rather than the file. `run`
+searches and writes down how it searched. `render` writes `docs/catalogue.md`
+out of the catalogue, which is the only thing that should ever write it.
+
+Exit codes: 0 success, 1 a check failed, 2 usage or validation error.
+
+```bash
+forge test
+```
+
+runs every law against every specimen and asserts the diagonal: each law fails
+the specimen written for it and holds against the others. The corpus takes no
+external Solidity dependency: there is no `lib/`, no submodule and nothing to
+fetch.
+
+The catalogue holds nine laws in three families. Conservation: value is
+conserved across held assets, debt, claims and fees; assets reserved never
+exceed the claims recorded; and reserved plus borrowable never exceed what is
+held. Accrual: debt falls only against assets arriving, rises at rest only
+against assets leaving, and the same span costs the same however it is cut up.
+Withdrawal claims: a recorded claim is never written down smaller, nobody is
+paid ahead of somebody who has waited longer, and what a system declares
+payable it has set aside.
+
+Eight are exact. The ninth carries the corpus's only tolerance, and the bound
+is derived rather than chosen: linear accrual on principal truncates once per
+step, so `n` small steps differ from one long step by at most `n - 1` units.
+
+To point another engine at it, `src/campaigns/Specimens.sol` carries a harness
+per specimen declaring both `echidna_` and `property_` prefixes, since Echidna
+looks for the first and Medusa defaults to the second. Every entry point
+snapshots the system on the way in, which is what lets a pair law read a past.
+`explain()` returns each law's reason for the current state, so a failing
+sequence gives up its reason rather than making somebody derive it from a call
+trace.
+
+One harness passes everything and the contract underneath it is broken.
+`CompoundsPerStepCampaign` cannot see its own defect, because path independence
+compares two systems advanced by different routes and a campaign drives one
+along one route. It is the plainest illustration here of what a clean campaign
+is worth on its own.
+
+## Pointing it at a protocol
+
+`adapters/` is where the corpus meets somebody else's system. Two shapes, and
+the difference is a limit rather than a convenience.
+
+`CorpusObserver` holds any address and offers the five one-state laws. Nothing
+routes calls through it, so it offers no pair law: one that never sees a call
+has no past to compare with, and would report holding forever.
+
+`CorpusDriver` takes the calls. Extend it, write the protocol's entry points,
+put `records` on every one that changes state, and the three succession laws
+run as well. Nothing catches a forgotten `records` -- it looks like three laws
+holding quietly -- so `recordedCalls` is public and `successionExercised` reads
+it. Zero recorded calls means those laws searched nothing, whatever they
+reported.
+
+Path independence is in neither, because it compares two systems and an adapter
+fronts one. `PathIndependenceProbe` takes both.
+
+## Saying how it was searched
+
+A campaign result without its settings is an anecdote, which is the same
+refusal the corpus already makes of a tolerance that does not name its
+arithmetic. `run` writes a record naming the engine, the argv, the determinism
+class, the configuration read out of `foundry.toml` rather than restated, the
+sequence length and a digest of the corpus searched. It is shaped as an
+`ariadne` command entry, so a result drops into a release statement without
+translation.
+
+An engine that did not run is absent from the record, not present and empty.
+What nobody could read is absent rather than null. And a campaign killed by the
+timeout is neither passed nor failed: it ran, searched less than it was asked
+to, and says so.
+
+## What a law may read
+
+`ICreditObservables`. It names economic roles: the asset, total assets held,
+total debt, total lender claims, reserved and borrowable assets, accrued fees,
+and the time the observation describes. A target implements it, or a thin
+adapter does, and that adapter is the only place a protocol's own names appear.
+
+A system with a withdrawal queue also implements
+`IWithdrawalQueueObservables`: the claim count, each claim's owed and paid
+amounts, and the bound through which the system declares claims payable. Kept
+separate because a system with no queue would implement three members and mean
+none of them, and an observable that means nothing reports zero, which reads
+like an answer. A target that lacks it reverts on the read, and a revert is no
+verdict rather than a false one.
+
+This is enforced rather than requested. A property written against one
+protocol's function names is a property about one codebase, and the corpus
+exists because the same economic facts hold across codebases that share nothing
+else.
+
+## Pointed at a real design
+
+`integrations/wildcat/` is the corpus against a codebase it was not written
+for: a reduced model of a Wildcat market with batched withdrawals, a reserve
+the borrower may not touch, delinquency and penalty accrual.
+
+Six laws apply flatly. Three do not, and the three are what the integration is
+for.
+
+`queue-order-preserved` applies at batch granularity and says nothing per
+lender, because a batch is paid pro rata. `path-independent` holds while the
+market is solvent and stops once penalty accrual runs, because the grace timer
+advances when the market is poked. And `recorded-claim-never-shrinks` does not
+hold over a batch that is still open: a batch accumulates while open, so the
+amount owed on it rises, and the law says a recorded claim keeps its amount.
+
+That third one was found by Echidna against the shipped adapter, after the
+applicability notes had already claimed the law held. Reading found two
+conditions; running the corpus against a real design found the third, in a
+document that had already got it wrong.
+
+None of the three is a yes or a no.
+`integrations/wildcat/APPLICABILITY.md` carries all of them with their reasons.
+
+## The documents
+
+`docs/catalogue.md` renders every law for a reader, and it is a rendering
+rather than a second source: `pandects render` writes it, and a test compares
+the committed bytes with what the renderer produces. `docs/writing-a-law.md`
+has the six parts in the order somebody adding a law meets them.
+`docs/applicability.md` states the rules once -- what a law may read, the two
+shapes, what a pair law does with a pair it cannot judge, and what a revert
+means.
+
+## What this never does
+
+- Replace an engine. Echidna, Medusa and Foundry search; the corpus says what
+  to look for.
+- Generate a harness for one repository. That is `fizz`, which can select and
+  adapt these laws and stays useful where no public law describes the protocol.
+- Report a campaign under an engine that did not run. A result carries its
+  engine, configuration, seed, sequence length and corpus digest, or it is an
+  anecdote.
+- Present Wildcat-shaped law as universal law. Every law states the accounting
+  model it assumes, and a law with no applicability contract is not in the
+  corpus.
+- Decide whether a law is true. The checker decides whether something is a law
+  at all, which is a lower bar and the one worth enforcing mechanically.

--- a/plugins/pandects/skills/pandects/SKILL.md
+++ b/plugins/pandects/skills/pandects/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: pandects
+description: >
+  Check a credit protocol against executable laws: conservation, accrual and
+  withdrawal claims, each one a Solidity component with a broken specimen it is
+  proven to catch. Use when someone asks which invariants a lending or credit
+  system should hold, wants properties for a fuzzing campaign, or hands over a
+  protocol and asks what could be checked mechanically. Do not use it to
+  generate a harness for one repository; that is fizz. Never report a campaign
+  under an engine that did not run.
+metadata:
+  version: "0.1.0"
+---
+
+# Pandects
+
+A fuzzer searches a state space. It cannot decide which economic facts must
+survive that search. Generic token property libraries cover balances, approvals
+and round trips; credit adds time, accrual, queues, changing terms,
+delinquency, partial repayment and claims that are neither liquid nor reducible
+to a token balance. Every audit rediscovers those facts in prose, implements a
+subset in a local harness, and the harness dies with the engagement.
+
+This is the corpus that survives it.
+
+`$SKILL_DIR` is the directory holding this file. The tool lives at
+`$SKILL_DIR/../../scripts/pandects.py`; resolve it from where you loaded this
+skill.
+
+## Day to day
+
+**Security and audit.** A credit protocol arrives and the invariants have to be
+worked out before anything can be fuzzed. The corpus states them, says which
+accounting model each one assumes, and ships the broken contract each is proven
+to catch, so a law that holds against your target is a law you can see working.
+
+**Developers.** A change touches accrual or the withdrawal queue and the
+question is what it might have broken. Point the corpus at the build and read
+which laws stopped holding, with the quantities that were compared.
+
+## What a law is
+
+Six parts. Anything with fewer is not a law, and the checker refuses it:
+
+1. **It executes.** A Solidity component, not a sentence.
+2. **It catches something.** A deliberately broken contract it is proven to
+   fail against. A law that has never failed may be a tautology; a property
+   asserting `seen() >= 0` survives a campaign of five hundred calls without
+   complaint, and nothing in that run distinguishes it from a real law.
+3. **It has been reduced.** A minimal counterexample, replayable without a
+   fuzzer.
+4. **It says where it applies.** The accounting model, the assumptions and the
+   observables it requires.
+5. **Its bounds are justified.** Exact, or a tolerance naming the arithmetic
+   that produces it. An epsilon chosen because it made a test pass is refused.
+6. **It judges rather than reverts.** A law returns `(bool held, string
+   detail)`.
+
+That last one is the decision worth knowing about. A campaign runs with
+`fail_on_revert = false`, because a credit system reverts constantly and
+correctly. Under that setting a revert carries no verdict, so a law using
+`require` to mean "violated" reports nothing and is counted as silence. Silence
+read as assent is what this exists to prevent.
+
+## Two shapes
+
+Conservation is a fact about one state, so a `Law` reads one target. Accrual is
+not: debt falling without payment cannot be violated by any single state,
+because the violation is in the transition. A `PairLaw` judges two
+`Observation`s instead, each a snapshot of everything a target reports.
+
+Three pair laws compare a system with its own past. One compares two systems
+started identically and advanced over the same span by different routes, which
+is the only way to see interest compounding when it should not. A law says
+which kind of pair it means in its applicability, and handed one it cannot
+judge it either holds or refuses on a single rule: a pair that spans real time
+is a state of the world, and a pair nobody could have meant is a mistake by
+whoever built it.
+
+## The commands
+
+```bash
+python3 scripts/pandects.py laws
+python3 scripts/pandects.py check
+python3 scripts/pandects.py run --out search-record.json
+python3 scripts/pandects.py render
+```
+
+`laws` lists the catalogue with each law's applicability. `check` refuses a law
+missing any of its six parts, naming the part rather than the file. `run`
+searches and writes down how it searched. `render` writes `docs/catalogue.md`
+out of the catalogue, which is the only thing that should ever write it.
+
+Exit codes: 0 success, 1 a check failed, 2 usage or validation error.
+
+```bash
+forge test
+```
+
+runs every law against every specimen and asserts the diagonal: each law fails
+the specimen written for it and holds against the others. The corpus takes no
+external Solidity dependency: there is no `lib/`, no submodule and nothing to
+fetch.
+
+The catalogue holds nine laws in three families. Conservation: value is
+conserved across held assets, debt, claims and fees; assets reserved never
+exceed the claims recorded; and reserved plus borrowable never exceed what is
+held. Accrual: debt falls only against assets arriving, rises at rest only
+against assets leaving, and the same span costs the same however it is cut up.
+Withdrawal claims: a recorded claim is never written down smaller, nobody is
+paid ahead of somebody who has waited longer, and what a system declares
+payable it has set aside.
+
+Eight are exact. The ninth carries the corpus's only tolerance, and the bound
+is derived rather than chosen: linear accrual on principal truncates once per
+step, so `n` small steps differ from one long step by at most `n - 1` units.
+
+To point another engine at it, `src/campaigns/Specimens.sol` carries a harness
+per specimen declaring both `echidna_` and `property_` prefixes, since Echidna
+looks for the first and Medusa defaults to the second. Every entry point
+snapshots the system on the way in, which is what lets a pair law read a past.
+`explain()` returns each law's reason for the current state, so a failing
+sequence gives up its reason rather than making somebody derive it from a call
+trace.
+
+One harness passes everything and the contract underneath it is broken.
+`CompoundsPerStepCampaign` cannot see its own defect, because path independence
+compares two systems advanced by different routes and a campaign drives one
+along one route. It is the plainest illustration here of what a clean campaign
+is worth on its own.
+
+## Pointing it at a protocol
+
+`adapters/` is where the corpus meets somebody else's system. Two shapes, and
+the difference is a limit rather than a convenience.
+
+`CorpusObserver` holds any address and offers the five one-state laws. Nothing
+routes calls through it, so it offers no pair law: one that never sees a call
+has no past to compare with, and would report holding forever.
+
+`CorpusDriver` takes the calls. Extend it, write the protocol's entry points,
+put `records` on every one that changes state, and the three succession laws
+run as well. Nothing catches a forgotten `records` -- it looks like three laws
+holding quietly -- so `recordedCalls` is public and `successionExercised` reads
+it. Zero recorded calls means those laws searched nothing, whatever they
+reported.
+
+Path independence is in neither, because it compares two systems and an adapter
+fronts one. `PathIndependenceProbe` takes both.
+
+## Saying how it was searched
+
+A campaign result without its settings is an anecdote, which is the same
+refusal the corpus already makes of a tolerance that does not name its
+arithmetic. `run` writes a record naming the engine, the argv, the determinism
+class, the configuration read out of `foundry.toml` rather than restated, the
+sequence length and a digest of the corpus searched. It is shaped as an
+`ariadne` command entry, so a result drops into a release statement without
+translation.
+
+An engine that did not run is absent from the record, not present and empty.
+What nobody could read is absent rather than null. And a campaign killed by the
+timeout is neither passed nor failed: it ran, searched less than it was asked
+to, and says so.
+
+## What a law may read
+
+`ICreditObservables`. It names economic roles: the asset, total assets held,
+total debt, total lender claims, reserved and borrowable assets, accrued fees,
+and the time the observation describes. A target implements it, or a thin
+adapter does, and that adapter is the only place a protocol's own names appear.
+
+A system with a withdrawal queue also implements
+`IWithdrawalQueueObservables`: the claim count, each claim's owed and paid
+amounts, and the bound through which the system declares claims payable. Kept
+separate because a system with no queue would implement three members and mean
+none of them, and an observable that means nothing reports zero, which reads
+like an answer. A target that lacks it reverts on the read, and a revert is no
+verdict rather than a false one.
+
+This is enforced rather than requested. A property written against one
+protocol's function names is a property about one codebase, and the corpus
+exists because the same economic facts hold across codebases that share nothing
+else.
+
+## Pointed at a real design
+
+`integrations/wildcat/` is the corpus against a codebase it was not written
+for: a reduced model of a Wildcat market with batched withdrawals, a reserve
+the borrower may not touch, delinquency and penalty accrual.
+
+Six laws apply flatly. Three do not, and the three are what the integration is
+for.
+
+`queue-order-preserved` applies at batch granularity and says nothing per
+lender, because a batch is paid pro rata. `path-independent` holds while the
+market is solvent and stops once penalty accrual runs, because the grace timer
+advances when the market is poked. And `recorded-claim-never-shrinks` does not
+hold over a batch that is still open: a batch accumulates while open, so the
+amount owed on it rises, and the law says a recorded claim keeps its amount.
+
+That third one was found by Echidna against the shipped adapter, after the
+applicability notes had already claimed the law held. Reading found two
+conditions; running the corpus against a real design found the third, in a
+document that had already got it wrong.
+
+None of the three is a yes or a no.
+`integrations/wildcat/APPLICABILITY.md` carries all of them with their reasons.
+
+## The documents
+
+`docs/catalogue.md` renders every law for a reader, and it is a rendering
+rather than a second source: `pandects render` writes it, and a test compares
+the committed bytes with what the renderer produces. `docs/writing-a-law.md`
+has the six parts in the order somebody adding a law meets them.
+`docs/applicability.md` states the rules once -- what a law may read, the two
+shapes, what a pair law does with a pair it cannot judge, and what a revert
+means.
+
+## What this never does
+
+- Replace an engine. Echidna, Medusa and Foundry search; the corpus says what
+  to look for.
+- Generate a harness for one repository. That is `fizz`, which can select and
+  adapt these laws and stays useful where no public law describes the protocol.
+- Report a campaign under an engine that did not run. A result carries its
+  engine, configuration, seed, sequence length and corpus digest, or it is an
+  anecdote.
+- Present Wildcat-shaped law as universal law. Every law states the accounting
+  model it assumes, and a law with no applicability contract is not in the
+  corpus.
+- Decide whether a law is true. The checker decides whether something is a law
+  at all, which is a lower bar and the one worth enforcing mechanically.

--- a/plugins/pandects/skills/pandects/agents/openai.yaml
+++ b/plugins/pandects/skills/pandects/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Pandects"
+  short_description: "Executable laws for credit contracts, each proven against a contract built to break it"
+  default_prompt: "Use $pandects to check this credit protocol against the executable laws in the corpus."

--- a/plugins/pandects/specimens/AccruesAtRest.sol
+++ b/plugins/pandects/specimens/AccruesAtRest.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Sound} from "./Sound.sol";
+
+/// @title A deliberately broken credit system. Do not deploy this.
+/// @notice Caught by `accrual/no-accrual-at-rest/v1`, and by nothing else.
+///
+/// The defect is interest charged on a call rather than on a duration. The
+/// clock does not move and the borrower owes more anyway, which is the shape of
+/// every accrual that runs from a state update instead of from elapsed time:
+/// two transactions in one block, an accrual triggered by a read, a rate
+/// applied once per interaction.
+///
+/// Conservation holds throughout, because the interest is credited to lenders
+/// exactly as it is charged to borrowers. The system takes from the borrower
+/// and gives to the lender, keeps nothing, and its books balance the whole way.
+contract AccruesAtRest is Sound {
+    function poke(uint256 amount) external {
+        uint256 value = bounded(amount) % 1e6;
+        interest += value;
+        claims += value;
+    }
+}

--- a/plugins/pandects/specimens/ClaimHaircut.sol
+++ b/plugins/pandects/specimens/ClaimHaircut.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Sound} from "./Sound.sol";
+
+/// @title A deliberately broken credit system. Do not deploy this.
+/// @notice Caught by `claims/recorded-claim-never-shrinks/v1`, and by nothing
+/// else.
+///
+/// The defect is that a recorded claim can be written down after the fact. The
+/// amount taken off the claim is moved into fees and the earmark is recomputed,
+/// so the books balance, reserves stay within claims, and the queue stays in
+/// order. Every single-state law in the corpus is satisfied.
+///
+/// The lender asked to leave, was told a number, and the number changed. That
+/// is visible only by comparing the queue with the queue as it was, which is
+/// the entire reason the claims family needs a law over a pair.
+contract ClaimHaircut is Sound {
+    function haircut(uint256 index, uint256 amount) external {
+        if (owedAt.length == 0) {
+            return;
+        }
+        uint256 i = index % owedAt.length;
+        uint256 unpaid = owedAt[i] - paidAt[i];
+        uint256 value = bounded(amount);
+        if (value > unpaid) {
+            value = unpaid;
+        }
+        if (value > claims) {
+            value = claims;
+        }
+        owedAt[i] -= value;
+        claims -= value;
+        fees += value;
+        reserved = earmark();
+    }
+}

--- a/plugins/pandects/specimens/CompoundsPerStep.sol
+++ b/plugins/pandects/specimens/CompoundsPerStep.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Sound} from "./Sound.sol";
+
+/// @title A deliberately broken credit system. Do not deploy this.
+/// @notice Caught by `accrual/path-independent/v1`, and by nothing else.
+///
+/// The defect is one line: interest is charged on principal plus the interest
+/// already accrued, so each step charges for the last one. Every rule about
+/// direction still holds -- debt rises only with time, falls only against
+/// payment -- and a single observation of this system is indistinguishable from
+/// a correct one.
+///
+/// What it costs a borrower depends on how often somebody pokes the contract.
+/// Two borrowers on identical terms owe different amounts because one of them
+/// happened to be in a busier market, and neither can read that off the terms
+/// they agreed to.
+contract CompoundsPerStep is Sound {
+    function accrualBase() internal view override returns (uint256) {
+        return principal + interest;
+    }
+}

--- a/plugins/pandects/specimens/DebtForgiven.sol
+++ b/plugins/pandects/specimens/DebtForgiven.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Sound} from "./Sound.sol";
+
+/// @title A deliberately broken credit system. Do not deploy this.
+/// @notice Caught by `accrual/debt-falls-only-against-payment/v1`, and by
+/// nothing else.
+///
+/// The defect is that debt can be written off. The write-off is charged against
+/// fees the protocol has already accrued, so nothing here breaks conservation:
+/// the left side falls by exactly what the right side falls by, and every
+/// single-state law in the corpus is satisfied at every moment.
+///
+/// That is what makes it worth a specimen. A system can lose a borrower's debt
+/// and balance its own books perfectly, and no observation of one state will
+/// ever say so. Only the transition shows it, and only against the assets that
+/// did not arrive.
+contract DebtForgiven is Sound {
+    function forgive(uint256 amount) external {
+        uint256 owed = principal + interest;
+        uint256 value = bounded(amount);
+        if (value > owed) {
+            value = owed;
+        }
+        if (value > fees) {
+            value = fees;
+        }
+        if (value > interest) {
+            principal -= value - interest;
+            interest = 0;
+        } else {
+            interest -= value;
+        }
+        fees -= value;
+    }
+}

--- a/plugins/pandects/specimens/MintedClaims.sol
+++ b/plugins/pandects/specimens/MintedClaims.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Sound} from "./Sound.sol";
+
+/// @title A deliberately broken credit system. Do not deploy this.
+/// @notice Caught by `conservation/value-conserved/v1`, and by nothing else.
+///
+/// The defect is one line: a deposit credits the lender twice while the system
+/// receives once. Value appears on the right-hand side that never arrived on
+/// the left, which is the shape of every accounting bug that pays the first
+/// lender out with the second lender's money.
+contract MintedClaims is Sound {
+    function deposit(uint256 amount) external override {
+        uint256 value = bounded(amount);
+        held += value;
+        claims += value * 2;
+    }
+}

--- a/plugins/pandects/specimens/OverPromised.sol
+++ b/plugins/pandects/specimens/OverPromised.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Sound} from "./Sound.sol";
+
+/// @title A deliberately broken credit system. Do not deploy this.
+/// @notice Caught by `conservation/held-assets-partitioned/v1`, and by nothing
+/// else.
+///
+/// The defect is that borrowable liquidity is recorded rather than derived, and
+/// reserving forgets to reduce it. The same asset is offered to the borrower
+/// and promised to a departing lender, and whichever of them arrives second
+/// finds it gone.
+contract OverPromised is Sound {
+    uint256 internal promised;
+
+    function borrowableAssets() external view override returns (uint256) {
+        return promised;
+    }
+
+    function deposit(uint256 amount) external override {
+        uint256 value = bounded(amount);
+        held += value;
+        claims += value;
+        promised += value;
+    }
+
+    function borrow(uint256 amount) external override {
+        uint256 value = bounded(amount);
+        if (value > promised) {
+            value = promised;
+        }
+        if (value > held) {
+            value = held;
+        }
+        held -= value;
+        promised -= value;
+        principal += value;
+    }
+}

--- a/plugins/pandects/specimens/OverReserved.sol
+++ b/plugins/pandects/specimens/OverReserved.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Sound} from "./Sound.sol";
+
+/// @title A deliberately broken credit system. Do not deploy this.
+/// @notice Caught by `conservation/reserves-backed-by-claims/v1`, and by
+/// nothing else.
+///
+/// The defect is one line: reserving checks the assets held and forgets to
+/// check what anybody actually claimed. The system starves the borrower of
+/// liquidity it is charging them for, against withdrawals nobody requested.
+contract OverReserved is Sound {
+    function reserve(uint256 amount) external override {
+        uint256 value = bounded(amount);
+        if (value > held) {
+            value = held;
+        }
+        reserved = value;
+    }
+}

--- a/plugins/pandects/specimens/PayableBeyondReserves.sol
+++ b/plugins/pandects/specimens/PayableBeyondReserves.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Sound} from "./Sound.sol";
+
+/// @title A deliberately broken credit system. Do not deploy this.
+/// @notice Caught by `claims/reserves-cover-payable/v1`, and by nothing else.
+///
+/// The defect is one line: the system declares every recorded claim payable,
+/// whatever it has actually set aside. It still pays in order, still pays only
+/// what it holds, and every other law in the corpus is satisfied at every
+/// moment -- because the defect is not in what it does, it is in what it says.
+///
+/// A lender reading the declaration stops looking for liquidity elsewhere. The
+/// system has moved the risk of not getting out onto them without telling them,
+/// and the only observable that carries the lie is the declaration itself.
+/// This is why `payableThrough` is declared rather than derived: a figure
+/// computed from the reserves could not be wrong, and could not be checked.
+contract PayableBeyondReserves is Sound {
+    function payableThrough() external view override returns (uint256) {
+        return owedAt.length;
+    }
+}

--- a/plugins/pandects/specimens/QueueJumped.sol
+++ b/plugins/pandects/specimens/QueueJumped.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Sound} from "./Sound.sol";
+
+/// @title A deliberately broken credit system. Do not deploy this.
+/// @notice Caught by `claims/queue-order-preserved/v1`, and by nothing else.
+///
+/// The defect is that payment goes to the newest claim the system can settle
+/// rather than the oldest. Nothing is created, nothing is destroyed, no claim
+/// is written down and the reserves still cover what is declared payable. The
+/// only thing wrong is who gets paid.
+///
+/// This is the shape of a queue that pays whoever is quickest to ask, or
+/// whoever the operator picks. Under full liquidity nobody notices, because
+/// everyone is paid; it matters exactly when there is not enough to go round,
+/// which is the state a system is in when the ordering was the thing being
+/// relied on.
+contract QueueJumped is Sound {
+    function payClaim(uint256 amount) external override {
+        uint256 through = payableCount();
+        for (uint256 i = through; i > 0; i--) {
+            uint256 index = i - 1;
+            uint256 unpaid = owedAt[index] - paidAt[index];
+            if (unpaid == 0) {
+                continue;
+            }
+            settle(index, amount, unpaid);
+            return;
+        }
+    }
+}

--- a/plugins/pandects/specimens/Sound.sol
+++ b/plugins/pandects/specimens/Sound.sol
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ICreditObservables} from "../src/ICreditObservables.sol";
+import {IWithdrawalQueueObservables} from "../src/IWithdrawalQueueObservables.sol";
+
+/// @title A small credit system that holds every law in the corpus.
+/// @notice Not a specimen. This is the reference the broken ones inherit from,
+/// so that each of those differs by exactly one function and the defect is the
+/// diff rather than a paragraph claiming there is one.
+///
+/// The model is the smallest thing that can be got wrong in the ways credit is
+/// got wrong: deposits create claims, borrowing moves held assets into debt,
+/// time turns principal into interest, repayment moves assets back, a fee moves
+/// value from lenders to the protocol, and a withdrawal request records a claim
+/// and earmarks assets against it.
+///
+/// Every operation preserves conservation by construction:
+///
+/// - `deposit` adds to held assets and to claims, one on each side.
+/// - `borrow` and `repay` move between held assets and debt, both on the left.
+/// - `advance` adds interest to debt and to claims, one on each side.
+/// - `accrueFee` moves between claims and fees, both on the right.
+/// - `reserve` records a claim and marks held assets; it moves nothing.
+/// - `payClaim` hands assets to a departing lender and retires their claim.
+///
+/// Two things about time. The clock is the system's own rather than the
+/// block's, because `observedAt` exists so a law can be checked against a
+/// recorded state as well as a live one, and a reference that read
+/// `block.timestamp` could never be advanced deliberately. And interest accrues
+/// on principal alone, never on interest already accrued, which is what makes
+/// the same span cost the same however it is cut up. A reference that
+/// compounded would fail `accrual/path-independent/v1`, and the specimen that
+/// does compound differs from this file by one line.
+///
+/// Amounts are bounded so a fuzzer spends its calls on sequences rather than on
+/// overflow reverts, which carry no verdict.
+contract Sound is ICreditObservables, IWithdrawalQueueObservables {
+    uint256 internal constant CEILING = 1e30;
+
+    /// @dev Scaled by `RATE_SCALE` and applied per second, so a span costs the
+    /// same whether it is charged once or in pieces. What matters is that it is
+    /// a rate on a duration rather than a charge on a call. The figure is a
+    /// tenth per 365 days, chosen to be recognisable and small enough that the
+    /// specimen which compounds can run a fuzzer's worth of years without
+    /// reaching an overflow, since an overflow reverts and a revert carries no
+    /// verdict.
+    uint256 internal constant RATE = 3_170_979_198;
+    uint256 internal constant RATE_SCALE = 1e18;
+
+    /// @dev A single advance is capped so that a fuzzer cannot reach a span
+    /// where the accrual arithmetic overflows, which would revert and carry no
+    /// verdict.
+    uint256 internal constant MAX_STEP = 365 days;
+
+    /// @dev The queue is bounded because every observation of it is copied into
+    /// memory and, in the campaign harness, into storage. That is a harness
+    /// cost rather than an economic claim: no credit system has eight
+    /// withdrawals in it and no more.
+    uint256 internal constant MAX_CLAIMS = 8;
+
+    /// @dev A placeholder. These specimens model units of one asset rather
+    /// than a token, and reporting a zero address would be an observable
+    /// saying the quantities are denominated in nothing.
+    address public constant asset = address(uint160(uint256(keccak256("pandects.specimen.asset"))));
+
+    uint256 internal clock;
+    uint256 internal held;
+    uint256 internal principal;
+    uint256 internal interest;
+    uint256 internal claims;
+    uint256 internal fees;
+    uint256 internal reserved;
+
+    uint256[] internal owedAt;
+    uint256[] internal paidAt;
+
+    function bounded(uint256 amount) internal pure returns (uint256) {
+        return amount % CEILING;
+    }
+
+    // -- the core observables -----------------------------------------------
+
+    function totalAssets() external view returns (uint256) {
+        return held;
+    }
+
+    function totalDebt() external view returns (uint256) {
+        return principal + interest;
+    }
+
+    function totalLenderClaims() external view returns (uint256) {
+        return claims;
+    }
+
+    function accruedFees() external view returns (uint256) {
+        return fees;
+    }
+
+    function reservedAssets() external view returns (uint256) {
+        return reserved;
+    }
+
+    /// @notice What a borrower may take: held assets that are not spoken for.
+    /// @dev Virtual because a specimen breaks the partition by recording this
+    /// rather than deriving it, which is the defect worth having a specimen for.
+    function borrowableAssets() external view virtual returns (uint256) {
+        return held > reserved ? held - reserved : 0;
+    }
+
+    function observedAt() external view returns (uint256) {
+        return clock;
+    }
+
+    // -- the withdrawal queue -----------------------------------------------
+
+    function claimCount() external view returns (uint256) {
+        return owedAt.length;
+    }
+
+    function claimAt(uint256 index)
+        external
+        view
+        returns (uint256 owed, uint256 paid)
+    {
+        return (owedAt[index], paidAt[index]);
+    }
+
+    /// @notice How far down the queue this system says it can settle now.
+    /// @dev Derived here from what has actually been set aside, which is what
+    /// makes the reference hold `claims/reserves-cover-payable/v1`. It is
+    /// `virtual` because the specimen for that law declares payability without
+    /// looking at the reserves, and the whole point of the law is that the
+    /// declaration can be wrong.
+    function payableThrough() external view virtual returns (uint256) {
+        return payableCount();
+    }
+
+    /// @notice The honest answer, used by `payClaim` whatever the observable says.
+    function payableCount() internal view returns (uint256) {
+        uint256 covered = reserved;
+        uint256 through;
+        for (uint256 i = 0; i < owedAt.length; i++) {
+            uint256 unpaid = owedAt[i] - paidAt[i];
+            if (unpaid > covered) {
+                break;
+            }
+            covered -= unpaid;
+            through++;
+        }
+        return through;
+    }
+
+    function unpaidTotal() internal view returns (uint256) {
+        uint256 total;
+        for (uint256 i = 0; i < owedAt.length; i++) {
+            total += owedAt[i] - paidAt[i];
+        }
+        return total;
+    }
+
+    /// @notice What the system earmarks: everything queued, within what it has.
+    function earmark() internal view returns (uint256) {
+        uint256 outstanding = unpaidTotal();
+        uint256 ceiling = claims < held ? claims : held;
+        return outstanding < ceiling ? outstanding : ceiling;
+    }
+
+    // -- the operations -----------------------------------------------------
+
+    function deposit(uint256 amount) external virtual {
+        uint256 value = bounded(amount);
+        held += value;
+        claims += value;
+    }
+
+    function borrow(uint256 amount) external virtual {
+        uint256 available = held > reserved ? held - reserved : 0;
+        uint256 value = bounded(amount);
+        if (value > available) {
+            value = available;
+        }
+        held -= value;
+        principal += value;
+    }
+
+    function repay(uint256 amount) external virtual {
+        uint256 owed = principal + interest;
+        uint256 value = bounded(amount);
+        if (value > owed) {
+            value = owed;
+        }
+        // Interest first, then principal. Which order a system chooses is a
+        // policy question and no law in the corpus has an opinion on it; what
+        // matters here is that both reduce debt against assets arriving.
+        if (value > interest) {
+            principal -= value - interest;
+            interest = 0;
+        } else {
+            interest -= value;
+        }
+        held += value;
+    }
+
+    /// @notice What interest is charged on.
+    /// @dev Principal, and never interest already accrued. Virtual because the
+    /// specimen for path independence changes exactly this and nothing else.
+    function accrualBase() internal view virtual returns (uint256) {
+        return principal;
+    }
+
+    /// @notice Move the system's clock forward and charge for the time.
+    function advance(uint256 elapsed) external virtual {
+        uint256 step = elapsed % (MAX_STEP + 1);
+        uint256 accrued = (accrualBase() * RATE * step) / RATE_SCALE;
+        clock += step;
+        interest += accrued;
+        claims += accrued;
+    }
+
+    /// @notice Take a fee out of what lenders are owed.
+    /// @dev The one operation that separates held assets from claims, which is
+    /// what lets a state exist where reserving more than is claimed is still
+    /// within the assets held.
+    ///
+    /// The fee is capped at the claims that are not already reserved. Value
+    /// earmarked against a recorded withdrawal has been promised to a lender
+    /// who asked for it, and a protocol that takes its fee out of that is
+    /// taking money it already owed to somebody leaving. Without the cap, a fee
+    /// charged after a reservation drops claims below what is reserved, which
+    /// is what `reserves-backed-by-claims` refuses.
+    function accrueFee(uint256 amount) external virtual {
+        uint256 available = claims > reserved ? claims - reserved : 0;
+        uint256 value = bounded(amount);
+        if (value > available) {
+            value = available;
+        }
+        claims -= value;
+        fees += value;
+    }
+
+    /// @notice Record a withdrawal claim and earmark held assets against it.
+    function reserve(uint256 amount) external virtual {
+        uint256 ceiling = claims < held ? claims : held;
+        uint256 value = bounded(amount);
+        if (value > ceiling) {
+            value = ceiling;
+        }
+        if (value > 0 && owedAt.length < MAX_CLAIMS) {
+            owedAt.push(value);
+            paidAt.push(0);
+        }
+        reserved = earmark();
+    }
+
+    /// @notice Hand assets to the oldest claim the system can settle.
+    /// @dev Virtual because the specimen for queue order pays a different one.
+    function payClaim(uint256 amount) external virtual {
+        uint256 through = payableCount();
+        for (uint256 i = 0; i < through; i++) {
+            uint256 unpaid = owedAt[i] - paidAt[i];
+            if (unpaid == 0) {
+                continue;
+            }
+            settle(i, amount, unpaid);
+            return;
+        }
+    }
+
+    /// @notice Pay one claim, within everything that bounds it.
+    function settle(uint256 index, uint256 amount, uint256 unpaid) internal {
+        uint256 value = bounded(amount);
+        if (value > unpaid) {
+            value = unpaid;
+        }
+        if (value > reserved) {
+            value = reserved;
+        }
+        if (value > held) {
+            value = held;
+        }
+        if (value > claims) {
+            value = claims;
+        }
+        paidAt[index] += value;
+        held -= value;
+        claims -= value;
+        reserved -= value;
+    }
+}

--- a/plugins/pandects/src/ICreditObservables.sol
+++ b/plugins/pandects/src/ICreditObservables.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+/// @title The economic roles a law is allowed to read.
+/// @notice A law names roles, never implementations. That is not a style
+/// preference: a property written against `market.totalSupply()` is a property
+/// about one codebase, and the corpus exists because the same economic facts
+/// hold across codebases that share nothing else.
+///
+/// A target implements this directly, or a thin adapter does it on the target's
+/// behalf. The adapter is the only place a protocol's own names appear.
+///
+/// Every quantity is denominated in `asset()` and expressed in that asset's own
+/// units. No value is scaled, normalised or converted, because a law that
+/// depends on a conversion depends on whoever wrote it.
+interface ICreditObservables {
+    /// @notice The asset every other quantity here is denominated in.
+    function asset() external view returns (address);
+
+    /// @notice Assets the system holds and can account for right now.
+    /// @dev What is held, not what is owed or promised. A system that has lent
+    /// out its deposits holds less than its lenders may eventually claim, and
+    /// that difference is the point of most of the corpus.
+    function totalAssets() external view returns (uint256);
+
+    /// @notice Principal plus accrued interest currently owed by borrowers.
+    function totalDebt() external view returns (uint256);
+
+    /// @notice What lenders may eventually withdraw, accrued to now.
+    /// @dev Including claims already queued and not yet paid. A claim that has
+    /// been recorded and not paid is still owed, and a system that drops it
+    /// from this number is the subject of a law.
+    function totalLenderClaims() external view returns (uint256);
+
+    /// @notice Assets earmarked against recorded withdrawal claims.
+    /// @dev Reserved assets are held by the system and unavailable to the
+    /// borrower. A system with no withdrawal queue reports zero.
+    function reservedAssets() external view returns (uint256);
+
+    /// @notice Assets a borrower may currently take.
+    /// @dev Never includes reserved assets. The separation is a law, so this
+    /// function exists to let the law read both sides of it.
+    function borrowableAssets() external view returns (uint256);
+
+    /// @notice Fees accrued to a protocol or operator and not yet paid out.
+    function accruedFees() external view returns (uint256);
+
+    /// @notice The time the observations above describe.
+    /// @dev Read from the target rather than from `block.timestamp` so a law
+    /// can be checked against a recorded state as well as a live one.
+    function observedAt() external view returns (uint256);
+}

--- a/plugins/pandects/src/IWithdrawalQueueObservables.sol
+++ b/plugins/pandects/src/IWithdrawalQueueObservables.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+/// @title What a system with a withdrawal queue additionally exposes.
+/// @notice An extension, deliberately kept out of `ICreditObservables`. A
+/// system with no queue would have to implement a claim count, a claim
+/// accessor and a payable bound that all mean nothing, and an observable that
+/// means nothing is worse than an absent one: it reports zero, and zero reads
+/// like an answer.
+///
+/// A law that needs this says so in its applicability, and a target that does
+/// not implement it reverts on the read. That is the limit `Law` already
+/// states: the state could not be observed, the law has no opinion, and the
+/// harness counts a revert. It is not a violation and it is not a pass.
+///
+/// The queue is an ordering over recorded claims, not over lenders. Two claims
+/// from the same lender are two entries, and a system that merges them has
+/// changed what it owes on each, which is the subject of a law.
+interface IWithdrawalQueueObservables {
+    /// @notice How many withdrawal claims the system has recorded.
+    /// @dev Recorded, not outstanding. A claim paid in full stays in the count
+    /// and stays at its index, because the laws over this interface compare
+    /// claims across two observations by index, and a queue that renumbers
+    /// itself makes that comparison meaningless.
+    function claimCount() external view returns (uint256);
+
+    /// @notice One recorded claim.
+    /// @param index Position in the queue, oldest first.
+    /// @return owed The amount recorded against this claim when it was made.
+    /// @return paid How much of that has since been handed over.
+    function claimAt(uint256 index)
+        external
+        view
+        returns (uint256 owed, uint256 paid);
+
+    /// @notice The exclusive bound of the claims the system declares payable.
+    /// @dev Claims at indices below this are ones the system says it can
+    /// settle now. It is a declaration rather than a derivation, which is
+    /// precisely why it is worth a law: a system that declares more payable
+    /// than it has set aside has promised something it cannot do, and only the
+    /// declaration makes that visible from outside.
+    function payableThrough() external view returns (uint256);
+}

--- a/plugins/pandects/src/Law.sol
+++ b/plugins/pandects/src/Law.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ICreditObservables} from "./ICreditObservables.sol";
+
+/// @title One executable law.
+/// @notice A law judges a state and says what it decided. It does not revert
+/// to signal a failure, and the reason is the harness rather than taste.
+///
+/// A stateful campaign runs with `fail_on_revert = false`, because a credit
+/// system reverts constantly and correctly: a withdrawal past the queue, a
+/// borrow past the reserve, a repayment of more than is owed. Under that
+/// setting a revert carries no verdict, so a law using `require` to mean
+/// "violated" would report nothing at all and be counted as silence. Silence
+/// read as assent is what this corpus exists to prevent. A law therefore
+/// returns `false` to mean violated, and never reverts to mean it.
+///
+/// The converse is a limit rather than a guarantee, and worth stating exactly.
+/// If the target reverts on a read, the law reverts with it. That is neither a
+/// violation nor a pass: the state could not be observed, the law has no
+/// opinion, and the harness counts a revert. What an unobservable state means
+/// is the adapter's decision, not this contract's.
+///
+/// `detail` is for the reader who finds the failure six months later. It says
+/// which quantities were compared and what they were, because a counterexample
+/// without the numbers is a bug report nobody can act on.
+abstract contract Law {
+    /// @notice Stable identifier, matching this law's entry in the catalogue.
+    /// @dev The catalogue carries the statement, applicability and specimen;
+    /// this ties the executing component to that entry. A test fails when one
+    /// exists without the other, so a law cannot be documented without being
+    /// executable or executable without being documented.
+    function id() external pure virtual returns (string memory);
+
+    /// @notice The law in one sentence, as a reader would state it.
+    function statement() external pure virtual returns (string memory);
+
+    /// @notice Judge one observed state.
+    /// @param target The system under test, or an adapter over it.
+    /// @return held True when the law holds for this state.
+    /// @return detail What was compared, and what the values were.
+    function check(ICreditObservables target)
+        external
+        view
+        virtual
+        returns (bool held, string memory detail);
+}

--- a/plugins/pandects/src/Observation.sol
+++ b/plugins/pandects/src/Observation.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ICreditObservables} from "./ICreditObservables.sol";
+import {IWithdrawalQueueObservables} from "./IWithdrawalQueueObservables.sol";
+
+/// @notice One recorded withdrawal claim, as observed.
+struct ClaimRecord {
+    uint256 owed;
+    uint256 paid;
+}
+
+/// @notice Every quantity a target reports, taken at one moment.
+/// @dev A snapshot rather than a live target, because the laws that need two
+/// observations need to hold the earlier one after the system has moved past
+/// it. A law handed two targets could only ever compare two systems; a law
+/// handed two observations can compare one system with its own past.
+///
+/// `queueObserved` is a claim about the reading, not about the system. False
+/// means nobody looked, which is why it is here rather than being inferred
+/// from an empty array: a queue with no claims and a queue nobody read are
+/// different things, and a law that confuses them would pass on the second.
+struct Observation {
+    uint256 totalAssets;
+    uint256 totalDebt;
+    uint256 totalLenderClaims;
+    uint256 reservedAssets;
+    uint256 borrowableAssets;
+    uint256 accruedFees;
+    uint256 observedAt;
+    bool queueObserved;
+    uint256 payableThrough;
+    ClaimRecord[] queue;
+}
+
+/// @title Reading a target into an observation.
+library Observe {
+    /// @notice The core observables, and nothing else.
+    function take(ICreditObservables target)
+        internal
+        view
+        returns (Observation memory found)
+    {
+        found.totalAssets = target.totalAssets();
+        found.totalDebt = target.totalDebt();
+        found.totalLenderClaims = target.totalLenderClaims();
+        found.reservedAssets = target.reservedAssets();
+        found.borrowableAssets = target.borrowableAssets();
+        found.accruedFees = target.accruedFees();
+        found.observedAt = target.observedAt();
+    }
+
+    /// @notice The core observables and the withdrawal queue.
+    /// @dev Reads every recorded claim, one external call each, so a long
+    /// enough queue exhausts the gas and reverts. That is the same limit the
+    /// queue laws carry and it is deliberate: a partial snapshot would let a
+    /// law about the whole queue return a verdict about part of one.
+    ///
+    /// Reverts if the target does not implement the queue extension. That
+    /// is the intended behaviour and the same limit `Law` states: an
+    /// unobservable state produces no verdict rather than a false one. Take
+    /// the core observables instead when the target may have no queue.
+    function takeWithQueue(ICreditObservables target)
+        internal
+        view
+        returns (Observation memory found)
+    {
+        found = take(target);
+        IWithdrawalQueueObservables queue =
+            IWithdrawalQueueObservables(address(target));
+        uint256 count = queue.claimCount();
+        found.queue = new ClaimRecord[](count);
+        for (uint256 i = 0; i < count; i++) {
+            (uint256 owed, uint256 paid) = queue.claimAt(i);
+            found.queue[i] = ClaimRecord({owed: owed, paid: paid});
+        }
+        found.payableThrough = queue.payableThrough();
+        found.queueObserved = true;
+    }
+}

--- a/plugins/pandects/src/PairLaw.sol
+++ b/plugins/pandects/src/PairLaw.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Observation} from "./Observation.sol";
+
+/// @title One executable law over a pair of observations.
+/// @notice The same contract as `Law` in every respect that matters -- it
+/// judges rather than reverts, it carries an id and a statement, and it
+/// returns the reason with the verdict. It differs in arity, and only because
+/// the facts differ in arity.
+///
+/// Conservation is a fact about one state: the sums agree or they do not, and
+/// no history is needed to say which. Accrual is not. "Debt falls only against
+/// payment" cannot be violated by any single state, however wrong that state
+/// is, because the violation is in the transition. Bending the one-state shape
+/// to cover it would mean a law holding its own history in storage, which
+/// makes the law stateful, order-dependent and impossible to point at a
+/// recorded state after the fact.
+///
+/// So there are two shapes and there is no third. Both are checked by the same
+/// tooling, both appear in the same catalogue, and a reader has to know which
+/// one a law is only when they call it.
+///
+/// The two observations are not always a before and an after. Three of these
+/// laws compare a system with its own past; one compares two systems advanced
+/// differently over the same span. Each says which it means in its
+/// applicability.
+///
+/// Handed a pair it cannot judge, a law follows one rule, and it is worth
+/// stating here once rather than three times in three files. Ask whose mistake
+/// the pair is. A pair that spans real time, or that shows a system somewhere
+/// this law says nothing about, is a state of the world: hold, and say why.
+/// A pair nobody could have meant -- two runs that never reached the same
+/// moment, a queue law handed observations with no queue in them -- is a
+/// mistake by whoever built it: refuse, and say why. Holding there would
+/// report a comparison nobody made, which is the silence this corpus exists to
+/// prevent, arriving from the harness instead of from the system.
+abstract contract PairLaw {
+    /// @notice Stable identifier, matching this law's entry in the catalogue.
+    function id() external pure virtual returns (string memory);
+
+    /// @notice The law in one sentence, as a reader would state it.
+    function statement() external pure virtual returns (string memory);
+
+    /// @notice Judge a pair of observations.
+    /// @param earlier The first observation.
+    /// @param later The second.
+    /// @return held True when the law holds for this pair.
+    /// @return detail What was compared, and what the values were.
+    /// @dev `view` rather than `pure`, because a law may carry a bound. Only
+    /// one does, and the alternative was a second entry point holding the real
+    /// law while `check` answered a different question with a default bound.
+    /// A law with two doors, one of which is wrong, is worse than a law that
+    /// declares it might read something.
+    function check(Observation memory earlier, Observation memory later)
+        external
+        view
+        virtual
+        returns (bool held, string memory detail);
+}

--- a/plugins/pandects/src/campaigns/Adapters.sol
+++ b/plugins/pandects/src/campaigns/Adapters.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {CorpusEchidna, DrivenCorpusEchidna} from "../../adapters/echidna/CorpusEchidna.sol";
+import {CorpusMedusa, DrivenCorpusMedusa} from "../../adapters/medusa/CorpusMedusa.sol";
+import {ICreditObservables} from "../ICreditObservables.sol";
+import {ClaimHaircut} from "../../specimens/ClaimHaircut.sol";
+import {QueueJumped} from "../../specimens/QueueJumped.sol";
+
+/// @title The adapters, pointed at a target they did not build.
+/// @dev Under `src/` for the same reason `Specimens.sol` is: crytic-compile
+/// skips `test/` when it builds a Foundry project, and a harness the engine
+/// cannot see is a campaign that quietly tests nothing. It is also what makes
+/// the adapters compile at all -- they are abstract, so nothing checks them
+/// until something concrete extends them.
+///
+/// Each of these is what an integrator writes: a few lines naming their system
+/// and their entry points. The laws arrive with the base.
+///
+/// One engine per contract. The prefixes are fixed by Echidna and Medusa, and a
+/// contract carrying both would answer every question twice.
+
+/// @notice `QueueJumped` observed rather than fronted. `queue_order_preserved`
+/// is expected to fail once the specimen has paid out of turn, and it fails
+/// through an adapter that never saw the call that did it -- which is the whole
+/// case for the observing form.
+contract ObservedQueueJumpedEchidna is CorpusEchidna {
+    QueueJumped internal immutable system = new QueueJumped();
+
+    function target() public view override returns (ICreditObservables) {
+        return system;
+    }
+
+    function deposit(uint256 amount) external {
+        system.deposit(amount);
+    }
+
+    function reserve(uint256 amount) external {
+        system.reserve(amount);
+    }
+
+    function payClaim(uint256 amount) external {
+        system.payClaim(amount);
+    }
+}
+
+/// @notice `ClaimHaircut` fronted, so the succession laws have a past to read.
+/// `recorded_claim_never_shrinks` is expected to fail. Every entry point below
+/// carries `records`, which is the entire mechanism.
+contract DrivenClaimHaircutEchidna is DrivenCorpusEchidna {
+    ClaimHaircut internal immutable system = new ClaimHaircut();
+
+    function target() public view override returns (ICreditObservables) {
+        return system;
+    }
+
+    function deposit(uint256 amount) external records {
+        system.deposit(amount);
+    }
+
+    function reserve(uint256 amount) external records {
+        system.reserve(amount);
+    }
+
+    function haircut(uint256 index, uint256 amount) external records {
+        system.haircut(index, amount);
+    }
+}
+
+/// @notice The observing adapter under Medusa's prefix.
+contract ObservedQueueJumpedMedusa is CorpusMedusa {
+    QueueJumped internal immutable system = new QueueJumped();
+
+    function target() public view override returns (ICreditObservables) {
+        return system;
+    }
+
+    function deposit(uint256 amount) external {
+        system.deposit(amount);
+    }
+
+    function reserve(uint256 amount) external {
+        system.reserve(amount);
+    }
+
+    function payClaim(uint256 amount) external {
+        system.payClaim(amount);
+    }
+}
+
+/// @notice The driving adapter under Medusa's prefix.
+contract DrivenClaimHaircutMedusa is DrivenCorpusMedusa {
+    ClaimHaircut internal immutable system = new ClaimHaircut();
+
+    function target() public view override returns (ICreditObservables) {
+        return system;
+    }
+
+    function deposit(uint256 amount) external records {
+        system.deposit(amount);
+    }
+
+    function reserve(uint256 amount) external records {
+        system.reserve(amount);
+    }
+
+    function haircut(uint256 index, uint256 amount) external records {
+        system.haircut(index, amount);
+    }
+}

--- a/plugins/pandects/src/campaigns/Specimens.sol
+++ b/plugins/pandects/src/campaigns/Specimens.sol
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Law} from "../Law.sol";
+import {Observation, Observe} from "../Observation.sol";
+import {PairLaw} from "../PairLaw.sol";
+import {ValueConserved} from "../laws/ValueConserved.sol";
+import {ReservesBackedByClaims} from "../laws/ReservesBackedByClaims.sol";
+import {HeldAssetsPartitioned} from "../laws/HeldAssetsPartitioned.sol";
+import {QueueOrderPreserved} from "../laws/QueueOrderPreserved.sol";
+import {ReservesCoverPayableClaims} from "../laws/ReservesCoverPayableClaims.sol";
+import {DebtFallsOnlyAgainstPayment} from "../laws/DebtFallsOnlyAgainstPayment.sol";
+import {NoAccrualAtRest} from "../laws/NoAccrualAtRest.sol";
+import {RecordedClaimNeverShrinks} from "../laws/RecordedClaimNeverShrinks.sol";
+import {Sound} from "../../specimens/Sound.sol";
+import {MintedClaims} from "../../specimens/MintedClaims.sol";
+import {OverReserved} from "../../specimens/OverReserved.sol";
+import {OverPromised} from "../../specimens/OverPromised.sol";
+import {DebtForgiven} from "../../specimens/DebtForgiven.sol";
+import {AccruesAtRest} from "../../specimens/AccruesAtRest.sol";
+import {CompoundsPerStep} from "../../specimens/CompoundsPerStep.sol";
+import {ClaimHaircut} from "../../specimens/ClaimHaircut.sol";
+import {QueueJumped} from "../../specimens/QueueJumped.sol";
+import {PayableBeyondReserves} from "../../specimens/PayableBeyondReserves.sol";
+
+/// @title Campaign entry points, for the engines that are not Foundry.
+/// @dev Under `src/` rather than `test/` because crytic-compile skips `test/`
+/// when it builds a Foundry project, and a harness the engine cannot see is a
+/// campaign that quietly tests nothing.
+/// @notice One harness per specimen, exposing the operations a fuzzer may call
+/// and one property per law.
+///
+/// Both prefixes are declared on every harness. Echidna looks for `echidna_`
+/// and Medusa defaults to `property_`, so a harness carrying only one of them
+/// is a harness that silently does nothing under the other engine. Each pair
+/// delegates to the same internal function, so the two engines are asked the
+/// same question.
+///
+/// Eight of these ten are expected to fail one property, and the expectation is
+/// the point: a campaign that reports every property holding against a contract
+/// built to break one has not searched hard enough, and the failure is the
+/// evidence that the law is a law. `audit/AUDIT.md` records what each engine
+/// found.
+///
+/// The pair laws need the state as it was before the last call, so every
+/// mutating entry point takes a snapshot on the way in. That is the whole of
+/// the mechanism: `previous` is the system one call ago, the property compares
+/// it with the system now, and an engine that has made no call yet finds
+/// `previous` unobserved and every pair property holding vacuously.
+///
+/// `accrual/path-independent/v1` is absent, and its absence is not an
+/// oversight. It compares two systems advanced over the same span by different
+/// routes, and a campaign drives one system along one route. It is covered
+/// deterministically in `test/Pairs.t.sol` and reduced in
+/// `test/counterexamples/Accrual.t.sol`.
+abstract contract Campaign {
+    Law internal immutable conserved = new ValueConserved();
+    Law internal immutable backed = new ReservesBackedByClaims();
+    Law internal immutable partitioned = new HeldAssetsPartitioned();
+    Law internal immutable ordered = new QueueOrderPreserved();
+    Law internal immutable covered = new ReservesCoverPayableClaims();
+
+    PairLaw internal immutable falls = new DebtFallsOnlyAgainstPayment();
+    PairLaw internal immutable atRest = new NoAccrualAtRest();
+    PairLaw internal immutable shrinks = new RecordedClaimNeverShrinks();
+
+    /// @notice The system as it was immediately before the last call.
+    Observation internal previous;
+
+    function target() internal view virtual returns (Sound);
+
+    /// @notice Record the state on the way in, so a pair law has a past to read.
+    modifier records() {
+        remember();
+        _;
+    }
+
+    /// @dev Field by field, and the queue entry by entry. A whole-struct
+    /// assignment from memory to storage needs the IR pipeline, and turning
+    /// that on for the repository would change how every consumer of this
+    /// corpus compiles in order to save nine lines here.
+    function remember() internal {
+        Observation memory found = Observe.takeWithQueue(target());
+        previous.totalAssets = found.totalAssets;
+        previous.totalDebt = found.totalDebt;
+        previous.totalLenderClaims = found.totalLenderClaims;
+        previous.reservedAssets = found.reservedAssets;
+        previous.borrowableAssets = found.borrowableAssets;
+        previous.accruedFees = found.accruedFees;
+        previous.observedAt = found.observedAt;
+        previous.payableThrough = found.payableThrough;
+        previous.queueObserved = true;
+        while (previous.queue.length > found.queue.length) {
+            previous.queue.pop();
+        }
+        for (uint256 i = 0; i < found.queue.length; i++) {
+            if (i < previous.queue.length) {
+                previous.queue[i] = found.queue[i];
+            } else {
+                previous.queue.push(found.queue[i]);
+            }
+        }
+    }
+
+    function deposit(uint256 amount) external records {
+        target().deposit(amount);
+    }
+
+    function borrow(uint256 amount) external records {
+        target().borrow(amount);
+    }
+
+    function repay(uint256 amount) external records {
+        target().repay(amount);
+    }
+
+    function advance(uint256 elapsed) external records {
+        target().advance(elapsed);
+    }
+
+    function accrueFee(uint256 amount) external records {
+        target().accrueFee(amount);
+    }
+
+    function reserve(uint256 amount) external records {
+        target().reserve(amount);
+    }
+
+    function payClaim(uint256 amount) external records {
+        target().payClaim(amount);
+    }
+
+    // A law returns a verdict and a reason. A property function may return
+    // only the verdict, and `explain` wants only the reason, so each site here
+    // takes one half on purpose. Disabled at each site rather than repository
+    // wide, so the next thing this detector catches is read rather than
+    // filtered out along with these.
+
+    // slither-disable-next-line unused-return
+    function judge(Law law) internal view returns (bool ok) {
+        (ok, ) = law.check(target());
+    }
+
+    /// @dev Vacuously true before the first call. An engine evaluates
+    /// properties against the starting state, where there is no previous
+    /// observation to compare with, and reporting a violation there would be
+    /// reporting on the harness rather than on the system.
+    // slither-disable-next-line unused-return
+    function judgePair(PairLaw law) internal view returns (bool ok) {
+        if (!previous.queueObserved) {
+            return true;
+        }
+        (ok, ) = law.check(previous, Observe.takeWithQueue(target()));
+    }
+
+    /// @notice Why each law decided as it did, in this state.
+    /// @dev Every law builds a detail string saying which quantities it
+    /// compared and what they were, for the reader who finds the failure
+    /// later. A property function may return only a boolean, so the harness
+    /// cannot carry that string out through one, and emitting it would make
+    /// the property non-view, which is not what an engine expects to call.
+    ///
+    /// This is where it goes instead. Replay a failing sequence, call this,
+    /// and the reason arrives with the numbers in it rather than having to be
+    /// worked out again from the call trace.
+    function explain() external view returns (string[8] memory details) {
+        Observation memory now_ = Observe.takeWithQueue(target());
+        // slither-disable-start unused-return
+        (, details[0]) = conserved.check(target());
+        (, details[1]) = backed.check(target());
+        (, details[2]) = partitioned.check(target());
+        (, details[3]) = ordered.check(target());
+        (, details[4]) = covered.check(target());
+        if (previous.queueObserved) {
+            (, details[5]) = falls.check(previous, now_);
+            (, details[6]) = atRest.check(previous, now_);
+            (, details[7]) = shrinks.check(previous, now_);
+        }
+        // slither-disable-end unused-return
+    }
+
+    function echidna_value_conserved() external view returns (bool) {
+        return judge(conserved);
+    }
+
+    function echidna_reserves_backed() external view returns (bool) {
+        return judge(backed);
+    }
+
+    function echidna_held_partitioned() external view returns (bool) {
+        return judge(partitioned);
+    }
+
+    function echidna_queue_order_preserved() external view returns (bool) {
+        return judge(ordered);
+    }
+
+    function echidna_reserves_cover_payable() external view returns (bool) {
+        return judge(covered);
+    }
+
+    function echidna_debt_falls_only_against_payment() external view returns (bool) {
+        return judgePair(falls);
+    }
+
+    function echidna_no_accrual_at_rest() external view returns (bool) {
+        return judgePair(atRest);
+    }
+
+    function echidna_recorded_claim_never_shrinks() external view returns (bool) {
+        return judgePair(shrinks);
+    }
+
+    // Medusa looks for `property_` by default. The prefix is an engine's
+    // contract rather than a style choice, so the convention detector is
+    // answered here rather than obeyed.
+    // slither-disable-start naming-convention
+    function property_value_conserved() external view returns (bool) {
+        return judge(conserved);
+    }
+
+    function property_reserves_backed() external view returns (bool) {
+        return judge(backed);
+    }
+
+    function property_held_partitioned() external view returns (bool) {
+        return judge(partitioned);
+    }
+
+    function property_queue_order_preserved() external view returns (bool) {
+        return judge(ordered);
+    }
+
+    function property_reserves_cover_payable() external view returns (bool) {
+        return judge(covered);
+    }
+
+    function property_debt_falls_only_against_payment() external view returns (bool) {
+        return judgePair(falls);
+    }
+
+    function property_no_accrual_at_rest() external view returns (bool) {
+        return judgePair(atRest);
+    }
+
+    function property_recorded_claim_never_shrinks() external view returns (bool) {
+        return judgePair(shrinks);
+    }
+    // slither-disable-end naming-convention
+}
+
+/// Every law is expected to hold here, under any sequence.
+contract SoundCampaign is Campaign {
+    Sound internal immutable system = new Sound();
+
+    function target() internal view override returns (Sound) {
+        return system;
+    }
+}
+
+/// `value_conserved` is expected to fail. The others are expected to hold.
+contract MintedClaimsCampaign is Campaign {
+    MintedClaims internal immutable system = new MintedClaims();
+
+    function target() internal view override returns (Sound) {
+        return system;
+    }
+}
+
+/// `reserves_backed` is expected to fail. The others are expected to hold.
+contract OverReservedCampaign is Campaign {
+    OverReserved internal immutable system = new OverReserved();
+
+    function target() internal view override returns (Sound) {
+        return system;
+    }
+}
+
+/// `held_partitioned` is expected to fail. The others are expected to hold.
+contract OverPromisedCampaign is Campaign {
+    OverPromised internal immutable system = new OverPromised();
+
+    function target() internal view override returns (Sound) {
+        return system;
+    }
+}
+
+/// `debt_falls_only_against_payment` is expected to fail once `forgive` has
+/// something to write off. The others are expected to hold.
+contract DebtForgivenCampaign is Campaign {
+    DebtForgiven internal immutable system = new DebtForgiven();
+
+    function target() internal view override returns (Sound) {
+        return system;
+    }
+
+    function forgive(uint256 amount) external records {
+        system.forgive(amount);
+    }
+}
+
+/// `no_accrual_at_rest` is expected to fail on the first `poke`. The others
+/// are expected to hold.
+contract AccruesAtRestCampaign is Campaign {
+    AccruesAtRest internal immutable system = new AccruesAtRest();
+
+    function target() internal view override returns (Sound) {
+        return system;
+    }
+
+    function poke(uint256 amount) external records {
+        system.poke(amount);
+    }
+}
+
+/// Every property here is expected to hold, and that is the finding. The
+/// defect this specimen carries is path independence, which no single campaign
+/// can see; `test/Pairs.t.sol` is where it is caught. A harness reporting all
+/// clear against a contract known to be broken is the sharpest illustration in
+/// the corpus of why a passing campaign is not evidence.
+contract CompoundsPerStepCampaign is Campaign {
+    CompoundsPerStep internal immutable system = new CompoundsPerStep();
+
+    function target() internal view override returns (Sound) {
+        return system;
+    }
+}
+
+/// `recorded_claim_never_shrinks` is expected to fail. The others are expected
+/// to hold.
+contract ClaimHaircutCampaign is Campaign {
+    ClaimHaircut internal immutable system = new ClaimHaircut();
+
+    function target() internal view override returns (Sound) {
+        return system;
+    }
+
+    function haircut(uint256 index, uint256 amount) external records {
+        system.haircut(index, amount);
+    }
+}
+
+/// `queue_order_preserved` is expected to fail. The others are expected to hold.
+contract QueueJumpedCampaign is Campaign {
+    QueueJumped internal immutable system = new QueueJumped();
+
+    function target() internal view override returns (Sound) {
+        return system;
+    }
+}
+
+/// `reserves_cover_payable` is expected to fail. The others are expected to hold.
+contract PayableBeyondReservesCampaign is Campaign {
+    PayableBeyondReserves internal immutable system = new PayableBeyondReserves();
+
+    function target() internal view override returns (Sound) {
+        return system;
+    }
+}

--- a/plugins/pandects/src/campaigns/Wildcat.sol
+++ b/plugins/pandects/src/campaigns/Wildcat.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {DrivenCorpusEchidna} from "../../adapters/echidna/CorpusEchidna.sol";
+import {DrivenCorpusMedusa} from "../../adapters/medusa/CorpusMedusa.sol";
+import {ICreditObservables} from "../ICreditObservables.sol";
+import {WildcatMarketModel} from "../../integrations/wildcat/WildcatMarketModel.sol";
+
+/// @title The Wildcat model, driven through the step 4 adapters.
+/// @dev No harness written specially for it. These are the same adapters an
+/// integrator extends, and the point of the integration is that the corpus
+/// arrives whole rather than being re-derived for each design.
+///
+/// Under `src/` because crytic-compile skips `test/`.
+///
+/// `path-independent` is absent, as it is from every campaign: it compares two
+/// markets advanced by different routes. For this design that absence carries
+/// more than usual, because the law is conditional here --
+/// `test/Wildcat.t.sol` holds it while the market is solvent and watches it
+/// fail once the penalty is running.
+///
+/// `recorded_claim_never_shrinks` is expected to fail here, and the failure is
+/// the finding rather than a defect. A batch accumulates while it is open, so
+/// the amount owed on it rises, and the law says a recorded claim keeps its
+/// amount. Echidna found it against this contract after the applicability notes
+/// had already claimed the law held.
+/// `integrations/wildcat/APPLICABILITY.md` is where that is settled.
+contract WildcatMarketCampaign is DrivenCorpusEchidna {
+    WildcatMarketModel internal immutable market = new WildcatMarketModel();
+
+    function target() public view override returns (ICreditObservables) {
+        return market;
+    }
+
+    function deposit(uint256 amount) external records {
+        market.deposit(amount);
+    }
+
+    function borrow(uint256 amount) external records {
+        market.borrow(amount);
+    }
+
+    function repay(uint256 amount) external records {
+        market.repay(amount);
+    }
+
+    function advance(uint256 elapsed) external records {
+        market.advance(elapsed);
+    }
+
+    function accrueFee(uint256 amount) external records {
+        market.accrueFee(amount);
+    }
+
+    function requestWithdrawal(uint256 amount) external records {
+        market.requestWithdrawal(amount);
+    }
+
+    function payBatch(uint256 amount) external records {
+        market.payBatch(amount);
+    }
+}
+
+/// @notice The same market, under the prefix Medusa reads.
+contract WildcatMarketCampaignMedusa is DrivenCorpusMedusa {
+    WildcatMarketModel internal immutable market = new WildcatMarketModel();
+
+    function target() public view override returns (ICreditObservables) {
+        return market;
+    }
+
+    function deposit(uint256 amount) external records {
+        market.deposit(amount);
+    }
+
+    function borrow(uint256 amount) external records {
+        market.borrow(amount);
+    }
+
+    function repay(uint256 amount) external records {
+        market.repay(amount);
+    }
+
+    function advance(uint256 elapsed) external records {
+        market.advance(elapsed);
+    }
+
+    function accrueFee(uint256 amount) external records {
+        market.accrueFee(amount);
+    }
+
+    function requestWithdrawal(uint256 amount) external records {
+        market.requestWithdrawal(amount);
+    }
+
+    function payBatch(uint256 amount) external records {
+        market.payBatch(amount);
+    }
+}

--- a/plugins/pandects/src/laws/AccrualPathIndependent.sol
+++ b/plugins/pandects/src/laws/AccrualPathIndependent.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Observation} from "../Observation.sol";
+import {PairLaw} from "../PairLaw.sol";
+
+/// @title The same span accrues the same interest, however it is cut up.
+/// @notice Two systems start identically. One is advanced once across a span;
+/// the other is advanced across the same span in `subdivisions` equal steps.
+/// Under linear accrual on principal they owe the same at the end, and the
+/// only thing that can separate them is integer truncation.
+///
+/// This is the law that catches accrual charged per call rather than per
+/// second, and interest quietly compounding because each step accrues on a
+/// balance the previous step already grew. Both are invisible in a single
+/// state and invisible across one transition. They show up only when the same
+/// elapsed time is reached by two different routes, which is why this law is
+/// the one differential law in the corpus: its pair is two systems, not one
+/// system and its past.
+///
+/// One thing this law cannot check, and it is the sharpest edge on it. Nothing
+/// in either observation says how many steps the subdivided run took. The
+/// bound comes from `subdivisions`, fixed when the law is deployed, and a law
+/// built for two steps shown a run of eight compares against a bound five
+/// sixths too small; built for a thousand and shown two, it accepts a gap
+/// hundreds of times wider than the arithmetic allows. Both are silent, and no
+/// reading of the two observations can tell them apart.
+///
+/// So the number is part of the question rather than part of the answer. Deploy
+/// the law with the count the run actually used, or the verdict is about a run
+/// nobody made. The applicability says so and `test/Pairs.t.sol` shows both
+/// mistakes producing wrong verdicts, because a hazard nobody has watched fail
+/// is a hazard people assume is handled.
+///
+/// A pair at different observation times is refused rather than held. That is
+/// the opposite of `accrual/no-accrual-at-rest/v1`, and the difference is
+/// whose mistake it is. A pair spanning real time is something the world does;
+/// a pair of runs that did not reach the same moment is something the harness
+/// did, and a law that held there would report success for a comparison nobody
+/// made.
+///
+/// The bound is the one tolerance in the corpus, and it names its arithmetic
+/// rather than being fitted to a test. Let the exact interest for one step be
+/// `x`. The subdivided run accrues `n * floor(x)`; the single run accrues
+/// `floor(n * x)`. The gap between those is at most `n - 1`, because each of
+/// the `n` truncations discards less than one unit and the single truncation
+/// discards less than one in the other direction. So `n - 1` units, exactly,
+/// for `n` subdivisions.
+contract AccrualPathIndependent is PairLaw {
+    /// @notice How many steps the subdivided run was advanced in.
+    uint256 public immutable subdivisions;
+
+    constructor(uint256 subdivisions_) {
+        subdivisions = subdivisions_;
+    }
+
+    function id() external pure override returns (string memory) {
+        return "accrual/path-independent/v1";
+    }
+
+    function statement() external pure override returns (string memory) {
+        return
+            "One long step and the same span in equal small steps agree on debt, within one unit per step less one.";
+    }
+
+    /// @notice The widest gap this law accepts.
+    /// @dev Zero subdivisions describes no subdivided run at all, so the two
+    /// observations must agree exactly. Written as a floor rather than a
+    /// rejection because a law does not revert to mean anything.
+    function tolerance() public view returns (uint256) {
+        return subdivisions == 0 ? 0 : subdivisions - 1;
+    }
+
+    function check(Observation memory earlier, Observation memory later)
+        external
+        view
+        override
+        returns (bool held, string memory detail)
+    {
+        if (earlier.observedAt != later.observedAt) {
+            return (
+                false,
+                "the two runs did not reach the same moment, so nothing was compared"
+            );
+        }
+        uint256 gap = earlier.totalDebt > later.totalDebt
+            ? earlier.totalDebt - later.totalDebt
+            : later.totalDebt - earlier.totalDebt;
+        if (gap <= tolerance()) {
+            return (true, "the two runs agree on debt within the bound");
+        }
+        return (false, "the two runs disagree on debt beyond truncation");
+    }
+}

--- a/plugins/pandects/src/laws/DebtFallsOnlyAgainstPayment.sol
+++ b/plugins/pandects/src/laws/DebtFallsOnlyAgainstPayment.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Observation} from "../Observation.sol";
+import {PairLaw} from "../PairLaw.sol";
+
+/// @title Debt goes down only when assets come in.
+/// @notice What a borrower owes falls only against the system receiving at
+/// least as much. Debt that shrinks with nothing arriving has been forgiven,
+/// written off, or lost to an accounting error, and from outside those three
+/// look identical.
+///
+/// The observable form matters. "Debt never decreases between repayments"
+/// cannot be checked, because nothing a target reports says a repayment
+/// happened; a law written that way would need the harness to tell it, and a
+/// law that trusts the harness is a law about the harness. What is observable
+/// is that held assets rose by at least the fall, which is what a repayment
+/// looks like from outside and what a write-off does not.
+///
+/// The law is one-directional on purpose. It says nothing about debt rising:
+/// interest does that legitimately, and `accrual/no-accrual-at-rest/v1` is
+/// where rising debt is constrained.
+///
+/// Exact, with no tolerance. Two subtractions and a comparison.
+contract DebtFallsOnlyAgainstPayment is PairLaw {
+    function id() external pure override returns (string memory) {
+        return "accrual/debt-falls-only-against-payment/v1";
+    }
+
+    function statement() external pure override returns (string memory) {
+        return
+            "Debt falls only against held assets rising by at least the fall.";
+    }
+
+    function check(Observation memory earlier, Observation memory later)
+        external
+        pure
+        override
+        returns (bool held, string memory detail)
+    {
+        if (later.totalDebt >= earlier.totalDebt) {
+            return (true, "debt did not fall between the two observations");
+        }
+        uint256 fall = earlier.totalDebt - later.totalDebt;
+        uint256 arrived = later.totalAssets > earlier.totalAssets
+            ? later.totalAssets - earlier.totalAssets
+            : 0;
+        if (arrived >= fall) {
+            return (true, "debt fell no further than held assets rose");
+        }
+        return (false, "debt fell further than held assets rose");
+    }
+}

--- a/plugins/pandects/src/laws/HeldAssetsPartitioned.sol
+++ b/plugins/pandects/src/laws/HeldAssetsPartitioned.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ICreditObservables} from "../ICreditObservables.sol";
+import {Law} from "../Law.sol";
+
+/// @title Held assets are partitioned, not double counted.
+/// @notice What is reserved against withdrawals and what a borrower may take
+/// are drawn from the same held assets, and together they never exceed them.
+/// A system that offers the borrower liquidity it has already promised to a
+/// departing lender has sold the same asset twice, and whichever of them
+/// arrives second finds it gone.
+///
+/// Exact, with no tolerance. Nothing here divides.
+contract HeldAssetsPartitioned is Law {
+    function id() external pure override returns (string memory) {
+        return "conservation/held-assets-partitioned/v1";
+    }
+
+    function statement() external pure override returns (string memory) {
+        return
+            "Reserved assets plus borrowable assets never exceed assets held.";
+    }
+
+    function check(ICreditObservables target)
+        external
+        view
+        override
+        returns (bool held, string memory detail)
+    {
+        uint256 reserved = target.reservedAssets();
+        uint256 borrowable = target.borrowableAssets();
+        uint256 assets = target.totalAssets();
+
+        // Unchecked with the overflow reported, for the reason given in
+        // ValueConserved: a revert here would be silence where the numbers are
+        // furthest wrong.
+        uint256 committed;
+        unchecked {
+            committed = reserved + borrowable;
+        }
+        if (committed < reserved) {
+            return (false, "reserved plus borrowable overflows");
+        }
+        if (committed <= assets) {
+            return (true, "reserved and borrowable fit within assets held");
+        }
+        return (false, "reserved plus borrowable exceeds assets held");
+    }
+}

--- a/plugins/pandects/src/laws/NoAccrualAtRest.sol
+++ b/plugins/pandects/src/laws/NoAccrualAtRest.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Observation} from "../Observation.sol";
+import {PairLaw} from "../PairLaw.sol";
+
+/// @title Interest needs time to exist.
+/// @notice Between two observations that describe the same moment, debt rises
+/// only against held assets leaving. Borrowing raises debt with no time
+/// passing and moves assets out the door to do it. Interest raises debt with
+/// nothing moving, and cannot happen at a standstill.
+///
+/// The naive statement -- that nothing changes when no time passes -- is false
+/// of every correct system, which is worth saying plainly because it is the
+/// easy version to write. A deposit, a borrowing, a repayment and a fee all
+/// land within one block and all move the numbers. Time is not what makes them
+/// legitimate; the assets moving is. So the law watches the one quantity that
+/// has no business moving on its own, and admits every rise that was paid for
+/// in liquidity.
+///
+/// Interest compounding on a read, a rate applied on a call rather than on a
+/// duration, an accrual that runs twice for one block: each shows up here as
+/// debt appearing while the clock stands still and nothing leaving to explain
+/// it.
+///
+/// This law says nothing about pairs at different times. It holds on them, and
+/// says so, because a pair spanning real time is a state of the world rather
+/// than a mistake by whoever built the pair. That is the opposite of what
+/// `accrual/path-independent/v1` does with a pair it cannot judge, and the
+/// asymmetry is deliberate: there, an ill-formed pair is a harness error, and
+/// holding would hide it.
+///
+/// Exact, with no tolerance. Two subtractions and a comparison.
+contract NoAccrualAtRest is PairLaw {
+    function id() external pure override returns (string memory) {
+        return "accrual/no-accrual-at-rest/v1";
+    }
+
+    function statement() external pure override returns (string memory) {
+        return
+            "At equal observation times, debt rises only against held assets leaving.";
+    }
+
+    function check(Observation memory earlier, Observation memory later)
+        external
+        pure
+        override
+        returns (bool held, string memory detail)
+    {
+        if (earlier.observedAt != later.observedAt) {
+            return (true, "time passed between the observations");
+        }
+        if (later.totalDebt <= earlier.totalDebt) {
+            return (true, "debt did not rise while time stood still");
+        }
+        uint256 rise = later.totalDebt - earlier.totalDebt;
+        uint256 left = earlier.totalAssets > later.totalAssets
+            ? earlier.totalAssets - later.totalAssets
+            : 0;
+        if (left >= rise) {
+            return (true, "debt rose no further than held assets left");
+        }
+        return (false, "debt rose while time stood still and assets stayed");
+    }
+}

--- a/plugins/pandects/src/laws/QueueOrderPreserved.sol
+++ b/plugins/pandects/src/laws/QueueOrderPreserved.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ICreditObservables} from "../ICreditObservables.sol";
+import {IWithdrawalQueueObservables} from "../IWithdrawalQueueObservables.sol";
+import {Law} from "../Law.sol";
+
+/// @title Nobody is paid ahead of somebody who has been waiting longer.
+/// @notice No claim receives payment while an older claim is still owed
+/// something. A withdrawal queue is a promise about order as much as about
+/// amount, and a queue that pays out of order under partial liquidity is the
+/// mechanism by which whoever is quickest, best connected or first to notice
+/// gets out and the rest do not.
+///
+/// A single state is enough to see this, which is why it is a `Law` rather
+/// than a `PairLaw`: partial payment is recorded against the claim, so a queue
+/// carrying an unpaid entry ahead of a partly paid one is already evidence.
+/// Nothing about the history is needed.
+///
+/// The law reads the queue extension by casting the target, which is the
+/// corpus's only way to ask a target for more than the core observables while
+/// keeping one law shape. A target with no queue reverts on the read, and that
+/// is the limit `Law` already states: the state could not be observed and the
+/// law has no opinion. It is not silence dressed as a pass, because the
+/// harness counts the revert.
+///
+/// The traversal is unbounded, and that is a limit rather than an oversight.
+/// This reads every recorded claim, one external call each, so against a system
+/// with a long enough queue it runs out of gas and reverts -- and a revert is
+/// no verdict. There is no partial answer available: the property is about the
+/// whole queue, and a law that read half of it and held would be reporting on
+/// half a system. The applicability says so, and a target that queues more than
+/// can be read in one call needs an adapter that pages, not a law that guesses.
+///
+/// Exact, with no tolerance. Comparisons only.
+contract QueueOrderPreserved is Law {
+    function id() external pure override returns (string memory) {
+        return "claims/queue-order-preserved/v1";
+    }
+
+    function statement() external pure override returns (string memory) {
+        return
+            "No withdrawal claim is paid while an older claim is still owed something.";
+    }
+
+    function check(ICreditObservables target)
+        external
+        view
+        override
+        returns (bool held, string memory detail)
+    {
+        IWithdrawalQueueObservables queue =
+            IWithdrawalQueueObservables(address(target));
+        uint256 count = queue.claimCount();
+        bool anOlderClaimIsStillOwed = false;
+        for (uint256 i = 0; i < count; i++) {
+            (uint256 owed, uint256 paid) = queue.claimAt(i);
+            if (anOlderClaimIsStillOwed && paid > 0) {
+                return (false, "a claim was paid while an older one was still owed");
+            }
+            if (paid < owed) {
+                anOlderClaimIsStillOwed = true;
+            }
+        }
+        return (true, "no claim was paid ahead of an older one");
+    }
+}

--- a/plugins/pandects/src/laws/RecordedClaimNeverShrinks.sol
+++ b/plugins/pandects/src/laws/RecordedClaimNeverShrinks.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ClaimRecord, Observation} from "../Observation.sol";
+import {PairLaw} from "../PairLaw.sol";
+
+/// @title A claim written down is never written down smaller.
+/// @notice Once a withdrawal claim is recorded, the amount it is owed does not
+/// change and the payment against it never runs backwards. A lender who asked
+/// to leave has a number attached to their name, and a system that quietly
+/// reduces it has taken something without paying for it.
+///
+/// The pooled total is the wrong place to look for this. Lender claims fall
+/// legitimately every time a fee is taken, so a law over `totalLenderClaims`
+/// either admits fees -- and then says only that value went somewhere, which
+/// is conservation restated -- or refuses them, and fails against every
+/// correct system. What is actually invariant is the individual record, which
+/// is why this law needs the queue extension and the conservation family
+/// does not.
+///
+/// Three ways to break it, all of them things real systems have done: rewrite
+/// an entry downwards under a haircut, drop an entry so the queue gets shorter,
+/// or renumber the queue so index three is a different claim than it was. The
+/// third is why the extension documents that a paid claim keeps its index; a
+/// queue that compacts itself makes every comparison here meaningless, and
+/// this law would report the compaction rather than miss it.
+///
+/// Exact, with no tolerance. Comparisons only.
+contract RecordedClaimNeverShrinks is PairLaw {
+    function id() external pure override returns (string memory) {
+        return "claims/recorded-claim-never-shrinks/v1";
+    }
+
+    function statement() external pure override returns (string memory) {
+        return
+            "A recorded claim keeps its owed amount and never loses payment already made.";
+    }
+
+    function check(Observation memory earlier, Observation memory later)
+        external
+        pure
+        override
+        returns (bool held, string memory detail)
+    {
+        if (!earlier.queueObserved || !later.queueObserved) {
+            // Not a violation by the system, and not a pass either. Reported
+            // as a violation because the alternative is holding on a
+            // comparison nobody made: whoever built this pair asked for the
+            // core observables and then asked a question only the queue can
+            // answer.
+            return (false, "the withdrawal queue was not observed");
+        }
+        if (later.queue.length < earlier.queue.length) {
+            return (false, "a recorded claim was dropped from the queue");
+        }
+        for (uint256 i = 0; i < earlier.queue.length; i++) {
+            ClaimRecord memory was = earlier.queue[i];
+            ClaimRecord memory now_ = later.queue[i];
+            if (now_.owed != was.owed) {
+                return (false, "a recorded claim's owed amount changed");
+            }
+            if (now_.paid < was.paid) {
+                return (false, "payment already made against a claim was reversed");
+            }
+        }
+        return (true, "every recorded claim kept its amount and its payment");
+    }
+}

--- a/plugins/pandects/src/laws/ReservesBackedByClaims.sol
+++ b/plugins/pandects/src/laws/ReservesBackedByClaims.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ICreditObservables} from "../ICreditObservables.sol";
+import {Law} from "../Law.sol";
+
+/// @title Nothing is reserved that nobody has claimed.
+/// @notice Assets earmarked against withdrawal claims never exceed the claims
+/// recorded. Reserving more than is owed is not a conservative error: it takes
+/// liquidity away from the borrower, which is the thing the borrower is paying
+/// for, and it does so without anyone having asked.
+///
+/// Independent of the other two conservation laws by construction. A state can
+/// break this while conserving value and while keeping its held assets within
+/// their partition, which is what the diagonal in `test/Corpus.t.sol` asserts.
+///
+/// Exact, with no tolerance. This is a comparison and nothing else.
+contract ReservesBackedByClaims is Law {
+    function id() external pure override returns (string memory) {
+        return "conservation/reserves-backed-by-claims/v1";
+    }
+
+    function statement() external pure override returns (string memory) {
+        return "Assets reserved never exceed the lender claims recorded.";
+    }
+
+    function check(ICreditObservables target)
+        external
+        view
+        override
+        returns (bool held, string memory detail)
+    {
+        uint256 reserved = target.reservedAssets();
+        uint256 claims = target.totalLenderClaims();
+        if (reserved <= claims) {
+            return (true, "reserved is within recorded claims");
+        }
+        return (false, "reserved exceeds recorded claims");
+    }
+}

--- a/plugins/pandects/src/laws/ReservesCoverPayableClaims.sol
+++ b/plugins/pandects/src/laws/ReservesCoverPayableClaims.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ICreditObservables} from "../ICreditObservables.sol";
+import {IWithdrawalQueueObservables} from "../IWithdrawalQueueObservables.sol";
+import {Law} from "../Law.sol";
+
+/// @title What the system says it can pay, it has set aside.
+/// @notice Everything still owed on the claims the system declares payable is
+/// covered by the assets it has reserved. A declaration of payability is a
+/// statement a lender acts on: they stop looking for liquidity elsewhere, they
+/// stop pricing the risk of not getting out, and a system that declares more
+/// than it holds has moved that risk onto them without telling them.
+///
+/// This is why `payableThrough` is a declaration rather than something derived
+/// from the reserves. A derived figure cannot be wrong and therefore cannot be
+/// checked; the law exists precisely to compare what a system says with what it
+/// has.
+///
+/// Distinct from `conservation/reserves-backed-by-claims/v1`, which bounds
+/// reserves from above against the pooled total. This bounds them from below
+/// against a named subset. A system can satisfy either alone.
+///
+/// The traversal is unbounded, and that is a limit rather than an oversight.
+/// This reads every recorded claim, one external call each, so against a system
+/// with a long enough queue it runs out of gas and reverts -- and a revert is
+/// no verdict. There is no partial answer available: the property is about the
+/// whole queue, and a law that read half of it and held would be reporting on
+/// half a system. The applicability says so, and a target that queues more than
+/// can be read in one call needs an adapter that pages, not a law that guesses.
+///
+/// Exact, with no tolerance. A sum and a comparison.
+contract ReservesCoverPayableClaims is Law {
+    function id() external pure override returns (string memory) {
+        return "claims/reserves-cover-payable/v1";
+    }
+
+    function statement() external pure override returns (string memory) {
+        return
+            "Reserved assets cover everything still owed on the claims declared payable.";
+    }
+
+    function check(ICreditObservables target)
+        external
+        view
+        override
+        returns (bool held, string memory detail)
+    {
+        IWithdrawalQueueObservables queue =
+            IWithdrawalQueueObservables(address(target));
+        uint256 count = queue.claimCount();
+        uint256 through = queue.payableThrough();
+        if (through > count) {
+            // Marginally broader than the statement, and deliberately so. The
+            // alternative is reading past the end of the queue, which reverts,
+            // and a revert is no verdict: the loudest possible nonsense in a
+            // declaration would produce the quietest possible result.
+            return (false, "more claims were declared payable than exist");
+        }
+
+        uint256 outstanding;
+        for (uint256 i = 0; i < through; i++) {
+            (uint256 owed, uint256 paid) = queue.claimAt(i);
+            // A claim paid beyond what it was owed contributes nothing here.
+            // It is a defect, and no law in the corpus covers it yet; folding
+            // it into this one would make this law catch something its
+            // statement does not describe, and a law broader than its
+            // statement is the thing the diagonal exists to fail.
+            if (paid >= owed) {
+                continue;
+            }
+            // Summed unchecked with the overflow reported, for the reason
+            // given in ValueConserved: reverting here would be silence exactly
+            // where the numbers are furthest wrong.
+            uint256 next;
+            unchecked {
+                next = outstanding + (owed - paid);
+            }
+            if (next < outstanding) {
+                return (false, "the payable claims sum to more than can be counted");
+            }
+            outstanding = next;
+        }
+
+        if (outstanding <= target.reservedAssets()) {
+            return (true, "reserves cover what is declared payable");
+        }
+        return (false, "more is declared payable than is reserved");
+    }
+}

--- a/plugins/pandects/src/laws/ValueConserved.sol
+++ b/plugins/pandects/src/laws/ValueConserved.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ICreditObservables} from "../ICreditObservables.sol";
+import {Law} from "../Law.sol";
+
+/// @title Value is conserved across the system.
+/// @notice What the system holds, plus what its borrowers owe, is exactly what
+/// its lenders may claim plus the fees it has accrued. Value does not appear
+/// and does not vanish.
+///
+/// The equality is the point. A system that writes down a defaulted debt
+/// without writing down the claims against it has made value disappear from
+/// one side and not the other, and this is the law that says so. A system that
+/// credits a lender without receiving anything has made value appear.
+///
+/// Exact, with no tolerance. Nothing here divides, so nothing here rounds.
+contract ValueConserved is Law {
+    function id() external pure override returns (string memory) {
+        return "conservation/value-conserved/v1";
+    }
+
+    function statement() external pure override returns (string memory) {
+        return
+            "Assets held plus debt owed equals lender claims plus accrued fees.";
+    }
+
+    function check(ICreditObservables target)
+        external
+        view
+        override
+        returns (bool held, string memory detail)
+    {
+        uint256 assets = target.totalAssets();
+        uint256 debt = target.totalDebt();
+        uint256 claims = target.totalLenderClaims();
+        uint256 fees = target.accruedFees();
+
+        // Both sums are computed unchecked and their overflow reported rather
+        // than reverted. In 0.8 an overflow reverts, and a revert carries no
+        // verdict to a campaign running with fail_on_revert = false, so a law
+        // that overflowed would fall silent exactly where the numbers went
+        // furthest wrong. No honest credit system holds 2^255 of anything, so
+        // the overflow is itself the finding.
+        uint256 owed;
+        uint256 promised;
+        unchecked {
+            owed = assets + debt;
+            promised = claims + fees;
+        }
+        if (owed < assets) {
+            return (false, "assets plus debt overflows");
+        }
+        if (promised < claims) {
+            return (false, "claims plus fees overflows");
+        }
+        if (owed == promised) {
+            return (true, "held plus owed equals claimed plus accrued");
+        }
+        return (false, "held plus owed differs from claimed plus accrued");
+    }
+}

--- a/plugins/pandects/test/Adapters.t.sol
+++ b/plugins/pandects/test/Adapters.t.sol
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {CorpusObserver} from "../adapters/CorpusBase.sol";
+import {PathIndependenceProbe} from "../adapters/foundry/PathIndependenceProbe.sol";
+import {ICreditObservables} from "../src/ICreditObservables.sol";
+import {DrivenClaimHaircutEchidna, ObservedQueueJumpedEchidna} from "../src/campaigns/Adapters.sol";
+import {Sound} from "../specimens/Sound.sol";
+import {CompoundsPerStep} from "../specimens/CompoundsPerStep.sol";
+import {QueueJumped} from "../specimens/QueueJumped.sol";
+
+/// @title The adapters, against targets they did not build.
+/// @notice Three claims. An observing adapter judges a target nobody routed
+/// calls through, and offers no pair law. A driving adapter offers them, and
+/// one fires. And the ninth law, which no adapter can carry, is reachable
+/// through a probe that takes both systems.
+/// A target that reports the core observables and has no withdrawal queue.
+/// Plenty of credit systems have none, and the corpus is meant to stay useful
+/// for them rather than narrowing to systems shaped like the reference.
+contract NoQueue is ICreditObservables {
+    address public asset;
+
+    function totalAssets() external pure returns (uint256) {
+        return 0;
+    }
+
+    function totalDebt() external pure returns (uint256) {
+        return 0;
+    }
+
+    function totalLenderClaims() external pure returns (uint256) {
+        return 0;
+    }
+
+    function accruedFees() external pure returns (uint256) {
+        return 0;
+    }
+
+    function reservedAssets() external pure returns (uint256) {
+        return 0;
+    }
+
+    function borrowableAssets() external pure returns (uint256) {
+        return 0;
+    }
+
+    function observedAt() external pure returns (uint256) {
+        return 0;
+    }
+}
+
+contract AdaptersTest {
+    uint256 internal constant PRINCIPAL = 100_000;
+    uint256 internal constant HALF_SPAN = 182.5 days;
+    uint256 internal constant WHOLE_SPAN = 365 days;
+
+    // -- the observing adapter ----------------------------------------------
+
+    /// @notice A target driven by somebody else, judged anyway.
+    /// @dev The specimen is built here and handed over. Nothing routes its
+    /// calls through the adapter, and the one-state laws still decide.
+    function test_the_observer_judges_a_target_it_does_not_front() external {
+        QueueJumped system = new QueueJumped();
+        CorpusObserver observer = new CorpusObserver(ICreditObservables(address(system)));
+
+        require(observer.coreHolds(), "a sound state was reported as violated");
+        require(observer.queueHolds(), "an ordered queue was reported as violated");
+
+        system.deposit(2);
+        system.reserve(1);
+        system.reserve(1);
+        system.payClaim(1);
+
+        require(observer.coreHolds(), "the conservation laws were dragged down with it");
+        require(!observer.queueHolds(), "the observer missed a queue paid out of turn");
+    }
+
+    /// @notice The observer offers no pair law, and this is how that is checked.
+    /// @dev Not a comment: the selector is absent from the deployed code, so
+    /// the call reverts. An observer that answered here would answer for every
+    /// target forever, because nothing gave it a past to compare with.
+    function test_the_observer_offers_no_pair_law() external {
+        CorpusObserver observer =
+            new CorpusObserver(ICreditObservables(address(new Sound())));
+        (bool ok, ) = address(observer).staticcall(
+            abi.encodeWithSignature("successionHolds()")
+        );
+        require(!ok, "the observer answered a question it cannot have an answer to");
+    }
+
+    /// @notice And the reasons come back in the laws' own words.
+    function test_the_observer_carries_a_reason_for_every_verdict() external {
+        QueueJumped system = new QueueJumped();
+        system.deposit(2);
+        system.reserve(1);
+        system.reserve(1);
+        system.payClaim(1);
+        CorpusObserver observer = new CorpusObserver(ICreditObservables(address(system)));
+        string[5] memory details = observer.explainOneState();
+        for (uint256 i = 0; i < 5; i++) {
+            require(bytes(details[i]).length > 0, "a verdict without a detail");
+        }
+        require(
+            keccak256(bytes(details[3]))
+                == keccak256("a claim was paid while an older one was still owed"),
+            "the reason is not the one the law gives"
+        );
+    }
+
+    /// @notice A target with no queue still gets the reasons it can have.
+    /// @dev `explainOneState` reads all five and reverts here, which is the
+    /// documented limit. `explainCore` is the three that had an answer, and the
+    /// point is that they are reachable rather than taken down with the other
+    /// two.
+    function test_a_queueless_target_still_gets_the_core_reasons() external {
+        CorpusObserver observer =
+            new CorpusObserver(ICreditObservables(address(new NoQueue())));
+
+        (bool everything, ) = address(observer).staticcall(
+            abi.encodeWithSignature("explainOneState()")
+        );
+        require(!everything, "a queue was read off a target that has none");
+
+        string[3] memory core = observer.explainCore();
+        for (uint256 i = 0; i < 3; i++) {
+            require(bytes(core[i]).length > 0, "a law that could judge gave no reason");
+        }
+        require(observer.coreHolds(), "an empty system was reported as violated");
+    }
+
+    // -- the driving adapter -------------------------------------------------
+
+    /// @notice A succession law fires through the adapter that fronted the call.
+    function test_the_driver_catches_a_claim_written_down() external {
+        DrivenClaimHaircutEchidna driven = new DrivenClaimHaircutEchidna();
+
+        require(driven.successionHolds(), "a pair law fired before any call was made");
+
+        driven.deposit(1);
+        driven.reserve(1);
+        require(driven.successionHolds(), "a pair law fired on a sound transition");
+
+        driven.haircut(0, 1);
+        require(!driven.successionHolds(), "the driver missed a claim written down");
+
+        string[3] memory why = driven.explainSuccession();
+        require(
+            keccak256(bytes(why[2]))
+                == keccak256("a recorded claim's owed amount changed"),
+            "the reason is not the one the law gives"
+        );
+    }
+
+    /// @notice The engine prefix is present, and answers.
+    function test_the_echidna_entry_points_answer() external {
+        ObservedQueueJumpedEchidna observed = new ObservedQueueJumpedEchidna();
+        require(observed.echidna_value_conserved(), "a sound state was reported as violated");
+        require(observed.echidna_queue_order_preserved(), "an ordered queue was reported as violated");
+        observed.deposit(2);
+        observed.reserve(1);
+        observed.reserve(1);
+        observed.payClaim(1);
+        require(!observed.echidna_queue_order_preserved(), "the campaign missed the jump");
+        require(observed.echidna_value_conserved(), "an unrelated law was dragged down");
+    }
+
+    /// @notice A driver whose entry points forgot `records` reports holding.
+    /// @dev The failure mode this cannot prevent, made visible instead. The
+    /// succession laws return true because nothing gave them a past, which is
+    /// indistinguishable from them holding -- so the count is what tells the two
+    /// apart, and an integrator has something to assert on.
+    function test_a_driver_that_recorded_nothing_says_so() external {
+        DrivenClaimHaircutEchidna driven = new DrivenClaimHaircutEchidna();
+
+        require(driven.successionHolds(), "an unexercised pair law reported a violation");
+        require(!driven.successionExercised(), "nothing was called and it claims otherwise");
+        require(driven.recordedCalls() == 0, "a call was recorded before any was made");
+
+        string[3] memory why = driven.explainSuccession();
+        require(
+            keccak256(bytes(why[0]))
+                == keccak256("no call was recorded, so no transition was judged"),
+            "the adapter did not say that it judged nothing"
+        );
+
+        driven.deposit(1);
+        require(driven.successionExercised(), "a recorded call was not counted");
+        require(driven.recordedCalls() == 1, "the count is not one after one call");
+    }
+
+    // -- the probe -----------------------------------------------------------
+
+    /// @notice The ninth law, reached through the only shape that can carry it.
+    function test_the_probe_catches_compounding_and_clears_the_reference() external {
+        PathIndependenceProbe probe = new PathIndependenceProbe(2);
+        require(probe.tolerance() == 1, "the bound is not n-1 for two subdivisions");
+
+        (Sound soundCoarse, Sound soundFine) = race(new Sound(), new Sound());
+        (bool sound, ) = probe.check(soundCoarse, soundFine);
+        require(sound, "the reference was reported as path dependent");
+
+        (Sound coarse, Sound fine) = race(new CompoundsPerStep(), new CompoundsPerStep());
+        (bool broken, string memory why) = probe.check(coarse, fine);
+        require(!broken, "the probe missed a system that compounds");
+        require(bytes(why).length > 0, "a verdict without a detail");
+    }
+
+    /// @notice A probe built for the wrong run is wrong, and says nothing.
+    /// @dev The hazard belongs to the law and the caller meets it here, so it
+    /// is asserted here too.
+    function test_a_probe_built_for_the_wrong_run_passes_a_broken_system() external {
+        PathIndependenceProbe generous = new PathIndependenceProbe(1000);
+        (Sound coarse, Sound fine) = race(new CompoundsPerStep(), new CompoundsPerStep());
+        (bool held, ) = generous.check(coarse, fine);
+        require(held, "the bound did not widen with the count, so this proves nothing");
+    }
+
+    function race(Sound coarse, Sound fine) internal returns (Sound, Sound) {
+        coarse.deposit(PRINCIPAL);
+        coarse.borrow(PRINCIPAL);
+        fine.deposit(PRINCIPAL);
+        fine.borrow(PRINCIPAL);
+        coarse.advance(WHOLE_SPAN);
+        fine.advance(HALF_SPAN);
+        fine.advance(HALF_SPAN);
+        return (coarse, fine);
+    }
+}

--- a/plugins/pandects/test/Corpus.t.sol
+++ b/plugins/pandects/test/Corpus.t.sol
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ICreditObservables} from "../src/ICreditObservables.sol";
+import {Law} from "../src/Law.sol";
+import {ValueConserved} from "../src/laws/ValueConserved.sol";
+import {ReservesBackedByClaims} from "../src/laws/ReservesBackedByClaims.sol";
+import {HeldAssetsPartitioned} from "../src/laws/HeldAssetsPartitioned.sol";
+import {QueueOrderPreserved} from "../src/laws/QueueOrderPreserved.sol";
+import {ReservesCoverPayableClaims} from "../src/laws/ReservesCoverPayableClaims.sol";
+import {Sound} from "../specimens/Sound.sol";
+import {MintedClaims} from "../specimens/MintedClaims.sol";
+import {OverReserved} from "../specimens/OverReserved.sol";
+import {OverPromised} from "../specimens/OverPromised.sol";
+import {DebtForgiven} from "../specimens/DebtForgiven.sol";
+import {AccruesAtRest} from "../specimens/AccruesAtRest.sol";
+import {CompoundsPerStep} from "../specimens/CompoundsPerStep.sol";
+import {ClaimHaircut} from "../specimens/ClaimHaircut.sol";
+import {QueueJumped} from "../specimens/QueueJumped.sol";
+import {PayableBeyondReserves} from "../specimens/PayableBeyondReserves.sol";
+
+/// A state at the arithmetic limit. Not a catalogue specimen: it exists to
+/// prove a law reports rather than reverts where the numbers are furthest
+/// wrong, which is exactly where a reverting law would fall silent.
+contract Extreme is ICreditObservables {
+    address public asset;
+
+    function totalAssets() external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function totalDebt() external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function totalLenderClaims() external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function accruedFees() external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function reservedAssets() external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function borrowableAssets() external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function observedAt() external view returns (uint256) {
+        return block.timestamp;
+    }
+}
+
+/// @title The diagonal, for the laws that judge one state.
+/// @notice Every one-state law against every specimen. The claim being tested
+/// is not that the laws pass: it is that each law fails exactly the specimen
+/// written to break it and holds against the others.
+///
+/// A law that catches a specimen it was not written for is broader than its
+/// statement claims, and this suite fails. A law that catches nothing may be a
+/// tautology, and this suite fails. Those two failures are the reason the
+/// corpus requires a specimen at all.
+///
+/// Four specimens here are expected to break nothing. Their defects live in
+/// transitions rather than states, and no observation of one moment can show
+/// them; that is the whole reason `PairLaw` exists, and `test/Pairs.t.sol` is
+/// where they are caught. Asserting here that they hold every one-state law is
+/// half of what makes them independent.
+contract CorpusTest {
+    ValueConserved internal conserved;
+    ReservesBackedByClaims internal backed;
+    HeldAssetsPartitioned internal partitioned;
+    QueueOrderPreserved internal ordered;
+    ReservesCoverPayableClaims internal covered;
+
+    uint256 internal constant CONSERVED = 0;
+    uint256 internal constant BACKED = 1;
+    uint256 internal constant PARTITIONED = 2;
+    uint256 internal constant ORDERED = 3;
+    uint256 internal constant COVERED = 4;
+    uint256 internal constant COUNT = 5;
+
+    /// No one-state law is expected to catch this specimen.
+    uint256 internal constant NOTHING = type(uint256).max;
+
+    function setUp() public {
+        conserved = new ValueConserved();
+        backed = new ReservesBackedByClaims();
+        partitioned = new HeldAssetsPartitioned();
+        ordered = new QueueOrderPreserved();
+        covered = new ReservesCoverPayableClaims();
+    }
+
+    function laws() internal view returns (Law[COUNT] memory) {
+        return [
+            Law(conserved),
+            Law(backed),
+            Law(partitioned),
+            Law(ordered),
+            Law(covered)
+        ];
+    }
+
+    /// Every law against one target, as a list of which held.
+    function verdicts(ICreditObservables target)
+        internal
+        view
+        returns (bool[COUNT] memory out)
+    {
+        Law[COUNT] memory all = laws();
+        for (uint256 i = 0; i < COUNT; i++) {
+            (bool held, ) = all[i].check(target);
+            out[i] = held;
+        }
+    }
+
+    function assertDiagonal(ICreditObservables target, uint256 breaks) internal view {
+        bool[COUNT] memory held = verdicts(target);
+        for (uint256 i = 0; i < COUNT; i++) {
+            if (i == breaks) {
+                require(!held[i], "the law written for this specimen did not catch it");
+            } else {
+                require(held[i], "a law caught a specimen it was not written for");
+            }
+        }
+    }
+
+    // -- the sound reference ------------------------------------------------
+
+    function test_the_sound_reference_holds_every_law() external {
+        Sound target = new Sound();
+        target.deposit(100);
+        target.borrow(30);
+        target.advance(86400);
+        target.accrueFee(10);
+        target.reserve(20);
+        target.payClaim(5);
+        assertDiagonal(target, NOTHING);
+    }
+
+    function test_a_sound_system_at_rest_holds_every_law() external {
+        Sound target = new Sound();
+        assertDiagonal(target, NOTHING);
+    }
+
+    // -- the diagonal -------------------------------------------------------
+
+    function test_minted_claims_breaks_conservation_alone() external {
+        MintedClaims target = new MintedClaims();
+        target.deposit(100);
+        assertDiagonal(target, CONSERVED);
+    }
+
+    function test_over_reserved_breaks_reserve_backing_alone() external {
+        OverReserved target = new OverReserved();
+        target.deposit(100);
+        target.accrueFee(60);
+        target.reserve(80);
+        assertDiagonal(target, BACKED);
+    }
+
+    function test_over_promised_breaks_the_partition_alone() external {
+        OverPromised target = new OverPromised();
+        target.deposit(100);
+        target.reserve(50);
+        assertDiagonal(target, PARTITIONED);
+    }
+
+    function test_queue_jumped_breaks_the_ordering_alone() external {
+        QueueJumped target = new QueueJumped();
+        target.deposit(2);
+        target.reserve(1);
+        target.reserve(1);
+        target.payClaim(1);
+        assertDiagonal(target, ORDERED);
+    }
+
+    function test_payable_beyond_reserves_breaks_the_cover_alone() external {
+        PayableBeyondReserves target = new PayableBeyondReserves();
+        target.deposit(1);
+        target.reserve(1);
+        target.reserve(1);
+        assertDiagonal(target, COVERED);
+    }
+
+    // -- the specimens no one-state law can see -----------------------------
+
+    function test_debt_forgiven_holds_every_one_state_law() external {
+        DebtForgiven target = new DebtForgiven();
+        target.deposit(1);
+        target.borrow(1);
+        target.accrueFee(1);
+        target.forgive(1);
+        assertDiagonal(target, NOTHING);
+    }
+
+    function test_accrues_at_rest_holds_every_one_state_law() external {
+        AccruesAtRest target = new AccruesAtRest();
+        target.poke(1);
+        assertDiagonal(target, NOTHING);
+    }
+
+    function test_compounds_per_step_holds_every_one_state_law() external {
+        CompoundsPerStep target = new CompoundsPerStep();
+        target.deposit(1000);
+        target.borrow(1000);
+        target.advance(31536000);
+        target.advance(31536000);
+        assertDiagonal(target, NOTHING);
+    }
+
+    function test_claim_haircut_holds_every_one_state_law() external {
+        ClaimHaircut target = new ClaimHaircut();
+        target.deposit(1);
+        target.reserve(1);
+        target.haircut(0, 1);
+        assertDiagonal(target, NOTHING);
+    }
+
+    // -- what a law must not do ---------------------------------------------
+
+    /// @notice Reporting rather than reverting, where the numbers are worst.
+    /// @dev Only the three conservation laws are asked. `Extreme` reports the
+    /// core observables and implements no withdrawal queue, so the two queue
+    /// laws revert on the read rather than on the arithmetic. That is the
+    /// documented limit and not the thing this test is about: an unobservable
+    /// state produces no verdict, and the harness counts the revert.
+    function test_no_law_reverts_at_the_arithmetic_limit() external {
+        Extreme target = new Extreme();
+        Law[3] memory summing = [Law(conserved), Law(backed), Law(partitioned)];
+        for (uint256 i = 0; i < 3; i++) {
+            (bool ok, ) = address(summing[i]).staticcall(
+                abi.encodeWithSelector(Law.check.selector, address(target))
+            );
+            require(ok, "a law reverted where the numbers are furthest wrong");
+        }
+    }
+
+    /// @notice A law asked about a state it cannot observe reverts, and says
+    /// nothing.
+    /// @dev Worth asserting rather than assuming. The two queue laws reach
+    /// past the core observables, and the corpus's answer to a target that
+    /// cannot answer is a revert -- neither a violation nor a pass. A law that
+    /// returned `true` here would be reporting that a system with no queue
+    /// keeps its queue in order.
+    function test_a_queue_law_over_a_target_with_no_queue_reverts() external {
+        Extreme target = new Extreme();
+        Law[2] memory queueLaws = [Law(ordered), Law(covered)];
+        for (uint256 i = 0; i < 2; i++) {
+            (bool ok, ) = address(queueLaws[i]).staticcall(
+                abi.encodeWithSelector(Law.check.selector, address(target))
+            );
+            require(!ok, "a queue law claimed a verdict it could not have");
+        }
+    }
+
+    /// @notice Overflow is a verdict, and only for the laws that add.
+    /// @dev Worth separating from the revert test above, because the two are
+    /// different claims. Both laws that sum report the overflow as a
+    /// violation. The law that only compares holds, and correctly so: at the
+    /// limit, reserved really is no greater than claims. A test asserting all
+    /// three were violated would have been asserting something false.
+    function test_a_sum_that_overflows_is_reported_as_a_violation() external {
+        Extreme target = new Extreme();
+        (bool conservedHeld, ) = conserved.check(target);
+        (bool partitionedHeld, ) = partitioned.check(target);
+        (bool backedHeld, ) = backed.check(target);
+        require(!conservedHeld, "an overflowing sum was not reported");
+        require(!partitionedHeld, "an overflowing sum was not reported");
+        require(backedHeld, "a comparison that holds was reported as violated");
+    }
+
+    function test_every_law_returns_a_detail_whichever_way_it_decides() external {
+        Sound sound = new Sound();
+        MintedClaims broken = new MintedClaims();
+        broken.deposit(100);
+        Law[COUNT] memory all = laws();
+        for (uint256 i = 0; i < COUNT; i++) {
+            (, string memory onSound) = all[i].check(sound);
+            (, string memory onBroken) = all[i].check(broken);
+            require(bytes(onSound).length > 0, "a verdict without a detail");
+            require(bytes(onBroken).length > 0, "a verdict without a detail");
+        }
+    }
+
+    function test_every_law_carries_an_identifier_and_a_statement() external view {
+        Law[COUNT] memory all = laws();
+        for (uint256 i = 0; i < COUNT; i++) {
+            require(bytes(all[i].id()).length > 0, "a law with no id");
+            require(bytes(all[i].statement()).length > 0, "a law with no statement");
+        }
+    }
+}

--- a/plugins/pandects/test/Explain.t.sol
+++ b/plugins/pandects/test/Explain.t.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {AccruesAtRestCampaign, MintedClaimsCampaign} from "../src/campaigns/Specimens.sol";
+
+/// @title The reason a campaign gives, after it fails.
+/// @notice A property function can only say no. `explain` is where the reason
+/// lives, and this asserts that replaying a failing sequence and calling it
+/// returns the law's own words rather than something the harness invented.
+contract ExplainTest {
+    function test_explain_names_the_quantities_that_disagreed() external {
+        MintedClaimsCampaign campaign = new MintedClaimsCampaign();
+        campaign.deposit(1);
+        string[8] memory details = campaign.explain();
+        require(bytes(details[0]).length > 0, "no reason given");
+        require(
+            keccak256(bytes(details[0]))
+                == keccak256("held plus owed differs from claimed plus accrued"),
+            "the reason is not the one the law gives"
+        );
+    }
+
+    /// @notice The same, for a law that judges a transition rather than a state.
+    /// @dev Worth its own case. A pair law's reason has to survive the harness
+    /// holding one of the two observations in storage between calls, and a
+    /// harness that lost the earlier one would still return a string -- just
+    /// the wrong one.
+    function test_explain_carries_the_reason_a_pair_law_gave() external {
+        AccruesAtRestCampaign campaign = new AccruesAtRestCampaign();
+        campaign.poke(1);
+        string[8] memory details = campaign.explain();
+        require(
+            keccak256(bytes(details[6]))
+                == keccak256("debt rose while time stood still and assets stayed"),
+            "the reason is not the one the law gives"
+        );
+    }
+
+    /// @notice Before any call, a pair law has nothing to compare and says so.
+    function test_explain_is_empty_for_the_pair_laws_before_the_first_call()
+        external
+    {
+        AccruesAtRestCampaign campaign = new AccruesAtRestCampaign();
+        string[8] memory details = campaign.explain();
+        require(bytes(details[0]).length > 0, "a one-state law gave no reason");
+        require(bytes(details[5]).length == 0, "a pair law judged a pair it did not have");
+    }
+}

--- a/plugins/pandects/test/Law.t.sol
+++ b/plugins/pandects/test/Law.t.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ICreditObservables} from "../src/ICreditObservables.sol";
+import {Law} from "../src/Law.sol";
+
+/// A target whose numbers are whatever the test sets them to.
+contract Observable is ICreditObservables {
+    address public asset;
+    uint256 public totalAssets;
+    uint256 public totalDebt;
+    uint256 public totalLenderClaims;
+    uint256 public reservedAssets;
+    uint256 public borrowableAssets;
+    uint256 public accruedFees;
+    uint256 public observedAt;
+
+    function set(uint256 held, uint256 claims) external {
+        totalAssets = held;
+        totalLenderClaims = claims;
+    }
+}
+
+/// A target that will not answer. Not a law failing: a state nobody can see.
+contract Unobservable is ICreditObservables {
+    function asset() external pure returns (address) {
+        revert("no");
+    }
+
+    function totalAssets() external pure returns (uint256) {
+        revert("no");
+    }
+
+    function totalDebt() external pure returns (uint256) {
+        revert("no");
+    }
+
+    function totalLenderClaims() external pure returns (uint256) {
+        revert("no");
+    }
+
+    function reservedAssets() external pure returns (uint256) {
+        revert("no");
+    }
+
+    function borrowableAssets() external pure returns (uint256) {
+        revert("no");
+    }
+
+    function accruedFees() external pure returns (uint256) {
+        revert("no");
+    }
+
+    function observedAt() external pure returns (uint256) {
+        revert("no");
+    }
+}
+
+/// Not a shipped law. The shape a law has, exercised here so the base is
+/// tested before any law depends on it.
+contract SampleLaw is Law {
+    function id() external pure override returns (string memory) {
+        return "sample/held-covers-claims/v1";
+    }
+
+    function statement() external pure override returns (string memory) {
+        return "Assets held cover the claims recorded against them.";
+    }
+
+    function check(ICreditObservables target)
+        external
+        view
+        override
+        returns (bool held, string memory detail)
+    {
+        uint256 assets = target.totalAssets();
+        uint256 claims = target.totalLenderClaims();
+        if (assets >= claims) {
+            return (true, "assets cover claims");
+        }
+        return (false, "assets below claims");
+    }
+}
+
+contract LawTest {
+    SampleLaw internal law;
+    Observable internal target;
+
+    function setUp() public {
+        law = new SampleLaw();
+        target = new Observable();
+    }
+
+    function test_a_law_holding_returns_true_with_its_detail() external {
+        SampleLaw sample = new SampleLaw();
+        Observable observable = new Observable();
+        observable.set(100, 90);
+        (bool held, string memory detail) = sample.check(observable);
+        require(held, "law should hold");
+        require(bytes(detail).length > 0, "a verdict without a detail");
+    }
+
+    /// The decision the base exists to enforce: violated is a return value,
+    /// never a revert, because a revert carries no verdict to the harness.
+    function test_a_law_violated_returns_false_rather_than_reverting() external {
+        SampleLaw sample = new SampleLaw();
+        Observable observable = new Observable();
+        observable.set(90, 100);
+        (bool held, string memory detail) = sample.check(observable);
+        require(!held, "law should be violated");
+        require(bytes(detail).length > 0, "a verdict without a detail");
+    }
+
+    /// The stated limit: an unobservable target takes the law down with it,
+    /// and that is a revert rather than a pass.
+    function test_an_unobservable_target_reverts_rather_than_passing() external {
+        SampleLaw sample = new SampleLaw();
+        Unobservable unobservable = new Unobservable();
+        (bool ok, ) = address(sample).staticcall(
+            abi.encodeWithSelector(sample.check.selector, address(unobservable))
+        );
+        require(!ok, "reading an unobservable target should not succeed");
+    }
+
+    function test_a_law_carries_its_identifier_and_statement() external {
+        SampleLaw sample = new SampleLaw();
+        require(bytes(sample.id()).length > 0, "no id");
+        require(bytes(sample.statement()).length > 0, "no statement");
+    }
+}

--- a/plugins/pandects/test/Pairs.t.sol
+++ b/plugins/pandects/test/Pairs.t.sol
@@ -1,0 +1,383 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Observation, Observe} from "../src/Observation.sol";
+import {PairLaw} from "../src/PairLaw.sol";
+import {DebtFallsOnlyAgainstPayment} from "../src/laws/DebtFallsOnlyAgainstPayment.sol";
+import {NoAccrualAtRest} from "../src/laws/NoAccrualAtRest.sol";
+import {AccrualPathIndependent} from "../src/laws/AccrualPathIndependent.sol";
+import {RecordedClaimNeverShrinks} from "../src/laws/RecordedClaimNeverShrinks.sol";
+import {Sound} from "../specimens/Sound.sol";
+import {MintedClaims} from "../specimens/MintedClaims.sol";
+import {OverReserved} from "../specimens/OverReserved.sol";
+import {OverPromised} from "../specimens/OverPromised.sol";
+import {DebtForgiven} from "../specimens/DebtForgiven.sol";
+import {AccruesAtRest} from "../specimens/AccruesAtRest.sol";
+import {CompoundsPerStep} from "../specimens/CompoundsPerStep.sol";
+import {ClaimHaircut} from "../specimens/ClaimHaircut.sol";
+import {QueueJumped} from "../specimens/QueueJumped.sol";
+import {PayableBeyondReserves} from "../specimens/PayableBeyondReserves.sol";
+
+/// @title The diagonal, for the laws that judge a pair.
+/// @notice Three of these laws compare a system with its own past. They are
+/// checked the same way the one-state diagonal is: each fails exactly the
+/// specimen written for it and holds against every other, including against
+/// every transition a correct system can make.
+///
+/// The fourth is different in kind and is tested apart from the other three.
+/// `accrual/path-independent/v1` compares two systems advanced differently
+/// over the same span, so a before-and-after pair of one system is not
+/// something it can judge -- and it says so rather than holding, which is
+/// asserted below.
+contract PairsTest {
+    using Observe for Sound;
+
+    DebtFallsOnlyAgainstPayment internal falls;
+    NoAccrualAtRest internal atRest;
+    RecordedClaimNeverShrinks internal shrinks;
+    AccrualPathIndependent internal path;
+
+    uint256 internal constant FALLS = 0;
+    uint256 internal constant AT_REST = 1;
+    uint256 internal constant SHRINKS = 2;
+    uint256 internal constant COUNT = 3;
+    uint256 internal constant NOTHING = type(uint256).max;
+
+    /// @dev Two subdivisions, so the bound is one unit. Small on purpose: a
+    /// generous bound would let a compounding system slip through, and the
+    /// point of the bound is that it is derived rather than chosen.
+    uint256 internal constant SUBDIVISIONS = 2;
+
+    /// @dev Large enough that the truncation the bound describes is visible.
+    /// At this principal the sound reference lands exactly on the bound, one
+    /// unit apart, which is the strongest evidence available that the bound is
+    /// the arithmetic rather than a margin somebody picked.
+    uint256 internal constant PRINCIPAL = 100_000;
+
+    /// @dev Half a year each, so two of them make the single step below.
+    uint256 internal constant HALF_SPAN = 182.5 days;
+    uint256 internal constant WHOLE_SPAN = 365 days;
+
+    function setUp() public {
+        falls = new DebtFallsOnlyAgainstPayment();
+        atRest = new NoAccrualAtRest();
+        shrinks = new RecordedClaimNeverShrinks();
+        path = new AccrualPathIndependent(SUBDIVISIONS);
+    }
+
+    function succession() internal view returns (PairLaw[COUNT] memory) {
+        return [PairLaw(falls), PairLaw(atRest), PairLaw(shrinks)];
+    }
+
+    function assertPairDiagonal(
+        Observation memory earlier,
+        Observation memory later,
+        uint256 breaks
+    ) internal view {
+        PairLaw[COUNT] memory all = succession();
+        for (uint256 i = 0; i < COUNT; i++) {
+            (bool held, ) = all[i].check(earlier, later);
+            if (i == breaks) {
+                require(!held, "the law written for this specimen did not catch it");
+            } else {
+                require(held, "a law caught a transition it was not written for");
+            }
+        }
+    }
+
+    /// Every transition a correct system can make, each one judged.
+    function assertEveryTransitionHolds(Sound target) internal {
+        // Deliberately not a loop over an operation list: each call needs its
+        // own argument, and a table of selectors would put the harness between
+        // the law and the thing it judges.
+        Observation memory earlier = Observe.takeWithQueue(target);
+        Observation memory later;
+
+        target.deposit(1000);
+        later = Observe.takeWithQueue(target);
+        assertPairDiagonal(earlier, later, NOTHING);
+
+        earlier = later;
+        target.borrow(400);
+        later = Observe.takeWithQueue(target);
+        assertPairDiagonal(earlier, later, NOTHING);
+
+        earlier = later;
+        target.advance(HALF_SPAN);
+        later = Observe.takeWithQueue(target);
+        assertPairDiagonal(earlier, later, NOTHING);
+
+        earlier = later;
+        target.repay(50);
+        later = Observe.takeWithQueue(target);
+        assertPairDiagonal(earlier, later, NOTHING);
+
+        earlier = later;
+        target.accrueFee(20);
+        later = Observe.takeWithQueue(target);
+        assertPairDiagonal(earlier, later, NOTHING);
+
+        earlier = later;
+        target.reserve(30);
+        later = Observe.takeWithQueue(target);
+        assertPairDiagonal(earlier, later, NOTHING);
+
+        earlier = later;
+        target.payClaim(10);
+        later = Observe.takeWithQueue(target);
+        assertPairDiagonal(earlier, later, NOTHING);
+    }
+
+    // -- the sound reference ------------------------------------------------
+
+    function test_no_transition_of_the_sound_reference_breaks_a_pair_law() external {
+        assertEveryTransitionHolds(new Sound());
+    }
+
+    // -- the diagonal -------------------------------------------------------
+
+    function test_debt_forgiven_breaks_the_payment_law_alone() external {
+        DebtForgiven target = new DebtForgiven();
+        target.deposit(1);
+        target.borrow(1);
+        target.accrueFee(1);
+        Observation memory earlier = Observe.takeWithQueue(target);
+        target.forgive(1);
+        assertPairDiagonal(earlier, Observe.takeWithQueue(target), FALLS);
+    }
+
+    function test_accrues_at_rest_breaks_the_rest_law_alone() external {
+        AccruesAtRest target = new AccruesAtRest();
+        Observation memory earlier = Observe.takeWithQueue(target);
+        target.poke(1);
+        assertPairDiagonal(earlier, Observe.takeWithQueue(target), AT_REST);
+    }
+
+    function test_claim_haircut_breaks_the_claim_law_alone() external {
+        ClaimHaircut target = new ClaimHaircut();
+        target.deposit(1);
+        target.reserve(1);
+        Observation memory earlier = Observe.takeWithQueue(target);
+        target.haircut(0, 1);
+        assertPairDiagonal(earlier, Observe.takeWithQueue(target), SHRINKS);
+    }
+
+    // -- every other specimen, against every transition ----------------------
+
+    function test_the_one_state_specimens_break_no_pair_law() external {
+        assertEveryTransitionHolds(new MintedClaims());
+        assertEveryTransitionHolds(new OverReserved());
+        assertEveryTransitionHolds(new OverPromised());
+    }
+
+    function test_the_other_pair_specimens_break_no_pair_law_in_passing() external {
+        assertEveryTransitionHolds(new CompoundsPerStep());
+        assertEveryTransitionHolds(new QueueJumped());
+        assertEveryTransitionHolds(new PayableBeyondReserves());
+    }
+
+    // -- path independence ---------------------------------------------------
+
+    /// Two systems from the same start, advanced over the same span by
+    /// different routes.
+    function race(Sound coarse, Sound fine)
+        internal
+        returns (Observation memory, Observation memory)
+    {
+        coarse.deposit(PRINCIPAL);
+        coarse.borrow(PRINCIPAL);
+        fine.deposit(PRINCIPAL);
+        fine.borrow(PRINCIPAL);
+
+        coarse.advance(WHOLE_SPAN);
+        for (uint256 i = 0; i < SUBDIVISIONS; i++) {
+            fine.advance(HALF_SPAN);
+        }
+        return (Observe.take(coarse), Observe.take(fine));
+    }
+
+    function test_the_sound_reference_is_path_independent() external {
+        (Observation memory coarse, Observation memory fine) =
+            race(new Sound(), new Sound());
+        (bool held, ) = path.check(coarse, fine);
+        require(held, "linear accrual on principal was not path independent");
+    }
+
+    function test_compounding_per_step_breaks_path_independence_alone() external {
+        (Observation memory coarse, Observation memory fine) =
+            race(new CompoundsPerStep(), new CompoundsPerStep());
+        (bool held, ) = path.check(coarse, fine);
+        require(!held, "compounding was not caught by the path-independence law");
+    }
+
+    function test_no_other_specimen_breaks_path_independence() external {
+        Sound[6] memory coarse = [
+            Sound(new MintedClaims()),
+            Sound(new OverReserved()),
+            Sound(new OverPromised()),
+            Sound(new DebtForgiven()),
+            Sound(new AccruesAtRest()),
+            Sound(new QueueJumped())
+        ];
+        Sound[6] memory fine = [
+            Sound(new MintedClaims()),
+            Sound(new OverReserved()),
+            Sound(new OverPromised()),
+            Sound(new DebtForgiven()),
+            Sound(new AccruesAtRest()),
+            Sound(new QueueJumped())
+        ];
+        for (uint256 i = 0; i < 6; i++) {
+            (Observation memory a, Observation memory b) = race(coarse[i], fine[i]);
+            (bool held, ) = path.check(a, b);
+            require(held, "path independence caught a specimen it was not written for");
+        }
+    }
+
+    /// @notice The bound at its edge, and one unit past it.
+    /// @dev Built by hand rather than by running a system, because the claim is
+    /// about the law's arithmetic and not about any particular target. Two
+    /// subdivisions truncate at most once each against a single truncation the
+    /// other way, so the widest honest gap is one unit.
+    function test_the_bound_holds_at_its_edge_and_not_beyond() external view {
+        require(path.tolerance() == SUBDIVISIONS - 1, "the bound is not n-1");
+
+        Observation memory a;
+        Observation memory b;
+        a.observedAt = 1000;
+        b.observedAt = 1000;
+        a.totalDebt = 500;
+
+        b.totalDebt = 500 + path.tolerance();
+        (bool atEdge, ) = path.check(a, b);
+        require(atEdge, "a gap of exactly the bound was reported as a violation");
+
+        b.totalDebt = 500 + path.tolerance() + 1;
+        (bool beyond, ) = path.check(a, b);
+        require(!beyond, "a gap one unit past the bound was not reported");
+    }
+
+    /// @notice A bound built for the wrong run gives the wrong verdict.
+    /// @dev The hazard this law cannot defend against, shown failing in both
+    /// directions rather than described. Nothing in either observation says how
+    /// many steps the subdivided run took, so the count is part of the
+    /// question: a law deployed with the wrong one is answering about a run
+    /// nobody made, and it does so without any sign that it has.
+    function test_a_bound_built_for_the_wrong_run_is_wrong_in_both_directions()
+        external
+    {
+        (Observation memory coarse, Observation memory fine) =
+            race(new CompoundsPerStep(), new CompoundsPerStep());
+
+        // The compounding specimen ran in two steps. Asked with the count it
+        // used, the law catches it.
+        (bool correct, ) = path.check(coarse, fine);
+        require(!correct, "the law built for this run did not catch it");
+
+        // Asked with a count far larger than the run used, the same gap fits
+        // inside the bound and the same defect passes.
+        AccrualPathIndependent generous = new AccrualPathIndependent(1000);
+        (bool tooWide, ) = generous.check(coarse, fine);
+        require(tooWide, "the bound did not widen with the count, so this proves nothing");
+
+        // And the sound reference, path independent to within one unit, is
+        // reported as violated by a law built for a single step.
+        (Observation memory a, Observation memory b) = race(new Sound(), new Sound());
+        AccrualPathIndependent mean = new AccrualPathIndependent(1);
+        (bool tooTight, ) = mean.check(a, b);
+        require(!tooTight, "a correct system was not misjudged by a bound that is too tight");
+    }
+
+    /// @notice A pair it cannot judge is refused, not held.
+    /// @dev The asymmetry with `no-accrual-at-rest` is deliberate and worth a
+    /// test rather than a comment. A pair spanning real time is a state of the
+    /// world, and that law holds on it. Two runs that never reached the same
+    /// moment are a mistake by whoever built the pair, and holding there would
+    /// report a comparison nobody made.
+    function test_a_pair_at_different_times_is_refused() external view {
+        Observation memory a;
+        Observation memory b;
+        a.observedAt = 1000;
+        b.observedAt = 1001;
+        a.totalDebt = 500;
+        b.totalDebt = 500;
+        (bool held, ) = path.check(a, b);
+        require(!held, "two runs at different moments were compared anyway");
+
+        (bool restHeld, ) = atRest.check(a, b);
+        require(restHeld, "a pair spanning real time was treated as a mistake");
+    }
+
+    // -- what a pair law must not do -----------------------------------------
+
+    /// @notice A queue law handed observations nobody read the queue into
+    /// refuses rather than holds.
+    function test_an_unobserved_queue_is_refused() external {
+        Sound target = new Sound();
+        Observation memory earlier = Observe.take(target);
+        Observation memory later = Observe.take(target);
+        (bool held, string memory detail) = shrinks.check(earlier, later);
+        require(!held, "a law about the queue held on a pair with no queue in it");
+        require(bytes(detail).length > 0, "a verdict without a detail");
+    }
+
+    /// @notice A law that does not need the queue is judgeable without one.
+    /// @dev The other half of the applicability claim, and the half nothing
+    /// asserted. `recorded-claim-never-shrinks` refuses a pair with no queue in
+    /// it, which is above. The two accrual laws must do the opposite: read a
+    /// pair taken with `Observe.take`, decide, and never touch the queue at
+    /// all. Their independence from it is visible in the signature, and a
+    /// signature is not evidence -- a law could read `queueObserved` and refuse,
+    /// exactly as its neighbour does, and nothing here would have noticed.
+    function test_the_laws_that_need_no_queue_judge_a_pair_without_one() external {
+        Sound target = new Sound();
+        target.deposit(1000);
+        target.borrow(400);
+
+        Observation memory earlier = Observe.take(target);
+        require(!earlier.queueObserved, "the queue was read after all");
+
+        // A repayment: debt falls, held assets rise by the same, both laws hold.
+        target.repay(100);
+        Observation memory later = Observe.take(target);
+        (bool paidBack, ) = falls.check(earlier, later);
+        (bool atRestHeld, ) = atRest.check(earlier, later);
+        require(paidBack, "a repayment was read as an unpaid fall in debt");
+        require(atRestHeld, "a repayment was read as accrual at rest");
+
+        // And they decide the other way on a pair with no queue in it either,
+        // so the passes above are verdicts rather than a law declining to look.
+        //
+        // Built field by field rather than copied from `later`. A memory struct
+        // assigned to another memory variable shares its storage, so mutating
+        // the second mutates the first, and the law would have been handed one
+        // observation twice -- which holds, and proves nothing at all.
+        Observation memory before;
+        Observation memory after_;
+        before.totalAssets = later.totalAssets;
+        before.totalDebt = later.totalDebt;
+        before.observedAt = later.observedAt;
+        after_.totalAssets = later.totalAssets;
+        after_.totalDebt = later.totalDebt - 1;
+        after_.observedAt = later.observedAt;
+
+        (bool caught, ) = falls.check(before, after_);
+        require(!caught, "a fall with nothing arriving was not caught");
+
+        after_.totalDebt = later.totalDebt + 1;
+        (bool rose, ) = atRest.check(before, after_);
+        require(!rose, "debt appearing at rest was not caught");
+
+        require(!before.queueObserved && !after_.queueObserved, "a queue crept in");
+    }
+
+    function test_every_pair_law_carries_an_identifier_and_a_statement() external view {
+        PairLaw[COUNT] memory all = succession();
+        for (uint256 i = 0; i < COUNT; i++) {
+            require(bytes(all[i].id()).length > 0, "a law with no id");
+            require(bytes(all[i].statement()).length > 0, "a law with no statement");
+        }
+        require(bytes(path.id()).length > 0, "a law with no id");
+        require(bytes(path.statement()).length > 0, "a law with no statement");
+    }
+}

--- a/plugins/pandects/test/SoundInvariant.t.sol
+++ b/plugins/pandects/test/SoundInvariant.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Law} from "../src/Law.sol";
+import {ValueConserved} from "../src/laws/ValueConserved.sol";
+import {ReservesBackedByClaims} from "../src/laws/ReservesBackedByClaims.sol";
+import {HeldAssetsPartitioned} from "../src/laws/HeldAssetsPartitioned.sol";
+import {QueueOrderPreserved} from "../src/laws/QueueOrderPreserved.sol";
+import {ReservesCoverPayableClaims} from "../src/laws/ReservesCoverPayableClaims.sol";
+import {Sound} from "../specimens/Sound.sol";
+
+/// @title The sound reference, under search.
+/// @notice The diagonal in `Corpus.t.sol` checks each law against a state that
+/// somebody chose. This checks the sound reference against states nobody chose:
+/// any sequence of deposits, borrowings, repayments, fees and reservations the
+/// fuzzer can reach.
+///
+/// Only `Sound` is a target. The laws are deployed in the constructor rather
+/// than in `setUp`, because Foundry fuzzes what `setUp` creates and the laws
+/// have nothing to call.
+///
+/// The broken specimens are deliberately absent. An invariant harness cannot
+/// assert that something eventually fails, so the proof that a law catches its
+/// specimen lives in the diagonal and in the campaigns recorded in
+/// `audit/AUDIT.md`.
+///
+/// Only the one-state laws are here. A pair law needs the state as it was
+/// before the last call, and a Foundry invariant runs after the call with no
+/// way to have taken a snapshot before it. The campaign harness in
+/// `src/campaigns/Specimens.sol` records one on the way into every entry point,
+/// which is what lets Echidna and Medusa search the pair laws; under Foundry
+/// they are covered deterministically in `test/Pairs.t.sol`, transition by
+/// transition.
+contract SoundInvariantTest {
+    Sound internal target;
+    Law internal conserved;
+    Law internal backed;
+    Law internal partitioned;
+    Law internal ordered;
+    Law internal covered;
+
+    constructor() {
+        conserved = new ValueConserved();
+        backed = new ReservesBackedByClaims();
+        partitioned = new HeldAssetsPartitioned();
+        ordered = new QueueOrderPreserved();
+        covered = new ReservesCoverPayableClaims();
+    }
+
+    function setUp() public {
+        target = new Sound();
+    }
+
+    function invariant_value_is_conserved() public view {
+        (bool held, ) = conserved.check(target);
+        require(held, "the sound reference stopped conserving value");
+    }
+
+    function invariant_reserves_are_backed_by_claims() public view {
+        (bool held, ) = backed.check(target);
+        require(held, "the sound reference reserved beyond its claims");
+    }
+
+    function invariant_held_assets_stay_partitioned() public view {
+        (bool held, ) = partitioned.check(target);
+        require(held, "the sound reference promised the same asset twice");
+    }
+
+    function invariant_the_queue_stays_in_order() public view {
+        (bool held, ) = ordered.check(target);
+        require(held, "the sound reference paid a claim out of turn");
+    }
+
+    function invariant_reserves_cover_what_is_payable() public view {
+        (bool held, ) = covered.check(target);
+        require(held, "the sound reference declared more payable than it held");
+    }
+}

--- a/plugins/pandects/test/Wildcat.t.sol
+++ b/plugins/pandects/test/Wildcat.t.sol
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {CorpusObserver} from "../adapters/CorpusBase.sol";
+import {PathIndependenceProbe} from "../adapters/foundry/PathIndependenceProbe.sol";
+import {ICreditObservables} from "../src/ICreditObservables.sol";
+import {Law} from "../src/Law.sol";
+import {Observation, Observe} from "../src/Observation.sol";
+import {PairLaw} from "../src/PairLaw.sol";
+import {ValueConserved} from "../src/laws/ValueConserved.sol";
+import {ReservesBackedByClaims} from "../src/laws/ReservesBackedByClaims.sol";
+import {HeldAssetsPartitioned} from "../src/laws/HeldAssetsPartitioned.sol";
+import {QueueOrderPreserved} from "../src/laws/QueueOrderPreserved.sol";
+import {ReservesCoverPayableClaims} from "../src/laws/ReservesCoverPayableClaims.sol";
+import {DebtFallsOnlyAgainstPayment} from "../src/laws/DebtFallsOnlyAgainstPayment.sol";
+import {NoAccrualAtRest} from "../src/laws/NoAccrualAtRest.sol";
+import {RecordedClaimNeverShrinks} from "../src/laws/RecordedClaimNeverShrinks.sol";
+import {WildcatMarketModel} from "../integrations/wildcat/WildcatMarketModel.sol";
+import {WildcatMarketCampaign} from "../src/campaigns/Wildcat.sol";
+
+/// @title The corpus against a design it was not written for.
+/// @notice Every law so far has been proven against a specimen built to break
+/// it. That proves a law is a law. It does not touch the claim the corpus
+/// actually makes, which is that the same economic facts hold across codebases
+/// sharing nothing else.
+///
+/// This is the first codebase. What is being tested is not that the laws hold
+/// -- though they do -- but that the applicability contract says the right
+/// things about a design nobody wrote them for. Two cases carry that:
+/// `queue-order-preserved` is true here at a unit the corpus does not name, and
+/// `path-independent` is true here only under a condition.
+contract WildcatTest {
+    Law internal conserved;
+    Law internal backed;
+    Law internal partitioned;
+    Law internal ordered;
+    Law internal covered;
+    PairLaw internal falls;
+    PairLaw internal atRest;
+    PairLaw internal shrinks;
+
+    uint256 internal constant WHOLE_SPAN = 365 days;
+    uint256 internal constant HALF_SPAN = 182.5 days;
+
+    function setUp() public {
+        conserved = new ValueConserved();
+        backed = new ReservesBackedByClaims();
+        partitioned = new HeldAssetsPartitioned();
+        ordered = new QueueOrderPreserved();
+        covered = new ReservesCoverPayableClaims();
+        falls = new DebtFallsOnlyAgainstPayment();
+        atRest = new NoAccrualAtRest();
+        shrinks = new RecordedClaimNeverShrinks();
+    }
+
+    /// A market with lenders in, a borrower out, time passed and a batch open.
+    function market() internal returns (WildcatMarketModel model) {
+        model = new WildcatMarketModel();
+        model.deposit(100_000);
+        model.borrow(50_000);
+        model.advance(WHOLE_SPAN);
+        model.requestWithdrawal(10_000);
+        model.payBatch(4_000);
+        model.repay(1_000);
+    }
+
+    function holds(Law law, ICreditObservables on) internal view returns (bool ok) {
+        (ok, ) = law.check(on);
+    }
+
+    // -- the laws the model claims -------------------------------------------
+
+    /// @notice Law by law, rather than in aggregate.
+    /// @dev An aggregate assertion passes when four laws hold and one is never
+    /// reached. Each of these is its own line so a failure names the law.
+    function test_the_model_holds_every_one_state_law_it_claims() external {
+        WildcatMarketModel model = market();
+        require(holds(conserved, model), "the model stopped conserving value");
+        require(holds(backed, model), "the model reserved beyond its claims");
+        require(holds(partitioned, model), "the model promised the same asset twice");
+        require(holds(ordered, model), "the model paid a batch out of turn");
+        require(holds(covered, model), "the model declared more payable than it holds");
+    }
+
+    /// @notice The succession laws, across every operation the design has.
+    function test_no_transition_of_the_model_breaks_a_succession_law() external {
+        WildcatMarketModel model = new WildcatMarketModel();
+        Observation memory earlier = Observe.takeWithQueue(model);
+        Observation memory later;
+
+        model.deposit(100_000);
+        later = Observe.takeWithQueue(model);
+        assertSuccession(earlier, later);
+
+        earlier = later;
+        model.borrow(50_000);
+        later = Observe.takeWithQueue(model);
+        assertSuccession(earlier, later);
+
+        earlier = later;
+        model.advance(WHOLE_SPAN);
+        later = Observe.takeWithQueue(model);
+        assertSuccession(earlier, later);
+
+        earlier = later;
+        model.requestWithdrawal(10_000);
+        later = Observe.takeWithQueue(model);
+        assertSuccession(earlier, later);
+
+        earlier = later;
+        model.payBatch(4_000);
+        later = Observe.takeWithQueue(model);
+        assertSuccession(earlier, later);
+
+        earlier = later;
+        model.repay(1_000);
+        later = Observe.takeWithQueue(model);
+        assertSuccession(earlier, later);
+
+        earlier = later;
+        model.accrueFee(500);
+        later = Observe.takeWithQueue(model);
+        assertSuccession(earlier, later);
+    }
+
+    function assertSuccession(Observation memory earlier, Observation memory later)
+        internal
+        view
+    {
+        (bool a, ) = falls.check(earlier, later);
+        (bool b, ) = atRest.check(earlier, later);
+        (bool c, ) = shrinks.check(earlier, later);
+        require(a, "debt fell further than assets rose");
+        require(b, "debt rose while the clock stood still");
+        require(c, "a recorded batch was written down");
+    }
+
+    // -- the unit the corpus does not name ------------------------------------
+
+    /// @notice Order between batches, and no order at all inside one.
+    /// @dev The finding this integration exists for. Two lenders requesting in
+    /// the same cycle join one batch, and a payment against that batch settles
+    /// part of both. Read as a per-lender promise the law would be false here:
+    /// neither lender is ahead of the other and neither is paid in full. Read
+    /// as a per-batch promise it is exactly what the design guarantees, and
+    /// that is what holds.
+    function test_a_batch_paid_pro_rata_does_not_break_the_ordering() external {
+        WildcatMarketModel model = new WildcatMarketModel();
+        model.deposit(100_000);
+        model.requestWithdrawal(10_000);
+        model.requestWithdrawal(10_000);
+
+        require(model.claimCount() == 1, "two requests in one cycle made two batches");
+        (uint256 owed, uint256 paid) = model.claimAt(0);
+        require(owed == 20_000 && paid == 0, "the batch did not pool both requests");
+
+        model.payBatch(5_000);
+        (, paid) = model.claimAt(0);
+        require(paid == 5_000, "the batch was not paid into");
+        require(holds(ordered, model), "a partly paid batch was read as a jump");
+    }
+
+    /// @notice And a newer batch waits for an older one.
+    function test_an_older_batch_is_settled_first() external {
+        WildcatMarketModel model = new WildcatMarketModel();
+        model.deposit(100_000);
+        model.requestWithdrawal(10_000);
+        model.payBatch(1_000);
+        model.requestWithdrawal(10_000);
+
+        require(model.claimCount() == 2, "a paid batch stayed open for new requests");
+        model.payBatch(500);
+
+        (, uint256 firstPaid) = model.claimAt(0);
+        (, uint256 secondPaid) = model.claimAt(1);
+        require(firstPaid == 1_500, "the older batch was not the one paid");
+        require(secondPaid == 0, "the newer batch was paid ahead of the older one");
+        require(holds(ordered, model), "the law disagreed with the payment order");
+    }
+
+    /// @notice A law the corpus has that this design does not satisfy.
+    /// @dev Found by Echidna against the shipped adapter, not by reading. The
+    /// law says a recorded claim keeps its owed amount. A Wildcat batch
+    /// accumulates while it is open: a second request in the same cycle joins
+    /// the batch and the amount owed on it rises.
+    ///
+    /// Neither side is wrong. For a queue of individual claims, an amount that
+    /// changes after the fact is the defect the law was written for. For a
+    /// batched design, an open batch is not yet a claim that has been recorded
+    /// -- it is a claim still being assembled -- and the law starts applying
+    /// when the batch closes.
+    ///
+    /// Asserted rather than described, because a limitation nobody has watched
+    /// happen is a limitation people assume was handled.
+    function test_an_open_batch_grows_and_the_claim_law_refuses_it() external {
+        WildcatMarketModel model = new WildcatMarketModel();
+        model.deposit(100_000);
+        model.requestWithdrawal(10_000);
+
+        Observation memory earlier = Observe.takeWithQueue(model);
+        model.requestWithdrawal(5_000);
+        Observation memory later = Observe.takeWithQueue(model);
+
+        require(earlier.queue[0].owed == 10_000, "the batch did not open at 10000");
+        require(later.queue[0].owed == 15_000, "the second request did not join it");
+
+        (bool held, string memory why) = shrinks.check(earlier, later);
+        require(!held, "the law accepted an owed amount that changed");
+        require(
+            keccak256(bytes(why))
+                == keccak256("a recorded claim's owed amount changed"),
+            "the law refused it for some other reason"
+        );
+    }
+
+    /// @notice And once a batch is closed, the law holds over it.
+    /// @dev Which is what makes this a condition rather than a rejection. A
+    /// batch stops accepting requests as soon as anything is paid out of it,
+    /// and from that moment its owed amount is fixed.
+    function test_a_closed_batch_satisfies_the_claim_law() external {
+        WildcatMarketModel model = new WildcatMarketModel();
+        model.deposit(100_000);
+        model.requestWithdrawal(10_000);
+        model.payBatch(1_000);
+
+        Observation memory earlier = Observe.takeWithQueue(model);
+        model.requestWithdrawal(5_000);
+        model.payBatch(1_000);
+        Observation memory later = Observe.takeWithQueue(model);
+
+        require(later.queue.length == 2, "the closed batch took another request");
+        require(later.queue[0].owed == 10_000, "a closed batch changed amount");
+
+        (bool held, ) = shrinks.check(earlier, later);
+        require(held, "the law refused a design that keeps closed batches fixed");
+    }
+
+    // -- the law that holds under a condition ----------------------------------
+
+    /// @notice Path independence, while the market is solvent.
+    /// @dev Base interest is linear on principal, so the span costs the same
+    /// however it is cut up, to within the bound the law derives.
+    function test_a_solvent_market_is_path_independent() external {
+        PathIndependenceProbe probe = new PathIndependenceProbe(2);
+
+        WildcatMarketModel coarse = solvent();
+        WildcatMarketModel fine = solvent();
+        coarse.advance(WHOLE_SPAN);
+        fine.advance(HALF_SPAN);
+        fine.advance(HALF_SPAN);
+
+        require(!coarse.penalised() && !fine.penalised(), "the markets went delinquent");
+        (bool held, ) = probe.check(coarse, fine);
+        require(held, "a solvent market was reported as path dependent");
+    }
+
+    /// @notice And not, once the penalty is running.
+    /// @dev The condition, watched rather than described. The grace timer moves
+    /// when the market is poked, so a market crossing into delinquency mid-span
+    /// owes a different penalty depending on how often somebody updated it.
+    /// This is not a defect in the design and not a defect in the law: it is a
+    /// design the law does not describe once that rate is on, and the
+    /// applicability note is where that is written down.
+    function test_a_penalised_market_is_not_path_independent() external {
+        PathIndependenceProbe probe = new PathIndependenceProbe(2);
+
+        WildcatMarketModel coarse = delinquent();
+        WildcatMarketModel fine = delinquent();
+        coarse.advance(WHOLE_SPAN);
+        fine.advance(HALF_SPAN);
+        fine.advance(HALF_SPAN);
+
+        require(fine.penalised(), "the subdivided market never reached the penalty");
+        (bool held, ) = probe.check(coarse, fine);
+        require(!held, "the two runs agreed, so the condition is not real");
+    }
+
+    /// A market with plenty of liquidity behind its obligations.
+    function solvent() internal returns (WildcatMarketModel model) {
+        model = new WildcatMarketModel();
+        model.deposit(100_000);
+        model.borrow(10_000);
+    }
+
+    /// A market short of the liquidity it owes, with its grace period intact.
+    /// @dev The grace has to be unspent, because that is where the path
+    /// dependence lives. A market already past it charges the penalty for every
+    /// step whatever the subdivision, and the two runs would agree.
+    function delinquent() internal returns (WildcatMarketModel model) {
+        model = new WildcatMarketModel();
+        model.deposit(100_000);
+        model.borrow(100_000);
+        model.requestWithdrawal(100_000);
+        require(model.delinquent(), "the market did not go delinquent");
+        require(!model.penalised(), "the grace period was already spent");
+    }
+
+    // -- through the adapters, not a harness written for it ---------------------
+
+    function test_the_model_runs_through_the_shipped_adapter() external {
+        WildcatMarketCampaign campaign = new WildcatMarketCampaign();
+        require(campaign.echidna_value_conserved(), "conservation failed at rest");
+
+        campaign.deposit(100_000);
+        campaign.borrow(50_000);
+        campaign.advance(WHOLE_SPAN);
+        campaign.requestWithdrawal(10_000);
+        campaign.payBatch(4_000);
+
+        require(campaign.successionExercised(), "the adapter recorded nothing");
+        require(campaign.echidna_value_conserved(), "conservation failed");
+        require(campaign.echidna_reserves_backed(), "reserve backing failed");
+        require(campaign.echidna_held_partitioned(), "the partition failed");
+        require(campaign.echidna_queue_order_preserved(), "the ordering failed");
+        require(campaign.echidna_reserves_cover_payable(), "the cover failed");
+        require(campaign.echidna_debt_falls_only_against_payment(), "the payment law failed");
+        require(campaign.echidna_no_accrual_at_rest(), "the rest law failed");
+        require(campaign.echidna_recorded_claim_never_shrinks(), "the claim law failed");
+    }
+
+    // -- what the design actually does ------------------------------------------
+
+    /// @notice Liquidity a borrower may take is not everything unreserved.
+    /// @dev The reserve ratio is the part of this design a model without it
+    /// gets wrong, and it is why `held-assets-partitioned` is not trivially
+    /// satisfied here.
+    function test_the_borrower_cannot_take_the_required_reserve() external {
+        WildcatMarketModel model = new WildcatMarketModel();
+        model.deposit(100_000);
+        model.borrow(100_000);
+        require(model.totalAssets() == 20_000, "the reserve was lent out");
+        require(model.borrowableAssets() == 0, "more was offered than is held");
+        require(holds(partitioned, model), "the partition broke");
+    }
+
+    /// @notice Delinquency arrives with the request, not with the borrowing.
+    /// @dev Worth asserting in that order, because it is the order that makes
+    /// the design what it is. Borrowing cannot cause delinquency: the reserve
+    /// is subtracted before the borrower is offered anything. What causes it is
+    /// a lender asking to leave a market whose liquidity has already gone out
+    /// the door, which no amount of care at borrow time can prevent.
+    function test_delinquency_arrives_with_the_request() external {
+        WildcatMarketModel model = new WildcatMarketModel();
+        model.deposit(100_000);
+        model.borrow(100_000);
+        require(!model.delinquent(), "borrowing within the reserve caused delinquency");
+
+        model.requestWithdrawal(100_000);
+        require(model.delinquent(), "a market that cannot pay a request was not delinquent");
+        require(!model.penalised(), "the penalty started inside the grace period");
+
+        model.advance(1 days);
+        require(!model.penalised(), "the penalty started inside the grace period");
+        model.advance(30 days);
+        require(model.penalised(), "the penalty never started");
+    }
+}

--- a/plugins/pandects/test/counterexamples/Accrual.t.sol
+++ b/plugins/pandects/test/counterexamples/Accrual.t.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Observation, Observe} from "../../src/Observation.sol";
+import {DebtFallsOnlyAgainstPayment} from "../../src/laws/DebtFallsOnlyAgainstPayment.sol";
+import {NoAccrualAtRest} from "../../src/laws/NoAccrualAtRest.sol";
+import {AccrualPathIndependent} from "../../src/laws/AccrualPathIndependent.sol";
+import {Sound} from "../../specimens/Sound.sol";
+import {DebtForgiven} from "../../specimens/DebtForgiven.sol";
+import {AccruesAtRest} from "../../specimens/AccruesAtRest.sol";
+import {CompoundsPerStep} from "../../specimens/CompoundsPerStep.sol";
+
+/// @title The counterexamples for the accrual family.
+/// @notice One reduced sequence per law, replayable with no fuzzer, no seed
+/// and no engine. This is the corpus's third requirement: a law that has only
+/// ever been argued for is not reduced, and a failure nobody can reproduce on
+/// demand is a story rather than a finding.
+///
+/// These differ from the conservation counterexamples in one way that matters.
+/// A conservation counterexample is a state, so replaying it means reaching
+/// that state. An accrual counterexample is a transition, so replaying it means
+/// holding an observation, letting the system move, and comparing. The
+/// snapshot is the thing that makes it replayable at all.
+contract AccrualCounterexamples {
+    uint256 internal constant PRINCIPAL = 100_000;
+    uint256 internal constant HALF_SPAN = 182.5 days;
+    uint256 internal constant WHOLE_SPAN = 365 days;
+
+    /// `DebtForgiven.deposit(1)`, `borrow(1)`, `accrueFee(1)`, `forgive(1)`.
+    /// Four calls, and four is the floor: the write-off is charged against
+    /// fees, fees come from claims, claims come from a deposit, and there is no
+    /// debt to forgive without a borrowing.
+    ///
+    /// Debt goes from one to nothing while held assets stay at nothing. The
+    /// books balance on both sides of the transition, which is why no
+    /// conservation law sees it.
+    function test_debt_falls_only_against_payment_counterexample() external {
+        DebtForgiven target = new DebtForgiven();
+        target.deposit(1);
+        target.borrow(1);
+        target.accrueFee(1);
+
+        Observation memory earlier = Observe.take(target);
+        require(earlier.totalDebt == 1, "debt is not 1");
+        require(earlier.totalAssets == 0, "held is not 0");
+        require(earlier.accruedFees == 1, "fees is not 1");
+
+        target.forgive(1);
+        Observation memory later = Observe.take(target);
+        require(later.totalDebt == 0, "debt is not 0");
+        require(later.totalAssets == 0, "held moved, so nothing was forgiven");
+
+        DebtFallsOnlyAgainstPayment law = new DebtFallsOnlyAgainstPayment();
+        (bool held, ) = law.check(earlier, later);
+        require(!held, "the counterexample no longer reproduces");
+    }
+
+    /// `AccruesAtRest.poke(1)`, one call, from an empty system. Nothing has
+    /// been deposited, nothing borrowed, and the borrower owes a unit anyway.
+    ///
+    /// The shortest counterexample in the corpus, and the point of it is that
+    /// the state it produces is perfectly consistent: one owed, one claimed,
+    /// the books balanced. Only the clock says otherwise.
+    function test_no_accrual_at_rest_counterexample() external {
+        AccruesAtRest target = new AccruesAtRest();
+
+        Observation memory earlier = Observe.take(target);
+        require(earlier.totalDebt == 0, "debt is not 0");
+
+        target.poke(1);
+        Observation memory later = Observe.take(target);
+        require(later.observedAt == earlier.observedAt, "the clock moved");
+        require(later.totalDebt == 1, "debt is not 1");
+        require(later.totalAssets == earlier.totalAssets, "assets moved");
+
+        NoAccrualAtRest law = new NoAccrualAtRest();
+        (bool held, ) = law.check(earlier, later);
+        require(!held, "the counterexample no longer reproduces");
+    }
+
+    /// Two `CompoundsPerStep` systems, each `deposit(100000)` and
+    /// `borrow(100000)`. One is advanced 365 days once; the other 182.5 days
+    /// twice. Six calls across two systems, which is the floor for a law whose
+    /// pair is two systems.
+    ///
+    /// The arithmetic, so the bound can be checked rather than believed. The
+    /// sound reference accrues 9999 over the single step and 4999 twice over
+    /// the subdivided one, a gap of exactly one unit: the bound for two
+    /// subdivisions is `n - 1`, and one is where truncation actually lands. The
+    /// compounding specimen accrues 4999 and then 5249, because its second step
+    /// charges on the first step's interest, for a gap of 249.
+    ///
+    /// One unit is the arithmetic. Two hundred and forty-nine is a defect.
+    function test_accrual_path_independent_counterexample() external {
+        AccrualPathIndependent law = new AccrualPathIndependent(2);
+        require(law.tolerance() == 1, "the bound is not one unit");
+
+        Sound soundCoarse = new Sound();
+        Sound soundFine = new Sound();
+        (Observation memory a, Observation memory b) = race(soundCoarse, soundFine);
+        require(a.totalDebt == PRINCIPAL + 9999, "the single step did not accrue 9999");
+        require(b.totalDebt == PRINCIPAL + 9998, "the subdivided run did not accrue 9998");
+        (bool soundHeld, ) = law.check(a, b);
+        require(soundHeld, "the sound reference stopped being path independent");
+
+        CompoundsPerStep coarse = new CompoundsPerStep();
+        CompoundsPerStep fine = new CompoundsPerStep();
+        (Observation memory c, Observation memory d) = race(coarse, fine);
+        require(c.totalDebt == PRINCIPAL + 9999, "the single step did not accrue 9999");
+        require(d.totalDebt == PRINCIPAL + 10248, "the subdivided run did not accrue 10248");
+
+        (bool held, ) = law.check(c, d);
+        require(!held, "the counterexample no longer reproduces");
+    }
+
+    function race(Sound coarse, Sound fine)
+        internal
+        returns (Observation memory, Observation memory)
+    {
+        coarse.deposit(PRINCIPAL);
+        coarse.borrow(PRINCIPAL);
+        fine.deposit(PRINCIPAL);
+        fine.borrow(PRINCIPAL);
+
+        coarse.advance(WHOLE_SPAN);
+        fine.advance(HALF_SPAN);
+        fine.advance(HALF_SPAN);
+
+        return (Observe.take(coarse), Observe.take(fine));
+    }
+}

--- a/plugins/pandects/test/counterexamples/Claims.t.sol
+++ b/plugins/pandects/test/counterexamples/Claims.t.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {Observation, Observe} from "../../src/Observation.sol";
+import {RecordedClaimNeverShrinks} from "../../src/laws/RecordedClaimNeverShrinks.sol";
+import {QueueOrderPreserved} from "../../src/laws/QueueOrderPreserved.sol";
+import {ReservesCoverPayableClaims} from "../../src/laws/ReservesCoverPayableClaims.sol";
+import {ClaimHaircut} from "../../specimens/ClaimHaircut.sol";
+import {QueueJumped} from "../../specimens/QueueJumped.sol";
+import {PayableBeyondReserves} from "../../specimens/PayableBeyondReserves.sol";
+
+/// @title The counterexamples for the withdrawal-claim family.
+/// @notice One reduced sequence per law, replayable with no fuzzer, no seed
+/// and no engine.
+///
+/// All three run at a scale of one or two units. That is not a stylistic
+/// preference: a queue defect is about which entry moves rather than how much,
+/// so the smallest amounts that keep the entries distinct are the ones that
+/// show it, and a counterexample moving a hundred units would be hiding its
+/// shape behind its size.
+contract ClaimsCounterexamples {
+    /// `ClaimHaircut.deposit(1)`, `reserve(1)`, `haircut(0, 1)`. Three calls,
+    /// and three is the floor: there is no claim to write down without a
+    /// reservation, and nothing to reserve without a deposit.
+    ///
+    /// The claim recorded at one is rewritten to nothing, and the unit is moved
+    /// into fees. Conservation holds across the write-down, the reserves are
+    /// recomputed so they stay within claims, and the queue is still in order.
+    /// The only thing that changed is a number a lender was given.
+    function test_recorded_claim_never_shrinks_counterexample() external {
+        ClaimHaircut target = new ClaimHaircut();
+        target.deposit(1);
+        target.reserve(1);
+
+        Observation memory earlier = Observe.takeWithQueue(target);
+        require(earlier.queue.length == 1, "the queue does not hold one claim");
+        require(earlier.queue[0].owed == 1, "the claim is not owed 1");
+
+        target.haircut(0, 1);
+        Observation memory later = Observe.takeWithQueue(target);
+        require(later.queue[0].owed == 0, "the claim was not written down");
+        require(later.accruedFees == 1, "the unit did not become a fee");
+
+        RecordedClaimNeverShrinks law = new RecordedClaimNeverShrinks();
+        (bool held, ) = law.check(earlier, later);
+        require(!held, "the counterexample no longer reproduces");
+    }
+
+    /// `QueueJumped.deposit(2)`, `reserve(1)`, `reserve(1)`, `payClaim(1)`.
+    /// Four calls. Two claims are the minimum for an ordering to exist at all,
+    /// and each needs its own reservation.
+    ///
+    /// The second claim is paid in full while the first has received nothing.
+    /// Every amount involved is correct: one unit left the system, one unit of
+    /// claim was retired, and the reserves fell by one. A single state is
+    /// enough to see it, because the payment is recorded against the claim.
+    function test_queue_order_preserved_counterexample() external {
+        QueueJumped target = new QueueJumped();
+        target.deposit(2);
+        target.reserve(1);
+        target.reserve(1);
+        target.payClaim(1);
+
+        (uint256 firstOwed, uint256 firstPaid) = target.claimAt(0);
+        (, uint256 secondPaid) = target.claimAt(1);
+        require(firstOwed == 1 && firstPaid == 0, "the older claim was not skipped");
+        require(secondPaid == 1, "the newer claim was not paid");
+
+        QueueOrderPreserved law = new QueueOrderPreserved();
+        (bool held, ) = law.check(target);
+        require(!held, "the counterexample no longer reproduces");
+    }
+
+    /// `PayableBeyondReserves.deposit(1)`, `reserve(1)`, `reserve(1)`. Three
+    /// calls, and no payment at all.
+    ///
+    /// Both reservations are individually within what the system holds, so each
+    /// is recorded; together they ask for two units against the one unit
+    /// deposited, so only one unit is ever set aside. A correct system declares
+    /// the first claim payable and stops. This one declares both, and the
+    /// second lender is holding a promise the system cannot keep.
+    ///
+    /// Nothing has gone wrong yet in any observable except the declaration,
+    /// which is the point: the lie is available to read before anybody acts on
+    /// it.
+    function test_reserves_cover_payable_counterexample() external {
+        PayableBeyondReserves target = new PayableBeyondReserves();
+        target.deposit(1);
+        target.reserve(1);
+        target.reserve(1);
+
+        require(target.claimCount() == 2, "two claims were not recorded");
+        require(target.reservedAssets() == 1, "more than one unit was set aside");
+        require(target.payableThrough() == 2, "the system did not declare both payable");
+
+        ReservesCoverPayableClaims law = new ReservesCoverPayableClaims();
+        (bool held, ) = law.check(target);
+        require(!held, "the counterexample no longer reproduces");
+    }
+}

--- a/plugins/pandects/test/counterexamples/Conservation.t.sol
+++ b/plugins/pandects/test/counterexamples/Conservation.t.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ValueConserved} from "../../src/laws/ValueConserved.sol";
+import {ReservesBackedByClaims} from "../../src/laws/ReservesBackedByClaims.sol";
+import {HeldAssetsPartitioned} from "../../src/laws/HeldAssetsPartitioned.sol";
+import {MintedClaims} from "../../specimens/MintedClaims.sol";
+import {OverReserved} from "../../specimens/OverReserved.sol";
+import {OverPromised} from "../../specimens/OverPromised.sol";
+
+/// @title The counterexamples for the conservation family.
+/// @notice One reduced sequence per law, replayable with no fuzzer, no seed
+/// and no engine. This is the corpus's sixth requirement: a law that has only
+/// ever been argued for is not reduced, and a failure nobody can reproduce on
+/// demand is a story rather than a finding.
+///
+/// Each sequence below is the shortest that reaches the violation. They were
+/// derived by hand and then checked against the engines, which is how two of
+/// them came to be smaller than they were: Echidna reduced the first and third
+/// to a single unit of value where the hand-written versions moved a hundred.
+/// Echidna and Medusa both reproduce all three, and `audit/AUDIT.md` records
+/// the campaigns.
+contract ConservationCounterexamples {
+    /// `MintedClaims.deposit(1)`, one call. Reduced by Echidna from the
+    /// hand-written `deposit(100)`.
+    /// Held rises by one and claims by two, so the right-hand side gains value
+    /// the left never received.
+    function test_value_conserved_counterexample() external {
+        MintedClaims target = new MintedClaims();
+        target.deposit(1);
+
+        require(target.totalAssets() == 1, "held is not 1");
+        require(target.totalLenderClaims() == 2, "claims is not 2");
+
+        ValueConserved law = new ValueConserved();
+        (bool held, ) = law.check(target);
+        require(!held, "the counterexample no longer reproduces");
+    }
+
+    /// `OverReserved.deposit(2)`, `accrueFee(1)`, `reserve(2)`, three calls.
+    /// The fee is what separates claims from held assets: without it there is
+    /// no state where reserving beyond claims still fits inside the assets, and
+    /// this law could not be broken alone. Echidna found the same three-call
+    /// shape at magnitudes near the ceiling; this is that shape at its floor.
+    function test_reserves_backed_by_claims_counterexample() external {
+        OverReserved target = new OverReserved();
+        target.deposit(2);
+        target.accrueFee(1);
+        target.reserve(2);
+
+        require(target.totalLenderClaims() == 1, "claims is not 1");
+        require(target.reservedAssets() == 2, "reserved is not 2");
+
+        ReservesBackedByClaims law = new ReservesBackedByClaims();
+        (bool held, ) = law.check(target);
+        require(!held, "the counterexample no longer reproduces");
+    }
+
+    /// `OverPromised.deposit(1)`, `reserve(1)`, two calls. Reduced by Echidna
+    /// from the hand-written hundreds.
+    /// Borrowable stays at one because it is recorded rather than derived, so
+    /// one reserved and one offered are drawn from one held.
+    function test_held_assets_partitioned_counterexample() external {
+        OverPromised target = new OverPromised();
+        target.deposit(1);
+        target.reserve(1);
+
+        require(target.reservedAssets() == 1, "reserved is not 1");
+        require(target.borrowableAssets() == 1, "borrowable is not 1");
+
+        HeldAssetsPartitioned law = new HeldAssetsPartitioned();
+        (bool held, ) = law.check(target);
+        require(!held, "the counterexample no longer reproduces");
+    }
+}

--- a/plugins/pandects/tests/support.py
+++ b/plugins/pandects/tests/support.py
@@ -1,0 +1,10 @@
+"""Put the plugin's scripts directory on the path for every test module."""
+
+import os
+import sys
+
+PLUGIN_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPTS = os.path.join(PLUGIN_ROOT, "scripts")
+
+if SCRIPTS not in sys.path:
+    sys.path.insert(0, SCRIPTS)

--- a/plugins/pandects/tests/test_catalogue.py
+++ b/plugins/pandects/tests/test_catalogue.py
@@ -1,0 +1,210 @@
+"""The catalogue's shape, and the bounds on reading it."""
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from . import support  # noqa: F401  (sets sys.path)
+
+from pandects_lib import catalogue as catalogue_module  # noqa: E402
+from pandects_lib import safejson  # noqa: E402
+
+PLUGIN_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SHIPPED = os.path.join(PLUGIN_ROOT, "catalogue", "pandects.json")
+
+
+def document(**overrides):
+    raw = {
+        "version": "0.1.0",
+        "observables": "ICreditObservables",
+        "families": {"conservation": "held against each other"},
+        "laws": [],
+    }
+    raw.update(overrides)
+    return raw
+
+
+class ShapeTests(unittest.TestCase):
+    def test_a_well_formed_catalogue_parses(self):
+        found = catalogue_module.parse(document())
+        self.assertEqual(found.version, "0.1.0")
+        self.assertEqual(found.laws, [])
+
+    def test_a_missing_top_level_field_is_refused(self):
+        raw = document()
+        del raw["families"]
+        with self.assertRaises(catalogue_module.CatalogueError) as caught:
+            catalogue_module.parse(raw)
+        self.assertIn("families", str(caught.exception))
+
+    def test_families_must_not_be_empty(self):
+        with self.assertRaises(catalogue_module.CatalogueError):
+            catalogue_module.parse(document(families={}))
+
+    def test_laws_must_be_an_array(self):
+        with self.assertRaises(catalogue_module.CatalogueError):
+            catalogue_module.parse(document(laws={"a": 1}))
+
+    def test_a_law_without_an_id_is_refused_at_parse_time(self):
+        """Without an id there is nothing to name in any later message."""
+        with self.assertRaises(catalogue_module.CatalogueError) as caught:
+            catalogue_module.parse(document(laws=[{"statement": "something"}]))
+        self.assertIn("no id", str(caught.exception))
+
+    def test_two_laws_sharing_an_id_are_refused(self):
+        with self.assertRaises(catalogue_module.CatalogueError) as caught:
+            catalogue_module.parse(
+                document(laws=[{"id": "a/b/v1"}, {"id": "a/b/v1"}])
+            )
+        self.assertIn("share the id", str(caught.exception))
+
+    def test_a_field_a_law_does_not_define_is_refused(self):
+        with self.assertRaises(catalogue_module.CatalogueError) as caught:
+            catalogue_module.parse(
+                document(laws=[{"id": "a/b/v1", "severity": "high"}])
+            )
+        self.assertIn("severity", str(caught.exception))
+
+    def test_a_law_can_be_found_by_id(self):
+        found = catalogue_module.parse(document(laws=[{"id": "a/b/v1"}]))
+        self.assertIsNotNone(found.law("a/b/v1"))
+        self.assertIsNone(found.law("nothing/here/v1"))
+
+
+class BoundedReadingTests(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.root)
+
+    def write(self, body):
+        path = os.path.join(self.root, "catalogue.json")
+        with open(path, "w") as handle:
+            handle.write(body)
+        return path
+
+    def test_a_document_that_is_not_json_is_refused(self):
+        with self.assertRaises(catalogue_module.CatalogueError) as caught:
+            catalogue_module.load(self.write("{not json"))
+        self.assertIn("not valid JSON", str(caught.exception))
+
+    def test_a_repeated_key_is_refused(self):
+        path = self.write('{"version":"1","version":"2"}')
+        with self.assertRaises(catalogue_module.CatalogueError) as caught:
+            catalogue_module.load(path)
+        self.assertIn("duplicate key", str(caught.exception))
+
+    def test_nesting_past_the_cap_is_refused_before_parsing(self):
+        path = self.write("[" * 200 + "]" * 200)
+        with self.assertRaises(catalogue_module.CatalogueError) as caught:
+            catalogue_module.load(path)
+        self.assertIn("refused before parsing", str(caught.exception))
+
+    def test_a_missing_file_is_refused(self):
+        with self.assertRaises(catalogue_module.CatalogueError):
+            catalogue_module.load(os.path.join(self.root, "absent.json"))
+
+    def test_a_document_over_the_size_cap_is_refused(self):
+        with self.assertRaises(safejson.InputError):
+            safejson.loads(b'{"a":"' + b"x" * 500 + b'"}', max_bytes=64)
+
+    def test_brackets_inside_strings_do_not_count_as_depth(self):
+        self.assertIn("a", safejson.loads(json.dumps({"a": "[[[[[[" * 40}), max_depth=8))
+
+
+class ShippedCatalogueTests(unittest.TestCase):
+    def test_the_shipped_catalogue_parses(self):
+        found = catalogue_module.load(SHIPPED)
+        self.assertTrue(found.families)
+        self.assertTrue(found.laws, "the shipped catalogue carries no laws")
+
+    def test_every_shipped_law_is_findable_by_its_id(self):
+        found = catalogue_module.load(SHIPPED)
+        for law in found.laws:
+            self.assertIsNotNone(found.law(law.id))
+
+    def test_every_law_declares_a_family_the_catalogue_lists(self):
+        found = catalogue_module.load(SHIPPED)
+        for law in found.laws:
+            self.assertIn(law.get("family"), found.families, law.id)
+
+
+class AccrualAndClaimsTests(unittest.TestCase):
+    """The step-3 families, as the shipped catalogue records them.
+
+    Generic shape tests pass over an empty catalogue and over a wrong one. These
+    are about the six entries themselves: that the one inexact law is the one
+    that divides, that every law needing the queue extension says so, and that
+    the two families are filed where the reader is told to look.
+    """
+
+    def setUp(self):
+        self.catalogue = catalogue_module.load(SHIPPED)
+
+    def family(self, name):
+        found = [law for law in self.catalogue.laws if law.get("family") == name]
+        self.assertTrue(found, "no law is filed under %r" % name)
+        return found
+
+    def test_exactly_one_law_in_the_corpus_carries_a_tolerance(self):
+        """A second tolerance would need its own argument, not this one's."""
+        inexact = [law for law in self.catalogue.laws if law.get("bounds") != "exact"]
+        self.assertEqual([law.id for law in inexact], ["accrual/path-independent/v1"])
+
+    def test_the_one_tolerance_names_the_arithmetic_that_produces_it(self):
+        law = self.catalogue.law("accrual/path-independent/v1")
+        bounds = law.get("bounds")
+        self.assertIn("subdivision", bounds["tolerance"])
+        self.assertIn("truncates", bounds["arithmetic"])
+
+    def test_every_claims_law_declares_the_queue_it_reads(self):
+        """The extension is optional, so a law that needs it must say so.
+
+        A claims law whose applicability listed only core observables would be
+        checkable against a target with no queue, which it is not: the read
+        reverts.
+        """
+        for law in self.family("claims"):
+            required = law.get("applicability")["requires"]
+            self.assertTrue(
+                any(name.startswith("withdrawalQueue.") for name in required),
+                "%s reads the queue and does not say so" % law.id,
+            )
+
+    def test_no_law_outside_the_claims_family_needs_the_queue(self):
+        for law in self.catalogue.laws:
+            if law.get("family") == "claims":
+                continue
+            required = law.get("applicability")["requires"]
+            for name in required:
+                self.assertFalse(
+                    name.startswith("withdrawalQueue."),
+                    "%s is filed away from the claims family and reads the queue" % law.id,
+                )
+
+    def test_every_accrual_law_reads_debt(self):
+        for law in self.family("accrual"):
+            self.assertIn("totalDebt", law.get("applicability")["requires"], law.id)
+
+    def test_every_law_over_a_pair_says_which_kind_of_pair_it_means(self):
+        """One of these compares two systems; three compare one with its past.
+
+        Reading them the wrong way round is the mistake available to a user of
+        this corpus, so the assumption is not optional prose.
+        """
+        pairs = {
+            "accrual/debt-falls-only-against-payment/v1": "its own past",
+            "accrual/no-accrual-at-rest/v1": "its own past",
+            "claims/recorded-claim-never-shrinks/v1": "its own past",
+            "accrual/path-independent/v1": "two systems",
+        }
+        for law_id, expected in pairs.items():
+            law = self.catalogue.law(law_id)
+            self.assertIsNotNone(law, law_id)
+            assumes = " ".join(law.get("applicability")["assumes"])
+            self.assertIn(expected, assumes, law_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/pandects/tests/test_checker.py
+++ b/plugins/pandects/tests/test_checker.py
@@ -1,0 +1,370 @@
+"""The six parts, each removed in turn.
+
+Every test here builds a law that passes, breaks exactly one part, and asserts
+the checker names that part. A test that broke two things at once would pass
+for the wrong reason, which is the same discipline the corpus asks of a
+specimen.
+"""
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from . import support  # noqa: F401  (sets sys.path)
+
+from pandects_lib import catalogue as catalogue_module  # noqa: E402
+from pandects_lib import checker  # noqa: E402
+
+COMPONENT = """// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ICreditObservables} from "../ICreditObservables.sol";
+import {Law} from "../Law.sol";
+
+contract Sound is Law {
+    function id() external pure override returns (string memory) {
+        return "%s";
+    }
+
+    function statement() external pure override returns (string memory) {
+        return "Assets held cover the claims recorded against them.";
+    }
+
+    function check(ICreditObservables target)
+        external
+        view
+        override
+        returns (bool held, string memory detail)
+    {
+        if (target.totalAssets() >= target.totalLenderClaims()) {
+            return (true, "covered");
+        }
+        return (false, "not covered");
+    }
+}
+"""
+
+SPECIMEN = """// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+/// @notice A deliberately broken credit contract. Do not deploy this.
+contract Broken {}
+"""
+
+COUNTEREXAMPLE = """// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+contract Replay {}
+"""
+
+IDENTIFIER = "conservation/held-covers-claims/v1"
+
+
+def law(**overrides):
+    entry = {
+        "id": IDENTIFIER,
+        "family": "conservation",
+        "statement": "Assets held cover the claims recorded against them.",
+        "component": "src/laws/HeldCoversClaims.sol",
+        "specimen": "specimens/DroppedClaim.sol",
+        "counterexample": "test/counterexamples/HeldCoversClaims.t.sol",
+        "applicability": {
+            "accounting_model": "pooled deposits with a withdrawal queue",
+            "assumes": ["claims are denominated in the deposit asset"],
+            "requires": ["reservedAssets", "totalLenderClaims"],
+        },
+        "bounds": "exact",
+    }
+    entry.update(overrides)
+    return entry
+
+
+class CheckerCase(unittest.TestCase):
+    """A plugin root on disk, valid until a test breaks one part of it."""
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.root)
+        self.write("src/laws/HeldCoversClaims.sol", COMPONENT % IDENTIFIER)
+        self.write("specimens/DroppedClaim.sol", SPECIMEN)
+        self.write("test/counterexamples/HeldCoversClaims.t.sol", COUNTEREXAMPLE)
+        self.entry = law()
+
+    def write(self, relative, body):
+        path = os.path.join(self.root, relative)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as handle:
+            handle.write(body)
+        return path
+
+    def findings(self, entry=None):
+        raw = {
+            "version": "0.1.0",
+            "observables": "ICreditObservables",
+            "families": {"conservation": "held against each other"},
+            "laws": [entry if entry is not None else self.entry],
+        }
+        found = catalogue_module.parse(raw)
+        return checker.check(self.root, found)
+
+    def parts(self, entry=None):
+        return sorted({f.part for f in self.findings(entry)})
+
+
+class CompleteLawTests(CheckerCase):
+    def test_a_law_with_every_part_passes(self):
+        self.assertEqual(self.findings(), [])
+
+
+class ExecutesTests(CheckerCase):
+    def test_a_missing_component_fails(self):
+        self.assertIn("executes", self.parts(law(component="src/laws/Absent.sol")))
+
+    def test_a_component_whose_id_disagrees_with_the_catalogue_fails(self):
+        self.write("src/laws/HeldCoversClaims.sol", COMPONENT % "something/else/v1")
+        found = self.findings()
+        self.assertIn("executes", [f.part for f in found])
+        self.assertIn("something/else/v1", found[0].detail)
+
+    def test_a_component_outside_the_plugin_is_refused(self):
+        self.assertIn("executes", self.parts(law(component="../../../etc/passwd")))
+
+    def test_a_path_the_filesystem_refuses_is_a_finding_rather_than_a_crash(self):
+        """An embedded null byte raises out of realpath, not out of this."""
+        self.assertIn("executes", self.parts(law(component="src/laws/\x00.sol")))
+
+    def test_a_component_declaring_no_id_fails(self):
+        self.write("src/laws/HeldCoversClaims.sol", "contract Nameless {}")
+        self.assertIn("executes", self.parts())
+
+    def test_a_law_reverting_to_signal_a_violation_fails(self):
+        """Under fail_on_revert = false a revert carries no verdict."""
+        reverting = COMPONENT % IDENTIFIER
+        reverting = reverting.replace(
+            'return (false, "not covered");',
+            'require(false, "not covered");\n        return (false, "unreachable");',
+        )
+        self.write("src/laws/HeldCoversClaims.sol", reverting)
+        found = self.findings()
+        self.assertIn("judges rather than reverts", [f.part for f in found])
+
+    def test_a_law_may_still_read_a_target_that_reverts(self):
+        """The ban is on reverting to mean violated, not on calling a target."""
+        self.assertEqual(self.findings(), [])
+
+    def test_assert_is_caught_with_require_and_revert(self):
+        """A panic is as silent as any other revert under fail_on_revert."""
+        using = COMPONENT % IDENTIFIER
+        using = using.replace(
+            'return (false, "not covered");', "assert(false);\n        return (false, \"x\");"
+        )
+        self.write("src/laws/HeldCoversClaims.sol", using)
+        found = self.findings()
+        self.assertIn("judges rather than reverts", [f.part for f in found])
+        self.assertIn("assert", found[0].detail)
+
+    def test_the_word_require_in_a_comment_is_not_evidence(self):
+        commented = COMPONENT % IDENTIFIER
+        commented = commented.replace(
+            "        if (target.totalAssets()",
+            "        // this law does not require(x) of its target\n        if (target.totalAssets()",
+        )
+        self.write("src/laws/HeldCoversClaims.sol", commented)
+        self.assertEqual(self.findings(), [])
+
+    def test_the_revert_scan_survives_a_law_formatted_differently(self):
+        """The scan reads the component, not a parsed body, so a formatting
+        difference cannot silently switch the check off."""
+        oneline = (
+            "// SPDX-License-Identifier: Apache-2.0\n"
+            "contract L { function id() external pure returns (string memory) "
+            '{ return "%s"; } '
+            "function check() external view { require(false); } }" % IDENTIFIER
+        )
+        self.write("src/laws/HeldCoversClaims.sol", oneline)
+        self.assertIn("judges rather than reverts", self.parts())
+
+    def test_a_helper_named_for_reverting_is_not_a_revert(self):
+        """`revertHelper` is a name, not a verdict."""
+        named = COMPONENT % IDENTIFIER
+        named = named.replace(
+            "contract Sound is Law {",
+            "contract Sound is Law {\n    function revertHelper(uint256 x) internal pure returns (uint256) { return x; }\n",
+        )
+        self.write("src/laws/HeldCoversClaims.sol", named)
+        self.assertEqual(self.findings(), [])
+
+    def test_a_statement_describing_a_requirement_is_not_a_revert(self):
+        """The sentence a law states is prose, and prose is not evidence."""
+        describing = COMPONENT % IDENTIFIER
+        describing = describing.replace(
+            'return "Assets held cover the claims recorded against them.";',
+            'return "The system must require(collateral) before it lends.";',
+        )
+        self.write("src/laws/HeldCoversClaims.sol", describing)
+        self.assertEqual(self.findings(), [])
+
+    def test_a_component_that_is_not_text_is_a_finding_rather_than_a_crash(self):
+        path = os.path.join(self.root, "src/laws/HeldCoversClaims.sol")
+        with open(path, "wb") as handle:
+            handle.write(b"\xff\xfe\x00binary")
+        found = self.findings()
+        self.assertIn("executes", [f.part for f in found])
+        self.assertIn("not readable text", found[0].detail)
+
+
+class CatchesTests(CheckerCase):
+    def test_a_missing_specimen_fails(self):
+        self.assertIn("catches", self.parts(law(specimen="specimens/Absent.sol")))
+
+    def test_a_specimen_that_is_not_text_is_a_finding_rather_than_a_crash(self):
+        path = os.path.join(self.root, "specimens/DroppedClaim.sol")
+        with open(path, "wb") as handle:
+            handle.write(b"\xff\xfe\x00binary")
+        found = self.findings()
+        self.assertIn("catches", [f.part for f in found])
+
+    def test_a_specimen_that_does_not_say_it_is_broken_fails(self):
+        self.write("specimens/DroppedClaim.sol", "contract Quiet {}")
+        found = self.findings()
+        self.assertIn("catches", [f.part for f in found])
+        self.assertIn("gets copied", found[0].detail)
+
+
+class ReducedTests(CheckerCase):
+    def test_a_missing_counterexample_fails(self):
+        self.assertIn(
+            "has been reduced",
+            self.parts(law(counterexample="test/counterexamples/Absent.t.sol")),
+        )
+
+
+class ApplicabilityTests(CheckerCase):
+    def test_a_law_with_no_applicability_fails(self):
+        self.assertIn("says where it applies", self.parts(law(applicability={})))
+
+    def test_an_empty_accounting_model_fails(self):
+        entry = law()
+        entry["applicability"]["accounting_model"] = "   "
+        self.assertIn("says where it applies", self.parts(entry))
+
+    def test_assumptions_must_be_a_list_so_empty_is_a_claim(self):
+        entry = law()
+        entry["applicability"]["assumes"] = "none"
+        self.assertIn("says where it applies", self.parts(entry))
+
+    def test_an_empty_assumption_list_is_allowed_because_it_is_a_claim(self):
+        entry = law()
+        entry["applicability"]["assumes"] = []
+        self.assertEqual(self.findings(entry), [])
+
+
+class BoundsTests(CheckerCase):
+    def test_exact_is_a_complete_answer(self):
+        self.assertEqual(self.findings(law(bounds="exact")), [])
+
+    def test_a_tolerance_naming_its_arithmetic_passes(self):
+        entry = law(
+            bounds={
+                "tolerance": "1 wei per accrual step",
+                "arithmetic": "truncating division in the per-second rate",
+            }
+        )
+        self.assertEqual(self.findings(entry), [])
+
+    def test_a_tolerance_without_its_arithmetic_fails(self):
+        entry = law(bounds={"tolerance": "1 wei"})
+        found = self.findings(entry)
+        self.assertIn("bounds are justified", [f.part for f in found])
+        self.assertIn("made a test pass", found[0].detail)
+
+    def test_a_bare_number_is_not_a_bound(self):
+        self.assertIn("bounds are justified", self.parts(law(bounds=1)))
+
+    def test_missing_bounds_fails_as_a_finding_rather_than_a_parse_error(self):
+        """A missing part is the checker's business, so the reader is told
+        which part rather than that the file is malformed."""
+        entry = law()
+        del entry["bounds"]
+        self.assertIn("bounds are justified", self.parts(entry))
+
+
+class FilingTests(CheckerCase):
+    def test_a_family_the_catalogue_does_not_declare_fails(self):
+        self.assertIn("is filed", self.parts(law(family="invented")))
+
+    def test_a_component_on_disk_that_no_entry_claims_fails(self):
+        self.write("src/laws/Unfiled.sol", COMPONENT % "unfiled/law/v1")
+        found = self.findings()
+        self.assertIn("is filed", [f.part for f in found])
+        self.assertTrue(any("Unfiled.sol" in f.law for f in found))
+
+
+class StatementTests(CheckerCase):
+    def test_an_empty_statement_fails(self):
+        self.assertIn("states itself", self.parts(law(statement="  ")))
+
+
+PLUGIN_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SHIPPED = os.path.join(PLUGIN_ROOT, "catalogue", "pandects.json")
+
+PART_FOR_FIELD = {
+    "component": "executes",
+    "specimen": "catches",
+    "counterexample": "has been reduced",
+    "applicability": "says where it applies",
+    "bounds": "bounds are justified",
+    "statement": "states itself",
+    "family": "is filed",
+}
+
+
+class ShippedLawsTests(unittest.TestCase):
+    """Every part removed in turn, from every law the corpus actually ships.
+
+    The tests above prove the checker works on a law built to be broken. This
+    proves it works on the laws in the catalogue, which is a different claim: a
+    gate that fires on a synthetic entry and not on a real one has been tested
+    against itself.
+    """
+
+    def setUp(self):
+        self.catalogue = catalogue_module.load(SHIPPED)
+
+    def findings_for(self, entries):
+        raw = {
+            "version": self.catalogue.version,
+            "observables": "ICreditObservables",
+            "families": self.catalogue.families,
+            "laws": entries,
+        }
+        return checker.check(PLUGIN_ROOT, catalogue_module.parse(raw))
+
+    def test_every_shipped_law_passes_with_every_part_present(self):
+        self.assertEqual(self.findings_for([law.raw for law in self.catalogue.laws]), [])
+
+    def test_every_shipped_law_is_refused_with_any_part_removed(self):
+        for law in self.catalogue.laws:
+            for field, part in PART_FOR_FIELD.items():
+                broken = dict(law.raw)
+                del broken[field]
+                found = self.findings_for([broken])
+                # Filtered to this law's own findings. Checking one law in
+                # isolation leaves the other eight components on disk
+                # unclaimed, and those are reported under "is filed" too, so an
+                # unfiltered assertion would pass for the removal of `family`
+                # whatever the checker did.
+                named = [
+                    f for f in found if f.part == part and f.law == law.id
+                ]
+                self.assertTrue(
+                    named,
+                    "%s lost its %s and the checker did not say so: %r"
+                    % (law.id, field, [f.line() for f in found]),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/pandects/tests/test_cli.py
+++ b/plugins/pandects/tests/test_cli.py
@@ -1,0 +1,133 @@
+"""The two subcommands, and what they exit with."""
+
+import contextlib
+import io
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from . import support  # noqa: F401  (sets sys.path)
+
+import pandects  # noqa: E402
+
+
+def run(argv):
+    out = io.StringIO()
+    err = io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        try:
+            code = pandects.main(argv)
+        except SystemExit as exit:
+            code = exit.code
+    return code, out.getvalue(), err.getvalue()
+
+
+class LawsTests(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.root)
+
+    def empty_catalogue(self):
+        path = os.path.join(self.root, "empty.json")
+        with open(path, "w") as handle:
+            json.dump(
+                {
+                    "version": "0.1.0",
+                    "observables": "ICreditObservables",
+                    "families": {"conservation": "held against each other"},
+                    "laws": [],
+                },
+                handle,
+            )
+        return path
+
+    def test_an_empty_catalogue_says_so_rather_than_printing_nothing(self):
+        code, out, _ = run(["laws", "--catalogue", self.empty_catalogue()])
+        self.assertEqual(code, 0)
+        self.assertIn("no laws yet", out)
+        self.assertIn("conservation", out)
+
+    def test_the_shipped_catalogue_lists_its_laws_with_applicability(self):
+        code, out, _ = run(["laws"])
+        self.assertEqual(code, 0)
+        self.assertIn("conservation/value-conserved/v1", out)
+        self.assertIn("applies to:", out)
+
+    def test_the_json_form_is_the_catalogue(self):
+        code, out, _ = run(["laws", "--json"])
+        self.assertEqual(code, 0)
+        found = json.loads(out)
+        self.assertIn("families", found)
+        self.assertTrue(found["laws"])
+        for law in found["laws"]:
+            self.assertIn("applicability", law)
+
+
+class CheckTests(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.root)
+
+    def write(self, body):
+        path = os.path.join(self.root, "catalogue.json")
+        with open(path, "w") as handle:
+            handle.write(body if isinstance(body, str) else json.dumps(body))
+        return path
+
+    def test_the_shipped_catalogue_passes(self):
+        code, out, _ = run(["check"])
+        self.assertEqual(code, 0)
+        self.assertIn("every part present", out)
+
+    def test_a_law_missing_a_part_exits_one_and_names_the_part(self):
+        path = self.write(
+            {
+                "version": "0.1.0",
+                "observables": "ICreditObservables",
+                "families": {"conservation": "held against each other"},
+                "laws": [
+                    {
+                        "id": "conservation/invented/v1",
+                        "family": "conservation",
+                        "statement": "Something hopeful.",
+                        "component": "src/laws/Absent.sol",
+                        "specimen": "specimens/Absent.sol",
+                        "counterexample": "test/counterexamples/Absent.t.sol",
+                        "applicability": {
+                            "accounting_model": "pooled deposits",
+                            "assumes": [],
+                            "requires": [],
+                        },
+                        "bounds": "exact",
+                    }
+                ],
+            }
+        )
+        code, out, _ = run(["check", "--catalogue", path])
+        self.assertEqual(code, 1)
+        self.assertIn("executes", out)
+        self.assertIn("catches", out)
+        self.assertIn("has been reduced", out)
+
+    def test_a_malformed_catalogue_exits_two(self):
+        path = self.write("{not json")
+        code, _, err = run(["check", "--catalogue", path])
+        self.assertEqual(code, 2)
+        self.assertIn("not valid JSON", err)
+
+    def test_the_json_form_carries_the_verdict(self):
+        code, out, _ = run(["check", "--json"])
+        self.assertEqual(code, 0)
+        found = json.loads(out)
+        self.assertTrue(found["ok"])
+        self.assertEqual(found["findings"], [])
+
+    def test_no_subcommand_prints_help_and_exits_two(self):
+        code, _, _ = run([])
+        self.assertEqual(code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/pandects/tests/test_documents.py
+++ b/plugins/pandects/tests/test_documents.py
@@ -1,0 +1,190 @@
+"""The documents, against what is actually on disk.
+
+A rendered catalogue is a second copy of the truth, and a second copy drifts.
+These are the checks that make it a rendering instead: a law added without
+appearing in the document fails, a document naming a law that is not there
+fails, and a specimen nobody filed fails.
+"""
+
+import json
+import os
+import re
+import unittest
+
+from . import support  # noqa: F401  (sets sys.path)
+
+from pandects_lib import catalogue as catalogue_module  # noqa: E402
+from pandects_lib import render as render_module  # noqa: E402
+
+PLUGIN_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SHIPPED = os.path.join(PLUGIN_ROOT, "catalogue", "pandects.json")
+RENDERED = os.path.join(PLUGIN_ROOT, "docs", "catalogue.md")
+
+LAW_HEADING = re.compile(r"^### `([^`]+)`$", re.MULTILINE)
+BACKTICKED = re.compile(r"`([^`]+\.sol)`")
+
+#: Contracts under `specimens/` that are not specimens. The sound reference is
+#: what every specimen inherits from, so no catalogue entry claims it and none
+#: should.
+NOT_A_SPECIMEN = {"Sound.sol"}
+
+
+class RenderedCatalogueTests(unittest.TestCase):
+    def setUp(self):
+        self.catalogue = catalogue_module.load(SHIPPED)
+        with open(RENDERED) as handle:
+            self.rendered = handle.read()
+        self.headings = LAW_HEADING.findall(self.rendered)
+
+    def test_the_document_names_every_law_in_the_catalogue(self):
+        missing = [law.id for law in self.catalogue.laws if law.id not in self.headings]
+        self.assertEqual(missing, [], "laws filed and not rendered")
+
+    def test_the_document_names_no_law_the_catalogue_lacks(self):
+        known = {law.id for law in self.catalogue.laws}
+        extra = [found for found in self.headings if found not in known]
+        self.assertEqual(extra, [], "laws rendered and not filed")
+
+    def test_the_document_renders_each_law_once(self):
+        self.assertEqual(len(self.headings), len(set(self.headings)))
+
+    def test_every_rendered_statement_matches_the_catalogue(self):
+        """A rendering that paraphrases is a second source.
+
+        The statement is the law as a reader would state it, and a document
+        carrying a friendlier version of it is a document somebody will quote.
+        """
+        for law in self.catalogue.laws:
+            self.assertIn("> %s" % law.get("statement"), self.rendered, law.id)
+
+    def test_every_rendered_path_exists(self):
+        for relative in set(BACKTICKED.findall(self.rendered)):
+            self.assertTrue(
+                os.path.isfile(os.path.join(PLUGIN_ROOT, relative)),
+                "%s is named in the document and not on disk" % relative,
+            )
+
+
+class RendererTests(unittest.TestCase):
+    """The document is what the renderer produces, byte for byte.
+
+    Without this, "rendering rather than a second source" is a claim about
+    intent. The drift tests above catch a document that stopped agreeing with
+    the catalogue and offer no way to fix it; somebody adding a law was told the
+    document was wrong and left to work out what it should have said.
+    """
+
+    def setUp(self):
+        self.catalogue = catalogue_module.load(SHIPPED)
+        with open(RENDERED) as handle:
+            self.committed = handle.read()
+
+    def test_the_committed_document_is_what_the_renderer_writes(self):
+        self.assertEqual(
+            self.committed,
+            render_module.render(self.catalogue),
+            "docs/catalogue.md differs from the renderer; run "
+            "`python3 scripts/pandects.py render`",
+        )
+
+    def test_the_rendering_is_stable(self):
+        once = render_module.render(self.catalogue)
+        self.assertEqual(once, render_module.render(self.catalogue))
+
+    def test_the_preamble_counts_what_was_rendered(self):
+        """Rather than a figure somebody typed once.
+
+        The drift test above cannot catch a wrong count: it compares the
+        document against this renderer, so a hardcoded number makes both wrong
+        the same way. This is the check that has to come from outside.
+        """
+        body = render_module.render(self.catalogue)
+        self.assertIn("Nine laws in three families", body)
+
+        raw = json.loads(json.dumps(self.catalogue.raw))
+        raw["laws"] = raw["laws"][:1]
+        smaller = render_module.render(catalogue_module.parse(raw))
+        self.assertIn("One law in one family", smaller)
+
+    def test_a_law_in_an_unfamiliar_family_is_still_rendered(self):
+        """A renderer must not drop what it was not told about.
+
+        Looping over its own vocabulary rather than the catalogue would make a
+        law filed under a new family vanish from the document, and the drift
+        test would not see it, because the document is what this produces.
+        """
+        raw = json.loads(json.dumps(self.catalogue.raw))
+        raw["families"]["novel"] = "a family the renderer has no blurb for"
+        raw["laws"][0]["family"] = "novel"
+        body = render_module.render(catalogue_module.parse(raw))
+        self.assertIn("## Novel", body)
+        self.assertIn(raw["laws"][0]["id"], body)
+
+    def test_a_family_with_no_laws_is_skipped_rather_than_printed_empty(self):
+        raw = dict(self.catalogue.raw)
+        raw["families"] = dict(raw["families"])
+        raw["families"]["nothing-here"] = "a family nobody has filed under"
+        body = render_module.render(catalogue_module.parse(raw))
+        self.assertNotIn("Nothing-here", body)
+
+
+class IntegrationNotesTests(unittest.TestCase):
+    """Every law is spoken about where the corpus meets a real design.
+
+    A law added to the catalogue and left out of the integration's notes is a
+    law nobody has asked the applicability question about, which is the question
+    that integration exists to answer.
+    """
+
+    def setUp(self):
+        self.catalogue = catalogue_module.load(SHIPPED)
+        path = os.path.join(
+            PLUGIN_ROOT, "integrations", "wildcat", "APPLICABILITY.md"
+        )
+        with open(path) as handle:
+            self.notes = handle.read()
+
+    def test_every_law_appears_in_the_wildcat_notes(self):
+        for law in self.catalogue.laws:
+            self.assertIn(law.id, self.notes, "%s is unmentioned" % law.id)
+
+
+class SpecimenTests(unittest.TestCase):
+    def setUp(self):
+        self.catalogue = catalogue_module.load(SHIPPED)
+
+    def test_every_specimen_on_disk_is_claimed_by_a_law(self):
+        """The reverse of a missing specimen, and the easier mistake.
+
+        A broken contract nobody filed is a broken contract with no law saying
+        what it is for, sitting in a directory a reader is invited to copy from.
+        """
+        claimed = {
+            os.path.basename(law.get("specimen") or "") for law in self.catalogue.laws
+        }
+        directory = os.path.join(PLUGIN_ROOT, "specimens")
+        for name in sorted(os.listdir(directory)):
+            if not name.endswith(".sol") or name in NOT_A_SPECIMEN:
+                continue
+            self.assertIn(name, claimed, "%s is on disk and in no catalogue entry" % name)
+
+    def test_every_claimed_specimen_says_it_is_broken(self):
+        for law in self.catalogue.laws:
+            path = os.path.join(PLUGIN_ROOT, law.get("specimen"))
+            with open(path) as handle:
+                self.assertIn("deliberately broken", handle.read().lower(), law.id)
+
+
+class GuideTests(unittest.TestCase):
+    """The documents a reader is sent to actually exist."""
+
+    def test_the_guides_are_present_and_not_empty(self):
+        for name in ("writing-a-law.md", "applicability.md", "catalogue.md"):
+            path = os.path.join(PLUGIN_ROOT, "docs", name)
+            self.assertTrue(os.path.isfile(path), name)
+            with open(path) as handle:
+                self.assertGreater(len(handle.read()), 500, name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/pandects/tests/test_search_record.py
+++ b/plugins/pandects/tests/test_search_record.py
@@ -1,0 +1,346 @@
+"""The search record: its shape, its digest, and what it leaves out.
+
+A campaign result is only worth something if it says how the search was made.
+These tests are about the three ways that goes wrong: a record that claims an
+engine nobody ran, a record ariadne would refuse, and a digest that does not
+track the thing it claims to digest.
+"""
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from . import support  # noqa: F401  (sets sys.path)
+
+from pandects_lib import catalogue as catalogue_module  # noqa: E402
+from pandects_lib import run as run_module  # noqa: E402
+
+PLUGIN_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SHIPPED = os.path.join(PLUGIN_ROOT, "catalogue", "pandects.json")
+
+#: Ariadne's determinism gate, restated as the two things it enforces. Kept
+#: here rather than imported: the plugins share no code, and a copy that drifts
+#: is a failing test, which is the point of pinning it.
+ARIADNE_COMMAND_FIELDS = {"name", "argv", "determinism", "output_digest", "detail"}
+ARIADNE_DETERMINISM = ("exact", "nondeterministic")
+
+
+class CommandShapeTests(unittest.TestCase):
+    def test_a_command_carries_only_the_fields_ariadne_allows(self):
+        entry = run_module.command(
+            "fuzz campaign: example", ["forge", "test"], "nondeterministic", {"engine": "foundry"}
+        )
+        self.assertEqual(set(entry) - ARIADNE_COMMAND_FIELDS, set())
+        self.assertIn(entry["determinism"], ARIADNE_DETERMINISM)
+
+    def test_an_empty_argv_is_refused(self):
+        """Ariadne's wording: nobody else could run it."""
+        with self.assertRaises(run_module.RunError) as caught:
+            run_module.command("c", [], "nondeterministic", {})
+        self.assertIn("argv", str(caught.exception))
+
+    def test_an_argv_entry_that_is_not_a_string_is_refused(self):
+        with self.assertRaises(run_module.RunError):
+            run_module.command("c", ["forge", 7], "nondeterministic", {})
+
+    def test_a_determinism_class_outside_the_two_is_refused(self):
+        with self.assertRaises(run_module.RunError) as caught:
+            run_module.command("c", ["forge"], "mostly", {})
+        self.assertIn("mostly", str(caught.exception))
+
+    def test_an_exact_command_without_an_output_digest_is_refused(self):
+        """The gate's reason, enforced at the point of writing.
+
+        An exact command promises a replay can be compared byte for byte. With
+        no digest there is nothing to compare against, so the promise is empty
+        and the record should never have been written.
+        """
+        with self.assertRaises(run_module.RunError) as caught:
+            run_module.command("c", ["forge"], "exact", {})
+        self.assertIn("nothing to compare", str(caught.exception))
+
+    def test_an_exact_command_with_a_digest_is_accepted(self):
+        entry = run_module.command(
+            "c", ["forge"], "exact", {}, output_digest={"sha256": "ab" * 32}
+        )
+        self.assertEqual(entry["output_digest"], {"sha256": "ab" * 32})
+
+
+class AbsentEngineTests(unittest.TestCase):
+    """An engine that did not run is absent, not present and empty."""
+
+    def setUp(self):
+        self.catalogue = catalogue_module.load(SHIPPED)
+
+    def test_a_missing_engine_produces_no_command_at_all(self):
+        """Driven rather than asserted in prose.
+
+        `run_foundry` returns None when the engine is not on the path, and the
+        record is built from what came back. Pointing it at a directory with no
+        `forge` reachable is the same path a machine without Foundry takes.
+        """
+        original = run_module.run_foundry
+        run_module.run_foundry = lambda root, match=None, timeout=1800: None
+        try:
+            record = run_module.search_record(PLUGIN_ROOT, self.catalogue)
+        finally:
+            run_module.run_foundry = original
+        self.assertEqual(record["commands"], [])
+
+    def test_a_record_with_no_engine_still_names_the_corpus(self):
+        """Absence of a search is not absence of a subject.
+
+        The record says which corpus nothing was run against, which is what
+        makes an empty `commands` list readable as "nobody searched" rather than
+        as a file somebody truncated.
+        """
+        original = run_module.run_foundry
+        run_module.run_foundry = lambda root, match=None, timeout=1800: None
+        try:
+            record = run_module.search_record(PLUGIN_ROOT, self.catalogue)
+        finally:
+            run_module.run_foundry = original
+        self.assertEqual(record["corpus"]["laws"], len(self.catalogue.laws))
+        self.assertIn("sha256", record["corpus"]["digest"])
+
+    def test_a_seed_nobody_can_read_is_absent_rather_than_null(self):
+        """Foundry reports no seed, so the record says nothing about one.
+
+        A `"seed": null` would be a claim that the run had no seed. What is true
+        is that nobody can read the one it used, and those are different.
+        """
+        result = {"argv": ["forge", "test"], "returncode": 0, "output": ""}
+        entry = run_module.foundry_record(PLUGIN_ROOT, self.catalogue, result)
+        self.assertNotIn("seed", entry["detail"])
+
+    def test_an_engine_version_nobody_could_read_is_absent_too(self):
+        """The same rule as the seed, applied in the same record.
+
+        A field that is null in one place and absent in another for the same
+        reason is a record that has to be read twice. Both mean "nobody could
+        read this", so both are absent.
+        """
+        original = run_module.engine_version
+        run_module.engine_version = lambda argv, timeout=60: None
+        try:
+            result = {"argv": ["forge", "test"], "returncode": 0, "output": ""}
+            entry = run_module.foundry_record(PLUGIN_ROOT, self.catalogue, result)
+        finally:
+            run_module.engine_version = original
+        self.assertNotIn("engine_version", entry["detail"])
+        self.assertNotIn("seed", entry["detail"])
+
+    def test_no_field_in_a_record_is_ever_null(self):
+        """The rule, stated once over the whole record rather than per field."""
+        record = run_module.search_record(PLUGIN_ROOT, self.catalogue, match="LawTest")
+
+        def walk(value, path="record"):
+            if value is None:
+                self.fail("%s is null; absent is how this record says unknown" % path)
+            if isinstance(value, dict):
+                for key, child in value.items():
+                    walk(child, "%s.%s" % (path, key))
+            elif isinstance(value, list):
+                for i, child in enumerate(value):
+                    walk(child, "%s[%d]" % (path, i))
+
+        walk(record)
+
+    def test_a_seed_that_was_given_is_recorded(self):
+        result = {"argv": ["echidna", "."], "returncode": 0, "output": ""}
+        entry = run_module.foundry_record(
+            PLUGIN_ROOT, self.catalogue, result, seed="20260816"
+        )
+        self.assertEqual(entry["detail"]["seed"], "20260816")
+
+
+class TimeoutTests(unittest.TestCase):
+    """A campaign that was killed is not a campaign that never happened."""
+
+    def setUp(self):
+        self.catalogue = catalogue_module.load(SHIPPED)
+
+    def test_a_timed_out_campaign_is_recorded_rather_than_dropped(self):
+        result = {
+            "argv": ["forge", "test"],
+            "returncode": None,
+            "timed_out_after": 1800,
+            "output": "",
+        }
+        detail = run_module.foundry_record(PLUGIN_ROOT, self.catalogue, result)["detail"]
+        self.assertEqual(detail["outcome"], "timed out")
+        self.assertEqual(detail["timed_out_after_seconds"], 1800)
+
+    def test_a_timeout_is_neither_passed_nor_failed(self):
+        """Folding it into either verdict loses what a reader needs.
+
+        Called passed, it claims a search that finished. Called failed, it
+        claims a law was violated. Neither happened.
+        """
+        killed = run_module.outcome_of({"returncode": None})
+        self.assertNotIn(killed, ("passed", "failed"))
+        self.assertEqual(run_module.outcome_of({"returncode": 0}), "passed")
+        self.assertEqual(run_module.outcome_of({"returncode": 1}), "failed")
+
+
+class SettingsTests(unittest.TestCase):
+    def setUp(self):
+        self.catalogue = catalogue_module.load(SHIPPED)
+
+    def test_the_record_names_every_field_the_gate_asks_for(self):
+        result = {"argv": ["forge", "test"], "returncode": 0, "output": ""}
+        detail = run_module.foundry_record(PLUGIN_ROOT, self.catalogue, result)["detail"]
+        for field in ("engine", "configuration", "sequence_length", "corpus_digest"):
+            self.assertIn(field, detail)
+
+    def test_the_configuration_is_read_from_foundry_toml_rather_than_restated(self):
+        """A record cannot describe a configuration nobody used."""
+        settings = run_module.foundry_settings(PLUGIN_ROOT)
+        self.assertEqual(settings.get("fail_on_revert"), "false")
+        self.assertIn("depth", settings)
+
+    def test_a_configuration_nobody_could_read_is_refused(self):
+        """Rather than reported as an empty one.
+
+        `"configuration": {}` reads as a campaign that ran under no settings.
+        What happened is that the settings could not be found, and a record
+        whose whole purpose is describing the search must not quietly describe
+        a different one.
+        """
+        root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, root)
+        with open(os.path.join(root, "foundry.toml"), "w") as handle:
+            handle.write("[profile.default]\nsrc = \"src\"\n")
+        with self.assertRaises(run_module.RunError) as caught:
+            run_module.foundry_settings(root)
+        self.assertIn("empty configuration", str(caught.exception))
+
+    def test_the_profile_scoped_section_is_read_too(self):
+        """Both headings are in use, and one reader would miss half of them."""
+        root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, root)
+        with open(os.path.join(root, "foundry.toml"), "w") as handle:
+            handle.write("[profile.default.invariant]\nruns = 128\ndepth = 32\n")
+        self.assertEqual(run_module.foundry_settings(root)["runs"], "128")
+
+    def test_a_failing_campaign_is_recorded_as_failed(self):
+        result = {"argv": ["forge", "test"], "returncode": 1, "output": ""}
+        entry = run_module.foundry_record(PLUGIN_ROOT, self.catalogue, result)
+        self.assertEqual(entry["detail"]["outcome"], "failed")
+
+
+class CorpusDigestTests(unittest.TestCase):
+    """The digest tracks the corpus and nothing else."""
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.root)
+        for relative in ("catalogue", "src/laws", "specimens", "test/counterexamples"):
+            os.makedirs(os.path.join(self.root, relative), exist_ok=True)
+        self.write("src/laws/One.sol", 'contract One { function id() external pure returns (string memory) { return "a/b/v1"; } }\n')
+        self.write("specimens/Broken.sol", "// deliberately broken\ncontract Broken {}\n")
+        self.raw = {
+            "version": "0.1.0",
+            "observables": "ICreditObservables",
+            "families": {"conservation": "held against each other"},
+            "laws": [
+                {
+                    "id": "a/b/v1",
+                    "family": "conservation",
+                    "statement": "something",
+                    "component": "src/laws/One.sol",
+                    "specimen": "specimens/Broken.sol",
+                    "counterexample": "test/counterexamples/One.t.sol",
+                    "applicability": {"accounting_model": "m", "assumes": [], "requires": []},
+                    "bounds": "exact",
+                }
+            ],
+        }
+
+    def write(self, relative, body):
+        path = os.path.join(self.root, relative)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as handle:
+            handle.write(body)
+
+    def digest(self, raw=None):
+        return run_module.corpus_digest(
+            self.root, catalogue_module.parse(raw or self.raw)
+        )["sha256"]
+
+    def test_the_digest_is_stable_across_two_reads(self):
+        self.assertEqual(self.digest(), self.digest())
+
+    def test_a_changed_law_changes_the_digest(self):
+        before = self.digest()
+        self.write("src/laws/One.sol", 'contract One { function id() external pure returns (string memory) { return "a/b/v2"; } }\n')
+        self.assertNotEqual(before, self.digest())
+
+    def test_a_changed_specimen_changes_the_digest(self):
+        before = self.digest()
+        self.write("specimens/Broken.sol", "// deliberately broken\ncontract Broken { uint256 x; }\n")
+        self.assertNotEqual(before, self.digest())
+
+    def test_a_changed_catalogue_changes_the_digest(self):
+        before = self.digest()
+        changed = json.loads(json.dumps(self.raw))
+        changed["laws"][0]["statement"] = "something else"
+        self.assertNotEqual(before, self.digest(changed))
+
+    def test_a_rewritten_comment_does_not_change_the_digest(self):
+        """The point of stripping comments rather than hashing the file.
+
+        A docstring rewrite is not a change to the corpus, and a digest that
+        moved every time somebody improved a sentence would be a digest nobody
+        could use to say two campaigns searched the same thing.
+        """
+        before = self.digest()
+        self.write(
+            "src/laws/One.sol",
+            "/// A much better explanation of what this law does.\n"
+            "// and a note\n"
+            'contract One { function id() external pure returns (string memory) { return "a/b/v1"; } }\n',
+        )
+        self.assertEqual(before, self.digest())
+
+    def test_a_slash_inside_a_string_is_not_a_comment(self):
+        """Where a regex would get it wrong.
+
+        A law's `statement()` is a string literal, and stripping from a `//`
+        inside one would silently drop the rest of the law from the digest.
+        """
+        source = 'contract One { function s() external pure returns (string memory) { return "http://x"; } }\n'
+        self.assertIn("http://x", run_module.strip_comments(source))
+
+    def test_a_quote_inside_a_comment_does_not_open_a_string(self):
+        source = '// it\'s fine\ncontract One { uint256 x; }\n'
+        self.assertIn("contract One", run_module.strip_comments(source))
+
+    def test_a_file_the_catalogue_claims_and_disk_lacks_is_refused(self):
+        """Refused rather than skipped.
+
+        A digest that quietly omitted a missing component would be a digest of
+        a smaller corpus, reported as the corpus.
+        """
+        os.remove(os.path.join(self.root, "specimens/Broken.sol"))
+        with self.assertRaises(run_module.RunError) as caught:
+            self.digest()
+        self.assertIn("specimens/Broken.sol", str(caught.exception))
+
+    def test_a_file_on_disk_that_no_law_claims_does_not_change_the_digest(self):
+        before = self.digest()
+        self.write("src/laws/Unfiled.sol", "contract Unfiled {}\n")
+        self.assertEqual(before, self.digest())
+
+
+class ShippedCorpusTests(unittest.TestCase):
+    def test_the_shipped_corpus_digests(self):
+        catalogue = catalogue_module.load(SHIPPED)
+        found = run_module.corpus_digest(PLUGIN_ROOT, catalogue)
+        self.assertEqual(len(found["sha256"]), 64)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #51.
Refs #53.

## What changed

- publishes the Pandects executable credit-law corpus, its nine laws, broken specimens, reduced counterexamples, adapters, Wildcat model, scripts, and tests
- adds the portable skill entrypoint and the Codex and Claude Code plugin manifests
- registers Pandects in both repository marketplaces and documents it in the public skills catalogue
- adds a dedicated CI workflow for the Python catalogue checks and Foundry corpus
- ignores generated Foundry, fuzzing, and audit output; the incubator's 2.6 MB crytic-compile export and empty Slither stderr file are deliberately not imported

## Cold-read corrections

- names both passing Pandects harnesses instead of assigning a misleading ordinal
- states throughout Ariadne that signing and signature verification belong to cosign
- makes Fizz select Hexaemeron's pinned X-Ray copy before host discovery, with no external installation path
- removes dead demo links and upstream installation prompts from the bundled Pashov browsing READMEs
- synchronizes the Hermes browsing README with its canonical skill
- fixes the duplicated Probitas wording and completes Pandects installation and discovery prose
- records the local Pashov distribution changes and the boundary between upstream prose and Wildcat's house lint

## Why

Pandects is complete in `laurenceday/wildcat-skills-todo`. Publishing it here makes the reviewed credit-law corpus installable from the public Wildcat skills distribution. The follow-up corrections make the surrounding instructions match the code and files that ship.

## Checks

- root repository tests: 5 passed
- Ariadne tests: 310 passed
- Hermes tests: 14 passed
- Hexaemeron and Imprimatur tests: 98 passed
- Pandects Python tests: 106 passed
- Pandects Foundry tests: 72 passed
- Probitas tests: 234 passed
- six changed skill directories pass the Agent Skills validator
- changed prose passes Proscribed with no defects
- JSON parsing, mirror equality, relative-link review, and `git diff --check` pass

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: https://github.com/wildcat-finance/skills/issues/51
Root-Issue-Successor: none-recorded
Root-Issue-Fiat-Required: 0
Root-Issue-Route: pr-only
Root-Issue-Classification-Source: live-contract
<!-- root-issue-analytics:v1:end -->
