### PR TITLE
Govern every plugin skill and widen Kronos to the whole marketplace

### DIFF
--- a/plugins/alexandria/skills/alexandria/EVOLUTION.md
+++ b/plugins/alexandria/skills/alexandria/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Alexandria evolution ledger
+
+Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
+
+- Current version: `alexandria-v0.2.0`
+- Frontier status: `open`
+- Frontier revision: `usdc-interval-collector`
+- Current frontier: Compound v3 Phase 0 now pins the Comet registry and preserves one verified Ethereum execution witness; a resumable, reconciled Ethereum USDC interval harvester remains unimplemented.
+- Next Fiat job: Build the first resumable Ethereum USDC interval collector with implementation-epoch discovery, bounded shards, a second-provider reconciliation path, explicit finality and offline raw-release verification. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `alexandria-v0.2.0` | baseline | `usdc-interval-collector` | `d5afa30db4e5769dccded9f28be061dc623e119b328dbbcd87b729567b7eaeff` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |

--- a/plugins/alexandria/skills/alexandria/SKILL.md
+++ b/plugins/alexandria/skills/alexandria/SKILL.md
@@ -14,6 +14,13 @@ metadata:
 
 # Alexandria
 
+## Frontier
+
+Alexandria owns its own preservation and credit-view frontier, not Hexaemeron's delivery or
+Solidity frontier. Its version, held target, next job, and maturity
+state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run
+another frontier pass after that ledger becomes mature.
+
 <!-- marketplace-context:start -->
 ## Where this sits
 

--- a/plugins/ariadne/skills/ariadne/EVOLUTION.md
+++ b/plugins/ariadne/skills/ariadne/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Ariadne evolution ledger
+
+Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
+
+- Current version: `ariadne-v0.1.0`
+- Frontier status: `open`
+- Frontier revision: `dataset-predicate`
+- Current frontier: The dataset predicate is the first unimplemented predicate; state-fixture and grounded-agent predicates also remain unimplemented.
+- Next Fiat job: Implement the dataset predicate with its schema, gates, conformance fixtures and capture path while keeping signing and signature verification external. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `ariadne-v0.1.0` | baseline | `dataset-predicate` | `0c0310a503de564b892e7206d6b8e88ec3acd4ad99a62d02f3f83cd16991bc20` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |

--- a/plugins/ariadne/skills/ariadne/SKILL.md
+++ b/plugins/ariadne/skills/ariadne/SKILL.md
@@ -14,6 +14,13 @@ metadata:
 
 # Ariadne
 
+## Frontier
+
+Ariadne owns its own attestation-predicate frontier, not Hexaemeron's delivery or
+Solidity frontier. Its version, held target, next job, and maturity
+state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run
+another frontier pass after that ledger becomes mature.
+
 <!-- marketplace-context:start -->
 ## Where this sits
 

--- a/plugins/hermes/skills/hermes/EVOLUTION.md
+++ b/plugins/hermes/skills/hermes/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Hermes evolution ledger
+
+Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
+
+- Current version: `hermes-v0.1.0`
+- Frontier status: `open`
+- Frontier revision: `live-evidence-bundle`
+- Current frontier: No complete, reproducible live Wildcat evidence bundle is published.
+- Next Fiat job: Publish a complete, reproducible Hermes evidence bundle against a real Wildcat release, with a scoped optimisation candidate and every gate outcome recorded. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `hermes-v0.1.0` | baseline | `live-evidence-bundle` | `7d5489a979e01a2ac5f27ad9dbc70811375104a76482f218b72b559bf6298f40` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |

--- a/plugins/hermes/skills/hermes/SKILL.md
+++ b/plugins/hermes/skills/hermes/SKILL.md
@@ -1,9 +1,18 @@
 ---
 name: hermes
 description: Optimise Solidity gas usage with an executable, fail-closed Foundry loop that measures savings, re-runs behaviour tests, checks storage layouts and method identifiers, and demands targeted differential or property evidence for state-sensitive unchecked arithmetic. Use for Solidity gas work, Forge snapshot reductions, gas-report reviews, storage packing, unchecked arithmetic, or any proposed EVM gas-saving change.
+metadata:
+  version: "0.1.0"
 ---
 
 # hermes gas optimiser
