### PR TITLE
Govern Hexaemeron frontiers and add Kronos

### DIFF
--- a/.agents/skills/hexaemeron/SKILL.md
+++ b/.agents/skills/hexaemeron/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hexaemeron
-description: Route explicit Hexaemeron delivery runs and named bundled fuzzing, audit or prose work to their canonical skills. Do not start the controller unless the user asks for it.
+description: Route explicit Hexaemeron delivery runs, Kronos frontier loops, and named bundled fuzzing, audit or prose work to their canonical skills. Do not start Fiat or Kronos unless the user asks for it.
 ---
 
 # Hexaemeron portable entrypoint
@@ -18,6 +18,12 @@ Hexaemeron runs an explicit, receipted delivery loop and also exposes its fuzzin
 Read [the Hexaemeron runtime contract](../../../plugins/hexaemeron/AGENTS.md).
 Use its selection table to choose the narrowest matching skill, then read that
 canonical `SKILL.md` in full and follow it.
+
+Before suggesting or starting Fiat work intended to advance `fiat`,
+`imprimatur`, `vulgate`, or `kronos`, read that skill's `EVOLUTION.md`. Refuse
+a further frontier run when its status is `mature`; a reworded request does
+not reopen it. Kronos may still orchestrate other non-mature skills because it
+excludes itself from selection.
 
 Invocation prefixes are aliases:
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
       "name": "hexaemeron",
       "displayName": "Hexaemeron",
       "source": "./plugins/hexaemeron",
