### PR TITLE
Add Sapheneia AuDHD interaction skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -29,6 +29,18 @@
       "category": "Developer Tools"
     },
     {
+      "name": "sapheneia",
+      "source": {
+        "source": "local",
+        "path": "./plugins/sapheneia"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
       "name": "probitas",
       "source": {
         "source": "local",

--- a/.agents/skills/sapheneia/SKILL.md
+++ b/.agents/skills/sapheneia/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sapheneia
+description: Route AuDHD-shaped agent interaction to Sapheneia. Keep actions, boundaries, state, evidence and next steps explicit across the session.
+---
+
+# Sapheneia portable entrypoint
+
+<!-- marketplace-context:start -->
+## Where this sits
+
+Sapheneia shapes the agent's own interaction with an AuDHD reader: the action, meaning, working state and evidence stay visible from turn to turn.
+
+**Use another tool when.** Use Imprimatur to inspect prose for banned machine-writing patterns, and use Vulgate or another voice mask to change register. Sapheneia governs interaction shape; it does not diagnose the reader or choose a house voice.
+
+**Current frontier.** Cross-model behaviour has not yet been held against a published AuDHD task corpus.
+<!-- marketplace-context:end -->
+
+Read [the Sapheneia runtime contract](../../../plugins/sapheneia/AGENTS.md),
+then read
+[the canonical Sapheneia skill](../../../plugins/sapheneia/skills/sapheneia/SKILL.md)
+in full and follow it.
+
+Once active, the canonical rules govern the agent's own commentary and final
+replies for the rest of the session, not only artefacts it produces. The
+canonical skill and runtime contract are authoritative if this entrypoint ever
+disagrees with them.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -50,6 +50,27 @@
       ]
     },
     {
+      "name": "sapheneia",
+      "displayName": "Sapheneia",
+      "source": "./plugins/sapheneia",
+      "description": "AuDHD-shaped replies with visible state and next actions.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Wildcat Labs",
+        "url": "https://wildcat.finance"
+      },
+      "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/sapheneia",
+      "repository": "https://github.com/wildcat-finance/skills",
+      "category": "Developer Tools",
+      "tags": [
+        "audhd",
+        "adhd",
+        "autism",
+        "accessibility",
+        "agent-communication"
+      ]
+    },
+    {
       "name": "probitas",
       "displayName": "Probitas",
       "source": "./plugins/probitas",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,15 +7,17 @@ the canonical `SKILL.md` it names.
 
 ## Marketplace boundaries
 
-The nine plugins form one marketplace, not nine competing descriptions of the
+The ten plugins form one marketplace, not ten competing descriptions of the
 same job. Alexandria preserves lending inputs; Tabularium interprets preserved
 venue records; Probitas assembles a counterparty dossier. Lazarus preserves the
 finite historical Ethereum state and exact RPC traffic a test needs, while
 Ariadne binds a released artefact digest to its evidence. Pandects supplies
 reviewed credit laws, Hermes measures a single gas-optimisation class,
 Hexaemeron controls a receipted delivery loop and Lemma stops after producing
-source-linked chunks. If a request crosses one of those boundaries, hand it to
-the named sibling rather than broadening the selected skill.
+source-linked chunks. Sapheneia shapes the agent's own replies for AuDHD
+readers without changing another skill's facts or gates. If a request crosses
+one of those boundaries, hand it to the named sibling rather than broadening
+the selected skill.
 
 ## Repository map
 
@@ -37,6 +39,9 @@ the named sibling rather than broadening the selected skill.
   before running its skill or changing that plugin.
 - Probitas is under `plugins/probitas/`. Read `plugins/probitas/AGENTS.md`
   before running its skill or changing that plugin.
+- Sapheneia is under `plugins/sapheneia/`. Read
+  `plugins/sapheneia/AGENTS.md` before running its skill or changing that
+  plugin.
 - Tabularium is under `plugins/tabularium/`. Read
   `plugins/tabularium/AGENTS.md` before running its skill or changing that
   plugin.
@@ -74,6 +79,7 @@ python3 plugins/lemma/tests/test_solidity.py
 python3 -m unittest discover -s plugins/lazarus/tests -t plugins/lazarus
 python3 -m unittest discover -s plugins/pandects/tests -t plugins/pandects
 python3 -m unittest discover -s plugins/probitas/tests -t plugins/probitas
+python3 -m unittest discover -s plugins/sapheneia/tests -t plugins/sapheneia
 python3 -m unittest discover -s plugins/tabularium/tests -t plugins/tabularium
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Agent skills written and used by [Wildcat Labs](https://wildcat.finance).
 
-This is where we publish workflows that have earned more than a prompt. Each
-plugin has a narrow job, a clear trigger and enough code, evidence and tests to
-make its result checkable. Read a plugin before running it: skills can execute
-commands and edit source.
+This is where we publish workflows and agent contracts that are worth keeping.
+Each plugin has a narrow job, a clear trigger and the instructions, code,
+evidence or tests that job needs. Read a plugin before running it: skills can
+execute commands and edit source.
 
 ## Choose the job, then the plugin
 
@@ -23,6 +23,7 @@ build.
 | [Lazarus](./plugins/lazarus) | Capturing a finite fixed-block Ethereum fixture, checking proof-backed state and replaying exact requests without fallback. | Alexandria for a lending archive; Tabularium for event interpretation. | Preservation-pipeline integration and an Ariadne state-fixture predicate remain unimplemented. |
 | [Pandects](./plugins/pandects) | Supplying executable credit laws, broken specimens and reduced counterexamples. | Fizz for a protocol-specific fuzz harness. | No law prevents fees from reducing pooled lender claims below amounts owed on open withdrawal batches. |
 | [Probitas](./plugins/probitas) | Building a sourced counterparty dossier from declared addresses, without identity inference or a Wildcat verdict. | Alexandria for archived inputs. | Euler v1/v2 now ship; Morpho Midnight fixed-maturity coverage and curation remain unimplemented. |
+| [Sapheneia](./plugins/sapheneia) | Shaping the agent's own replies so an AuDHD reader can see the action, boundaries, state and evidence. | Imprimatur for prose linting; Vulgate or another voice mask for register. | Cross-model behaviour has not yet been held against a published AuDHD task corpus. |
 | [Tabularium](./plugins/tabularium) | Mapping preserved venue-native records into reproducible, venue-qualified credit events. | Alexandria for raw harvesting; Probitas for a dossier. | Compound v3 Phase 0 now rebuilds ordered calls and signed-principal transitions from one verified Alexandria witness; the Phase 1 canonical adapter and Ethereum USDC specimen remain unimplemented. |
 
 ## Plugins
@@ -302,6 +303,39 @@ Probitas includes:
 
 **Security and audit.** A document arrives asserting things about a counterparty and you have to decide whether to believe it. Run `verify` against the evidence file it came with: every figure in the document has to trace back to a record with a transaction hash, and one that does not fails the check by arithmetic rather than by your reading it closely.
 
+### Sapheneia
+
+[Sapheneia](./plugins/sapheneia) shapes the agent's own replies for AuDHD
+engineers. It keeps the next action, task boundary, done condition, current
+state, evidence and unknowns visible from turn to turn.
+
+The contract sits upstream of whatever the agent is producing. It applies to
+commentary, progress updates, questions, errors and final replies for the rest
+of the session once selected. It does not diagnose the reader, and it yields
+as soon as the reader states a different preference.
+
+The ten rules are ranked. The first line carries the action or finished result;
+asks are literal and labelled; multi-step work has one active step; facts,
+assumptions and unknowns stay separate; and unfinished work ends with one next
+action. Imprimatur remains the prose lint, and a voice mask remains responsible
+for register.
+
+Sapheneia includes:
+
+- one canonical [`SKILL.md`](./plugins/sapheneia/skills/sapheneia/SKILL.md) shared by Codex, Claude Code and portable agents;
+- an agent-facing runtime contract that makes the agent itself the subject;
+- contract tests that hold the ranked rule count, persistence language, host descriptions and portable links together.
+
+#### Day to day
+
+**Developers.** A coding task spans several turns and the current step keeps
+falling out of view. Sapheneia keeps one step active, says what changed and
+what was verified, and ends with one next action.
+
+**Security and audit.** A finding mixes observed behaviour, inference and an
+untested assumption. Sapheneia labels each one and keeps the risk-bearing
+qualification attached to the decision it changes.
+
 ### Tabularium
 
 [Tabularium](./plugins/tabularium) preserves on-chain credit events in a form
@@ -374,14 +408,14 @@ economic meaning attached.
 
 Scored out of 10 for doing the job, not for reading the output. A marketer can quote a verified gas number without having any use for Hermes itself.
 
-| Role | Alexandria | Ariadne | Hermes | Hexaemeron | Lemma | Lazarus | Pandects | Probitas | Tabularium |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Developers | 8 | 8 | 9 | 9 | 6 | 8 | 8 | 4 | 7 |
-| Security and audit | 8 | 9 | 7 | 8 | 4 | 8 | 9 | 5 | 7 |
-| Marketing | 1 | 1 | 3 | 6 | 1 | 1 | 1 | 1 | 1 |
-| Business development | 6 | 2 | 2 | 5 | 1 | 2 | 2 | 9 | 3 |
-| Finance | 8 | 1 | 3 | 4 | 1 | 2 | 2 | 7 | 7 |
-| Legal | 3 | 3 | 1 | 4 | 1 | 2 | 2 | 4 | 2 |
+| Role | Alexandria | Ariadne | Hermes | Hexaemeron | Lemma | Lazarus | Pandects | Probitas | Sapheneia | Tabularium |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Developers | 8 | 8 | 9 | 9 | 6 | 8 | 8 | 4 | 8 | 7 |
+| Security and audit | 8 | 9 | 7 | 8 | 4 | 8 | 9 | 5 | 7 | 7 |
+| Marketing | 1 | 1 | 3 | 6 | 1 | 1 | 1 | 1 | 3 | 1 |
+| Business development | 6 | 2 | 2 | 5 | 1 | 2 | 2 | 9 | 4 | 3 |
+| Finance | 8 | 1 | 3 | 4 | 1 | 2 | 2 | 7 | 4 | 7 |
+| Legal | 3 | 3 | 1 | 4 | 1 | 2 | 2 | 4 | 4 | 2 |
 
 Five is the barrier. At or above it, the plugin's entry carries a worked example of what that role would use it for. Below it there is no example, because there is no honest one to give. These are engineering tools, and a 2 means we could not find a reason for that desk to open the plugin rather than read what it produced.
 
@@ -420,6 +454,7 @@ Add the same marketplace and install a plugin from inside Claude Code:
 /plugin install lazarus@wildcat-labs
 /plugin install pandects@wildcat-labs
 /plugin install probitas@wildcat-labs
+/plugin install sapheneia@wildcat-labs
 /plugin install tabularium@wildcat-labs
 ```
 
@@ -471,6 +506,12 @@ Probitas is available as:
 /probitas:probitas
 ```
 
+Sapheneia is available as:
+
+```text
+/sapheneia:sapheneia
+```
+
 Tabularium is available as:
 
 ```text
@@ -481,7 +522,7 @@ See Anthropic's [skills](https://code.claude.com/docs/en/skills) and [plugin mar
 
 ### Local agents
 
-Agents that support the open Agent Skills convention can discover the nine
+Agents that support the open Agent Skills convention can discover the ten
 host-neutral entries under [`.agents/skills`](./.agents/skills). Point the
 agent at this repository and include that directory in its project skill
 search path. Keep the repository layout intact: each entry routes to the
@@ -505,6 +546,7 @@ Use Lemma to chunk this Solidity standard input into JSONL.
 Use Lazarus to capture, verify or replay this finite historical Ethereum fixture.
 Use Pandects to check this credit protocol against the executable laws in the corpus.
 Use Probitas to build a dossier on this counterparty from the addresses they declared.
+Use Sapheneia to shape your replies for an AuDHD reader for the rest of this task.
 Use Tabularium to build and verify a source-bound Goldfinch, Euler v1 or Euler V2 credit-event release.
 ```
 
@@ -574,6 +616,15 @@ Use $probitas to build a sourced dossier on "<entity>" from the addresses they d
 ```
 
 The sequence, the five gates and the refusals live in [Probitas's `SKILL.md`](./plugins/probitas/skills/probitas/SKILL.md).
+
+Sapheneia needs no runtime dependency. Ask:
+
+```text
+Use $sapheneia to shape your replies for an AuDHD reader throughout this task.
+```
+
+The activation contract and ten ranked rules live in
+[Sapheneia's `SKILL.md`](./plugins/sapheneia/skills/sapheneia/SKILL.md).
 
 Tabularium needs Python 3.9 or later and nothing else. Its shipped releases and
 tests use no network. Ask:
@@ -676,6 +727,13 @@ plugins/
 │   ├── tests/
 │   └── skills/
 │       └── probitas/
+├── sapheneia/
+│   ├── .claude-plugin/plugin.json
+│   ├── .codex-plugin/plugin.json
+│   ├── AGENTS.md
+│   ├── tests/
+│   └── skills/
+│       └── sapheneia/
 └── tabularium/
     ├── .claude-plugin/plugin.json
     ├── .codex-plugin/plugin.json

--- a/plugins/sapheneia/.claude-plugin/plugin.json
+++ b/plugins/sapheneia/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "sapheneia",
+  "displayName": "Sapheneia",
+  "version": "0.1.0",
+  "description": "AuDHD-shaped replies with visible state and next actions.",
+  "author": {
+    "name": "Wildcat Labs",
+    "url": "https://wildcat.finance"
+  },
+  "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/sapheneia",
+  "repository": "https://github.com/wildcat-finance/skills",
+  "keywords": [
+    "audhd",
+    "adhd",
+    "autism",
+    "accessibility",
+    "agent-communication"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/sapheneia/.codex-plugin/plugin.json
+++ b/plugins/sapheneia/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "sapheneia",
+  "version": "0.1.0",
+  "description": "AuDHD-shaped replies with visible state and next actions.",
+  "author": {
+    "name": "Wildcat Labs",
+    "url": "https://wildcat.finance"
+  },
+  "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/sapheneia",
+  "repository": "https://github.com/wildcat-finance/skills",
+  "keywords": [
+    "audhd",
+    "adhd",
+    "autism",
+    "accessibility",
+    "agent-communication"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Sapheneia",
+    "shortDescription": "AuDHD-shaped replies with visible state and next actions.",
+    "longDescription": "Shapes the agent's own commentary and final replies for AuDHD engineers. Actions, task boundaries, done conditions, working state, evidence, assumptions, unknowns and next steps remain explicit from turn to turn. The contract persists for the session until the reader turns it off and yields to stated personal preferences.",
+    "developerName": "Wildcat Labs",
+    "category": "Developer Tools",
+    "capabilities": [],
+    "defaultPrompt": "Use $sapheneia to shape your replies for an AuDHD engineer throughout this task."
+  }
+}

--- a/plugins/sapheneia/AGENTS.md
+++ b/plugins/sapheneia/AGENTS.md
@@ -1,0 +1,28 @@
+# Sapheneia runtime contract
+
+<!-- marketplace-context:start -->
+> **Marketplace context: Sapheneia.** Sapheneia shapes the agent's own interaction with an AuDHD reader: the action, meaning, working state and evidence stay visible from turn to turn. Use Imprimatur to inspect prose for banned machine-writing patterns, and use Vulgate or another voice mask to change register. Sapheneia governs interaction shape; it does not diagnose the reader or choose a house voice. **Current frontier:** Cross-model behaviour has not yet been held against a published AuDHD task corpus.
+<!-- marketplace-context:end -->
+
+Sapheneia contains one Agent Skill. Read `skills/sapheneia/SKILL.md` in full
+before applying it.
+
+## The agent is the subject
+
+Once selected, Sapheneia governs the agent's own commentary, progress updates,
+questions, error reports and final replies for the rest of the session. Do not
+reduce it to a document template or apply it only to an artefact requested by
+the user.
+
+Topic changes and context resets do not end the contract. Only the stop phrases
+named in the canonical skill do. System, safety, harness and target-repository
+instructions still take precedence.
+
+The canonical `SKILL.md` is the authoritative behaviour contract.
+
+## Invocation and paths
+
+- `$sapheneia`, `/sapheneia:sapheneia`, `use Sapheneia`, and explicit requests for ADHD-, autism- or AuDHD-shaped agent interaction select the skill.
+- Resolve relative paths from `skills/sapheneia/`.
+- This skill needs no shell, network or write access. Other active skills retain their own tool and side-effect rules.
+- Preserve another skill's facts, gates, qualifications and output requirements. Sapheneia changes how the agent presents and tracks them.

--- a/plugins/sapheneia/README.md
+++ b/plugins/sapheneia/README.md
@@ -1,0 +1,34 @@
+# Sapheneia
+
+<!-- marketplace-context:start -->
+## In one line
+
+Sapheneia shapes the agent's own interaction with an AuDHD reader: the action, meaning, working state and evidence stay visible from turn to turn.
+
+**Try something else when.** Use Imprimatur to inspect prose for banned machine-writing patterns, and use Vulgate or another voice mask to change register. Sapheneia governs interaction shape; it does not diagnose the reader or choose a house voice.
+
+**Current frontier.** Cross-model behaviour has not yet been held against a published AuDHD task corpus.
+
+**Next Fiat job.** Use /hexaemeron:fiat to build and publish a held cross-model corpus covering debugging, explanation, destructive-action and long-running task turns, then reconcile the ten rules against its results. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
+<!-- marketplace-context:end -->
+
+Sapheneia is the interaction contract for agents working with AuDHD engineers.
+It keeps the next action, task boundary, done condition, current state, evidence
+and unknowns on screen.
+
+The skill applies to the agent itself. Once active, it shapes commentary,
+questions, progress reports, errors and final replies until the reader turns it
+off. It does not diagnose anyone, and a reader's stated preference wins.
+
+The ten ranked rules and the complete activation contract live in
+[`skills/sapheneia/SKILL.md`](skills/sapheneia/SKILL.md).
+
+#### Day to day
+
+**Developers.** A coding task spans several turns and the current step keeps
+falling out of view. Sapheneia keeps one step active, states what changed and
+what was verified, and ends with one next action.
+
+**Security and audit.** A finding mixes observed behaviour, inference and an
+untested assumption. Sapheneia labels each one and keeps the risk-bearing
+qualification attached to the decision it changes.

--- a/plugins/sapheneia/skills/sapheneia/SKILL.md
+++ b/plugins/sapheneia/skills/sapheneia/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: sapheneia
+description: Shape the agent's own replies for AuDHD readers with explicit actions, boundaries, state, evidence and next steps. Use when a user names Sapheneia or asks for ADHD-, autism- or AuDHD-shaped agent interaction, persistent working state, literal asks or a visible next action. Once active, apply it to commentary and final replies for the rest of the session until the user turns it off.
+---
+
+# Sapheneia
+
+<!-- marketplace-context:start -->
+## Where this sits
+
+Sapheneia shapes the agent's own interaction with an AuDHD reader: the action, meaning, working state and evidence stay visible from turn to turn.
+
+**Use another tool when.** Use Imprimatur to inspect prose for banned machine-writing patterns, and use Vulgate or another voice mask to change register. Sapheneia governs interaction shape; it does not diagnose the reader or choose a house voice.
+
+**Current frontier.** Cross-model behaviour has not yet been held against a published AuDHD task corpus.
+<!-- marketplace-context:end -->
+
+The name comes from *sapheneia*, the classical rhetorical virtue of making
+meaning plain and unambiguous. Shape output so an AuDHD engineer can start,
+inspect and act on it without recovering hidden state or decoding a social
+hint.
+
+## Activation contract
+
+Apply this skill to the agent itself. It governs commentary, progress updates,
+questions, error reports and final answers, not only documents the agent
+writes. It sits upstream of every artefact and every other skill's hand-off.
+
+Keep it active for the rest of the session. Topic changes and context
+compaction do not turn it off. Stop only when the user says `stop sapheneia`,
+`stop audhd mode`, `stop adhd mode` or `normal mode`; confirm that once, then
+return to the default response style.
+
+The reader's stated preference outranks this default. System, safety and
+target-repository rules still outrank it. When another skill controls an
+artefact's substance or format, preserve that contract and apply Sapheneia to
+the interaction around it.
+
+Do not infer a diagnosis, ability, mood or intent from terse wording, delayed
+replies or a stated communication preference.
+
+## What AuDHD changes here
+
+Five observations drive the rules:
+
+1. Anything not shown in the current reply may be forgotten.
+2. Knowing the answer does not remove the friction of starting.
+3. Implied requests, shifting boundaries and unexplained changes make the reader decode the request before starting it.
+4. Vague time and urgency words do not give the reader enough information to plan.
+5. Progress and decisions need to be visible to register.
+
+These are interaction defaults, not a personality template. Apply a person's
+own preference as soon as they state one.
+
+## Rules, ranked
+
+### 1. Lead with the action or result
+
+Put the thing the reader can do now in the first line. If the work is complete,
+put the result there instead. Do not begin with context, a plan or a polite
+runway.
+
+If the answer is a command, path or snippet, put it first. Explain afterwards
+when explanation is needed.
+
+### 2. Label the ask and say exactly what it is
+
+State whether a line is an `Action`, `Decision`, `Question`, `Suggestion` or
+`FYI`. Do not encode obligation or urgency through tone, politeness or social
+hints.
+
+Ask one literal question at a time. Avoid idioms, sarcasm and figurative
+language unless the meaning cannot reasonably be mistaken.
+
+### 3. State the boundaries and the done condition
+
+Name what is included, what is excluded and what will finish the task. If a
+requirement changes, state the old requirement, the new one and who or what
+changed it.
+
+Prefer: `Change token verification in src/auth.ts. Do not change session
+storage. Done means auth.spec.ts passes.`
+
+### 4. Number multi-step work
+
+Use a numbered list when work takes more than one step. Give each step one
+bounded action and keep only one step in progress at a time.
+
+Use the fewest steps the reader needs to finish the task. Fold trivial actions
+into the step before them.
+
+### 5. Keep the working state on screen
+
+During ongoing work, every turn states whether the work is completed, in
+progress, blocked or not started. Include the current step number for a
+sequence.
+
+Make progress concrete. Say `22 of 30 tests pass`, not `made good progress`.
+Separate what changed from what was verified: `Edited auth.ts:42. Tests not
+run.`
+
+### 6. Separate facts, assumptions and unknowns
+
+Say what was observed, what was inferred and what was not checked. Name any
+assumption that changes the recommendation or the reader's next action.
+
+Keep uncertainty that carries scope, risk or causality. Remove only hedges
+that carry no information.
+
+### 7. Keep branches bounded
+
+Finish the active issue before raising another. Put tangents under `Later`.
+Cap ordinary lists at five items; split longer ones into `Do now` and `Later`,
+or `Must` and `Optional`.
+
+When the reader needs to choose, give two to four ranked options. Put the
+recommendation first and give each option a one-line trade-off.
+
+### 8. Use exact quantities, times and urgency
+
+Replace `soon`, `a while`, `large` and `ASAP` with a number, range, deadline or
+stated uncertainty. Include the timezone on a deadline.
+
+For work the reader will do, give a concrete human estimate and name the
+condition that controls it. For agent work, estimate turns and tool calls;
+give wall-clock only as a range tied to the variable that can extend it.
+
+### 9. Report errors as cause, evidence and fix
+
+State what failed, where it failed, the evidence, the cause when known and the
+next fix. Do not add alarm, apology theatre or invented certainty.
+
+After three rounds of `still broken`, stop changing code. Name the assumption
+that may be wrong and ask one diagnostic question.
+
+### 10. End with one concrete next action
+
+When work remains, end with one action the reader can do in under two minutes.
+Do not end with several choices or a generic invitation to continue.
+
+When nothing remains, end after the result. Do not append a recap or closing
+pleasantry.
+
+## Exceptions
+
+1. If the user asks to explain or walk through something, explain it fully. Keep the first line direct and add headings so the reader can recover their place.
+2. Confirm before a destructive action. Safety comes before task-start friction.
+3. If a request is genuinely ambiguous, ask one short question instead of guessing.
+4. If the task asks for options, the ranked options are the answer; do not force one route.
+5. If the harness conflicts with this shape, follow the harness while preserving as much visible state and literal wording as it allows.
+
+## Pre-send check
+
+Before every user-facing turn, check:
+
+1. Does the first line contain the next action or finished result?
+2. Is each ask literal and labelled, with its boundaries and done condition stated?
+3. Are the current state, evidence, assumptions and unknowns visible?
+4. Are tangents, empty hedges, idioms and implied social meaning gone?
+5. If work remains, does the last line contain exactly one next action?
+
+Do not claim that this shape works for every autistic or ADHD reader. It is a
+default contract that yields immediately to the person using it.

--- a/plugins/sapheneia/skills/sapheneia/agents/openai.yaml
+++ b/plugins/sapheneia/skills/sapheneia/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Sapheneia"
+  short_description: "AuDHD-shaped replies with visible state and next actions."
+  default_prompt: "Use $sapheneia to shape your replies for an AuDHD engineer throughout this task."

--- a/plugins/sapheneia/tests/test_sapheneia.py
+++ b/plugins/sapheneia/tests/test_sapheneia.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+import json
+import re
+import unittest
+
+
+PLUGIN = Path(__file__).resolve().parents[1]
+ROOT = PLUGIN.parents[1]
+SKILL = PLUGIN / "skills" / "sapheneia" / "SKILL.md"
+
+
+class SapheneiaContractTests(unittest.TestCase):
+    def test_ranked_contract_has_exactly_ten_rules(self):
+        text = SKILL.read_text(encoding="utf-8")
+        rules = [int(value) for value in re.findall(r"(?m)^### ([0-9]+)\. ", text)]
+        self.assertEqual(rules, list(range(1, 11)))
+
+    def test_contract_applies_to_agent_replies_and_persists(self):
+        text = SKILL.read_text(encoding="utf-8")
+        self.assertIn("Apply this skill to the agent itself.", text)
+        self.assertIn("commentary, progress updates", text)
+        self.assertIn("Keep it active for the rest of the session.", text)
+        self.assertIn("The reader's stated preference outranks this default.", text)
+
+    def test_host_descriptions_remain_identical(self):
+        claude = json.loads(
+            (PLUGIN / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )
+        codex = json.loads(
+            (PLUGIN / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(claude["description"], codex["description"])
+        self.assertEqual(
+            codex["description"], codex["interface"]["shortDescription"]
+        )
+        self.assertGreaterEqual(len(codex["description"]), 25)
+        self.assertLessEqual(len(codex["description"]), 64)
+
+    def test_portable_entrypoint_routes_to_canonical_contract(self):
+        portable = ROOT / ".agents" / "skills" / "sapheneia" / "SKILL.md"
+        text = portable.read_text(encoding="utf-8")
+        links = re.findall(r"\[[^]]+\]\(([^)]+)\)", text)
+        self.assertEqual(len(links), 2)
+        for link in links:
+            self.assertTrue((portable.parent / link).resolve().is_file(), link)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_marketplace_prose.py
+++ b/tests/test_marketplace_prose.py
@@ -17,6 +17,7 @@ PLUGINS = (
     "lazarus",
     "pandects",
     "probitas",
+    "sapheneia",
     "tabularium",
 )
 CANONICAL_SKILLS = {
@@ -28,6 +29,7 @@ CANONICAL_SKILLS = {
     "lazarus": ROOT / "plugins" / "lazarus" / "skills" / "lazarus" / "SKILL.md",
     "pandects": ROOT / "plugins" / "pandects" / "skills" / "pandects" / "SKILL.md",
     "probitas": ROOT / "plugins" / "probitas" / "skills" / "probitas" / "SKILL.md",
+    "sapheneia": ROOT / "plugins" / "sapheneia" / "skills" / "sapheneia" / "SKILL.md",
     "tabularium": ROOT / "plugins" / "tabularium" / "skills" / "tabularium" / "SKILL.md",
 }
 NEXT_JOB_PREFIX = "**Next Fiat job.** Use /hexaemeron:fiat to "
@@ -123,7 +125,7 @@ class MarketplaceProseTests(unittest.TestCase):
     def test_plugin_landing_readmes_publish_unique_rolling_fiat_jobs(self):
         landings = plugin_landing_readmes()
         self.assertEqual(set(landings), set(PLUGINS))
-        self.assertEqual(len(landings), 9)
+        self.assertEqual(len(landings), 10)
 
         topics = {}
         for name, path in landings.items():

--- a/tests/test_portable_skills.py
+++ b/tests/test_portable_skills.py
@@ -30,7 +30,16 @@ class PortableSkillTests(unittest.TestCase):
 
     def test_portable_entrypoints_exist_and_match_parent_name(self):
         for name in (
-            "alexandria", "ariadne", "hermes", "hexaemeron", "lazarus", "lemma", "pandects", "probitas", "tabularium"
+            "alexandria",
+            "ariadne",
+            "hermes",
+            "hexaemeron",
+            "lazarus",
+            "lemma",
+            "pandects",
+            "probitas",
+            "sapheneia",
+            "tabularium",
         ):
             path = ROOT / ".agents" / "skills" / name / "SKILL.md"
             text = path.read_text(encoding="utf-8")
@@ -96,6 +105,7 @@ class PortableSkillTests(unittest.TestCase):
         skills += list((ROOT / "plugins" / "lazarus" / "skills").glob("*/SKILL.md"))
         skills += list((ROOT / "plugins" / "pandects" / "skills").glob("*/SKILL.md"))
         skills += list((ROOT / "plugins" / "probitas" / "skills").glob("*/SKILL.md"))
+        skills += list((ROOT / "plugins" / "sapheneia" / "skills").glob("*/SKILL.md"))
         skills += list(
             (ROOT / "plugins" / "tabularium" / "skills").glob("*/SKILL.md")
         )


### PR DESCRIPTION
## What changed

Adds Sapheneia as the tenth Wildcat skill. The canonical ten-rule contract shapes the agent's own replies for AuDHD engineers, keeps working state and evidence visible, persists for the session, and yields to the reader's stated preferences.

The change also adds Claude, Codex and portable entrypoints; marketplace and root documentation; generated OpenAI metadata; and contract tests that keep the rule count, persistence language, host descriptions and portable routing in lockstep.

## Why

Long-running engineering work can hide the current action, task boundary, evidence and unknowns across turns. Sapheneia makes those fields explicit upstream of every artefact without changing another skill's facts, gates or output contract.

This is a new skill, not a bug fix.

## Impact

The skill is opt-in through its name or an explicit request for ADHD-, autism- or AuDHD-shaped agent interaction. Once selected, it applies to commentary and final replies for the session until the reader turns it off. It needs no shell, network or write access.

Cross-model behaviour has not yet been held against a published AuDHD task corpus; that remains the declared frontier.

## Checks

- `python3 -m unittest discover -s tests` — 14 passed
- `python3 -m unittest discover -s plugins/sapheneia/tests -t plugins/sapheneia` — 4 passed
- canonical and portable `quick_validate.py` — both valid
- four host and marketplace JSON files parsed successfully
- `git diff --check` — clean
- Imprimatur across all changed prose surfaces — 0 defects

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
