### PR TITLE
Apply the withdrawal-batch-fee spec audit fixes

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -164,3 +164,25 @@ step ahead of the law, which the runbook argues against on the grounds that
 `pandects.py check` and the corpus diagonal leave no green intermediate state;
 and the seven property families deferred from the original delivery, which are
 outside this frontier.
+
+## Withdrawal batch fee law, step 1, round 2 -- 2026-08-18
+
+Again no Solidity in the diff and no campaign, for the same reason, stated again
+rather than counted as a clean suite run. This round read the round-1 fixes back,
+then checked the runbook's own numbers against the test files it points step 2 at.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R2-01 | medium | `plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md` | The runbook sized step 2's test work as the diagonal growing "from 9x9 to 10x10 over the single-state half". No such table exists. `test/Corpus.t.sol` runs its diagonal over the single-state laws alone, where `COUNT` is 5, and `test/Pairs.t.sol` runs over 3, with path independence handled separately. Nine and ten are corpus totals. Whoever implemented step 2 from the runbook would have gone looking for a table with the wrong shape. | Fixed in this round: the runbook names both dimensions and says that ten is a total rather than a dimension. |
+
+The round-1 fixes were re-read and hold. The four pair-law verdicts in the study
+match what was executed, the path-independence caveat is stated where the verdict
+appears, and the boundary sentence about the deployed contracts sits in the
+problem statement where a reader meets the figures.
+
+One check found nothing and is worth recording because it removes work from step
+2. `test_the_sound_reference_holds_every_law` charges its fee before it reserves,
+so the queue is empty when the cap applies and the tightened cap cannot change
+that test. The runbook now says so.
+
+Leads not pursued: the two carried from round 1, unchanged.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -140,3 +140,27 @@ published calibration and final reports replay without a byte difference.
 Leads not pursued: model authorship beyond the declared provenance rule,
 population-prevalence claims and tuning against the spent v1 holdout remain
 outside this frontier.
+
+## Withdrawal batch fee law, step 1, round 1 -- 2026-08-18
+
+The Pashov pair did not run and no campaign ran, because this step commits two
+markdown documents and touches no Solidity. Saying so is the point: the
+`security_suite` receipt names `x-ray`, `solidity-auditor` and `fizz`, none of
+them read this diff, and a zero count here would assert they had. The review
+instead read the committed spec against the risk register it declares, against
+the nine shipped laws, and against the two models it proposes to correct.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R1-01 | medium | `plugins/pandects/docs/withdrawal-batch-fee-law/study.md` | The study asserted that all nine laws hold in the violating state, but only the five single-state laws had been executed. The four pair laws were reasoned about from what a fee does not touch. In a corpus whose whole argument is that a passing campaign proves nothing without a specimen, an argued verdict presented beside measured ones is the same defect one level up. | Fixed in this round: all four pair laws executed against the pair on both models, and the study now reports what was run. `accrual/path-independent/v1` returns held and the study says that verdict carries no weight, because the law compares two runs rather than one system's before and after. |
+| S1-R1-02 | low | `plugins/pandects/docs/withdrawal-batch-fee-law/study.md` | The study named a fee leak in `integrations/wildcat/WildcatMarketModel.sol` with figures, and never fixed the boundary to the deployed market contracts. The plugin's own applicability document warns that nothing in the model should be mistaken for them; a reader meeting the figures first could take the study as a claim about the protocol. | Fixed in this round: the study states that the finding is about the reduced model and the corpus's silence, and that it establishes nothing either way about the deployed contracts. |
+
+A third lead was checked and is not a finding. The study's chosen statement is
+false of `Sound` as shipped, and the study says so and builds on it. That is the
+method in `docs/writing-a-law.md` working rather than a defect in the spec.
+
+Leads not pursued: whether the two model corrections should ship as their own
+step ahead of the law, which the runbook argues against on the grounds that
+`pandects.py check` and the corpus diagonal leave no green intermediate state;
+and the seven property families deferred from the original delivery, which are
+outside this frontier.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -222,3 +222,29 @@ hand-written and correctly listed.
 Leads not pursued: extending the search-record runner past `foundry`, now stated
 in the runbook as out of scope for this step and a candidate frontier of its own;
 and the two carried from round 1.