-      "description": "Receipted delivery from study to draft pull request, with audit, fuzzing and prose tools.",
+      "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing and prose tools.",
       "version": "1.0.0",
       "author": {
         "name": "Wildcat Labs",

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ build.
 | [Alexandria](./plugins/alexandria) | Preserving heterogeneous lending-source bytes, then deriving and querying reviewed credit views. | Tabularium for semantic event mapping; Probitas for a dossier. | Compound v3 Phase 0 now pins the Comet registry and preserves one verified Ethereum execution witness; a resumable, reconciled Ethereum USDC interval harvester remains unimplemented. |
 | [Ariadne](./plugins/ariadne) | Binding an artefact digest to build, test, review and deployment evidence. | An external Sigstore or cosign verifier for signatures. | The dataset predicate is the first unimplemented predicate; state-fixture and grounded-agent predicates also remain unimplemented. |
 | [Hermes](./plugins/hermes) | Measuring one Solidity gas-optimisation class through fail-closed Foundry checks. | Pandects or the audit skills for broader behavioural and security work. | No complete, reproducible live Wildcat evidence bundle is published. |
-| [Hexaemeron](./plugins/hexaemeron) | Running an explicit, receipted delivery loop, or using its fuzzing, audit and prose skills separately. | A named bundled skill when the controller is unnecessary. | The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery. |
+| [Hexaemeron](./plugins/hexaemeron) | Running an explicit, receipted delivery loop, ranking frontier work with Kronos, or using its fuzzing, audit and prose skills separately. | A named bundled skill when the controller is unnecessary. | The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery. |
 | [Lemma](./plugins/lemma) | Producing source-linked chunks from Solidity compiler inputs or Markdown. | An embedding, index, retrieval or answering system for every later stage. | Callable-surface ABI validation does not independently check return types or state mutability. |
 | [Lazarus](./plugins/lazarus) | Capturing a finite fixed-block Ethereum fixture, checking proof-backed state and replaying exact requests without fallback. | Alexandria for a lending archive; Tabularium for event interpretation. | Preservation-pipeline integration and an Ariadne state-fixture predicate remain unimplemented. |
 | [Pandects](./plugins/pandects) | Supplying executable credit laws, broken specimens and reduced counterexamples. | Fizz for a protocol-specific fuzz harness. | No law prevents fees from reducing pooled lender claims below amounts owed on open withdrawal batches. |
@@ -154,9 +154,10 @@ Hexaemeron includes:
 
 - the executable [`hexctl.py`](./plugins/hexaemeron/skills/fiat/scripts/hexctl.py) controller with a tamper-evident ledger (`verify` proves both chain and state);
 - the [`imprimatur`](./plugins/hexaemeron/skills/imprimatur) three-tier prose lint and the [`vulgate`](./plugins/hexaemeron/skills/vulgate) voice mask, invokable on their own;
+- [`kronos`](./plugins/hexaemeron/skills/kronos), which ranks eligible held frontier jobs and loops complete Fiat runs until none remain;
 - the Pashov Audit Group suite vendored verbatim (MIT; `LICENSE` and `NOTICE.md` in each skill directory);
 - Codex metadata for explicit or automatic invocation; and
-- 50 controller and contract tests, 56 lint tests, and a fuzz-audit log ([`audit/AUDIT.md`](./plugins/hexaemeron/audit/AUDIT.md)) covering the controller's own surfaces.
+- 61 controller and contract tests, 55 lint tests, and a fuzz-audit log ([`audit/AUDIT.md`](./plugins/hexaemeron/audit/AUDIT.md)) covering the controller's own surfaces.
 
 #### Day to day
 
@@ -542,7 +543,7 @@ The full command contract, layout rules and property standard live in [Hermes's 
 Hexaemeron needs Python 3, Git and `gh` in the target repository (plus [Foundry](https://getfoundry.sh/) when the run ships Solidity). Ask:
 
 ```text
-Use $hexaemeron to take "<topic>" from study to a pushed prototype, one receipted phase at a time.
+Use $hexaemeron to take "<topic>" from study to a merged delivery, one receipted phase at a time.
 ```
 
 The loop, the receipt contract and the controller reference live in [Hexaemeron's `SKILL.md`](./plugins/hexaemeron/skills/fiat/SKILL.md).

--- a/plugins/alexandria/README.md
+++ b/plugins/alexandria/README.md
@@ -9,7 +9,7 @@ Alexandria preserves heterogeneous lending data as digest-bound releases, then d
 
 **Current frontier.** Compound v3 Phase 0 now pins the Comet registry and preserves one verified Ethereum execution witness; a resumable, reconciled Ethereum USDC interval harvester remains unimplemented.
 
-**Next Fiat job.** Use /hexaemeron:fiat to build the first resumable Ethereum USDC interval collector with implementation-epoch discovery, bounded shards, a second-provider reconciliation path, explicit finality and offline raw-release verification. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose, then replace every completed or stale Next Fiat job with the next evidenced repair or frontier step.
+**Next Fiat job.** Use /hexaemeron:fiat to build the first resumable Ethereum USDC interval collector with implementation-epoch discovery, bounded shards, a second-provider reconciliation path, explicit finality and offline raw-release verification. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
 <!-- marketplace-context:end -->
 
 An offline tool for digest-bound lending-data releases.

--- a/plugins/ariadne/README.md
+++ b/plugins/ariadne/README.md
@@ -9,7 +9,7 @@ Ariadne binds an artefact digest to the build, test, review and deployment evide
 
 **Current frontier.** The dataset predicate is the first unimplemented predicate; state-fixture and grounded-agent predicates also remain unimplemented.
 
-**Next Fiat job.** Use /hexaemeron:fiat to implement the dataset predicate with its schema, gates, conformance fixtures and capture path while keeping signing and signature verification external. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose, then replace every completed or stale Next Fiat job with the next evidenced repair or frontier step.
+**Next Fiat job.** Use /hexaemeron:fiat to implement the dataset predicate with its schema, gates, conformance fixtures and capture path while keeping signing and signature verification external. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
 <!-- marketplace-context:end -->
 
 Release evidence another person can check.

--- a/plugins/hermes/README.md
+++ b/plugins/hermes/README.md
@@ -9,7 +9,7 @@ Hermes measures one Solidity gas optimisation class at a time and rejects the ca
 
 **Current frontier.** No complete, reproducible live Wildcat evidence bundle is published.
 
-**Next Fiat job.** Use /hexaemeron:fiat to publish a complete, reproducible Hermes evidence bundle against a real Wildcat release, with a scoped optimisation candidate and every gate outcome recorded. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose, then replace every completed or stale Next Fiat job with the next evidenced repair or frontier step.
+**Next Fiat job.** Use /hexaemeron:fiat to publish a complete, reproducible Hermes evidence bundle against a real Wildcat release, with a scoped optimisation candidate and every gate outcome recorded. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
 <!-- marketplace-context:end -->
 
 The canonical workflow and complete gate contract live in

--- a/plugins/hexaemeron/.claude-plugin/plugin.json
+++ b/plugins/hexaemeron/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "hexaemeron",
   "displayName": "Hexaemeron",
   "version": "1.0.0",
-  "description": "Receipted delivery from study to draft pull request, with audit, fuzzing and prose tools.",
+  "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing and prose tools.",
   "author": {
     "name": "Wildcat Labs",
     "url": "https://wildcat.finance"

--- a/plugins/hexaemeron/.codex-plugin/plugin.json
+++ b/plugins/hexaemeron/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hexaemeron",
   "version": "1.0.0+codex.20260816145806",
-  "description": "Receipted delivery from study to draft pull request, with audit, fuzzing and prose tools.",
+  "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing and prose tools.",
   "author": {
     "name": "Wildcat Labs",
     "url": "https://wildcat.finance"
@@ -20,8 +20,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Hexaemeron",
-    "shortDescription": "Receipted delivery from study to draft pull request, with audit, fuzzing and prose tools.",
-    "longDescription": "Takes a topic from nothing to a working prototype through a receipt-backed controller: a linted study, a runbook of discrete steps, then per step the simplest satisfying implementation, a security loop over the vendored Pashov suite (x-ray, solidity-auditor, fizz) until clean or reasoned out, a prose pass through the bundled imprimatur and vulgate masks, and a pushed PR. Completed state is archived and reset automatically when a new run begins; incomplete state remains resumable.",
+    "shortDescription": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing and prose tools.",
+    "longDescription": "Takes a topic from nothing to a working prototype through a receipt-backed controller: a linted study, a runbook of discrete steps, then per step the simplest satisfying implementation, a security loop over the vendored Pashov suite, a prose pass through Imprimatur and Vulgate, and a merged pull request with its task issue closed. Kronos can rank eligible held frontiers and repeat complete Fiat runs until no worthwhile frontier remains.",
     "developerName": "Wildcat Labs",
     "category": "Developer Tools",
     "capabilities": [],

--- a/plugins/hexaemeron/AGENTS.md
+++ b/plugins/hexaemeron/AGENTS.md
@@ -18,6 +18,13 @@ Hexaemeron skill matches a task.
 | `solidity-auditor` | `skills/solidity-auditor/SKILL.md` | Audit Solidity source for security findings |
 | `imprimatur` | `skills/imprimatur/SKILL.md` | Lint shipped prose against the banned lexicon |
 | `vulgate` | `skills/vulgate/SKILL.md` | Rewrite prose in a plain human register without changing its content |
+| `kronos` | `skills/kronos/SKILL.md` | Repeatedly rank eligible skill frontiers and send the best held job through Fiat |
+
+The first-party `fiat`, `imprimatur`, `vulgate`, and `kronos` directories each
+carry an `EVOLUTION.md` ledger governed by `skills/VERSIONING.md`. Read the
+selected skill's ledger before proposing a frontier run. A `mature` frontier
+is a hard stop unless a maintainer has recorded an evidenced epoch reopening.
+Kronos is terminal by design and excludes itself from its candidate set.
 
 ## Translate tool names by capability
 
@@ -61,6 +68,8 @@ preserve.
   user supplied absolute paths.
 - Names such as `hexaemeron:fizz` and `/hexaemeron:fiat` are logical skill
   aliases. Load the local canonical path from the table above.
+- Fiat's controller path is relative to the exact active Fiat instruction
+  file, never to `{PROJECT_ROOT}` or a GitHub URL.
 
 ## Side effects and truthfulness
 

--- a/plugins/hexaemeron/README.md
+++ b/plugins/hexaemeron/README.md
@@ -9,7 +9,7 @@ Hexaemeron runs an explicit, receipted delivery loop and also exposes its fuzzin
 
 **Current frontier.** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
 
-**Next Fiat job.** Use /hexaemeron:fiat to run and publish the first Solidity delivery that exercises the bundled x-ray, solidity-auditor and fizz loop end to end, recording every round and closing state. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose, then replace every completed or stale Next Fiat job with the next evidenced repair or frontier step.
+**Next Fiat job.** Use /hexaemeron:fiat to run and publish the first Solidity delivery that exercises the bundled x-ray, solidity-auditor and fizz loop end to end, recording every round and closing state. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
 <!-- marketplace-context:end -->
 
 Let there be light.
@@ -17,7 +17,7 @@ Let there be light.
 One command that takes a topic from nothing to a working prototype:
 study, runbook, then for each runbook step the simplest implementation that
 satisfies it, a security loop that runs until clean or
-reasoned out, a prose pass in the house voice, and a pushed PR. Every phase
+reasoned out, a prose pass in the house voice, and a merged PR. Every phase
 leaves a receipt in a hash-chained ledger, so the run survives context
 resets, crashes, and week-long pauses -- resume is the same command.
 
@@ -34,7 +34,7 @@ then rest. The entry skill is `fiat`, so the invocation is
 | 3-4 | `implement` | Build the step, least mental load that satisfies the runbook |
 | 5 | `audit` | The vendored Pashov suite in rounds until clean or reasoned out; fixes on a stacked branch |
 | 6 | `prose` | The `imprimatur` lint, then the `vulgate` voice mask, on every document and the PR text |
-| rest | `push` | Push, open the PR, move on |
+| rest | `push` | Stage and commit the final diff, push, merge the PR, clean up the branch, and close the task issue |
 
 Days 3 through the rest repeat per step. The sixth day makes the prose in
 a human image, which is roughly the joke the name is carrying.
@@ -46,7 +46,17 @@ a human image, which is roughly the joke the name is carrying.
 /hexaemeron:fiat --base release/v2.5 "..."                  # start from a ref
 /hexaemeron:fiat                                            # resume
 /hexaemeron:fiat status                                     # report
+/hexaemeron:kronos                                          # rank and run frontier jobs until none remain
 ```
+
+Kronos is the small loop around Fiat. It scores every eligible held frontier
+out of 100, sends the best one through a complete Fiat run, then ranks again.
+The name carries the old Kronos/Chronos knot: sickle for the ripest job, clock
+for keeping the sequence moving.
+
+> Highest first, then Fiat runs.
+>
+> Kronos cuts till work is done.
 
 The run stops on its own only for a decision that belongs to a human: the
 audit loop hit its round cap with findings still open, a push was
@@ -80,7 +90,25 @@ The receipts are opinionated where the process is: the audit phase will not
 open without a resolved (or explicitly waived) security suite; it will not
 close with findings open unless a reasoned no-further-leads verdict is
 recorded; a prose receipt missing either configured skill is rejected; and a
-push receipt requires a verifiable PR URL. Fiat creates no GitHub issues.
+push receipt requires the final head, a merged PR, and closure of any recorded
+task issue. Fiat creates no GitHub issue unless the user or target repository
+requires one.
+
+## Skill versions and the stopping rule
+
+The first-party Fiat, Imprimatur, Vulgate, and Kronos skills keep an
+`EVOLUTION.md` ledger beside `SKILL.md`. Labels use
+`{skill}-v{evolution}.{generation}.{epoch}`: evolution counts completed
+frontier advances, generation counts meaningful behavioural changes, and
+epoch marks a rare compatibility or provenance boundary. These are governed
+by `skills/VERSIONING.md`; they are not SemVer and do not change invocation
+names.
+
+A held Next Fiat job changes only after that exact frontier job completes.
+Once a capable review finds that another pass has no concrete chance of
+material improvement, the ledger becomes `mature`, its next job becomes
+`None -- mature`, and Fiat refuses further frontier runs. A different rewrite
+or another model's curiosity is not grounds to keep seasoning it.
 
 ## Configuration
 
@@ -117,9 +145,9 @@ mask that renders text into a plain human register) live under `skills/`
 and can be invoked on their own, outside the loop, whenever a draft needs
 the treatment. Edit the lexicon in place when a term needs adding.
 Upstream attribution for the absorbed lint material sits in
-`skills/imprimatur/NOTICE.md`. One boundary holds regardless: the plugin
-pushes PRs and never merges one -- merge review belongs to humans and to
-whatever gate the repo runs.
+`skills/imprimatur/NOTICE.md`. Fiat never bypasses a gate, but once the gates
+pass it merges its own PR and closes its own task issue rather than leaving
+routine publication work behind.
 
 ## Agents
 

--- a/plugins/hexaemeron/skills/VERSIONING.md
+++ b/plugins/hexaemeron/skills/VERSIONING.md
@@ -1,0 +1,59 @@
+# Skill evolution contract
+
+First-party Hexaemeron skills use labels of the form
+`{skill}-v{evolution}.{generation}.{epoch}`. These labels are not SemVer and
+do not rename the skill: invocations remain `fiat`, `imprimatur`, `vulgate`,
+and `kronos`.
+
+The adoption baseline for Fiat, Imprimatur, and Vulgate is `v1.1.0`. History
+begins at adoption; do not invent or reconstruct versions for work that
+predated this contract. Kronos was introduced after the reset and deliberately
+starts at `v0.0.0`.
+
+- **Evolution** is the first number. Increment it exactly once after a
+  completed frontier Fiat job changes that skill's `Next Fiat job`, including
+  a frontier-closing job that records `None -- mature`.
+- **Generation** is the second number. Increment it for a meaningful change
+  to scripts, checks, ordering, decisions, or other behaviour that is not a
+  completed frontier advance. Prose-only edits do not count.
+- **Epoch** is the third number. Increment it only when a skill crosses a
+  compatibility or provenance boundary that makes its earlier lineage an
+  unsafe guide: a replacement is absorbed, the execution contract is
+  deliberately broken, ownership moves, or the history must be rebuilt from
+  incomplete evidence. Do not use it as a patch number. The other counters do
+  not reset.
+
+Each first-party skill keeps `EVOLUTION.md` beside its `SKILL.md`. That ledger
+is the authority for the current label, frontier status, frontier revision,
+next job, and history. The numeric version in `SKILL.md` frontmatter must
+match it. Each history row also stores the SHA-256 of this exact UTF-8 line,
+including its final newline:
+
+```text
+{status}|{frontier revision}|{current frontier}|{next Fiat job}
+```
+
+## Frontier discipline
+
+`Next Fiat job` is a held target, not a rolling writing prompt.
+
+- A generation entry must retain the prior frontier revision and frontier
+  digest byte for byte.
+- A generation may clarify surrounding explanation to reflect earlier
+  changes, but it must not change the target or its acceptance condition.
+- Outside an evidenced epoch reopening, only a completed frontier Fiat job
+  may replace the target and increment the evolution counter.
+- At the end of a frontier job, judge whether another pass has a concrete,
+  evidenced chance of material improvement. Style alternatives, speculative
+  extensions, another rewrite, or a different implementation of already met
+  acceptance conditions do not qualify.
+- If no material improvement remains, set the status to `mature`, set the
+  next job to `None -- mature`, record the evidence, and stop. Do not suggest,
+  start, or resume another Fiat frontier run for that skill.
+
+A mature frontier can reopen only when a maintainer supplies a new external
+failure, requirement, dependency change, or other evidence that invalidates
+the closure. Record that compatibility boundary as an epoch entry, with the
+new frontier revision and digest, before a new frontier job is allowed.
+Enthusiasm, a reworded prompt, or a request to try once more is not reopening
+evidence.

--- a/plugins/hexaemeron/skills/fiat/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/fiat/EVOLUTION.md
@@ -1,0 +1,16 @@
+# Fiat evolution ledger
+
+Policy: [../VERSIONING.md](../VERSIONING.md)
+
+- Current version: `fiat-v1.2.0`
+- Frontier status: `open`
+- Frontier revision: `installed-path-and-maturity-proof`
+- Current frontier: Fiat's receipt-backed controller is thoroughly unit-tested, but its installed-path resolution and terminal maturity rule have not been proved together in a published delivery from a packaged plugin.
+- Next Fiat job: Run one bounded delivery from an installed Hexaemeron plugin, record the resolved controller path and receipts, and close with an evidenced decision on whether any material Fiat frontier remains.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `fiat-v1.1.0` | baseline | `installed-path-and-maturity-proof` | `a30bea33332e20c6780a77f5d82bc899d7004b8d09321628777d36289bd128d0` | [skills#74](https://github.com/wildcat-finance/skills/issues/74) | Versioning starts here. Fiat has explicit active-skill path resolution, a mature-frontier refusal, and its own held frontier. |
+| `fiat-v1.2.0` | generation | `installed-path-and-maturity-proof` | `a30bea33332e20c6780a77f5d82bc899d7004b8d09321628777d36289bd128d0` | [skills#74](https://github.com/wildcat-finance/skills/issues/74) | Made publish terminal only after final staging, push, merge, branch cleanup where permitted, and closure of any recorded task issue. |

--- a/plugins/hexaemeron/skills/fiat/SKILL.md
+++ b/plugins/hexaemeron/skills/fiat/SKILL.md
@@ -7,20 +7,23 @@ description: >
   or report a Hexaemeron or Fiat delivery, including /hexaemeron:fiat forms.
   Do not infer activation from a similar task.
 metadata:
-  version: "1.0.0"
+  version: "1.2.0"
 ---
 
 # Fiat
 
-<!-- marketplace-context:start -->
 ## Where this sits
 
-Hexaemeron runs an explicit, receipted delivery loop and also exposes its fuzzing, audit-readiness, security-review and prose skills on their own.
+Fiat owns the delivery controller, not Hexaemeron's bundled audit or prose
+skills. Its version, held frontier, next job, and maturity state live in
+[EVOLUTION.md](EVOLUTION.md). Read that ledger before suggesting, starting, or
+resuming work intended to advance Fiat itself.
 
-**Use another tool when.** Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks.
+**Use another tool when.** Run `imprimatur` or `vulgate` directly for prose,
+and the bundled Pashov skills directly for standalone Solidity review.
 
-**Current frontier.** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
-<!-- marketplace-context:end -->
+**Current frontier.** The ledger above is authoritative. Never substitute
+Hexaemeron's plugin-wide Solidity frontier for Fiat's own held target.
 
 Let there be light.
 
@@ -28,15 +31,26 @@ Drive the whole loop from durable controller state, never from conversation
 history. The controller emits one directive at a time; do the work it names,
 receipt it, ask for the next one. A phase without a receipt did not happen.
 
-`$SKILL_DIR` = the directory containing this SKILL.md file; resolve it from
-the path you loaded this skill from. `$PLUGIN_ROOT` = two directories above
-`$SKILL_DIR`; sibling skills live at `$PLUGIN_ROOT/skills/<name>/`. Both
-hold on any host that can read this file.
+Resolve paths from the exact `SKILL.md` file that activated Fiat. Do not
+resolve them from the target repository, the shell's current directory, the
+GitHub URL, or a guessed plugin-cache version.
+
+Before the first controller call:
+
+```text
+FIAT_SKILL_FILE=<exact path of the active fiat/SKILL.md>
+FIAT_SKILL_DIR=<real parent directory of FIAT_SKILL_FILE>
+PLUGIN_ROOT=<real directory two levels above FIAT_SKILL_DIR>
+PROJECT_ROOT=<real root of the user's target repository>
+```
+
+Fail closed if `FIAT_SKILL_DIR/scripts/hexctl.py` is not a file. Sibling
+skills live at `PLUGIN_ROOT/skills/<name>/`.
 
 Controller:
 
 ```text
-python3 "$SKILL_DIR/scripts/hexctl.py" --dir "$PWD" <cmd>
+python3 "$FIAT_SKILL_DIR/scripts/hexctl.py" --dir "$PROJECT_ROOT" <cmd>
 ```
 
 Alias it as `hexctl` mentally; every command below means that invocation.
@@ -73,16 +87,42 @@ the second.
 ## Start or resume
 
 1. If the user passed `status`, run `hexctl status` and report. Stop.
-2. If `.hexaemeron/state.json` exists, run `hexctl verify`, then
+2. Apply the frontier maturity gate below. This happens before `init` and
+   before resuming an existing frontier run.
+3. If `.hexaemeron/state.json` exists, run `hexctl verify`, then
    `hexctl status --json`. If its phase is `done`, run `hexctl reset` to
    archive the completed run, then continue immediately as a new run at step
-   3. Do not ask the user to remove, rename, or approve resetting completed
+   4. Do not ask the user to remove, rename, or approve resetting completed
    state. If the phase is not `done`, this is a resume: enter the loop and
    treat the state file as canonical.
-3. Otherwise: say exactly `Let there be light.` and nothing else before it,
-   then run preflight (below), then `hexctl init --topic "<topic>"
-   --base <ref>` and enter the loop. `--base` defaults to `main`; honour any
-   branch, repo, or commit the user named as the starting point.
+4. Otherwise: say exactly `Let there be light.` and nothing else before it,
+   run the read-only preflight checks below, then `hexctl init --topic
+   "<topic>" --base <ref>`, record the post-init receipts, and enter the loop.
+   `--base` defaults to `main`; honour any branch, repo, or commit the user
+   named as the starting point.
+
+## Frontier maturity gate
+
+Apply this gate only when the requested run is meant to advance a skill's
+declared frontier. Ordinary product or repository delivery still uses Fiat
+without pretending that it changes Fiat or another skill.
+
+1. Read the target skill's `EVOLUTION.md` and the shared
+   [versioning contract](../VERSIONING.md).
+2. If its frontier status is `mature`, refuse to start or resume. Do not
+   suggest another Fiat run. A new run is allowed only after the ledger
+   records an epoch reopening backed by a new failure, requirement,
+   dependency change, or equivalent external evidence.
+3. If the status is `open`, compare the held next job with current evidence.
+   If its acceptance condition is already met or another pass would only
+   produce stylistic, speculative, or interchangeable changes, do not start
+   the controller. Report that the frontier should close; do not overseason
+   the skill to manufacture work.
+4. At the end of a completed frontier job, update the ledger exactly once:
+   increment evolution, retain generation and epoch, and either record one
+   evidenced next job or set `Frontier status` to `mature` and `Next Fiat
+   job` to `None -- mature`. A normal Fiat delivery does not touch skill
+   versions or frontier text.
 
 ## Preflight (new runs only)
 
@@ -111,10 +151,10 @@ the second.
    If the run will produce no Solidity and no suite applies, record a waiver
    instead: `hexctl record security_suite '"waived: <reason>"'` -- and say so
    out loud. Never claim a tool ran when it did not.
-5. Nothing else. Fiat has no issue phase. Ignore ambient issue-first
-   conventions for this workflow: do not create, search for, register,
-   reconcile, or close GitHub issues. Only an explicit higher-priority policy
-   in the target repository can override this rule.
+5. If the user supplied a task issue or a higher-priority target-repository
+   rule required one, record its URL after init with `hexctl record task_issue
+   '"<url>"'`. Do not invent an issue otherwise.
+6. Nothing else.
 
 ## The loop
 
@@ -135,7 +175,7 @@ Act on the single directive it prints, then receipt it. The directory:
 | `close-audit` | Last round was clean; close the phase | [audit-loop.md](references/audit-loop.md) | `done audit [--fixes-ref <ref>]` |
 | `resolve-security-suite` | Suite receipt missing; resolve or waive | preflight step 4 | `record security_suite ...` |
 | `prose` | Rewrite every prose artefact and draft the PR text | [prose-pass.md](references/prose-pass.md) | `done prose --files <n> --skills <csv>` |
-| `push` | Push and open the PR | [push-discipline.md](references/push-discipline.md) | `done push --pr-url <url>` |
+| `push` | Stage and commit final changes, push, open and merge the PR, delete the task branch where allowed, and close any recorded task issue | [push-discipline.md](references/push-discipline.md) | `done push --pr-url <url> --head-commit <sha> --merge-commit <sha> [--closed-issue-url <url>]` |
 | `audit-verdict` | Max rounds hit with findings open | ask the user | `done audit --no-further-leads --reason ...` or `halt --reason ...` |
 | `halted` | Report the reason; wait for the user | -- | `resume --note ...` when cleared |
 | `done` | Final report | below | -- |
@@ -176,10 +216,13 @@ constant. Both are bundled: run the lint script by path, read the mask's
 SKILL.md by path and apply it. The receipt refuses a skills list missing
 either configured id.
 
-**Push.** Push the branch and open a PR using the prepared prose. Do not add
-an issue reference unless the user independently supplied one. Receipt the PR
-URL. Pushing opens a PR; it never merges one. Merge review belongs to humans
-and to whatever gate the repo runs.
+**Push.** Stage and commit every intended final change, push the branch, and
+open a PR using the prepared prose. Do not add an issue reference unless one
+was independently supplied or required by higher-priority repository policy.
+Wait for gates, merge without bypassing them, remove the task branch where
+allowed, and close any recorded task issue. Receipt the final head SHA, PR URL,
+merge SHA, and closed issue URL. A routine publish or closure action is not a
+handoff to a human.
 
 ## Delegation and context
 
@@ -203,10 +246,18 @@ Use `hexctl halt --reason ...` so the stop itself is on the ledger.
 - Never advance past a phase whose receipt command failed.
 - Never reconstruct progress from chat; `status` and `next` are the truth.
 - Never claim a lint, audit round, or test run happened when it did not.
-- Never merge a PR or force-push over someone else's work.
+- Never force-push over someone else's work or bypass a merge gate.
+- Never call a plan or implementation complete while its own final changes,
+  PR, task branch, or recorded issue still need routine stage, push, merge,
+  deletion, or closure work.
 - Never create a GitHub issue merely to satisfy this workflow.
 - Never disclose a failed, unavailable, or inconclusive contributor check.
 - Never install a wider-marketplace plugin before the study receipt exists.
+- Never run or recommend a frontier Fiat job for a skill whose ledger is
+  mature, or when a capable review finds no concrete material improvement.
+- Never change a held `Next Fiat job` during a generation update; only clarify
+  its context without changing its target or acceptance condition. An epoch
+  may replace it only with the reopening evidence required by the ledger.
 
 ## Final report
 

--- a/plugins/hexaemeron/skills/fiat/agents/openai.yaml
+++ b/plugins/hexaemeron/skills/fiat/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Hexaemeron"
-  short_description: "Issue-free delivery loop: study, runbook, build, audit, prose, push"
-  default_prompt: "Use $hexaemeron:fiat to start this topic in the current repository without creating GitHub issues. If the existing controller state is complete, archive and reset it automatically before starting."
+  short_description: "Governed delivery loop: study, build, audit, prose, push"
+  default_prompt: "Use $hexaemeron:fiat to start or resume this topic without creating GitHub issues, first refusing a skill-frontier run that is mature or offers no material improvement."

--- a/plugins/hexaemeron/skills/fiat/references/audit-loop.md
+++ b/plugins/hexaemeron/skills/fiat/references/audit-loop.md
@@ -1,9 +1,5 @@
 # Audit loop
 
-<!-- marketplace-context:start -->
-> **Marketplace context: Hexaemeron.** Hexaemeron runs an explicit, receipted delivery loop and also exposes its fuzzing, audit-readiness, security-review and prose skills on their own. Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks. **Current frontier:** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
-<!-- marketplace-context:end -->
-
 Budget accordingly: this phase is expected to take longer than the
 implementation it audits. The loop runs the security suite against the
 step's branch, logs everything, fixes on a stacked branch, and repeats

--- a/plugins/hexaemeron/skills/fiat/references/prose-pass.md
+++ b/plugins/hexaemeron/skills/fiat/references/prose-pass.md
@@ -1,9 +1,5 @@
 # Prose pass
 
-<!-- marketplace-context:start -->
-> **Marketplace context: Hexaemeron.** Hexaemeron runs an explicit, receipted delivery loop and also exposes its fuzzing, audit-readiness, security-review and prose skills on their own. Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks. **Current frontier:** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
-<!-- marketplace-context:end -->
-
 Everything a human will read ships in one plain voice, with the AI tells
 stripped. Code stays untouched; this phase is words only. Both masks are
 bundled in this plugin, so no external install is involved.

--- a/plugins/hexaemeron/skills/fiat/references/push-discipline.md
+++ b/plugins/hexaemeron/skills/fiat/references/push-discipline.md
@@ -1,11 +1,9 @@
 # Push discipline
 
-<!-- marketplace-context:start -->
-> **Marketplace context: Hexaemeron.** Hexaemeron runs an explicit, receipted delivery loop and also exposes its fuzzing, audit-readiness, security-review and prose skills on their own. Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks. **Current frontier:** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
-<!-- marketplace-context:end -->
-
-The pushed branch and pull request are the delivery trail. Fiat does not
-create or require a GitHub issue.
+The pushed branch, merged pull request, and closed task issue are the delivery
+trail. Fiat does not create an issue unless the user or a higher-priority
+target-repository rule requires one. If one exists, record it as
+`task_issue` and close it before the terminal receipt.
 
 ## Branches and commits
 
@@ -20,7 +18,7 @@ create or require a GitHub issue.
   Wildcat-Origin: shoggoth
   ```
 
-## Pull request
+## Pull request and closure
 
 Push the branch, then open a pull request using the title and body prepared in
 the prose phase. The body states what changed, why, where the audit record
@@ -37,11 +35,25 @@ Extra labels are additive. Do not remove or rename either provenance marker.
 Do not amend a pre-existing human commit or relabel a pre-existing human pull
 request merely because Fiat later resumes work around it.
 
-Verify the pull request URL after creation. Never merge it and never
-force-push over another person's work.
+Verify the pull request URL after creation. Wait for required checks, convert
+the PR from draft if necessary, then merge it using the repository's permitted
+merge method. Enable auto-merge when checks are still running and the host
+supports it. Never force-push over another person's work and never bypass a
+required review or failing gate.
+
+After merge, verify the merge commit and delete the remote task branch where
+repository policy permits. If a `task_issue` receipt exists, close that exact
+issue with a short comment linking the merged PR. A plan or implementation is
+not complete while its own branch, PR, or issue is awaiting routine agent
+action.
+
+If GitHub rejects the push or merge, a required independent approval cannot be
+self-supplied, or an external gate fails, record `hexctl halt --reason ...`
+with the exact blocker. Do not call the run complete.
 
 ## Receipt
 
 ```text
-hexctl done push --pr-url <url>
+hexctl done push --pr-url <url> --head-commit <sha> --merge-commit <sha> \
+  [--closed-issue-url <url>]
 ```

--- a/plugins/hexaemeron/skills/fiat/references/runbook-format.md
+++ b/plugins/hexaemeron/skills/fiat/references/runbook-format.md
@@ -1,9 +1,5 @@
 # Runbook format
 
-<!-- marketplace-context:start -->
-> **Marketplace context: Hexaemeron.** Hexaemeron runs an explicit, receipted delivery loop and also exposes its fuzzing, audit-readiness, security-review and prose skills on their own. Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks. **Current frontier:** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
-<!-- marketplace-context:end -->
-
 Turn the study into an ordered list of steps that ends at a working
 prototype. Write it to `.hexaemeron/runbook.md`, emit
 `.hexaemeron/steps.json`, and receipt both.

--- a/plugins/hexaemeron/skills/fiat/references/study.md
+++ b/plugins/hexaemeron/skills/fiat/references/study.md
@@ -1,9 +1,5 @@
 # Study
 
-<!-- marketplace-context:start -->
-> **Marketplace context: Hexaemeron.** Hexaemeron runs an explicit, receipted delivery loop and also exposes its fuzzing, audit-readiness, security-review and prose skills on their own. Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks. **Current frontier:** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
-<!-- marketplace-context:end -->
-
 Produce one markdown study that someone competent could build from without
 access to this conversation. Write it to `.hexaemeron/study.md` (the state
 directory is self-gitignored; a repo copy gets committed later, in step 1 of

--- a/plugins/hexaemeron/skills/fiat/references/wildcat-marketplace.md
+++ b/plugins/hexaemeron/skills/fiat/references/wildcat-marketplace.md
@@ -1,9 +1,5 @@
 # Wildcat Labs marketplace
 
-<!-- marketplace-context:start -->
-> **Marketplace context: Hexaemeron.** Hexaemeron runs an explicit, receipted delivery loop and also exposes its fuzzing, audit-readiness, security-review and prose skills on their own. Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks. **Current frontier:** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
-<!-- marketplace-context:end -->
-
 Use this only on a fresh run and, after a successful match, immediately after
 the study receipt. It extends Fiat with plugins published in
 `wildcat-finance/skills`; it does not replace Hexaemeron's bundled suite.

--- a/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
+++ b/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
@@ -8,7 +8,9 @@ command appends a ledger entry, so `verify` can prove the run history was not
 edited after the fact.
 
 Phase order is fixed. Globally: study -> runbook -> steps -> done.
-Within each step: implement -> audit -> prose -> push.
+Within each step: implement -> audit -> prose -> push. The push receipt is
+terminal only after the final head is pushed, its pull request is merged, and
+any recorded task issue is closed.
 
 Exit codes: 0 success, 2 validation/usage error, 1 unexpected failure.
 Stdout from `next` and `status --json` is a single JSON object; everything
@@ -593,7 +595,29 @@ def done_push(args, state: dict) -> None:
     step = require_step_phase(state, "push")
     if not args.pr_url:
         die("--pr-url is required")
-    step["receipts"]["push"] = {"pr_url": args.pr_url}
+    if not args.head_commit:
+        die("--head-commit is required")
+    if not args.merge_commit:
+        die("--merge-commit is required; the pull request is not terminal until merged")
+    task_issue = state["receipts"].get("task_issue")
+    expected_issue = None
+    if isinstance(task_issue, str):
+        expected_issue = task_issue
+    elif isinstance(task_issue, dict):
+        expected_issue = task_issue.get("url")
+    if task_issue is not None and not args.closed_issue_url:
+        die("--closed-issue-url is required because a task_issue receipt exists")
+    if expected_issue and args.closed_issue_url != expected_issue:
+        die(
+            "--closed-issue-url does not match the recorded task_issue "
+            f"({expected_issue})"
+        )
+    step["receipts"]["push"] = {
+        "pr_url": args.pr_url,
+        "head_commit": args.head_commit,
+        "merge_commit": args.merge_commit,
+        "closed_issue_url": args.closed_issue_url,
+    }
     step["status"] = "done"
     step["phase"] = "done"
     remaining = [s for s in state["steps"] if s["status"] == "pending"]
@@ -613,7 +637,7 @@ def done_push(args, state: dict) -> None:
         "done:push",
         {"step": step["n"], **step["receipts"]["push"]},
     )
-    print(f"step {step['n']} pushed and receipted; {tail}")
+    print(f"step {step['n']} published, merged, and receipted; {tail}")
 
 
 DONE_HANDLERS = {
@@ -874,6 +898,9 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--log")
     sp.add_argument("--files", type=int)
     sp.add_argument("--pr-url", dest="pr_url")
+    sp.add_argument("--head-commit", dest="head_commit")
+    sp.add_argument("--merge-commit", dest="merge_commit")
+    sp.add_argument("--closed-issue-url", dest="closed_issue_url")
     sp.set_defaults(fn=cmd_done)
 
     sp = sub.add_parser("audit-round", help="record one security round")

--- a/plugins/hexaemeron/skills/imprimatur/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/imprimatur/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Imprimatur evolution ledger
+
+Policy: [../VERSIONING.md](../VERSIONING.md)
+
+- Current version: `imprimatur-v1.1.0`
+- Frontier status: `open`
+- Frontier revision: `labelled-corpus-calibration`
+- Current frontier: Imprimatur has deterministic tiered linting and regression tests, but no held-out labelled corpus that measures false positives and misses by enforcement tier.
+- Next Fiat job: Build a held-out corpus of shipped human and model-assisted prose, report precision and recall by tier, tune only evidenced failures, and record whether another material calibration pass remains.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `imprimatur-v1.1.0` | baseline | `labelled-corpus-calibration` | `ed610953c08d982f939838315687b6672e19c2a20bdc0db6139fd4349e551535` | [skills#74](https://github.com/wildcat-finance/skills/issues/74) | Versioning starts here. Imprimatur has governed maturity handling and its own held frontier. |

--- a/plugins/hexaemeron/skills/imprimatur/NOTICE.md
+++ b/plugins/hexaemeron/skills/imprimatur/NOTICE.md
@@ -1,9 +1,5 @@
 # Notice
 
-<!-- marketplace-context:start -->
-> **Marketplace context: Hexaemeron.** Hexaemeron runs an explicit, receipted delivery loop and also exposes its fuzzing, audit-readiness, security-review and prose skills on their own. Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks. **Current frontier:** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
-<!-- marketplace-context:end -->
-
 This skill absorbs material from **slopkit** by ehmo, used under the MIT licence.
 
 - Upstream: https://github.com/ehmo/slopkit

--- a/plugins/hexaemeron/skills/imprimatur/SKILL.md
+++ b/plugins/hexaemeron/skills/imprimatur/SKILL.md
@@ -9,20 +9,17 @@ description: >-
   any prose that ships, when checking whether a draft reads as
   machine-written, or when the user names a term to ban.
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Imprimatur
 
-<!-- marketplace-context:start -->
-## Where this sits
+## Frontier
 
-Hexaemeron runs an explicit, receipted delivery loop and also exposes its fuzzing, audit-readiness, security-review and prose skills on their own.
-
-**Use another tool when.** Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks.
-
-**Current frontier.** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
-<!-- marketplace-context:end -->
+Imprimatur owns the prose-lint contract, not Hexaemeron's delivery or Solidity
+frontier. Its version, held calibration target, next job, and maturity state
+live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run another frontier
+pass after that ledger becomes mature.
 
 A banned lexicon with three enforcement tiers and a rule about why wordlists fail on their own.
 

--- a/plugins/hexaemeron/skills/imprimatur/references/agent-replies.md
+++ b/plugins/hexaemeron/skills/imprimatur/references/agent-replies.md
@@ -1,9 +1,5 @@
 # Agent replies
 
-<!-- marketplace-context:start -->
-> **Marketplace context: Hexaemeron.** Hexaemeron runs an explicit, receipted delivery loop and also exposes its fuzzing, audit-readiness, security-review and prose skills on their own. Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks. **Current frontier:** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
-<!-- marketplace-context:end -->
-
 Rules for the agent's own turns, absorbed from upstream (see `NOTICE.md`). These govern what the agent says while working, not the artefact it produces. For the artefact, see `rewriting.md`.
 
 Priority order: honesty, then structure, then plain language. A clear and actionable overstatement is worse than a muddy truth, so honesty outranks the rest. Never trade a true caveat for a cleaner line.

--- a/plugins/hexaemeron/skills/imprimatur/references/lexicon-rationale.md
+++ b/plugins/hexaemeron/skills/imprimatur/references/lexicon-rationale.md
@@ -1,9 +1,5 @@
 # Lexicon rationale
 
-<!-- marketplace-context:start -->
-> **Marketplace context: Hexaemeron.** Hexaemeron runs an explicit, receipted delivery loop and also exposes its fuzzing, audit-readiness, security-review and prose skills on their own. Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks. **Current frontier:** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
-<!-- marketplace-context:end -->
-
 Why each family is in the list, and why the list is organised by family at all.
 
 ## Substitution drift

--- a/plugins/hexaemeron/skills/imprimatur/references/rewriting.md
+++ b/plugins/hexaemeron/skills/imprimatur/references/rewriting.md
@@ -1,9 +1,5 @@
 # Rewriting
 
-<!-- marketplace-context:start -->
-> **Marketplace context: Hexaemeron.** Hexaemeron runs an explicit, receipted delivery loop and also exposes its fuzzing, audit-readiness, security-review and prose skills on their own. Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks. **Current frontier:** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
-<!-- marketplace-context:end -->
-
 What to do once the lint finds something. Absorbed from upstream (see `NOTICE.md`), compressed.
 
 ## Order of operations

--- a/plugins/hexaemeron/skills/kronos/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/kronos/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Kronos evolution ledger
+
+Policy: [../VERSIONING.md](../VERSIONING.md)
+
+- Current version: `kronos-v0.0.0`
+- Frontier status: `mature`
+- Frontier revision: `terminal-goal-loop`
+- Current frontier: Kronos ranks eligible held Next Fiat jobs, selects the highest-value one, sets one durable goal, runs Fiat, and repeats until none remain.
+- Next Fiat job: `None -- mature`
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `kronos-v0.0.0` | baseline | `terminal-goal-loop` | `ac28d95d80724aa001a92740f76416164e65d7b7b9cb5da43674d1ea73a214d1` | [skills#74](https://github.com/wildcat-finance/skills/issues/74) | Kronos starts here. It is complete and terminal by design. |

--- a/plugins/hexaemeron/skills/kronos/SKILL.md
+++ b/plugins/hexaemeron/skills/kronos/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: kronos
+description: >-
+  Rank the held Next Fiat jobs across explicitly in-scope, non-mature skills,
+  select the most worthwhile job out of 100, set one durable goal or loop,
+  run that job through Fiat, then repeat until no eligible frontier remains.
+  Use only when the user explicitly asks for Kronos or for a repeated ranked
+  Fiat frontier loop. Do not use it for one ordinary Fiat delivery.
+metadata:
+  version: "0.0.0"
+---
+
+# Kronos
+
+Read [EVOLUTION.md](EVOLUTION.md). Kronos is terminal by design; that maturity
+blocks attempts to improve Kronos itself, not the frontier loop it controls.
+
+Named for the old knot between Kronos and Chronos: a sickle for taking the
+ripest frontier first, and a clock that keeps Fiat moving until the field is
+bare.
+
+> Highest first, then Fiat runs.
+>
+> Kronos cuts till work is done.
+
+## Loop
+
+1. Resolve the scope from the user's named directories or repositories. If no
+   narrower scope was named, use the current marketplace checkout.
+2. Find every `EVOLUTION.md` in scope. Exclude:
+   - Kronos itself;
+   - vendored or third-party skills;
+   - a ledger whose `Frontier status` is `mature`;
+   - a ledger whose `Next Fiat job` is `None -- mature` or absent.
+3. Score each remaining held job out of 100:
+   - material user or protocol impact: 40;
+   - evidenced urgency or defect severity: 25;
+   - readiness of inputs and acceptance conditions: 20;
+   - leverage for other in-scope skills: 15.
+   Show the score and one-sentence basis for every candidate. Do not invent
+   work to fill the list.
+4. Select the highest score. Break a tie by impact, then readiness, then the
+   order in which the ledgers were found.
+5. When the runtime provides a durable goal facility, create one goal whose
+   objective is to repeat steps 1-8 until no eligible frontier remains. When
+   it does not, keep the same loop in the current run. Never create one goal
+   per skill.
+6. Read the selected skill's canonical instructions, its ledger, and Fiat's
+   `SKILL.md`. Invoke Fiat with the held Next Fiat job byte for byte.
+7. Let Fiat finish its complete terminal path: implement, validate, stage,
+   commit, push, merge, branch cleanup where permitted, and issue closure.
+   A PR merely opened is not a completed iteration.
+8. Require the completed frontier run to update that skill's ledger under
+   `VERSIONING.md`: evolution advances once and the held job is replaced, or
+   the frontier becomes mature. Rescan from disk, rerank from scratch, and
+   repeat.
+
+Stop successfully when no eligible ledger remains. If Fiat halts on a genuine
+external blocker, preserve the durable goal and report that blocker; do not
+skip to a lower-scoring job to make the loop look busy.
+
+## Hard rules
+
+- Never edit, implement, audit, or rewrite a target itself. Fiat owns the work.
+- Never score a mature, terminal, vendored, or out-of-scope skill.
+- Never alter a held Next Fiat job before its exact frontier job completes.
+- Never continue merely because the loop can continue. No eligible frontier
+  means the goal is complete.

--- a/plugins/hexaemeron/skills/kronos/agents/openai.yaml
+++ b/plugins/hexaemeron/skills/kronos/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Kronos"
+  short_description: "Ranks and runs the best remaining Fiat frontier"
+  default_prompt: "Use $hexaemeron:kronos to rank eligible frontier jobs and run the best one through Fiat until none remain."

--- a/plugins/hexaemeron/skills/vulgate/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/vulgate/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Vulgate evolution ledger
+
+Policy: [../VERSIONING.md](../VERSIONING.md)
+
+- Current version: `vulgate-v1.1.0`
+- Frontier status: `open`
+- Frontier revision: `content-parity-evaluation`
+- Current frontier: Vulgate defines a strict content-preserving voice mask, but its parity check is still a model judgement rather than a repeatable evaluation over facts, commitments, caveats, and registers.
+- Next Fiat job: Build and run a content-parity evaluation across all four registers, measure additions and omissions, fix only evidenced instruction failures, and record whether another material pass remains.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `vulgate-v1.1.0` | baseline | `content-parity-evaluation` | `3cc0e1a07e5bf3fbc443fa65825ecfcaf12bb9d7087eeb8387341a1df2505b29` | [skills#74](https://github.com/wildcat-finance/skills/issues/74) | Versioning starts here. Vulgate has an explicit version, governed maturity handling, and its own held frontier. |

--- a/plugins/hexaemeron/skills/vulgate/SKILL.md
+++ b/plugins/hexaemeron/skills/vulgate/SKILL.md
@@ -1,19 +1,18 @@
 ---
 name: vulgate
 description: Rewrite AI-assisted or generic text into a plain human register -- a mask that produces prose easier to grasp than the usual AI slop. Use whenever drafting or rewriting messages, docs, or announcements that should read as though a person wrote them, without touching what they say.
+metadata:
+  version: "1.1.0"
 ---
 
 # Vulgate
 
-<!-- marketplace-context:start -->
-## Where this sits
+## Frontier
 
-Hexaemeron runs an explicit, receipted delivery loop and also exposes its fuzzing, audit-readiness, security-review and prose skills on their own.
-
-**Use another tool when.** Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks.
-
-**Current frontier.** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
-<!-- marketplace-context:end -->
+Vulgate owns the content-preserving voice mask, not Hexaemeron's delivery or
+Solidity frontier. Its version, held parity target, next job, and maturity
+state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run another
+frontier pass after that ledger becomes mature.
 
 A voice mask: it renders machine-register text into the common tongue. The
 output should read as though a busy, competent person wrote it -- someone who

--- a/plugins/hexaemeron/tests/test_evolution.py
+++ b/plugins/hexaemeron/tests/test_evolution.py
@@ -1,0 +1,149 @@
+"""Govern first-party Hexaemeron skill versions and held frontiers."""
+
+from pathlib import Path
+import hashlib
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILLS = ROOT / "skills"
+FIRST_PARTY = ("fiat", "imprimatur", "vulgate", "kronos")
+PARENT_FRONTIER = (
+    "The bundled Solidity audit suite has not yet been exercised in a "
+    "published end-to-end Fiat delivery."
+)
+
+
+def field(text, name):
+    match = re.search(rf"(?m)^- {re.escape(name)}: (.+)$", text)
+    if match is None:
+        raise AssertionError(f"missing {name}")
+    return match.group(1).strip().strip("`")
+
+
+def version_parts(label, skill):
+    match = re.fullmatch(rf"{re.escape(skill)}-v(\d+)\.(\d+)\.(\d+)", label)
+    if match is None:
+        raise AssertionError(f"invalid version label: {label}")
+    return tuple(int(part) for part in match.groups())
+
+
+def history_rows(text):
+    rows = []
+    pattern = re.compile(
+        r"(?m)^\| `(?P<version>[^`]+)` \| (?P<axis>baseline|evolution|generation|epoch) "
+        r"\| `(?P<revision>[^`]+)` \| `(?P<digest>[0-9a-f]{64})` "
+        r"\| (?P<evidence>.*?) \| (?P<change>.*?) \|$"
+    )
+    for match in pattern.finditer(text):
+        rows.append(match.groupdict())
+    return rows
+
+
+class EvolutionContractTests(unittest.TestCase):
+    def test_first_party_skills_have_governed_ledgers(self):
+        for skill in FIRST_PARTY:
+            directory = SKILLS / skill
+            ledger = directory / "EVOLUTION.md"
+            instructions = directory / "SKILL.md"
+            with self.subTest(skill=skill):
+                self.assertTrue(ledger.is_file())
+                self.assertIn("[EVOLUTION.md](EVOLUTION.md)", instructions.read_text(encoding="utf-8"))
+
+    def test_skill_metadata_matches_current_ledger_version(self):
+        for skill in FIRST_PARTY:
+            instructions = (SKILLS / skill / "SKILL.md").read_text(encoding="utf-8")
+            ledger = (SKILLS / skill / "EVOLUTION.md").read_text(encoding="utf-8")
+            metadata = re.search(r'(?m)^  version: "(\d+\.\d+\.\d+)"$', instructions)
+            self.assertIsNotNone(metadata, skill)
+            current = field(ledger, "Current version")
+            self.assertEqual(current, f"{skill}-v{metadata.group(1)}")
+
+    def test_current_frontier_digest_matches_latest_history_row(self):
+        for skill in FIRST_PARTY:
+            ledger = (SKILLS / skill / "EVOLUTION.md").read_text(encoding="utf-8")
+            canonical = "|".join(
+                (
+                    field(ledger, "Frontier status"),
+                    field(ledger, "Frontier revision"),
+                    field(ledger, "Current frontier"),
+                    field(ledger, "Next Fiat job"),
+                )
+            ) + "\n"
+            digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+            rows = history_rows(ledger)
+            self.assertGreaterEqual(len(rows), 1, skill)
+            self.assertEqual(rows[-1]["version"], field(ledger, "Current version"))
+            self.assertEqual(rows[-1]["digest"], digest)
+            self.assertEqual(rows[-1]["revision"], field(ledger, "Frontier revision"))
+
+    def test_history_axes_enforce_independent_counters_and_frontier_hold(self):
+        for skill in FIRST_PARTY:
+            ledger = (SKILLS / skill / "EVOLUTION.md").read_text(encoding="utf-8")
+            rows = history_rows(ledger)
+            self.assertEqual(rows[0]["axis"], "baseline")
+            expected_baseline = (0, 0, 0) if skill == "kronos" else (1, 1, 0)
+            self.assertEqual(version_parts(rows[0]["version"], skill), expected_baseline)
+            previous = rows[0]
+            previous_version = version_parts(previous["version"], skill)
+            for row in rows[1:]:
+                current_version = version_parts(row["version"], skill)
+                with self.subTest(skill=skill, version=row["version"]):
+                    if row["axis"] == "evolution":
+                        self.assertEqual(current_version, (previous_version[0] + 1, previous_version[1], previous_version[2]))
+                        self.assertNotEqual(row["digest"], previous["digest"])
+                    elif row["axis"] == "generation":
+                        self.assertEqual(current_version, (previous_version[0], previous_version[1] + 1, previous_version[2]))
+                        self.assertEqual(row["revision"], previous["revision"])
+                        self.assertEqual(row["digest"], previous["digest"])
+                    elif row["axis"] == "epoch":
+                        self.assertEqual(current_version, (previous_version[0], previous_version[1], previous_version[2] + 1))
+                        if row["digest"] != previous["digest"]:
+                            self.assertIn("reopen", (row["evidence"] + row["change"]).lower())
+                previous = row
+                previous_version = current_version
+
+    def test_mature_frontiers_have_no_next_job(self):
+        for skill in FIRST_PARTY:
+            ledger = (SKILLS / skill / "EVOLUTION.md").read_text(encoding="utf-8")
+            status = field(ledger, "Frontier status")
+            self.assertIn(status, {"open", "mature"})
+            if status == "mature":
+                self.assertEqual(field(ledger, "Next Fiat job"), "None -- mature")
+
+    def test_subsidiaries_do_not_inherit_parent_frontier(self):
+        for skill in FIRST_PARTY:
+            instructions = (SKILLS / skill / "SKILL.md").read_text(encoding="utf-8")
+            with self.subTest(skill=skill):
+                self.assertNotIn(PARENT_FRONTIER, instructions)
+                self.assertNotIn("<!-- marketplace-context:start -->", instructions)
+
+    def test_fiat_resolves_controller_from_active_skill_file(self):
+        fiat = (SKILLS / "fiat" / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn("FIAT_SKILL_FILE=<exact path of the active fiat/SKILL.md>", fiat)
+        self.assertIn('"$FIAT_SKILL_DIR/scripts/hexctl.py"', fiat)
+        self.assertIn('--dir "$PROJECT_ROOT"', fiat)
+        self.assertNotIn('"$SKILL_DIR/scripts/hexctl.py"', fiat)
+        self.assertNotIn('--dir "$PWD"', fiat)
+
+    def test_fiat_refuses_mature_or_exhausted_frontiers(self):
+        fiat = (SKILLS / "fiat" / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn("If its frontier status is `mature`, refuse to start or resume", fiat)
+        self.assertIn("do not overseason", fiat)
+        self.assertIn("Never run or recommend a frontier Fiat job", fiat)
+
+    def test_kronos_only_ranks_and_loops_eligible_frontiers(self):
+        kronos = (SKILLS / "kronos" / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn("material user or protocol impact: 40", kronos)
+        self.assertIn("evidenced urgency or defect severity: 25", kronos)
+        self.assertIn("readiness of inputs and acceptance conditions: 20", kronos)
+        self.assertIn("leverage for other in-scope skills: 15", kronos)
+        self.assertIn("Never create one goal\n   per skill", kronos)
+        self.assertIn("Invoke Fiat with the held Next Fiat job byte for byte", kronos)
+        self.assertIn("Kronos itself", kronos)
+        self.assertIn("Never edit, implement, audit, or rewrite a target itself", kronos)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/hexaemeron/tests/test_fiat_skill.py
+++ b/plugins/hexaemeron/tests/test_fiat_skill.py
@@ -90,6 +90,13 @@ class FiatSkillContractTests(unittest.TestCase):
         self.assertIn("pre-existing human commit", self.push_discipline)
         self.assertIn("pre-existing human pull\nrequest", self.push_discipline)
 
+    def test_publish_phase_merges_and_closes_its_own_work(self):
+        self.assertIn("merge it using the repository's permitted", self.push_discipline)
+        self.assertIn("close that exact\nissue", self.push_discipline)
+        self.assertIn("--head-commit <sha> --merge-commit <sha>", self.push_discipline)
+        self.assertNotIn("Never merge it", self.push_discipline)
+        self.assertIn("routine publish or closure action is not a\nhandoff", self.fiat)
+
 
 class ContributorCheckTests(unittest.TestCase):
     @classmethod

--- a/plugins/hexaemeron/tests/test_hexctl.py
+++ b/plugins/hexaemeron/tests/test_hexctl.py
@@ -136,7 +136,12 @@ with module.held_lock(sys.argv[2], sys.argv[3]):
         self.run_ctl("done", "audit")
         self.run_ctl("done", "prose", "--files", "3",
                      "--skills", "hexaemeron:imprimatur,hexaemeron:vulgate")
-        self.run_ctl("done", "push", "--pr-url", f"https://x/pr/{step_no}")
+        self.run_ctl(
+            "done", "push",
+            "--pr-url", f"https://x/pr/{step_no}",
+            "--head-commit", f"head{step_no}",
+            "--merge-commit", f"merge{step_no}",
+        )
 
 
 class TestLifecycle(HexctlCase):
@@ -389,7 +394,44 @@ class TestProseAndPush(HexctlCase):
                      "--skills", "hexaemeron:imprimatur,hexaemeron:vulgate")
         proc = self.run_ctl("done", "push", expect=2)
         self.assertIn("--pr-url", proc.stderr)
-        self.run_ctl("done", "push", "--pr-url", "https://x/pr/1")
+        proc = self.run_ctl(
+            "done", "push", "--pr-url", "https://x/pr/1", expect=2
+        )
+        self.assertIn("--head-commit", proc.stderr)
+        proc = self.run_ctl(
+            "done", "push", "--pr-url", "https://x/pr/1",
+            "--head-commit", "abc123", expect=2,
+        )
+        self.assertIn("--merge-commit", proc.stderr)
+        self.run_ctl(
+            "done", "push", "--pr-url", "https://x/pr/1",
+            "--head-commit", "abc123", "--merge-commit", "def456",
+        )
+
+    def test_recorded_task_issue_must_be_closed_before_push_receipt(self):
+        self.to_prose()
+        self.run_ctl("record", "task_issue", '"https://x/issues/74"')
+        self.run_ctl(
+            "done", "prose", "--files", "1",
+            "--skills", "hexaemeron:imprimatur,hexaemeron:vulgate",
+        )
+        proc = self.run_ctl(
+            "done", "push", "--pr-url", "https://x/pr/1",
+            "--head-commit", "abc123", "--merge-commit", "def456",
+            expect=2,
+        )
+        self.assertIn("--closed-issue-url", proc.stderr)
+        proc = self.run_ctl(
+            "done", "push", "--pr-url", "https://x/pr/1",
+            "--head-commit", "abc123", "--merge-commit", "def456",
+            "--closed-issue-url", "https://x/issues/75", expect=2,
+        )
+        self.assertIn("does not match", proc.stderr)
+        self.run_ctl(
+            "done", "push", "--pr-url", "https://x/pr/1",
+            "--head-commit", "abc123", "--merge-commit", "def456",
+            "--closed-issue-url", "https://x/issues/74",
+        )
 
     def test_push_advances_steps_then_run_completes(self):
         self.to_steps(("One", "Two"))

--- a/plugins/lazarus/README.md
+++ b/plugins/lazarus/README.md
@@ -9,7 +9,7 @@ Lazarus captures the finite fixed-block Ethereum state and RPC evidence an appli
 
 **Current frontier.** Preservation-pipeline integration and an Ariadne state-fixture predicate remain unimplemented.
 
-**Next Fiat job.** Use /hexaemeron:fiat to bind a Lazarus fixture through an Ariadne state-fixture predicate in the first end-to-end Goldfinch preservation release without upgrading recorded RPC evidence into proof-backed state. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose, then replace every completed or stale Next Fiat job with the next evidenced repair or frontier step.
+**Next Fiat job.** Use /hexaemeron:fiat to bind a Lazarus fixture through an Ariadne state-fixture predicate in the first end-to-end Goldfinch preservation release without upgrading recorded RPC evidence into proof-backed state. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
 <!-- marketplace-context:end -->
 
 Lazarus preserves the finite part of historical Ethereum state and RPC

--- a/plugins/lemma/README.md
+++ b/plugins/lemma/README.md
@@ -9,7 +9,7 @@ Lemma turns Solidity compiler input or Markdown trees into validated, source-lin
 
 **Current frontier.** Callable-surface ABI validation does not independently check return types or state mutability.
 
-**Next Fiat job.** Use /hexaemeron:fiat to make callable-surface ABI validation cover return types and state mutability as well as names and input types, with any divergence rejecting the output. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose, then replace every completed or stale Next Fiat job with the next evidenced repair or frontier step.
+**Next Fiat job.** Use /hexaemeron:fiat to make callable-surface ABI validation cover return types and state mutability as well as names and input types, with any divergence rejecting the output. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
 <!-- marketplace-context:end -->
 
 Lemma turns Solidity compiler inputs and Markdown documents into JSONL chunks.

--- a/plugins/pandects/README.md
+++ b/plugins/pandects/README.md
@@ -9,7 +9,7 @@ Pandects supplies executable laws for credit contracts, each paired with a delib
 
 **Current frontier.** No law prevents fees from reducing pooled lender claims below amounts owed on open withdrawal batches.
 
-**Next Fiat job.** Use /hexaemeron:fiat to add and prove the missing law that fees cannot reduce pooled lender claims below amounts owed on open withdrawal batches, including its specimen, reduced counterexample and applicability. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose, then replace every completed or stale Next Fiat job with the next evidenced repair or frontier step.
+**Next Fiat job.** Use /hexaemeron:fiat to add and prove the missing law that fees cannot reduce pooled lender claims below amounts owed on open withdrawal batches, including its specimen, reduced counterexample and applicability. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
 <!-- marketplace-context:end -->
 
 Executable laws for credit contracts.

--- a/plugins/probitas/README.md
+++ b/plugins/probitas/README.md
@@ -9,7 +9,7 @@ Probitas builds a sourced record of what a counterparty did across lending venue
 
 **Current frontier.** Euler v1/v2 now ship; Morpho Midnight fixed-maturity coverage and curation remain unimplemented.
 
-**Next Fiat job.** Use /hexaemeron:fiat to add fail-closed Morpho Midnight fixed-maturity coverage so a dossier can establish whether repayment was timely. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose, then replace every completed or stale Next Fiat job with the next evidenced repair or frontier step.
+**Next Fiat job.** Use /hexaemeron:fiat to add fail-closed Morpho Midnight fixed-maturity coverage so a dossier can establish whether repayment was timely. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
 <!-- marketplace-context:end -->
 
 A sourced dossier on a counterparty's record across on-chain lending venues,

--- a/plugins/tabularium/README.md
+++ b/plugins/tabularium/README.md
@@ -9,7 +9,7 @@ Tabularium maps preserved venue-native records into reproducible, venue-qualifie
 
 **Current frontier.** Compound v3 Phase 0 now rebuilds ordered calls and signed-principal transitions from one verified Alexandria witness; the Phase 1 canonical adapter and Ethereum USDC specimen remain unimplemented.
 
-**Next Fiat job.** Use /hexaemeron:fiat to ship Compound v3 Phase 1 from Alexandria raw evidence with a new canonical and coverage schema version, supply, withdraw, base-transfer and absorb mappings, a mined borrower-to-borrower transfer witness, hostile fixtures and a byte-identical offline Ethereum USDC specimen. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose, then replace every completed or stale Next Fiat job with the next evidenced repair or frontier step.
+**Next Fiat job.** Use /hexaemeron:fiat to ship Compound v3 Phase 1 from Alexandria raw evidence with a new canonical and coverage schema version, supply, withdraw, base-transfer and absorb mappings, a mined borrower-to-borrower transfer witness, hostile fixtures and a byte-identical offline Ethereum USDC specimen. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
 <!-- marketplace-context:end -->
 
 A public record of on-chain credit events that keeps the venue's source record

--- a/tests/test_marketplace_prose.py
+++ b/tests/test_marketplace_prose.py
@@ -33,8 +33,8 @@ CANONICAL_SKILLS = {
 NEXT_JOB_PREFIX = "**Next Fiat job.** Use /hexaemeron:fiat to "
 NEXT_JOB_SUFFIX = (
     "Before the run finishes, cold-read and reconcile all mutable first-party "
-    "marketplace prose, then replace every completed or stale Next Fiat job "
-    "with the next evidenced repair or frontier step."
+    "marketplace prose. Change a skill's Next Fiat job only when that exact "
+    "frontier job completed; otherwise leave it unchanged."
 )
 MARKETPLACE_CONTEXT_START = "<!-- marketplace-context:start -->"
 MARKETPLACE_CONTEXT_END = "<!-- marketplace-context:end -->"
@@ -128,7 +128,7 @@ class MarketplaceProseTests(unittest.TestCase):
         topics = {}
         for name, path in landings.items():
             text = path.read_text(encoding="utf-8")
-            lines = [line for line in text.splitlines() if "Next Fiat job" in line]
+            lines = [line for line in text.splitlines() if line.startswith(NEXT_JOB_PREFIX)]
             with self.subTest(plugin=name):
                 self.assertEqual(text.count(NEXT_JOB_PREFIX), 1, path)
                 self.assertEqual(len(lines), 1, path)
@@ -157,7 +157,7 @@ class MarketplaceProseTests(unittest.TestCase):
             relative = path.relative_to(ROOT)
             if relative.parts[0] in {".git", ".hexaemeron"}:
                 continue
-            if "Next Fiat job" in path.read_text(encoding="utf-8"):
+            if "**Next Fiat job.**" in path.read_text(encoding="utf-8"):
                 found.add(path)
         self.assertEqual(found, allowed)
 

--- a/tests/test_portable_skills.py
+++ b/tests/test_portable_skills.py
@@ -80,7 +80,7 @@ class PortableSkillTests(unittest.TestCase):
         hexa_root = ROOT / "plugins" / "hexaemeron"
         contract = (hexa_root / "AGENTS.md").read_text(encoding="utf-8")
         paths = re.findall(r"`(skills/[^`]+/SKILL\.md)`", contract)
-        self.assertEqual(len(paths), 8)
+        self.assertEqual(len(paths), 9)
         for relative in paths:
             self.assertTrue((hexa_root / relative).is_file(), relative)
 


### PR DESCRIPTION
## Summary

- give Fiat, Imprimatur, and Vulgate independent held frontiers and evolution ledgers
- resolve Fiat from the active installed skill path, enforce maturity, and make publish terminal only after merge and issue closure
- add kronos-v0.0.0 to rank eligible Next Fiat jobs out of 100 and run the best through Fiat until none remain
- keep vendored Pashov skills untouched

## Why

Subsidiary skills inherited plugin-wide frontier prose and Fiat assumed a path rooted in the target checkout. That made their own evolution ambiguous and could point hexctl at the wrong location. The new contract holds a frontier steady until its exact job completes and stops further Fiat runs once material improvement is exhausted.

## Validation

- python3 plugins/hexaemeron/tests/run_tests.py — 61/61
- python3 plugins/hexaemeron/skills/imprimatur/tests/run_tests.py — 55/55
- python3 -m unittest discover -s tests — 14/14
- skill schema validation for Fiat, Imprimatur, Vulgate, and Kronos

Closes #74

<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: https://github.com/wildcat-finance/skills/issues/74
Root-Issue-Successor: none-recorded
Root-Issue-Fiat-Required: 1
Root-Issue-Route: fiat-required
Root-Issue-Classification-Source: live-contract
<!-- root-issue-analytics:v1:end -->