+
+## Frontier
+
+Hermes owns its own gas-optimisation evidence frontier, not Hexaemeron's delivery or
+Solidity frontier. Its version, held target, next job, and maturity
+state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run
+another frontier pass after that ledger becomes mature.
 
 <!-- marketplace-context:start -->
 ## Where this sits

--- a/plugins/hexaemeron/skills/VERSIONING.md
+++ b/plugins/hexaemeron/skills/VERSIONING.md
@@ -1,14 +1,23 @@
 # Skill evolution contract
 
-First-party Hexaemeron skills use labels of the form
+Governed first-party marketplace skills use labels of the form
 `{skill}-v{evolution}.{generation}.{epoch}`. These labels are not SemVer and
-do not rename the skill: invocations remain `fiat`, `imprimatur`, `vulgate`,
-and `kronos`.
+do not rename the skill: a label is built from the skill's own name, not its
+plugin's, so Lemma's skill is governed as `chunk`.
 
-The adoption baseline for Fiat, Imprimatur, and Vulgate is `v1.1.0`. History
-begins at adoption; do not invent or reconstruct versions for work that
-predated this contract. Kronos was introduced after the reset and deliberately
-starts at `v0.0.0`.
+This contract governs a skill, not a plugin. A plugin whose skills each hold
+their own frontier keeps one ledger per skill. Vendored or third-party skills
+are not governed and keep no ledger; inside Hexaemeron that exempts the
+bundled Pashov suite (`fizz`, `x-ray`, `solidity-auditor`), which remains
+covered by Hexaemeron's own plugin frontier.
+
+History begins at adoption; do not invent or reconstruct versions for work
+that predated this contract. The adoption baseline for Fiat, Imprimatur, and
+Vulgate is `v1.1.0`. Kronos was introduced after the reset and deliberately
+starts at `v0.0.0` to mark it terminal and outside the frontier loop. The
+nine top-level plugin skills adopted at whatever version their `SKILL.md`
+already declared, so their baselines are not uniform and no baseline value
+may be assumed.
 
 - **Evolution** is the first number. Increment it exactly once after a
   completed frontier Fiat job changes that skill's `Next Fiat job`, including
@@ -23,7 +32,7 @@ starts at `v0.0.0`.
   incomplete evidence. Do not use it as a patch number. The other counters do
   not reset.
 
-Each first-party skill keeps `EVOLUTION.md` beside its `SKILL.md`. That ledger
+Each governed skill keeps `EVOLUTION.md` beside its `SKILL.md`. That ledger
 is the authority for the current label, frontier status, frontier revision,
 next job, and history. The numeric version in `SKILL.md` frontmatter must
 match it. Each history row also stores the SHA-256 of this exact UTF-8 line,

--- a/plugins/hexaemeron/skills/kronos/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/kronos/EVOLUTION.md
@@ -2,7 +2,7 @@
 
 Policy: [../VERSIONING.md](../VERSIONING.md)
 
-- Current version: `kronos-v0.0.0`
+- Current version: `kronos-v0.1.0`
 - Frontier status: `mature`
 - Frontier revision: `terminal-goal-loop`
 - Current frontier: Kronos ranks eligible held Next Fiat jobs, selects the highest-value one, sets one durable goal, runs Fiat, and repeats until none remain.