+
+## Withdrawal batch fee law, step 1, round 5 -- 2026-08-18
+
+No Solidity and no campaign, for the fifth time and for the same reason. This
+round re-read the four earlier fixes against their sources and then resolved every
+file path the two documents name, which is the check that catches a spec rotting
+against a repository that moved under it.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| None | - | - | The fixed non-Solidity tree has no open finding. | clean |
+
+Thirty-nine distinct paths are named across the study and the runbook. Every one
+resolves, except the two the run exists to create,
+`src/laws/PooledClaimsCoverOpenBatches.sol` and `specimens/FeeFromQueued.sol`, and
+a glob in the sources list. The earlier fixes hold: the pair-law verdicts match
+what was executed, the deployed-contract boundary sits where the figures are, both
+diagonal dimensions match `COUNT` in their test files, `docs/catalogue.md` is
+regenerated rather than written, the two spec documents are declared records, and
+step 3 names the runner and its single engine.
+
+Leads not pursued: extending the search-record runner past `foundry`; whether the
+two model corrections should ship ahead of the law, which the runbook argues
+against on the grounds that no green intermediate state exists; and the seven
+property families deferred from the original delivery. Each is recorded in the
+round that raised it.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -186,3 +186,20 @@ so the queue is empty when the cap applies and the tightened cap cannot change
 that test. The runbook now says so.
 
 Leads not pursued: the two carried from round 1, unchanged.
+
+## Withdrawal batch fee law, step 1, round 3 -- 2026-08-18
+
+No Solidity and no campaign again. This round read the runbook's file lists
+against what the repository actually generates and against what it treats as a
+record, which is the class of error the previous two rounds had not looked at.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R3-01 | medium | `plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md` | Step 2 listed `docs/catalogue.md` as a file to write and step 4 listed it again as prose to reconcile. It is neither: `python3 scripts/pandects.py render` generates it and `tests/test_documents.py` checks it against the renderer. A hand-edit either fails that check, or passes it by reproducing what the renderer would have produced and thereby hides a real drift. An earlier round of the original delivery, S5-R2-01, fixed the renderer for exactly this reason. | Fixed in this round: step 2 regenerates it and says why, and step 4 drops it from the prose surfaces and names the command. |
+| S1-R3-02 | low | `plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md` | Step 4's reconciliation list left this run's own study and runbook out without saying so, and both of them claim Pandects ships nine laws. The omission reads as an oversight rather than a decision, so an implementer would either rewrite a spec into disagreement with the run it specifies, or leave a claim stale with nothing recording which was meant. | Fixed in this round: step 4 states that the two spec documents are records on the same footing as the audit log's historical rounds and are not reconciled, and why rewriting them would be worse. |
+
+The round-2 fix was re-read against the sources. `COUNT` is 5 in
+`test/Corpus.t.sol` and 3 in `test/Pairs.t.sol`, which is what the runbook now
+says.
+
+Leads not pursued: the two carried from round 1, unchanged.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -203,3 +203,22 @@ The round-2 fix was re-read against the sources. `COUNT` is 5 in
 says.
 
 Leads not pursued: the two carried from round 1, unchanged.
+
+## Withdrawal batch fee law, step 1, round 4 -- 2026-08-18
+
+No Solidity and no campaign. This round read step 3's evidence requirement
+against the tooling that exists to satisfy it, and re-checked which documents in
+the plugin are generated, which the previous round had only established for one of
+them.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R4-01 | medium | `plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md` | Step 3 asked for "a search record for each run" and for "a run record beside the existing campaign evidence", without naming a mechanism. One exists and does not cover the case: `python3 scripts/pandects.py run` writes a search record and knows only the `foundry` engine. An implementer would either read the requirement as satisfied by that command for all three engines, which would silently drop the two fuzzers the step exists to run, or invent a record format for them. | Fixed in this round: step 3 names the command for the Foundry record, says it has no Echidna or Medusa support, and requires the two fuzzers to be recorded as audit prose the way the original delivery recorded them. It also says not to extend the runner here. |
+
+`docs/applicability.md` was checked and is not generated. `pandects render` writes
+`docs/catalogue.md` and nothing else, so step 4's remaining prose surfaces are
+hand-written and correctly listed.
+
+Leads not pursued: extending the search-record runner past `foundry`, now stated
+in the runbook as out of scope for this step and a candidate frontier of its own;
+and the two carried from round 1.

