### PR TITLE
Resolve repository cold-read findings

### DIFF
--- a/.agents/skills/ariadne/SKILL.md
+++ b/.agents/skills/ariadne/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ariadne
-description: Route a request about signed release evidence to the canonical Ariadne instructions. Use when the user names Ariadne, hands over an attestation and asks what it covers, or wants a release bound to the build, test, review and deployment evidence behind it. Never use it to claim a signature was verified.
+description: Route a request about release evidence statements to the canonical Ariadne instructions. Use when the user names Ariadne, hands over an attestation and asks what it covers, or wants a release bound to the build, test, review and deployment evidence behind it. Ariadne neither signs nor verifies signatures.
 ---
 
 # Ariadne portable entrypoint

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -118,7 +118,7 @@
       "name": "ariadne",
       "displayName": "Ariadne",
       "source": "./plugins/ariadne",
-      "description": "Signed release evidence, with the absences kept in the statement.",
+      "description": "Release evidence statements with absences kept visible.",
       "version": "0.1.0",
       "author": {
         "name": "Wildcat Labs",

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ The statement is [in-toto's](https://github.com/in-toto/attestation) and the env
 
 1. Every claim names the exact digest it covers. A result tied to a repository or a branch is refused, because those move.
 2. The environment is recoverable. A compiler version without the optimiser settings, the EVM target, the dependency lock and the command is not a build description.
-3. Absence stays visible. Skipped, failed, timed-out and redacted work stays in the signed record, and anything other than a pass carries a reason.
+3. Absence stays visible. Skipped, failed, timed-out and redacted work stays in the statement record, and anything other than a pass carries a reason.
 4. Results are not upgraded into conclusions. A passing property records the property and the run, never that the artefact is safe.
 5. Deltas name both sides. A comparison fails when either baseline cannot be identified by digest, rather than degrading into a report of no changes.
 6. Replay distinguishes deterministic work. Bytecode can require an exact match; a fuzz campaign's coverage cannot.
-7. Signing is optional and verification is not. Ariadne holds no key, checks no signature, and says so every time it is asked.
+7. Signature verification is external. Ariadne holds no key, checks no signature, and says so every time it is asked.
 
 Five of those belong to an artefact-neutral core and run for any predicate, including a type the build has never seen. The other two come from the predicate, and a type without them is reported as unchecked rather than clean.
 
@@ -164,7 +164,7 @@ that moved.
 
 [Probitas](./plugins/probitas) builds a sourced dossier on what a counterparty has done across on-chain lending venues.
 
-Undercollateralised lending is the reason to want one: nothing stands between a lender and a total loss except a judgement about the borrower, and that judgement usually gets assembled by hand out of whatever whoever is asking happens to remember. The tool is not limited to that case. Most on-chain borrowing is collateralised and it still tells you plenty, because a liquidation says a price moved, a bad debt says somebody was not made whole, and a missed maturity says what it says anywhere.
+Undercollateralised lending is the reason to want one: nothing stands between a lender and a total loss except a judgement about the borrower, and that judgement usually gets assembled by hand from whatever the person asking happens to remember. The tool is not limited to that case. Most on-chain borrowing is collateralised and it still tells you plenty, because a liquidation says a price moved, a bad debt says somebody was not made whole, and a missed maturity says what it says anywhere.
 
 Two halves, doing different jobs. A deterministic collector queries venue adapters and writes an evidence file in which a record cannot exist without a transaction hash, a URL or a document reference. The model writes the narrative from that file, and a gate checker reads the document and the evidence together before either ships.
 
@@ -253,14 +253,14 @@ economic meaning attached.
 
 Scored out of 10 for doing the job, not for reading the output. A marketer can quote a verified gas number without having any use for Hermes itself.
 
-| Role | Ariadne | Hermes | Hexaemeron | Lemma | Probitas | Tabularium |
-| --- | --- | --- | --- | --- | --- | --- |
-| Developers | 8 | 9 | 9 | 6 | 4 | 7 |
-| Security and audit | 9 | 7 | 8 | 4 | 5 | 7 |
-| Marketing | 1 | 3 | 6 | 1 | 1 | 1 |
-| Business development | 2 | 2 | 5 | 1 | 9 | 3 |
-| Finance | 1 | 3 | 4 | 1 | 7 | 7 |
-| Legal | 3 | 1 | 4 | 1 | 4 | 2 |
+| Role | Ariadne | Hermes | Hexaemeron | Lemma | Pandects | Probitas | Tabularium |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Developers | 8 | 9 | 9 | 6 | 8 | 4 | 7 |
+| Security and audit | 9 | 7 | 8 | 4 | 9 | 5 | 7 |
+| Marketing | 1 | 3 | 6 | 1 | 1 | 1 | 1 |
+| Business development | 2 | 2 | 5 | 1 | 2 | 9 | 3 |
+| Finance | 1 | 3 | 4 | 1 | 2 | 7 | 7 |
+| Legal | 3 | 1 | 4 | 1 | 2 | 4 | 2 |
 
 Five is the barrier. At or above it, the plugin's entry carries a worked example of what that role would use it for. Below it there is no example, because there is no honest one to give. These are engineering tools, and a 2 means we could not find a reason for that desk to open the plugin rather than read what it produced.
 
@@ -295,6 +295,7 @@ Add the same marketplace and install a plugin from inside Claude Code:
 /plugin install hermes@wildcat-labs
 /plugin install hexaemeron@wildcat-labs
 /plugin install lemma@wildcat-labs
+/plugin install pandects@wildcat-labs
 /plugin install probitas@wildcat-labs
 /plugin install tabularium@wildcat-labs
 ```
@@ -323,6 +324,12 @@ Lemma is available as:
 /lemma:chunk
 ```
 
+Pandects is available as:
+
+```text
+/pandects:pandects
+```
+
 Probitas is available as:
 
 ```text
@@ -339,7 +346,7 @@ See Anthropic's [skills](https://code.claude.com/docs/en/skills) and [plugin mar
 
 ### Local agents
 
-Agents that support the open Agent Skills convention can discover the six
+Agents that support the open Agent Skills convention can discover the seven
 host-neutral entries under [`.agents/skills`](./.agents/skills). Point the
 agent at this repository and include that directory in its project skill
 search path. Keep the repository layout intact: each entry routes to the
@@ -354,11 +361,12 @@ planning, question, and subagent operations available in a local runtime.
 Plain-text activation works alongside host syntax:
 
 ```text
-Use Ariadne to capture this release into a signed statement and verify it.
+Use Ariadne to capture this release in an evidence statement, run its gates, and report its signature state without checking signatures.
 Use Hermes to optimise gas in this Foundry repository.
 Use Hexaemeron Fiat to take "<topic>" through the delivery loop.
 Use Hexaemeron Fizz to generate a stateful fuzz suite.
 Use Lemma to chunk this Solidity standard input into JSONL.
+Use Pandects to check this credit protocol against the executable laws in the corpus.
 Use Probitas to build a dossier on this counterparty from the addresses they declared.
 Use Tabularium to build and verify a source-bound Goldfinch credit-event release.
 ```
@@ -372,7 +380,7 @@ Ariadne needs Python 3 and nothing else. Capturing from a Foundry project needs
 that project's build output, which `forge build` already wrote. Ask:
 
 ```text
-Use $ariadne to capture this release into a signed statement and verify what it covers.
+Use $ariadne to capture this release in an evidence statement, run its gates, and report its signature state without checking signatures.
 ```
 
 The gates, the predicate and the refusals live in [Ariadne's `SKILL.md`](./plugins/ariadne/skills/ariadne/SKILL.md).

--- a/plugins/ariadne/.claude-plugin/plugin.json
+++ b/plugins/ariadne/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ariadne",
   "displayName": "Ariadne",
   "version": "0.1.0",
-  "description": "Signed evidence another person can check: an in-toto statement core with a predicate registry and a verifier that keeps absence visible, so a release claim stays joined to the build, test, review and deployment evidence behind it.",
+  "description": "Release evidence another person can check: an in-toto statement core with a predicate registry and gates that keep absence visible, without signing or verifying signatures.",
   "author": {
     "name": "Wildcat Labs",
     "url": "https://wildcat.finance"

--- a/plugins/ariadne/.codex-plugin/plugin.json
+++ b/plugins/ariadne/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ariadne",
   "version": "0.1.0",
-  "description": "Signed evidence another person can check: an in-toto statement core with a predicate registry and a verifier that keeps absence visible, so a release claim stays joined to the build, test, review and deployment evidence behind it.",
+  "description": "Release evidence another person can check: an in-toto statement core with a predicate registry and gates that keep absence visible, without signing or verifying signatures.",
   "author": {
     "name": "Wildcat Labs",
     "url": "https://wildcat.finance"
@@ -20,8 +20,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Ariadne",
-    "shortDescription": "Signed release evidence, with the absences kept in the statement.",
-    "longDescription": "A release publishes a claim while the evidence behind it sits somewhere else, joined by a URL and a promise. Ariadne writes the join down as a statement whose subject is a digest, borrowing in-toto's structure and DSSE's envelope rather than minting either, and adding what a bare statement does not carry: every claim names the exact digest it covers, skipped and failed work stays in the signed record, a result is never upgraded into a verdict, and a comparison fails when either baseline cannot be identified. The core is artefact-neutral, so a dataset, a chain-state fixture and a contract release share one verifier and one signing path without sharing a schema. Ariadne holds no signing key: it reads and writes the envelope and cosign signs it, and an unsigned statement is a supported state that is labelled unsigned rather than a degraded one.",
+    "shortDescription": "Release evidence statements with absences kept visible.",
+    "longDescription": "A release publishes a claim while the evidence behind it sits somewhere else, joined by a URL and a promise. Ariadne records the join in a statement whose subject is a digest, using in-toto's structure and optionally DSSE's envelope. Every claim names the exact digest it covers, skipped and failed work stays in the record, a result is never upgraded into a verdict, and a comparison fails when either baseline cannot be identified. The core is artefact-neutral, so datasets, chain-state fixtures, and contract releases can share the gates without sharing a schema. Ariadne holds no signing key, produces no signature, and checks no signature. Cosign performs signing and signature verification outside Ariadne.",
     "developerName": "Wildcat Labs",
     "category": "Developer Tools",
     "capabilities": [],

--- a/plugins/ariadne/AGENTS.md
+++ b/plugins/ariadne/AGENTS.md
@@ -5,7 +5,7 @@ Ariadne contains one Agent Skill. Select from this table, then read the chosen
 
 | Skill | Canonical instructions | Select when |
 | --- | --- | --- |
-| `ariadne` | `skills/ariadne/SKILL.md` | Read or write a signed statement binding an artefact to the evidence behind it |
+| `ariadne` | `skills/ariadne/SKILL.md` | Read or write an evidence statement binding an artefact to the record behind it |
 
 `skills/ariadne/README.md` is a copy of that file, kept identical so the
 directory renders when browsed. Read either; a test fails if they diverge.

--- a/plugins/ariadne/README.md
+++ b/plugins/ariadne/README.md
@@ -1,6 +1,6 @@
 # Ariadne
 
-Signed evidence another person can check.
+Release evidence another person can check.
 
 A release publishes a claim. The evidence behind it sits somewhere else, joined
 by a URL and a promise: the compiler that produced the bytecode, the test run,
@@ -12,7 +12,7 @@ The statement is [in-toto's](https://github.com/in-toto/attestation) and the
 envelope is [DSSE's](https://github.com/secure-systems-lab/dsse). Neither is
 forked. What Ariadne adds is the part a bare statement does not carry: every
 claim names the exact digest it covers, skipped and failed work stays in the
-signed record, a result is never upgraded into a verdict, a comparison fails
+statement record, a result is never upgraded into a verdict, a comparison fails
 when either baseline cannot be identified, and replay separates what must match
 byte for byte from what cannot.
 

--- a/plugins/ariadne/docs/design.md
+++ b/plugins/ariadne/docs/design.md
@@ -61,7 +61,7 @@ byte from what cannot.
 **A predicate is the shape for one kind of artefact.** It declares which fields
 a statement of that kind carries and how a verifier checks them. The core holds
 predicates apart so a dataset statement and a contract statement share a
-verifier and a signing path without sharing a schema.
+verifier and one envelope format without sharing a schema.
 
 | Module | Holds |
 | --- | --- |
@@ -87,11 +87,11 @@ predicate fills in.
 | --- | --- | --- |
 | 1 Every claim names its subject | core | A result tied to a repository or a branch is rejected; it names the digest it covers |
 | 2 The environment is recoverable | predicate | A bare tool version is not a build description |
-| 3 Absence stays visible | core | Skipped, failed, timed-out and redacted work stays in the signed statement |
+| 3 Absence stays visible | core | Skipped, failed, timed-out and redacted work stays in the statement |
 | 4 Results are not upgraded into conclusions | core | A passing property records the property and the run, not that the artefact is safe |
 | 5 Deltas name both sides | predicate | A comparison fails when either baseline cannot be identified exactly |
 | 6 Replay distinguishes deterministic work | core | Bytecode can require an exact match; a fuzz campaign's coverage cannot |
-| 7 Signing is optional, verification is not | core | An unsigned statement is labelled unsigned and receives no implied author |
+| 7 Signature verification is external | core | An unsigned statement is labelled unsigned and no statement receives an implied author |
 
 ## Choices, and what they cost
 

--- a/plugins/ariadne/examples/README.md
+++ b/plugins/ariadne/examples/README.md
@@ -46,11 +46,11 @@ pass instead. Nothing in the gates can tell that apart from a run that really
 passed, because both parse, both pass every gate, and neither contradicts
 anything else in the document.
 
-What catches it is the signature. A statement is signed over its bytes, so an
-edit after signing fails verification, and an edit before signing puts the
-producer's name on the claim. That is what gate 7 is protecting: signing is
-optional, verification is not, and an unsigned statement is labelled unsigned
-precisely because it carries nobody's name.
+What catches it is an externally verified signature. A statement is signed
+over its bytes, so an edit after signing fails verification, and an edit before
+signing puts the producer's name on the claim. Gate 7 keeps that boundary
+visible: Ariadne labels an unsigned statement unsigned and never supplies an
+author from a signature it did not check.
 
 The gates refuse the shapes that let a careless statement read as a careful
 one. They do not, and cannot, refuse a producer willing to lie in a document

--- a/plugins/ariadne/skills/ariadne/README.md
+++ b/plugins/ariadne/skills/ariadne/README.md
@@ -1,13 +1,13 @@
 ---
 name: ariadne
 description: >
-  Read and write the signed statements that keep a release joined to the
-  evidence behind it: an in-toto statement over a DSSE envelope, with a
-  predicate registry and gates that keep absence visible. Use when someone
-  hands over an attestation and asks what it actually covers, when a release
-  needs evidence a stranger can check rather than a badge, or when a new kind
-  of artefact needs a predicate of its own. Never use it to claim a signature
-  was verified; that is cosign's job.
+  Read and write the evidence statements that keep a release joined to the
+  record behind it: an in-toto statement, optionally inside a DSSE envelope,
+  with a predicate registry and gates that keep absence visible. Use when
+  someone hands over an attestation and asks what it actually covers, when a
+  release needs evidence a stranger can check rather than a badge, or when a
+  new kind of artefact needs a predicate of its own. Ariadne neither signs nor
+  verifies signatures; those operations belong to cosign.
 metadata:
   version: "0.1.0"
 ---
@@ -124,11 +124,11 @@ a predicate fills in.
 | --- | --- | --- |
 | 1 Every claim names its subject | core | A result tied to a repository or a branch is rejected; it names the digest it covers |
 | 2 The environment is recoverable | predicate | A bare tool version is not a build description |
-| 3 Absence stays visible | core | Skipped, failed, timed-out and redacted work stays in the signed statement |
+| 3 Absence stays visible | core | Skipped, failed, timed-out and redacted work stays in the statement |
 | 4 Results are not upgraded into conclusions | core | A passing property records the property and the run, not that the artefact is safe |
 | 5 Deltas name both sides | predicate | A comparison fails when either baseline cannot be identified exactly |
 | 6 Replay distinguishes deterministic work | core | Bytecode can require an exact match; a fuzz campaign's coverage cannot |
-| 7 Signing is optional, verification is not | core | An unsigned statement is labelled unsigned and receives no implied author |
+| 7 Signature verification is external | core | An unsigned statement is labelled unsigned and no statement receives an implied author |
 
 The five core gates run for any predicate, including a type this build has
 never heard of. Gates 2 and 5 come from the predicate: the Solidity release

--- a/plugins/ariadne/skills/ariadne/SKILL.md
+++ b/plugins/ariadne/skills/ariadne/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: ariadne
 description: >
-  Read and write the signed statements that keep a release joined to the
-  evidence behind it: an in-toto statement over a DSSE envelope, with a
-  predicate registry and gates that keep absence visible. Use when someone
-  hands over an attestation and asks what it actually covers, when a release
-  needs evidence a stranger can check rather than a badge, or when a new kind
-  of artefact needs a predicate of its own. Never use it to claim a signature
-  was verified; that is cosign's job.
+  Read and write the evidence statements that keep a release joined to the
+  record behind it: an in-toto statement, optionally inside a DSSE envelope,
+  with a predicate registry and gates that keep absence visible. Use when
+  someone hands over an attestation and asks what it actually covers, when a
+  release needs evidence a stranger can check rather than a badge, or when a
+  new kind of artefact needs a predicate of its own. Ariadne neither signs nor
+  verifies signatures; those operations belong to cosign.
 metadata:
   version: "0.1.0"
 ---
@@ -124,11 +124,11 @@ a predicate fills in.
 | --- | --- | --- |
 | 1 Every claim names its subject | core | A result tied to a repository or a branch is rejected; it names the digest it covers |
 | 2 The environment is recoverable | predicate | A bare tool version is not a build description |
-| 3 Absence stays visible | core | Skipped, failed, timed-out and redacted work stays in the signed statement |
+| 3 Absence stays visible | core | Skipped, failed, timed-out and redacted work stays in the statement |
 | 4 Results are not upgraded into conclusions | core | A passing property records the property and the run, not that the artefact is safe |
 | 5 Deltas name both sides | predicate | A comparison fails when either baseline cannot be identified exactly |
 | 6 Replay distinguishes deterministic work | core | Bytecode can require an exact match; a fuzz campaign's coverage cannot |
-| 7 Signing is optional, verification is not | core | An unsigned statement is labelled unsigned and receives no implied author |
+| 7 Signature verification is external | core | An unsigned statement is labelled unsigned and no statement receives an implied author |
 
 The five core gates run for any predicate, including a type this build has
 never heard of. Gates 2 and 5 come from the predicate: the Solidity release

--- a/plugins/ariadne/skills/ariadne/agents/openai.yaml
+++ b/plugins/ariadne/skills/ariadne/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Ariadne"
-  short_description: "Signed release evidence, with the absences kept in the statement"
-  default_prompt: "Use $ariadne to capture this release into a signed statement and verify what it covers."
+  short_description: "Release evidence statements with absences kept visible"
+  default_prompt: "Use $ariadne to capture this release in an evidence statement, run its gates, and report its signature state without checking signatures."

--- a/plugins/hermes/skills/hermes/README.md
+++ b/plugins/hermes/skills/hermes/README.md
@@ -1,6 +1,6 @@
 ---
 name: hermes
-description: Optimise Solidity gas usage with an executable, fail-closed Foundry loop that measures savings, re-runs behaviour tests, checks storage layouts and method identifiers, and demands targeted differential or property evidence for unchecked accrual code. Use for Solidity gas work, Forge snapshot reductions, gas-report reviews, storage packing, unchecked arithmetic, or any proposed EVM gas-saving change.
+description: Optimise Solidity gas usage with an executable, fail-closed Foundry loop that measures savings, re-runs behaviour tests, checks storage layouts and method identifiers, and demands targeted differential or property evidence for state-sensitive unchecked arithmetic. Use for Solidity gas work, Forge snapshot reductions, gas-report reviews, storage packing, unchecked arithmetic, or any proposed EVM gas-saving change.
 ---
 
 # hermes gas optimiser
@@ -60,7 +60,7 @@ Choose one value from the catalogue and make only that kind of source change. Do
 
 Review `candidate.solidity.diff` before attesting. The harness rejects Solidity file additions or removals, test-source edits, an empty candidate, added `unchecked` outside `unchecked-arithmetic`, and added assembly outside `assembly`. The attestation remains a judgement: read the diff and confirm that every hunk belongs to the declared class.
 
-If the required accrual property test is absent, add it in a preparatory change, get green, and take a fresh baseline. The optimisation candidate uses the existing fuzz suite rather than changing its own oracle.
+If the required property test is absent, add it in a preparatory change, get green, and take a fresh baseline. The optimisation candidate uses the existing fuzz suite rather than changing its own oracle.
 
 ## Gates 3 to 6: verify the candidate
 
@@ -71,41 +71,49 @@ python3 "$HERMES_PY" verify \
   --run-dir "<run-dir>" \
   --optimisation-class storage-load-caching \
   --attest-single-class \
-  --gas-target 'MarketTest:test_deposit' \
-  --gas-target 'MarketTest:test_withdraw' \
-  --no-accrual-unchecked
+  --gas-target 'LedgerTest:test_update' \
+  --gas-target 'LedgerTest:test_batch' \
+  --no-sensitive-unchecked
 ```
 
-For unchecked arithmetic outside accrual code, add a real explanation:
+For unchecked arithmetic outside state-sensitive code, add a real explanation:
 
 ```bash
-  --no-accrual-unchecked \
-  --non-accrual-rationale "The loop counter is bounded by the in-memory array length and cannot feed debt, rate, fee, timestamp, rounding, or withdrawal accounting."
+  --no-sensitive-unchecked \
+  --non-sensitive-rationale "The loop counter is bounded by the in-memory array length and cannot affect persistent state, asset balances, external call parameters, or rounding."
 ```
 
-For unchecked arithmetic in or feeding accrual code, run the existing targeted differential or property test:
+For unchecked arithmetic that can affect persistent state, asset accounting, external calls, permissions, or rounding, run the existing targeted differential or property test:
 
 ```bash
 python3 "$HERMES_PY" verify \
   --run-dir "<run-dir>" \
   --optimisation-class unchecked-arithmetic \
   --attest-single-class \
-  --gas-target 'AccrualTest:test_accrue' \
-  --accrual-unchecked \
-  --targeted-match-path 'test/AccrualDifferential.t.sol' \
-  --targeted-match-test 'testFuzz_diff_accrual' \
-  --property-proof "Compare the checked reference and candidate across the full reachable debt, rate, and timestamp domains; assert equal results and equal overflow reverts at the exact multiplication boundaries."
+  --gas-target 'LedgerTest:test_update' \
+  --sensitive-unchecked \
+  --targeted-match-path 'test/StateDifferential.t.sol' \
+  --targeted-match-test 'testFuzz_diff_stateTransition' \
+  --property-proof "Compare the checked reference and candidate across the complete reachable input domain; assert equal state transitions and equal overflow reverts at the arithmetic boundaries."
 ```
 
-The verification command executes these gates in order:
+### Gate 3: quantify the gas change
 
-1. Confirm one declared optimisation class against the sealed Solidity source set.
-2. Run `forge snapshot --diff <baseline>` and capture a candidate snapshot. Reject a positive delta anywhere, a changed measurement set, a target with no match, or a target with no saving. Then run `forge test --gas-report`.
-3. Run the full `forge test` suite again with the pinned seed, followed by a full unpinned run.
-4. Re-run `forge inspect <C> storageLayout --json --force` and `methodIdentifiers` for every recorded contract. Hard-abort on any frozen-layout difference or method-selector difference.
-5. Run the targeted accrual differential/property command when `--accrual-unchecked` applies. Record an explicit reason when it does not.
+Run `forge snapshot --diff <baseline>` and capture a candidate snapshot. Reject a positive deterministic delta anywhere, a changed measurement set, a target with no match, or a target with no saving. Then run `forge test --gas-report`.
 
-The extra candidate snapshot exists so Hermes can compare every row itself; it does not replace `forge snapshot --diff`.
+Historical Foundry snapshots also contain fuzz statistics whose sampled inputs can change when the compiled bytecode changes. Hermes records their baseline and candidate means and medians, but does not call those aggregates a gas regression or saving. It still rejects a changed fuzz-test set or run count. Foundry `invariant_callSummary()` rows are stricter: their test set, run count, call count, and revert count must stay identical.
+
+### Gate 4: prove behaviour is unchanged
+
+Run the full `forge test` suite with the pinned seed, followed by a full unpinned run. Any failure rejects the candidate.
+
+### Gate 5: preserve layouts and selectors
+
+Re-run `forge inspect <C> storageLayout --json --force` and `methodIdentifiers` for every recorded contract. The layout comparison canonicalises solc's compilation-local AST IDs, while retaining raw inspector output in evidence; it hard-aborts on any structural protected-layout difference or method-selector difference. A declared layout change is allowed only for an unprotected contract under the rules below.
+
+### Gate 6: prove state-sensitive unchecked arithmetic
+
+When `--sensitive-unchecked` applies, run the named targeted differential or property test and record its oracle. Otherwise, record why the candidate does not introduce or rely on state-sensitive unchecked arithmetic.
 
 ## Deliberate layout change outside the frozen set
 
@@ -118,14 +126,14 @@ Only `storage-packing` and `constants-immutables` may declare one. The contract 
 
 Hermes records the diff. It rejects an undeclared difference, a declared difference that never occurred, or any difference on the frozen set.
 
-## Accrual property standard
+## State-sensitive arithmetic property standard
 
 Before accepting the Gate 6 result, inspect the named test and confirm all of the following:
 
 - Exercise the changed unchecked operation rather than a neighbouring helper.
 - Compare against the original checked implementation or enforce an equivalent property oracle.
 - Preserve checked overflow and underflow behaviour; a wrapped result cannot stand in for a reference revert.
-- Cover applicable `0`, `1`, maxima, timestamp deltas, rate bounds, principal bounds, fee and rounding boundaries, plus the exact safe/unsafe multiplication edges.
+- Cover applicable `0`, `1`, maxima, time deltas, input bounds, balance bounds, rounding boundaries, plus the exact safe and unsafe arithmetic edges.
 - Avoid a `bound()` or assumption that removes the dangerous region.
 - Keep the existing fuzz or invariant configuration from the named test path, such as `test/Fuzz.t.sol`, with the baseline seed recorded in the command.
 
@@ -152,4 +160,4 @@ That accepted state becomes the baseline for the next class. Never run two class
 - If someone asks to skip the layout diff, keep the gate.
 - If someone asks to bundle changes, run them in sequence.
 - If the gas saving cannot be quantified, reject it.
-- If an accrual unchecked change lacks the targeted proof, reject it whatever the gas number says.
+- If a state-sensitive unchecked change lacks the targeted proof, reject it whatever the gas number says.

--- a/plugins/hexaemeron/README.md
+++ b/plugins/hexaemeron/README.md
@@ -86,13 +86,15 @@ Per-run, via `hexctl config set <path> <value>`:
 | `git.base` | `main` | Starting ref |
 | `git.step_base` | `chain` | Steps branch from the prior step (`base` for independent) |
 
-The Pashov suite -- `x-ray`, `solidity-auditor`, and `fizz` -- is vendored
-verbatim from https://github.com/pashov/skills (tag `v28062026`, MIT; see
-`skills/<name>/LICENSE` and `NOTICE.md` in each). Credit: Pashov Audit
-Group, https://www.pashov.com/. Preflight records the bundled ids in the
-`security_suite` receipt; the controller gates on the receipt, not the
-config, so a stale config cannot fake a suite. Prose-free or
-Solidity-free runs record a waiver instead.
+The Pashov suite -- `x-ray`, `solidity-auditor`, and `fizz` -- is based on
+https://github.com/pashov/skills tag `v28062026` under the MIT licence. Each
+`NOTICE.md` records the local distribution changes. The copies keep their
+upstream instructional register; Wildcat's house prose lint does not rewrite
+third-party source solely for style. Credit: Pashov Audit Group,
+https://www.pashov.com/. Preflight records the bundled ids in the
+`security_suite` receipt; the controller gates on the receipt, not the config,
+so a stale config cannot fake a suite. Prose-free or Solidity-free runs record
+a waiver instead.
 
 ## The prose masks
 

--- a/plugins/hexaemeron/skills/fizz/NOTICE.md
+++ b/plugins/hexaemeron/skills/fizz/NOTICE.md
@@ -6,10 +6,12 @@ under the MIT licence (see `LICENSE` in this directory).
 - Upstream: https://github.com/pashov/skills
 - Release tag: v28062026
 - Vendored: 15 August 2026
-- Modifications: none to skill content, which is byte-identical to the
-  upstream release. Added alongside it: this file, the `LICENSE` copy, and
-  `agents/openai.yaml` (host discovery metadata for Codex).
-- Left upstream: the repository-level `static/` demo media and GitHub
-  workflow files, which are not part of any skill.
+- Modifications: the browsing README uses bundled invocation names and omits
+  demo media that is not distributed here. The Fizz instructions resolve the
+  pinned sibling X-Ray skill before trying host discovery and never install an
+  unpinned copy. Added alongside the upstream files: this notice, the `LICENSE`
+  copy, and `agents/openai.yaml` for Codex discovery.
+- Left upstream: the repository-level `static/` demo media and GitHub workflow
+  files, which are not part of any skill.
 
 Credit: Pashov Audit Group (https://www.pashov.com/).

--- a/plugins/hexaemeron/skills/fizz/README.md
+++ b/plugins/hexaemeron/skills/fizz/README.md
@@ -18,24 +18,14 @@ One command produces:
 | `Reproduction tests` | A deterministic Foundry test for each distinct violation found |
 | `report.md` | Campaign summary — coverage reached and violations surfaced |
 
-## Demo
-
-_Part of a Fizz run shown below_
-
-![Running Fizz in the terminal](../static/fizz.gif)
-
 ## Usage
 
 ```
-Install https://github.com/pashov/skills/ and run fizz on the codebase
+Use the bundled `hexaemeron:fizz` skill to generate a fuzz suite for this codebase.
 ```
 
 ```
 Generate a fuzz suite for this lending protocol. Focus on solvency and liquidation invariants.
-```
-
-```
-update skill to latest version
 ```
 
 ## Tips

--- a/plugins/hexaemeron/skills/fizz/SKILL.md
+++ b/plugins/hexaemeron/skills/fizz/SKILL.md
@@ -127,20 +127,14 @@ Start by checking whether `{PROJECT_ROOT}/x-ray/` exists and contains `x-ray.md`
 
 If `{PROJECT_ROOT}/x-ray/x-ray.md` exists, read it first as the primary project-understanding source. Then also read any of these supplementary files present in `{PROJECT_ROOT}/x-ray/`:
 
-If `{PROJECT_ROOT}/x-ray/x-ray.md` does NOT exist, you MUST run the **x-ray Acquisition Protocol** below. The Protocol Analyzer fallback (Attempt 4) is FORBIDDEN until Attempts 1–3 have each been executed and their outcomes recorded in `/tmp/x-ray-attempts.md`. "I think x-ray isn't available" is NOT a valid skip — only the recorded output of an actual tool/command counts.
+If `{PROJECT_ROOT}/x-ray/x-ray.md` does NOT exist, you MUST run the **x-ray Acquisition Protocol** below. The Protocol Analyzer fallback (Attempt 4) is FORBIDDEN until Attempts 1 through 3 have each been executed and their outcomes recorded in `/tmp/x-ray-attempts.md`. "I think x-ray isn't available" is NOT a valid skip. Only the recorded output of an actual tool or command counts.
 
 ### x-ray Acquisition Protocol
 
 Before Attempt 1, delete `/tmp/x-ray-attempts.md` if it exists (`rm -f /tmp/x-ray-attempts.md`) — stale entries from a previous run would falsely satisfy the Attempt 4 gate. Then create a fresh `/tmp/x-ray-attempts.md` and append one entry per attempt: timestamp, attempt name, command/tool invoked, exact output (or "no output"), outcome (`SUCCESS` / `FAILED: {reason}` / `SKIPPED: {reason}`). Attempt 4 requires the file to contain exactly 3 entries (one per Attempt 1, 2, 3) — `SKIPPED` entries count toward this total.
 
-- **Attempt 1 — invoke the skill.** Call the `x-ray` skill via the `Skill` tool with `args="{PROJECT_ROOT}"`. Do NOT pre-judge availability — invoke it. Only a runtime error of the form "skill not found" / "unknown skill" counts as unavailable. If it runs, wait for completion, then verify `{PROJECT_ROOT}/x-ray/x-ray.md` was written. If yes → SUCCESS, exit Protocol.
-- **Attempt 2 — install from the official source and re-invoke.** Run:
-  ```bash
-  git clone --depth 1 https://github.com/pashov/skills.git /tmp/pashov-skills-xray-install \
-    && mkdir -p ~/.claude/skills \
-    && cp -r /tmp/pashov-skills-xray-install/x-ray ~/.claude/skills/x-ray
-  ```
-  Then re-invoke `Skill('x-ray', args="{PROJECT_ROOT}")`. If `{PROJECT_ROOT}/x-ray/x-ray.md` is produced → SUCCESS, exit Protocol. If the re-invocation still returns "skill not found" / "unknown skill" (auto-discovery did not pick up the freshly installed skill mid-session), do NOT mark this attempt failed yet — instead read `~/.claude/skills/x-ray/SKILL.md` (or `/tmp/pashov-skills-xray-install/x-ray/SKILL.md`) and execute its instructions inline against `{PROJECT_ROOT}`. If that produces `{PROJECT_ROOT}/x-ray/x-ray.md` → SUCCESS, exit Protocol. Only if ALL of (Skill re-invocation, inline execution) fail does this attempt count as FAILED.
+- **Attempt 1: run the bundled skill.** Resolve `{SKILL_PATH}/../x-ray/SKILL.md`, read it completely, and execute its instructions against `{PROJECT_ROOT}`. The sibling path is the pinned X-Ray copy distributed with Hexaemeron. If the file is absent or unreadable, record the exact path and failure. If it runs, wait for completion, then verify `{PROJECT_ROOT}/x-ray/x-ray.md` was written. If yes → SUCCESS, exit Protocol.
+- **Attempt 2: invoke a host-registered skill.** If the bundled copy failed, call the `x-ray` skill through the host skill tool with `args="{PROJECT_ROOT}"`. Do not install or update anything. Only a runtime error of the form "skill not found" or "unknown skill" counts as unavailable. If it runs, wait for completion, then verify `{PROJECT_ROOT}/x-ray/x-ray.md` was written. If yes → SUCCESS, exit Protocol. Otherwise record the exact failure.
 - **Attempt 3 — guided-mode user gate (guided only).** If `{MODE} = "guided"` AND Attempts 1–2 both failed, ASK the user: *"Could not obtain x-ray automatically (logs in `/tmp/x-ray-attempts.md`). Options: (a) paste an x-ray.md path, (b) authorize Protocol Analyzer fallback, (c) abort. Choose a/b/c."* Record their answer. If (a) and the file exists → copy to `{PROJECT_ROOT}/x-ray/x-ray.md`, SUCCESS. If (c) → halt the skill. Only (b) — explicit user authorization — permits Attempt 4. In `{MODE} = "automatic"`, skip this attempt and record `SKIPPED: automatic mode`.
 - **Attempt 4 — Protocol Analyzer fallback.** Permitted ONLY after Attempts 1–3 are recorded in `/tmp/x-ray-attempts.md` (with status FAILED, SKIPPED, or — for Attempt 3 only — `(b) authorized`). Before spawning, confirm the file exists and contains 3 entries; if not, GO BACK to the missing attempt — do not proceed.
 

--- a/plugins/hexaemeron/skills/solidity-auditor/NOTICE.md
+++ b/plugins/hexaemeron/skills/solidity-auditor/NOTICE.md
@@ -6,10 +6,11 @@ under the MIT licence (see `LICENSE` in this directory).
 - Upstream: https://github.com/pashov/skills
 - Release tag: v28062026
 - Vendored: 15 August 2026
-- Modifications: none to skill content, which is byte-identical to the
-  upstream release. Added alongside it: this file, the `LICENSE` copy, and
-  `agents/openai.yaml` (host discovery metadata for Codex).
-- Left upstream: the repository-level `static/` demo media and GitHub
-  workflow files, which are not part of any skill.
+- Modifications: the browsing README uses the bundled invocation name and
+  omits demo media that is not distributed here. Added alongside the upstream
+  files: this notice, the `LICENSE` copy, and `agents/openai.yaml` for Codex
+  discovery.
+- Left upstream: the repository-level `static/` demo media and GitHub workflow
+  files, which are not part of any skill.
 
 Credit: Pashov Audit Group (https://www.pashov.com/).

--- a/plugins/hexaemeron/skills/solidity-auditor/README.md
+++ b/plugins/hexaemeron/skills/solidity-auditor/README.md
@@ -10,24 +10,14 @@ Built for:
 
 Not a substitute for a formal audit - but the check you should never skip.
 
-## Demo
-
-_Portrayed below: finding multiple high-confidence vulnerabilities in a codebase_
-
-![Running solidity-auditor in terminal](../static/skill_pag.gif)
-
 ## Usage
 
 ```
-Install https://github.com/pashov/skills/ and run solidity auditor on the codebase
+Use the bundled `hexaemeron:solidity-auditor` skill to audit this codebase.
 ```
 
 ```
 run solidity auditor on *specified files*
-```
-
-```
-update skill to latest version
 ```
 
 ## Tips

--- a/plugins/hexaemeron/skills/x-ray/NOTICE.md
+++ b/plugins/hexaemeron/skills/x-ray/NOTICE.md
@@ -6,10 +6,11 @@ under the MIT licence (see `LICENSE` in this directory).
 - Upstream: https://github.com/pashov/skills
 - Release tag: v28062026
 - Vendored: 15 August 2026
-- Modifications: none to skill content, which is byte-identical to the
-  upstream release. Added alongside it: this file, the `LICENSE` copy, and
-  `agents/openai.yaml` (host discovery metadata for Codex).
-- Left upstream: the repository-level `static/` demo media and GitHub
-  workflow files, which are not part of any skill.
+- Modifications: the browsing README uses the bundled invocation name, omits
+  demo media that is not distributed here, and describes the current verdict
+  output. Added alongside the upstream files: this notice, the `LICENSE` copy,
+  and `agents/openai.yaml` for Codex discovery.
+- Left upstream: the repository-level `static/` demo media and GitHub workflow
+  files, which are not part of any skill.
 
 Credit: Pashov Audit Group (https://www.pashov.com/).

--- a/plugins/hexaemeron/skills/x-ray/README.md
+++ b/plugins/hexaemeron/skills/x-ray/README.md
@@ -20,20 +20,14 @@ One command produces:
 | `invariants.md` | Full invariant map — enforced guards, single-contract invariants, cross-contract trust assumptions, and higher-order economic properties |
 | `architecture.svg` | Visual architecture diagram — contracts, actors, trust boundaries |
 
-## Demo
-
-_Part of an X-Ray report generation shown below_
-
-![Running x-ray in terminal](../static/x_ray.gif)
-
 ## Usage
 
 ```
-Install latest https://github.com/pashov/skills/ and run x-ray on the codebase
+Use the bundled `hexaemeron:x-ray` skill to prepare this codebase for audit.
 ```
 
 ## Tips
 
-- **Start with the verdict.** The report ends with a tier (FORTIFIED → EXPOSED) and 3-5 action items. If you only read one section, read that.
+- **Start with the verdict.** The report ends with a tier and 3-5 structural facts. If you only read one section, read that.
 - **Use entry-points.md as your map.** Start with permissionless functions — those are the highest-risk surface.
-- **Check the action items.** The final section highlights concrete next steps — whether you're preparing for an audit or starting one.
+- **Follow the `invariants.md` links.** Attack-surface bullets point into that file where the underlying code relationships are recorded.

--- a/plugins/pandects/README.md
+++ b/plugins/pandects/README.md
@@ -199,11 +199,12 @@ point: a campaign reporting every property holding against a contract built to
 break one has not searched hard enough. Replay a failing sequence and call
 `explain()` for the reason, in the law's own words.
 
-The ninth is the one worth knowing about. `CompoundsPerStepCampaign` passes
-every property under both engines, and the contract underneath it is broken.
-Its defect is path independence, which compares two systems advanced by
-different routes; a campaign drives one system along one route and can never
-see it. That is what a passing campaign is worth on its own.
+Two harnesses pass. `SoundCampaign` is the sound specimen.
+`CompoundsPerStepCampaign` also passes every property under both engines, but
+the contract underneath it is broken. Its defect is path independence, which
+compares two systems advanced by different routes; a campaign drives one
+system along one route and can never see it. That is what a passing campaign
+is worth on its own.
 
 Exit codes: 0 success, 1 a check failed, 2 usage or validation error.
 

--- a/plugins/probitas/README.md
+++ b/plugins/probitas/README.md
@@ -9,8 +9,8 @@ could not be established.
 
 The reason to want this is undercollateralised lending, where nothing stands
 between a lender and a total loss except a judgement about the borrower, and
-that judgement usually gets assembled by hand out of whatever whoever is
-asking happens to remember. The tool is not limited to that case. Most
+that judgement usually gets assembled by hand from whatever the person asking
+happens to remember. The tool is not limited to that case. Most
 on-chain borrowing is overcollateralised and it still tells you plenty: a
 liquidation says a price moved, a bad debt says somebody was not made whole,
 and a missed maturity says what it says anywhere.


### PR DESCRIPTION
Closes #53.

## What changed

- names both passing Pandects harnesses and completes its catalogue, install, and discovery prose
- states throughout Ariadne that signing and signature verification belong to cosign
- makes Fizz select Hexaemeron's pinned X-Ray copy before host discovery, with no external installation path
- removes dead demo links and upstream installation prompts from the bundled Pashov browsing READMEs
- synchronizes the Hermes browsing README with its canonical skill
- fixes the duplicated Probitas wording
- records the local Pashov distribution changes and the boundary between upstream prose and Wildcat's house lint

## Why

A cold read after the Pandects import found instructions that did not match the code and files in the distribution. These corrections remove stale flags, dead media, misleading signature language, and an unpinned X-Ray acquisition path.

## Checks

- root repository tests: 5 passed
- Ariadne tests: 310 passed
- Hermes tests: 14 passed
- Hexaemeron tests: 50 passed
- Imprimatur tests: 56 passed
- Pandects Python tests: 106 passed
- Pandects Foundry tests: 72 passed
- Probitas tests: 234 passed
- six changed skill directories pass the Agent Skills validator
- changed prose passes Proscribed with no defects
- JSON parsing, mirror equality, relative-link review, and `git diff --check` pass

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: https://github.com/wildcat-finance/skills/issues/53
Root-Issue-Successor: none-recorded
Root-Issue-Fiat-Required: 0
Root-Issue-Route: pr-only
Root-Issue-Classification-Source: live-contract
<!-- root-issue-analytics:v1:end -->
