### PR TITLE
Sync private skills marketplace

### DIFF
--- a/.github/workflows/sync-skills-marketplace.yml
+++ b/.github/workflows/sync-skills-marketplace.yml
@@ -1,0 +1,29 @@
+name: Sync private skills marketplace
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-skills-marketplace
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    if: github.repository == 'wildcat-finance/skills-marketplace'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mirror public repository
+        env:
+          DESTINATION_REPOSITORY: ${{ github.repository }}
+          DESTINATION_TOKEN: ${{ github.token }}
+        run: |
+          git clone --bare https://github.com/wildcat-finance/skills.git source.git
+          git -C source.git push --force --prune \
+            "https://x-access-token:${DESTINATION_TOKEN}@github.com/${DESTINATION_REPOSITORY}.git" \
+            "refs/heads/*:refs/heads/*" \
+            "refs/tags/*:refs/tags/*"


### PR DESCRIPTION
Closes #72.

## What changed

- adds a five-minute and manually dispatchable mirror workflow
- runs only in `wildcat-finance/skills-marketplace`
- force-reconciles all branches and tags from the public source
- uses the private repository's short-lived `GITHUB_TOKEN`, with no cross-repository personal token

## Validation

- `git diff --check`
- `python3 -m unittest discover -s tests` (14 tests passed)

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: https://github.com/wildcat-finance/skills/issues/72
Root-Issue-Successor: none-recorded
Root-Issue-Fiat-Required: 1
Root-Issue-Route: fiat-required
Root-Issue-Classification-Source: live-contract
<!-- root-issue-analytics:v1:end -->