--- a/plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md
+++ b/plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md
@@ -75,16 +75,21 @@ the intermediate quantities.
   diagonal walks.
 
 **Tests.** One counterexample asserting `claims`, the queue total, `reserved` and
-`held` at the violating state, not only the verdict. The diagonal grows from 9x9
-to 10x10 over the single-state half. Expect the plugin catalogue suite to rise
-above 106 by the entries the new law adds, and `forge test` to rise above 72.
+`held` at the violating state, not only the verdict. The diagonal in
+`test/Corpus.t.sol` runs over the single-state laws alone, where `COUNT` is 5, and
+becomes 6; `test/Pairs.t.sol` runs over 3 and does not move. Ten is the corpus
+total and not a table dimension. Expect the plugin catalogue suite to rise above
+106 by the entries the new law adds, and `forge test` to rise above 72.
 
 **Watch.** The study's first risk. Around twenty existing call sites drive
 `reserve` and `accrueFee`, including repeated `reserve(1); reserve(1)` pairs in
 `test/Corpus.t.sol`, `test/Adapters.t.sol` and the counterexamples. A tighter cap
 can turn one of those into a no-op and leave a passing test asserting a state it
 no longer reaches. Read every one of them against the new caps rather than
-trusting a green suite.
+trusting a green suite. One is already known safe:
+`test_the_sound_reference_holds_every_law` charges its fee before it reserves
+anything, so the queue is empty when the cap applies and the tightening cannot
+reach it.
 
 ## Step 3: Reach the specimen from both engines
 

--- a/plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md
+++ b/plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md
@@ -102,14 +102,21 @@ engines found.
 **Entry.** Step 2's exit state.
 
 **Exit.** Echidna and Medusa both drive the new specimen and both report the
-violation; the harness exposes it under `echidna_` and `property_`; a search
-record for each run states engine, configuration digest, sequence length and
-corpus digest, with Echidna's seed recorded and Medusa's stated as unavailable
-rather than invented.
+violation, and the harness exposes it under `echidna_` and `property_`.
+
+Two mechanisms carry the evidence and they are not interchangeable.
+`python3 scripts/pandects.py run` writes a machine search record, and it knows one
+engine: `foundry`. It has no Echidna or Medusa support, and an engine that did not
+run is absent from a record rather than present and empty, which is the runner's
+own rule. So the Foundry record comes from that command, and the two fuzzers are
+recorded the way the original delivery recorded them, as prose in the audit round
+naming the engine, the configuration, the sequence and what failed, with Echidna's
+seed given and Medusa's stated as unavailable rather than invented. Do not extend
+the runner to a second engine in this step; that is its own frontier.
 
 **Files.** `src/campaigns/Specimens.sol`, extended. `adapters/echidna/CorpusEchidna.sol`
 and `adapters/medusa/CorpusMedusa.sol` where the new property needs an entry
-point. A run record beside the existing campaign evidence.
+point.
 
 **Tests.** `test/Corpus.t.sol` or `test/Adapters.t.sol` extended so the new
 entry point is exercised without an engine, the way the existing prefixed entry

--- a/plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md
+++ b/plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md
@@ -69,7 +69,10 @@ the intermediate quantities.
 - `catalogue/pandects.json`, one entry: family `claims`, bounds `exact`,
   applicability naming the accounting model, the assumptions that would make the
   law false, and the four observables it requires.
-- `docs/catalogue.md`, the rendering for that entry.
+- `docs/catalogue.md`, regenerated with `python3 scripts/pandects.py render`
+  rather than edited. It is a rendering of the catalogue, `tests/test_documents.py`
+  checks it against the renderer, and a hand-edit either fails that check or
+  makes a real drift invisible by matching it.
 - `test/counterexamples/Claims.t.sol`, extended.
 - `test/Corpus.t.sol`, the new law and specimen added to the corpus tables the
   diagonal walks.