@@ -13,3 +13,4 @@ Policy: [../VERSIONING.md](../VERSIONING.md)
 | Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
 | --- | --- | --- | --- | --- | --- |
 | `kronos-v0.0.0` | baseline | `terminal-goal-loop` | `ac28d95d80724aa001a92740f76416164e65d7b7b9cb5da43674d1ea73a214d1` | [skills#74](https://github.com/wildcat-finance/skills/issues/74) | Kronos starts here. It is complete and terminal by design. |
+| `kronos-v0.1.0` | generation | `terminal-goal-loop` | `ac28d95d80724aa001a92740f76416164e65d7b7b9cb5da43674d1ea73a214d1` | Maintainer report: nine governed plugin ledgers were invisible to discovery | Scope now spans every plugin in the checkout rather than the invoking plugin alone, discovery descends into each plugin's own skills directory and names a skill by its own directory, ungoverned skills are reported instead of dropped, and the end-of-loop rescan re-evaluates every governed skill. Terminal by design is unchanged: the evolution counter stays at 0. |

--- a/plugins/hexaemeron/skills/kronos/SKILL.md
+++ b/plugins/hexaemeron/skills/kronos/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   Use only when the user explicitly asks for Kronos or for a repeated ranked
   Fiat frontier loop. Do not use it for one ordinary Fiat delivery.
 metadata:
-  version: "0.0.0"
+  version: "0.1.0"
 ---
 
 # Kronos
@@ -26,12 +26,20 @@ bare.
 ## Loop
 
 1. Resolve the scope from the user's named directories or repositories. If no
-   narrower scope was named, use the current marketplace checkout.
-2. Find every `EVOLUTION.md` in scope. Exclude:
+   narrower scope was named, use the current marketplace checkout, rooted at
+   the checkout itself rather than at any one plugin. Scope spans every plugin
+   in that checkout, not only the plugin Kronos was invoked from.
+2. Walk the whole scope and find every `EVOLUTION.md` beneath it, descending
+   into each plugin's own skills directory. A governed skill is named by its
+   own directory and not by its plugin, so one plugin may hold several and a
+   skill may be named differently from the plugin around it. Exclude:
    - Kronos itself;
    - vendored or third-party skills;
    - a ledger whose `Frontier status` is `mature`;
    - a ledger whose `Next Fiat job` is `None -- mature` or absent.
+   Report any in-scope skill carrying no ledger as ungoverned instead of
+   dropping it silently. An ungoverned skill is never scored, but a skill that
+   has quietly lost its ledger must not vanish from the report.
 3. Score each remaining held job out of 100:
    - material user or protocol impact: 40;
    - evidenced urgency or defect severity: 25;
@@ -52,8 +60,11 @@ bare.
    A PR merely opened is not a completed iteration.
 8. Require the completed frontier run to update that skill's ledger under
    `VERSIONING.md`: evolution advances once and the held job is replaced, or
-   the frontier becomes mature. Rescan from disk, rerank from scratch, and
-   repeat.
+   the frontier becomes mature. Then rescan the entire scope from disk --
+   every plugin and every governed skill, not only those ranked in the
+   previous pass -- rerank from scratch, and repeat. A skill whose frontier
+   was replaced re-enters the ranking carrying its new held job, and a skill
+   whose ledger has appeared since the last pass enters for the first time.
 
 Stop successfully when no eligible ledger remains. If Fiat halts on a genuine
 external blocker, preserve the durable goal and report that blocker; do not

--- a/plugins/hexaemeron/tests/test_evolution.py
+++ b/plugins/hexaemeron/tests/test_evolution.py
@@ -83,8 +83,11 @@ class EvolutionContractTests(unittest.TestCase):
             ledger = (SKILLS / skill / "EVOLUTION.md").read_text(encoding="utf-8")
             rows = history_rows(ledger)
             self.assertEqual(rows[0]["axis"], "baseline")
-            expected_baseline = (0, 0, 0) if skill == "kronos" else (1, 1, 0)
-            self.assertEqual(version_parts(rows[0]["version"], skill), expected_baseline)
+            # Baselines are adopted, not assigned: a skill enters the contract at
+            # whatever version it already declared, so no fixed pair holds across
+            # the marketplace. Assert the label parses; tests/test_evolution_contract.py
+            # owns the rules that span every governed skill.
+            version_parts(rows[0]["version"], skill)
             previous = rows[0]
             previous_version = version_parts(previous["version"], skill)
             for row in rows[1:]:

--- a/plugins/lazarus/skills/lazarus/EVOLUTION.md
+++ b/plugins/lazarus/skills/lazarus/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Lazarus evolution ledger
+
+Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
+
+- Current version: `lazarus-v0.1.0`
+- Frontier status: `open`
+- Frontier revision: `ariadne-state-fixture-binding`
+- Current frontier: Preservation-pipeline integration and an Ariadne state-fixture predicate remain unimplemented.
+- Next Fiat job: Bind a Lazarus fixture through an Ariadne state-fixture predicate in the first end-to-end Goldfinch preservation release without upgrading recorded RPC evidence into proof-backed state. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `lazarus-v0.1.0` | baseline | `ariadne-state-fixture-binding` | `94c0f87fc8dd14562e948fb5b523c9248ffa6fd21849cc433d4a5bc47966daf5` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |

--- a/plugins/lazarus/skills/lazarus/SKILL.md
+++ b/plugins/lazarus/skills/lazarus/SKILL.md
@@ -12,6 +12,13 @@ metadata:
 
 # Lazarus
 
+## Frontier
+
+Lazarus owns its own state-fixture preservation frontier, not Hexaemeron's delivery or
+Solidity frontier. Its version, held target, next job, and maturity
+state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run
+another frontier pass after that ledger becomes mature.
+
 <!-- marketplace-context:start -->
 ## Where this sits
 

--- a/plugins/lemma/skills/chunk/EVOLUTION.md
+++ b/plugins/lemma/skills/chunk/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Chunk evolution ledger
+
+Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
+
+- Current version: `chunk-v0.1.0`
+- Frontier status: `open`
+- Frontier revision: `abi-return-and-mutability`
+- Current frontier: Callable-surface ABI validation does not independently check return types or state mutability.
+- Next Fiat job: Make callable-surface ABI validation cover return types and state mutability as well as names and input types, with any divergence rejecting the output. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `chunk-v0.1.0` | baseline | `abi-return-and-mutability` | `2d4f0d7948208fefdca52f4380b3f4c83261917a282256571a2ee611c5d9d36c` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |

--- a/plugins/lemma/skills/chunk/SKILL.md
+++ b/plugins/lemma/skills/chunk/SKILL.md
@@ -1,9 +1,18 @@
 ---
 name: chunk
 description: Turn Solidity solc standard JSON inputs or Markdown document trees into validated JSONL chunks with source locations and separate quotation, model, and embedding text. Use when asked to run Lemma, invoke lemma:chunk, prepare Solidity or Markdown for retrieval, generate citation-aware chunks, or inspect Lemma output. Do not use it to embed, index, retrieve, or answer from the chunks.
+metadata:
+  version: "0.1.0"
 ---
 
 # Chunk with Lemma
+
+## Frontier
+
+Chunk owns its own chunking and validation frontier, not Hexaemeron's delivery or
+Solidity frontier. Its version, held target, next job, and maturity
+state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run
+another frontier pass after that ledger becomes mature.
 
 <!-- marketplace-context:start -->
 ## Where this sits

--- a/plugins/pandects/skills/pandects/EVOLUTION.md
+++ b/plugins/pandects/skills/pandects/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Pandects evolution ledger
+
+Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
+
+- Current version: `pandects-v0.1.0`
+- Frontier status: `open`
+- Frontier revision: `withdrawal-batch-fee-law`
+- Current frontier: No law prevents fees from reducing pooled lender claims below amounts owed on open withdrawal batches.
+- Next Fiat job: Add and prove the missing law that fees cannot reduce pooled lender claims below amounts owed on open withdrawal batches, including its specimen, reduced counterexample and applicability. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `pandects-v0.1.0` | baseline | `withdrawal-batch-fee-law` | `c5156fb0e08112cd003f4baceb58c66856a5fee23f49e38d27ed73a458dda369` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |

--- a/plugins/pandects/skills/pandects/SKILL.md
+++ b/plugins/pandects/skills/pandects/SKILL.md
@@ -14,6 +14,13 @@ metadata:
 
 # Pandects
 
+## Frontier
+
+Pandects owns its own executable-law frontier, not Hexaemeron's delivery or
+Solidity frontier. Its version, held target, next job, and maturity
+state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run
+another frontier pass after that ledger becomes mature.
+
 <!-- marketplace-context:start -->
 ## Where this sits
 

--- a/plugins/probitas/skills/probitas/EVOLUTION.md
+++ b/plugins/probitas/skills/probitas/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Probitas evolution ledger
+
+Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
+
+- Current version: `probitas-v0.1.0`
+- Frontier status: `open`
+- Frontier revision: `morpho-midnight-coverage`
+- Current frontier: Euler v1/v2 now ship; Morpho Midnight fixed-maturity coverage and curation remain unimplemented.
+- Next Fiat job: Add fail-closed Morpho Midnight fixed-maturity coverage so a dossier can establish whether repayment was timely. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `probitas-v0.1.0` | baseline | `morpho-midnight-coverage` | `5f66077a0c39a9ee647bd34233504b3891493f864fe4a16a9eb0c0337b3ee688` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |

--- a/plugins/probitas/skills/probitas/SKILL.md
+++ b/plugins/probitas/skills/probitas/SKILL.md
@@ -14,6 +14,13 @@ metadata:
 
 # Probitas
 
+## Frontier
+
+Probitas owns its own counterparty-diligence frontier, not Hexaemeron's delivery or
+Solidity frontier. Its version, held target, next job, and maturity
+state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run
+another frontier pass after that ledger becomes mature.
+
 <!-- marketplace-context:start -->
 ## Where this sits
 

--- a/plugins/sapheneia/skills/sapheneia/EVOLUTION.md
+++ b/plugins/sapheneia/skills/sapheneia/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Sapheneia evolution ledger
+
+Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
+
+- Current version: `sapheneia-v0.1.0`
+- Frontier status: `open`
+- Frontier revision: `cross-model-corpus`
+- Current frontier: Cross-model behaviour has not yet been held against a published AuDHD task corpus.
+- Next Fiat job: Build and publish a held cross-model corpus covering debugging, explanation, destructive-action and long-running task turns, then reconcile the ten rules against its results. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `sapheneia-v0.1.0` | baseline | `cross-model-corpus` | `06034ab3a9291b328ab65bef2436652833ac137dcb5726dee911a08fa632df87` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |

--- a/plugins/sapheneia/skills/sapheneia/SKILL.md
+++ b/plugins/sapheneia/skills/sapheneia/SKILL.md
@@ -1,9 +1,18 @@
 ---
 name: sapheneia
 description: Shape the agent's own replies for AuDHD readers with explicit actions, boundaries, state, evidence and next steps. Use when a user names Sapheneia or asks for ADHD-, autism- or AuDHD-shaped agent interaction, persistent working state, literal asks or a visible next action. Once active, apply it to commentary and final replies for the rest of the session until the user turns it off.
+metadata:
+  version: "0.1.0"
 ---
 
 # Sapheneia
+
+## Frontier
+
+Sapheneia owns its own interaction-shaping frontier, not Hexaemeron's delivery or
+Solidity frontier. Its version, held target, next job, and maturity
+state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run
+another frontier pass after that ledger becomes mature.
 
 <!-- marketplace-context:start -->
 ## Where this sits

--- a/plugins/tabularium/skills/tabularium/EVOLUTION.md
+++ b/plugins/tabularium/skills/tabularium/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Tabularium evolution ledger
+
+Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
+
+- Current version: `tabularium-v0.3.0`
+- Frontier status: `open`
+- Frontier revision: `compound-v3-phase-1`
+- Current frontier: Compound v3 Phase 0 now rebuilds ordered calls and signed-principal transitions from one verified Alexandria witness; the Phase 1 canonical adapter and Ethereum USDC specimen remain unimplemented.
+- Next Fiat job: Ship Compound v3 Phase 1 from Alexandria raw evidence with a new canonical and coverage schema version, supply, withdraw, base-transfer and absorb mappings, a mined borrower-to-borrower transfer witness, hostile fixtures and a byte-identical offline Ethereum USDC specimen. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `tabularium-v0.3.0` | baseline | `compound-v3-phase-1` | `c3aac484a13f97742a45f07a4d3ca42cec29e4e4a9666cfd2701d825e4752d6e` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |

--- a/plugins/tabularium/skills/tabularium/SKILL.md
+++ b/plugins/tabularium/skills/tabularium/SKILL.md
@@ -15,6 +15,13 @@ metadata:
 
 # Tabularium
 
+## Frontier
+
+Tabularium owns its own credit-event release frontier, not Hexaemeron's delivery or
+Solidity frontier. Its version, held target, next job, and maturity
+state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run
+another frontier pass after that ledger becomes mature.
+
 <!-- marketplace-context:start -->
 ## Where this sits
 

--- a/tests/test_evolution_contract.py
+++ b/tests/test_evolution_contract.py
@@ -1,0 +1,161 @@
+"""Govern every skill evolution ledger in the marketplace.
+
+Hexaemeron-local rules stay in plugins/hexaemeron/tests/test_evolution.py.
+This file owns the rules that hold for every governed skill, wherever it
+lives, and deliberately assumes nothing about baseline version numbers:
+skills adopt this contract at whatever version they already declared.
+"""
+
+from pathlib import Path
+import hashlib
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGINS = ROOT / "plugins"
+
+# Vendored or third-party skills are not governed and keep no ledger. The
+# bundled Pashov suite stays covered by Hexaemeron's own plugin frontier.
+UNGOVERNED = {"fizz", "fizz-convert", "fizz-sync", "x-ray", "solidity-auditor"}
+
+AXES = ("baseline", "evolution", "generation", "epoch")
+
+
+def field(text, name):
+    match = re.search(rf"(?m)^- {re.escape(name)}: (.+)$", text)
+    if match is None:
+        raise AssertionError(f"missing {name}")
+    return match.group(1).strip().strip("`")
+
+
+def version_parts(label, skill):
+    match = re.fullmatch(rf"{re.escape(skill)}-v(\d+)\.(\d+)\.(\d+)", label)
+    if match is None:
+        raise AssertionError(f"invalid version label for {skill}: {label}")
+    return tuple(int(part) for part in match.groups())
+
+
+def history_rows(text):
+    pattern = re.compile(
+        r"(?m)^\| `(?P<version>[^`]+)` \| (?P<axis>baseline|evolution|generation|epoch) "
+        r"\| `(?P<revision>[^`]+)` \| `(?P<digest>[0-9a-f]{64})` "
+        r"\| (?P<evidence>.*?) \| (?P<change>.*?) \|$"
+    )
+    return [m.groupdict() for m in pattern.finditer(text)]
+
+
+def governed_skills():
+    """Every skill directory holding a SKILL.md, minus the ungoverned ones."""
+    for skill_md in sorted(PLUGINS.glob("*/skills/**/SKILL.md")):
+        directory = skill_md.parent
+        if directory.name in UNGOVERNED:
+            continue
+        yield directory.name, directory
+
+
+class EvolutionContractTests(unittest.TestCase):
+    def test_every_governed_skill_has_a_ledger(self):
+        for skill, directory in governed_skills():
+            with self.subTest(skill=skill):
+                self.assertTrue(
+                    (directory / "EVOLUTION.md").is_file(),
+                    f"{directory} has no EVOLUTION.md; add one or list it as ungoverned",
+                )
+                self.assertIn(
+                    "[EVOLUTION.md](EVOLUTION.md)",
+                    (directory / "SKILL.md").read_text(encoding="utf-8"),
+                )
+
+    def test_skill_metadata_matches_current_ledger_version(self):
+        for skill, directory in governed_skills():
+            instructions = (directory / "SKILL.md").read_text(encoding="utf-8")
+            ledger = (directory / "EVOLUTION.md").read_text(encoding="utf-8")
+            with self.subTest(skill=skill):
+                metadata = re.search(r'(?m)^  version: "(\d+\.\d+\.\d+)"$', instructions)
+                self.assertIsNotNone(metadata, f"{skill} has no metadata.version")
+                self.assertEqual(
+                    field(ledger, "Current version"), f"{skill}-v{metadata.group(1)}"
+                )
+
+    def test_current_frontier_digest_matches_latest_history_row(self):
+        for skill, directory in governed_skills():
+            ledger = (directory / "EVOLUTION.md").read_text(encoding="utf-8")
+            canonical = "|".join(
+                (
+                    field(ledger, "Frontier status"),
+                    field(ledger, "Frontier revision"),
+                    field(ledger, "Current frontier"),
+                    field(ledger, "Next Fiat job"),
+                )
+            ) + "\n"
+            rows = history_rows(ledger)
+            with self.subTest(skill=skill):
+                self.assertGreaterEqual(len(rows), 1)
+                self.assertEqual(rows[-1]["version"], field(ledger, "Current version"))
+                self.assertEqual(rows[-1]["revision"], field(ledger, "Frontier revision"))
+                self.assertEqual(
+                    rows[-1]["digest"],
+                    hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+                )
+
+    def test_history_axes_enforce_independent_counters_and_frontier_hold(self):
+        for skill, directory in governed_skills():
+            ledger = (directory / "EVOLUTION.md").read_text(encoding="utf-8")
+            rows = history_rows(ledger)
+            with self.subTest(skill=skill):
+                self.assertEqual(rows[0]["axis"], "baseline")
+            previous = rows[0]
+            previous_version = version_parts(rows[0]["version"], skill)
+            for row in rows[1:]:
+                current_version = version_parts(row["version"], skill)
+                with self.subTest(skill=skill, version=row["version"]):
+                    if row["axis"] == "evolution":
+                        self.assertEqual(
+                            current_version,
+                            (previous_version[0] + 1, previous_version[1], previous_version[2]),
+                        )
+                        self.assertNotEqual(row["digest"], previous["digest"])
+                    elif row["axis"] == "generation":
+                        self.assertEqual(
+                            current_version,
+                            (previous_version[0], previous_version[1] + 1, previous_version[2]),
+                        )
+                        self.assertEqual(row["revision"], previous["revision"])
+                        self.assertEqual(row["digest"], previous["digest"])
+                    elif row["axis"] == "epoch":
+                        self.assertEqual(
+                            current_version,
+                            (previous_version[0], previous_version[1], previous_version[2] + 1),
+                        )
+                        if row["digest"] != previous["digest"]:
+                            self.assertIn(
+                                "reopen", (row["evidence"] + row["change"]).lower()
+                            )
+                previous = row
+                previous_version = current_version
+
+    def test_mature_frontiers_have_no_next_job(self):
+        for skill, directory in governed_skills():
+            ledger = (directory / "EVOLUTION.md").read_text(encoding="utf-8")
+            status = field(ledger, "Frontier status")
+            with self.subTest(skill=skill):
+                self.assertIn(status, {"open", "mature"})
+                if status == "mature":
+                    self.assertEqual(field(ledger, "Next Fiat job"), "None -- mature")
+                else:
+                    self.assertNotEqual(field(ledger, "Next Fiat job"), "None -- mature")
+
+    def test_ledgers_cite_the_versioning_contract(self):
+        policy = (PLUGINS / "hexaemeron" / "skills" / "VERSIONING.md").resolve()
+        for skill, directory in governed_skills():
+            ledger_path = directory / "EVOLUTION.md"
+            ledger = ledger_path.read_text(encoding="utf-8")
+            match = re.search(r"(?m)^Policy: \[[^\]]+\]\(([^)]+)\)$", ledger)
+            with self.subTest(skill=skill):
+                self.assertIsNotNone(match, f"{skill} ledger cites no policy")
+                self.assertEqual((ledger_path.parent / match.group(1)).resolve(), policy)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Kronos discovers work by finding `EVOLUTION.md`, and resolved scope to the plugin it was invoked from. Only Hexaemeron's four first-party skills had ledgers, so the nine top-level plugin skills were never ranked — despite each holding a real `Next Fiat job` in its `README.md` marketplace-context block.

## What

**Ledgers for the nine plugin skills.** Alexandria, Ariadne, Hermes, Lazarus, Lemma's `chunk`, Pandects, Probitas, Sapheneia and Tabularium each get an `EVOLUTION.md` in the Hexaemeron shape. Frontier text and held job are adopted from each plugin's marketplace-context unchanged, minus the shared policy sentence that belongs in `VERSIONING.md`. Baselines adopt each skill's already-declared version rather than reconstructing history; Hermes, `chunk` and Sapheneia had no version metadata and start at `0.1.0`.

**Kronos widened** (`kronos-v0.1.0`, generation axis, revision and digest retained). Scope spans every plugin in the checkout; discovery descends into each plugin's own skills directory; a skill is named by its own directory rather than its plugin; ungoverned skills are reported rather than dropped silently; and the end-of-loop rescan re-evaluates every governed skill, so a replaced frontier re-enters the ranking and a newly governed skill enters for the first time.

Kronos stays terminal by design — its evolution counter remains at `0`, which is what carries that marker.

**`VERSIONING.md`** now describes a marketplace-wide contract over skills rather than Hexaemeron's four, records that labels follow the skill and not the plugin, exempts the vendored Pashov suite (`fizz`, `x-ray`, `solidity-auditor`), and states that baselines are adopted rather than assigned.

**`tests/test_evolution_contract.py`** governs all 13 ledgers: presence, metadata agreement, frontier digest, axis counters, maturity, policy citation. Hexaemeron-only rules stay in place, since all nine plugins legitimately carry a marketplace-context block that Hexaemeron's own subsidiaries may not.

That test also drops `expected_baseline`, which hardcoded `(0,0,0)` for Kronos and `(1,1,0)` for everything else and cannot survive skills adopting at their own declared versions.

## Effect

Eligible frontiers go from 2 to 11.

## Verification

Root suite 20 tests, Hexaemeron 3 modules, Pandects 106 — all pass. The contract test was mutation-tested: tampering with a held job breaks the digest, marking a frontier `mature` while it still holds a job fails, and deleting a ledger fails loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
