### PR TITLE
Cold-read repository prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Hexaemeron includes:
 - the [`imprimatur`](./plugins/hexaemeron/skills/imprimatur) three-tier prose lint and the [`vulgate`](./plugins/hexaemeron/skills/vulgate) voice mask, invokable on their own;
 - the Pashov Audit Group suite vendored verbatim (MIT; `LICENSE` and `NOTICE.md` in each skill directory);
 - Codex metadata for explicit or automatic invocation; and
-- 42 controller and contract tests, 56 lint tests, and a fuzz-audit log ([`audit/AUDIT.md`](./plugins/hexaemeron/audit/AUDIT.md)) covering the controller's own surfaces.
+- 50 controller and contract tests, 56 lint tests, and a fuzz-audit log ([`audit/AUDIT.md`](./plugins/hexaemeron/audit/AUDIT.md)) covering the controller's own surfaces.
 
 #### Day to day
 
@@ -267,7 +267,7 @@ Tabularium includes:
   release, its data dictionary and a fresh-directory rebuild demonstration;
 - an [adapter guide](./plugins/tabularium/docs/adding-an-adapter.md) and an
   immutable [release policy](./plugins/tabularium/docs/release-policy.md); and
-- 91 tests and an audit log
+- 92 tests and an audit log
   ([`audit/AUDIT.md`](./plugins/tabularium/audit/AUDIT.md)) recording every
   review round and fix.
 

--- a/plugins/hexaemeron/README.md
+++ b/plugins/hexaemeron/README.md
@@ -19,7 +19,7 @@ then rest. The entry skill is `fiat`, so the invocation is
 | --- | --- | --- |
 | 1 | `study` | Study the topic; write `.hexaemeron/study.md`, linted |
 | 2 | `runbook` | Divide the work into discrete, self-contained steps |
-| 3–4 | `implement` | Build the step, least mental load that satisfies the runbook |
+| 3-4 | `implement` | Build the step, least mental load that satisfies the runbook |
 | 5 | `audit` | The vendored Pashov suite in rounds until clean or reasoned out; fixes on a stacked branch |
 | 6 | `prose` | The `imprimatur` lint, then the `vulgate` voice mask, on every document and the PR text |
 | rest | `push` | Push, open the PR, move on |


### PR DESCRIPTION
## What changed

- correct the current Hexaemeron controller and Tabularium test totals in the repository README
- replace the remaining first-party en dash flagged by the house prose lint

## Cold-read evidence

- read all 138 Markdown documents with the Imprimatur and Vulgate rules
- every first-party document scores 100.0 with zero Imprimatur defects
- root tests: 5/5
- Hexaemeron controller tests: 50/50
- `git diff --check`: clean

The Pashov Audit Group documents were inspected but not rewritten. Hexaemeron distributes that third-party suite in its upstream instructional register, and its notices record the permitted local changes.

Closes #58

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: https://github.com/wildcat-finance/skills/issues/58
Root-Issue-Successor: none-recorded
Root-Issue-Fiat-Required: 1
Root-Issue-Route: fiat-required
Root-Issue-Classification-Source: live-contract
<!-- root-issue-analytics:v1:end -->