@@ -133,13 +136,14 @@ python3 scripts/pandects.py check
 ```
 
 Every claim of "nine laws" reconciled; the twelve documents carrying the frontier
-sentence updated; `python3 -m unittest discover -s tests` green, which is the gate
-on the marketplace-context blocks; the ledger advanced exactly once under
+sentence updated; `docs/catalogue.md` regenerated rather than edited;
+`python3 -m unittest discover -s tests` green, which is the gate on the
+marketplace-context blocks; the ledger advanced exactly once under
 `plugins/hexaemeron/skills/VERSIONING.md`.
 
 **Files.** `README.md` at the repository root, and inside the plugin
 `README.md`, `AGENTS.md`, `docs/applicability.md`, `docs/design.md`,
-`docs/writing-a-law.md`, `docs/catalogue.md`, `adapters/medusa/README.md`,
+`docs/writing-a-law.md`, `adapters/medusa/README.md`,
 `integrations/wildcat/APPLICABILITY.md`, `audit/AUDIT.md` for its
 marketplace-context block only, `skills/pandects/SKILL.md`,
 `skills/pandects/EVOLUTION.md`, and the `.agents/skills/pandects/SKILL.md` mirror.
@@ -157,6 +161,11 @@ rather than counting it among the laws that always held.
 `audit/AUDIT.md` records past audit rounds. Those are history and stay as
 written, including their nine-law counts. Only its marketplace-context block is
 mutable.
+
+This run's own study and runbook are records on the same footing, and they are
+not reconciled either. Both say Pandects ships nine laws, which is what was true
+when the spec was written and is the whole reason the run exists. Rewriting them
+to say ten would leave a spec describing work nobody needed to do.
 
 The ledger advances once: evolution increments, generation and epoch stay, and
 either one evidenced next job is recorded or the frontier is set to `mature` with

--- a/plugins/pandects/docs/withdrawal-batch-fee-law/study.md
+++ b/plugins/pandects/docs/withdrawal-batch-fee-law/study.md
@@ -31,9 +31,9 @@ over the same span by different routes, so a single system's before and after is
 not the comparison it describes.
 
 This is a finding about the reduced model in `integrations/wildcat/`, and about
-the corpus being silent on the state it reaches. It is not a claim about the
-deployed Wildcat market contracts, which are not read here and whose fee
-accounting this study does not establish either way.
+the corpus being silent on the state it reaches. Nothing here is a claim about the
+deployed Wildcat market contracts. They are not read, and this study establishes
+nothing either way about how they account for fees.
 
 The sound reference does the same thing on a shorter path: `deposit(100)`,
 `borrow(50)`, `reserve(100)`, `reserve(100)`, `accrueFee` lands on claims 50
@@ -65,8 +65,8 @@ locally.
 
 ## Why nine laws miss it
 
-Each of the three that come closest misses for a different reason, and the reasons
-are worth separating because two of them constrain the design.
+Three come close. Each misses for a different reason, and separating them matters,
+because two of those reasons constrain the design.
 
 `conservation/value-conserved/v1` cannot see it by construction. A fee moves value
 from claims to fees, both on the right-hand side of the equality, so the sums agree
@@ -150,8 +150,9 @@ withdrawal batches.** `totalLenderClaims() >= sum over recorded claims of
 (owed - paid)`, exact, needing the queue extension. **Chosen.** A single state is
 enough to see the violation -- claims 200 against 1000 owed is already evidence, and
 no history is needed to say so -- which is the corpus's own test for which shape a
-law takes. It is the cheapest of the four to comprehend: a sum and a comparison,
-the same shape as `reserves-cover-payable` with the two quantities changed.
+law takes. Of the four it is also the cheapest to comprehend: a sum and a
+comparison, the same shape as `reserves-cover-payable` with two quantities
+changed.
 
 **B. A `PairLaw` over the fall in pooled claims.** Bound the fall by payments
 recorded against the queue plus whatever was unqueued at the earlier observation.

--- a/plugins/pandects/docs/withdrawal-batch-fee-law/study.md
+++ b/plugins/pandects/docs/withdrawal-batch-fee-law/study.md
@@ -17,16 +17,28 @@ the plugin's own Wildcat model:
 | then `accrueFee` | **200** | **1000** | 200 | 200 | 800 |
 
 The market is delinquent, holds 200 because the borrow left the twenty per cent
-required reserve, and owes 1000 on one open batch. The fee takes 800 of it. Every
-one of the five single-state laws returns `held = true` in the second row, and the
-four pair laws hold across the transition: the accrual pair reads debt, which a fee
-does not touch, and `claims/recorded-claim-never-shrinks/v1` reads each batch's own
-`owed` and `paid`, which a fee does not touch either. The protocol has taken four
-fifths of what a departing lender is owed and the corpus has no opinion.
+required reserve, and owes 1000 on one open batch. The fee takes 800 of it. The
+protocol has taken four fifths of what a departing lender is owed and the corpus
+has no opinion.
+
+Every law was executed against that pair rather than argued about. The five
+single-state laws each return `held = true` on the second row.
+`claims/recorded-claim-never-shrinks/v1` holds, because a fee touches neither
+`owed` nor `paid` on any batch. Both accrual pair laws hold, because they read
+debt and a fee does not move it. `accrual/path-independent/v1` also returns held,
+and that verdict carries no weight either way: it compares two systems advanced
+over the same span by different routes, so a single system's before and after is
+not the comparison it describes.
+
+This is a finding about the reduced model in `integrations/wildcat/`, and about
+the corpus being silent on the state it reaches. It is not a claim about the
+deployed Wildcat market contracts, which are not read here and whose fee
+accounting this study does not establish either way.
 
 The sound reference does the same thing on a shorter path: `deposit(100)`,
 `borrow(50)`, `reserve(100)`, `reserve(100)`, `accrueFee` lands on claims 50
-against 100 owed, with all five single-state laws holding.
+against 100 owed, with all five single-state laws and all four pair laws holding,
+again by execution.
 
 **Working prototype.** A tenth law, `claims/pooled-claims-cover-open-batches/v1`,
 carrying all six parts, and both models corrected so they hold it. It works when
@@ -99,6 +111,12 @@ together those two comments are the bug: the fee is capped against `reserved`, a
 **In this repository.** `plugins/ariadne` carries the search record for any campaign
 this produces. `tests/test_marketplace_prose.py` gates the prose reconciliation the
 held job asks for, so that half of the job is machine-checked rather than eyeballed.
+
+The frontier is also not a fresh idea. `plugins/pandects/audit/AUDIT.md` closes its
+last round carrying, among its leads not pursued, the fee that can drop pooled
+claims below what is owed on open batches. The defect was seen during the original
+delivery's audit loop, judged not worth another round then, and written down instead
+of dropped. This run is that lead being taken up.
 
 **Outside.** `crytic/properties` covers ERC-20 and ERC-4626 and has no withdrawal
 queue, so there is no upstream property to adopt or contribute back to here.


### PR DESCRIPTION
The audit rounds for step 1, stacked on the step branch so the review trail stays
separate from the work it corrected.

Five rounds, six findings, all fixed here, clean on round 5. The step ships two
markdown documents and no Solidity, so `x-ray`, `solidity-auditor` and `fizz` had
nothing to read. Every round says so rather than recording a zero count, because a
zero would assert the suite ran.

What the rounds found, in order: the study claimed all nine laws hold in the
violating state having executed only five of them; it gave figures for a fee leak
in the reduced Wildcat model without saying they are not a claim about the
deployed contracts; the runbook sized step 2 against a diagonal that does not
exist; it told step 2 and step 4 to hand-edit a document `pandects render`
generates and `test_documents.py` drift-checks; it left this run's own spec
documents out of step 4's reconciliation without saying they are records; and it
asked for a search record without naming the one command that writes them or
noting that command knows a single engine.

The record is in `audit/AUDIT.md` under "Withdrawal batch fee law, step 1".

Proof:

```bash
python3 -m unittest discover -s tests
python3 -m unittest discover -s plugins/pandects/tests -t plugins/pandects
python3 plugins/pandects/scripts/pandects.py check
cd plugins/pandects && forge test
```

<!-- wildcat-origin: shoggoth -->
