### PR TITLE
Carry the recorded Fiat base through to the pull request

### DIFF
--- a/plugins/hexaemeron/skills/fiat/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/fiat/EVOLUTION.md
@@ -2,7 +2,7 @@
 
 Policy: [../VERSIONING.md](../VERSIONING.md)
 
-- Current version: `fiat-v2.2.0`
+- Current version: `fiat-v2.3.0`
 - Frontier status: `mature`
 - Frontier revision: `installed-path-and-maturity-proof`
 - Current frontier: Fiat's receipt-backed controller is unit-tested, and this delivery exercises its installed-path resolution and terminal maturity rule together from a packaged plugin.
@@ -15,3 +15,4 @@ Policy: [../VERSIONING.md](../VERSIONING.md)
 | `fiat-v1.1.0` | baseline | `installed-path-and-maturity-proof` | `a30bea33332e20c6780a77f5d82bc899d7004b8d09321628777d36289bd128d0` | [skills#74](https://github.com/wildcat-finance/skills/issues/74) | Versioning starts here. Fiat has explicit active-skill path resolution, a mature-frontier refusal, and its own held frontier. |
 | `fiat-v1.2.0` | generation | `installed-path-and-maturity-proof` | `a30bea33332e20c6780a77f5d82bc899d7004b8d09321628777d36289bd128d0` | [skills#74](https://github.com/wildcat-finance/skills/issues/74) | Made publish terminal only after final staging, push, merge, branch cleanup where permitted, and closure of any recorded task issue. |
 | `fiat-v2.2.0` | evolution | `installed-path-and-maturity-proof` | `17c94c70b434ea1cbc9c3cd6ff5f3054972af08f8e027b7ea9850f5e06695f77` | [installed delivery proof](../../docs/fiat-installed-path-and-maturity-proof/proof.md) | Closes the held frontier after recording the installed controller path and passing the installed and checkout test suites; later delivery receipts remain governed by the live controller. |
+| `fiat-v2.3.0` | generation | `installed-path-and-maturity-proof` | `17c94c70b434ea1cbc9c3cd6ff5f3054972af08f8e027b7ea9850f5e06695f77` | Maintainer report: stacked runs on a named base silently retargeted to the default branch | The push phase now passes the base recorded at `init` to `gh pr create` instead of letting GitHub default it, so a run started from a named branch merges back into that branch. Frontier unchanged and still mature. |

--- a/plugins/hexaemeron/skills/fiat/SKILL.md
+++ b/plugins/hexaemeron/skills/fiat/SKILL.md
@@ -7,7 +7,7 @@ description: >
   or report a Hexaemeron or Fiat delivery, including /hexaemeron:fiat forms.
   Do not infer activation from a similar task.
 metadata:
-  version: "2.2.0"
+  version: "2.3.0"
 ---
 
 # Fiat
@@ -99,7 +99,8 @@ the second.
    run the read-only preflight checks below, then `hexctl init --topic
    "<topic>" --base <ref>`, record the post-init receipts, and enter the loop.
    `--base` defaults to `main`; honour any branch, repo, or commit the user
-   named as the starting point.
+   named as the starting point, and carry that same ref through to the pull
+   request created in the push phase.
 
 ## Frontier maturity gate
 

--- a/plugins/hexaemeron/skills/fiat/references/push-discipline.md
+++ b/plugins/hexaemeron/skills/fiat/references/push-discipline.md
@@ -21,7 +21,11 @@ target-repository rule requires one. If one exists, record it as
 ## Pull request and closure
 
 Push the branch, then open a pull request using the title and body prepared in
-the prose phase. The body states what changed, why, where the audit record
+the prose phase. Target the base recorded at `init`, passing it explicitly as
+`gh pr create --base <recorded base>`. Never let the pull request fall back to
+the repository default branch: when the run was started from a named branch,
+that branch is where the work belongs, and a silent retarget to the default
+branch merges work the user meant to hold back. The body states what changed, why, where the audit record
 lives, and how to run the proof. Do not invent an issue reference. Include one
 only when the user independently supplied a relevant issue.
 


### PR DESCRIPTION
## Why

`hexctl` records a base at `init` (`--base <ref>`, default `main`) and `git.step_base: chain` branches each step from the previous one. But the push phase called `gh pr create` with no `--base`, so GitHub defaulted the pull request to the repository default branch.

The effect: a run deliberately started from a named branch still opened its PR against `main`, and merged there. Nothing in the receipts records the retarget, so it fails silently.

That matters for any stacked or long-running loop. Work the user meant to accumulate on a branch — to review as one diff, or to wind back in one move — lands on `main` an iteration at a time instead.

## What

`push-discipline.md` now requires the base recorded at `init` to be passed explicitly as `gh pr create --base <recorded base>`, and rules out the default-branch fallback. `SKILL.md` says the same ref carries from `init` through to the push phase.

Generation bump to `fiat-v2.3.0`, retaining frontier revision and digest. The frontier is unchanged and remains `mature` — this is a behaviour fix, not a frontier advance.

## Verification

Root suite 20 tests, Hexaemeron 22 tests — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
