### PR TITLE
Publish the withdrawal-batch-fee spec

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -164,3 +164,25 @@ step ahead of the law, which the runbook argues against on the grounds that
 `pandects.py check` and the corpus diagonal leave no green intermediate state;
 and the seven property families deferred from the original delivery, which are
 outside this frontier.
+
+## Withdrawal batch fee law, step 1, round 2 -- 2026-08-18
+
+Again no Solidity in the diff and no campaign, for the same reason, stated again
+rather than counted as a clean suite run. This round read the round-1 fixes back,
+then checked the runbook's own numbers against the test files it points step 2 at.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R2-01 | medium | `plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md` | The runbook sized step 2's test work as the diagonal growing "from 9x9 to 10x10 over the single-state half". No such table exists. `test/Corpus.t.sol` runs its diagonal over the single-state laws alone, where `COUNT` is 5, and `test/Pairs.t.sol` runs over 3, with path independence handled separately. Nine and ten are corpus totals. Whoever implemented step 2 from the runbook would have gone looking for a table with the wrong shape. | Fixed in this round: the runbook names both dimensions and says that ten is a total rather than a dimension. |
+
+The round-1 fixes were re-read and hold. The four pair-law verdicts in the study
+match what was executed, the path-independence caveat is stated where the verdict
+appears, and the boundary sentence about the deployed contracts sits in the
+problem statement where a reader meets the figures.
+
+One check found nothing and is worth recording because it removes work from step
+2. `test_the_sound_reference_holds_every_law` charges its fee before it reserves,
+so the queue is empty when the cap applies and the tightened cap cannot change
+that test. The runbook now says so.
+
+Leads not pursued: the two carried from round 1, unchanged.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -140,3 +140,27 @@ published calibration and final reports replay without a byte difference.
 Leads not pursued: model authorship beyond the declared provenance rule,
 population-prevalence claims and tuning against the spent v1 holdout remain
 outside this frontier.
+
+## Withdrawal batch fee law, step 1, round 1 -- 2026-08-18
+
+The Pashov pair did not run and no campaign ran, because this step commits two
+markdown documents and touches no Solidity. Saying so is the point: the
+`security_suite` receipt names `x-ray`, `solidity-auditor` and `fizz`, none of
+them read this diff, and a zero count here would assert they had. The review
+instead read the committed spec against the risk register it declares, against
+the nine shipped laws, and against the two models it proposes to correct.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R1-01 | medium | `plugins/pandects/docs/withdrawal-batch-fee-law/study.md` | The study asserted that all nine laws hold in the violating state, but only the five single-state laws had been executed. The four pair laws were reasoned about from what a fee does not touch. In a corpus whose whole argument is that a passing campaign proves nothing without a specimen, an argued verdict presented beside measured ones is the same defect one level up. | Fixed in this round: all four pair laws executed against the pair on both models, and the study now reports what was run. `accrual/path-independent/v1` returns held and the study says that verdict carries no weight, because the law compares two runs rather than one system's before and after. |
+| S1-R1-02 | low | `plugins/pandects/docs/withdrawal-batch-fee-law/study.md` | The study named a fee leak in `integrations/wildcat/WildcatMarketModel.sol` with figures, and never fixed the boundary to the deployed market contracts. The plugin's own applicability document warns that nothing in the model should be mistaken for them; a reader meeting the figures first could take the study as a claim about the protocol. | Fixed in this round: the study states that the finding is about the reduced model and the corpus's silence, and that it establishes nothing either way about the deployed contracts. |
+
+A third lead was checked and is not a finding. The study's chosen statement is
+false of `Sound` as shipped, and the study says so and builds on it. That is the
+method in `docs/writing-a-law.md` working rather than a defect in the spec.
+
+Leads not pursued: whether the two model corrections should ship as their own
+step ahead of the law, which the runbook argues against on the grounds that
+`pandects.py check` and the corpus diagonal leave no green intermediate state;
+and the seven property families deferred from the original delivery, which are
+outside this frontier.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -222,3 +222,29 @@ hand-written and correctly listed.
 Leads not pursued: extending the search-record runner past `foundry`, now stated
 in the runbook as out of scope for this step and a candidate frontier of its own;
 and the two carried from round 1.
+
+## Withdrawal batch fee law, step 1, round 5 -- 2026-08-18
+
+No Solidity and no campaign, for the fifth time and for the same reason. This
+round re-read the four earlier fixes against their sources and then resolved every
+file path the two documents name, which is the check that catches a spec rotting
+against a repository that moved under it.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| None | - | - | The fixed non-Solidity tree has no open finding. | clean |
+
+Thirty-nine distinct paths are named across the study and the runbook. Every one
+resolves, except the two the run exists to create,
+`src/laws/PooledClaimsCoverOpenBatches.sol` and `specimens/FeeFromQueued.sol`, and
+a glob in the sources list. The earlier fixes hold: the pair-law verdicts match
+what was executed, the deployed-contract boundary sits where the figures are, both
+diagonal dimensions match `COUNT` in their test files, `docs/catalogue.md` is
+regenerated rather than written, the two spec documents are declared records, and
+step 3 names the runner and its single engine.
+
+Leads not pursued: extending the search-record runner past `foundry`; whether the
+two model corrections should ship ahead of the law, which the runbook argues
+against on the grounds that no green intermediate state exists; and the seven
+property families deferred from the original delivery. Each is recorded in the
+round that raised it.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -186,3 +186,20 @@ so the queue is empty when the cap applies and the tightened cap cannot change
 that test. The runbook now says so.
 
 Leads not pursued: the two carried from round 1, unchanged.
+
+## Withdrawal batch fee law, step 1, round 3 -- 2026-08-18
+
+No Solidity and no campaign again. This round read the runbook's file lists
+against what the repository actually generates and against what it treats as a
+record, which is the class of error the previous two rounds had not looked at.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R3-01 | medium | `plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md` | Step 2 listed `docs/catalogue.md` as a file to write and step 4 listed it again as prose to reconcile. It is neither: `python3 scripts/pandects.py render` generates it and `tests/test_documents.py` checks it against the renderer. A hand-edit either fails that check, or passes it by reproducing what the renderer would have produced and thereby hides a real drift. An earlier round of the original delivery, S5-R2-01, fixed the renderer for exactly this reason. | Fixed in this round: step 2 regenerates it and says why, and step 4 drops it from the prose surfaces and names the command. |
+| S1-R3-02 | low | `plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md` | Step 4's reconciliation list left this run's own study and runbook out without saying so, and both of them claim Pandects ships nine laws. The omission reads as an oversight rather than a decision, so an implementer would either rewrite a spec into disagreement with the run it specifies, or leave a claim stale with nothing recording which was meant. | Fixed in this round: step 4 states that the two spec documents are records on the same footing as the audit log's historical rounds and are not reconciled, and why rewriting them would be worse. |
+
+The round-2 fix was re-read against the sources. `COUNT` is 5 in
+`test/Corpus.t.sol` and 3 in `test/Pairs.t.sol`, which is what the runbook now
+says.
+
+Leads not pursued: the two carried from round 1, unchanged.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -203,3 +203,22 @@ The round-2 fix was re-read against the sources. `COUNT` is 5 in
 says.
 
 Leads not pursued: the two carried from round 1, unchanged.
+
+## Withdrawal batch fee law, step 1, round 4 -- 2026-08-18
+
+No Solidity and no campaign. This round read step 3's evidence requirement
+against the tooling that exists to satisfy it, and re-checked which documents in
+the plugin are generated, which the previous round had only established for one of
+them.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R4-01 | medium | `plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md` | Step 3 asked for "a search record for each run" and for "a run record beside the existing campaign evidence", without naming a mechanism. One exists and does not cover the case: `python3 scripts/pandects.py run` writes a search record and knows only the `foundry` engine. An implementer would either read the requirement as satisfied by that command for all three engines, which would silently drop the two fuzzers the step exists to run, or invent a record format for them. | Fixed in this round: step 3 names the command for the Foundry record, says it has no Echidna or Medusa support, and requires the two fuzzers to be recorded as audit prose the way the original delivery recorded them. It also says not to extend the runner here. |
+
+`docs/applicability.md` was checked and is not generated. `pandects render` writes
+`docs/catalogue.md` and nothing else, so step 4's remaining prose surfaces are
+hand-written and correctly listed.
+
+Leads not pursued: extending the search-record runner past `foundry`, now stated
+in the runbook as out of scope for this step and a candidate frontier of its own;
+and the two carried from round 1.

--- a/plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md
+++ b/plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md
@@ -75,16 +75,21 @@ the intermediate quantities.
   diagonal walks.
 
 **Tests.** One counterexample asserting `claims`, the queue total, `reserved` and
-`held` at the violating state, not only the verdict. The diagonal grows from 9x9
-to 10x10 over the single-state half. Expect the plugin catalogue suite to rise
-above 106 by the entries the new law adds, and `forge test` to rise above 72.
+`held` at the violating state, not only the verdict. The diagonal in
+`test/Corpus.t.sol` runs over the single-state laws alone, where `COUNT` is 5, and
+becomes 6; `test/Pairs.t.sol` runs over 3 and does not move. Ten is the corpus
+total and not a table dimension. Expect the plugin catalogue suite to rise above
+106 by the entries the new law adds, and `forge test` to rise above 72.
 
 **Watch.** The study's first risk. Around twenty existing call sites drive
 `reserve` and `accrueFee`, including repeated `reserve(1); reserve(1)` pairs in
 `test/Corpus.t.sol`, `test/Adapters.t.sol` and the counterexamples. A tighter cap
 can turn one of those into a no-op and leave a passing test asserting a state it
 no longer reaches. Read every one of them against the new caps rather than
-trusting a green suite.
+trusting a green suite. One is already known safe:
+`test_the_sound_reference_holds_every_law` charges its fee before it reserves
+anything, so the queue is empty when the cap applies and the tightening cannot
+reach it.
 
 ## Step 3: Reach the specimen from both engines
 

--- a/plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md
+++ b/plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md
@@ -102,14 +102,21 @@ engines found.
 **Entry.** Step 2's exit state.
 
 **Exit.** Echidna and Medusa both drive the new specimen and both report the
-violation; the harness exposes it under `echidna_` and `property_`; a search
-record for each run states engine, configuration digest, sequence length and
-corpus digest, with Echidna's seed recorded and Medusa's stated as unavailable
-rather than invented.
+violation, and the harness exposes it under `echidna_` and `property_`.
+
+Two mechanisms carry the evidence and they are not interchangeable.
+`python3 scripts/pandects.py run` writes a machine search record, and it knows one
+engine: `foundry`. It has no Echidna or Medusa support, and an engine that did not
+run is absent from a record rather than present and empty, which is the runner's
+own rule. So the Foundry record comes from that command, and the two fuzzers are
+recorded the way the original delivery recorded them, as prose in the audit round
+naming the engine, the configuration, the sequence and what failed, with Echidna's
+seed given and Medusa's stated as unavailable rather than invented. Do not extend
+the runner to a second engine in this step; that is its own frontier.
 
 **Files.** `src/campaigns/Specimens.sol`, extended. `adapters/echidna/CorpusEchidna.sol`
 and `adapters/medusa/CorpusMedusa.sol` where the new property needs an entry
-point. A run record beside the existing campaign evidence.
+point.
 
 **Tests.** `test/Corpus.t.sol` or `test/Adapters.t.sol` extended so the new
 entry point is exercised without an engine, the way the existing prefixed entry

--- a/plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md
+++ b/plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md
@@ -1,0 +1,160 @@
+# Runbook: a law that stops a fee eating queued withdrawals
+
+Built from `.hexaemeron/study.md`. Base `loop/2026-08-18-kronos` at `9ad3c59`;
+every step branches in the chain and every pull request targets that branch.
+
+Four steps. The second is large and the study says why: `pandects.py check`
+refuses a law missing any of its six parts, and `test/Corpus.t.sol` requires the
+reference to hold every law, so the law, the two model corrections, the specimen,
+the counterexample and the catalogue entry cannot be separated without handing
+the next step a red tree. Splitting them would buy a smaller diff and pay for it
+with a step that is green at neither end.
+
+The documents land as `plugins/pandects/docs/withdrawal-batch-fee-law/`, matching
+the frontier revision and the subdirectory convention a second frontier run on an
+existing plugin already uses in this repository.
+
+## Step 1: Land the spec documents
+
+**Goal.** Commit the study and runbook so a reader can build the rest from the
+repository alone.
+
+**Entry.** `loop/2026-08-18-kronos` at `9ad3c59`. Baseline green: `forge test` 72
+passed, plugin catalogue suite 106 passed, repository suite 20 passed,
+`pandects.py check` nine laws.
+
+**Exit.** Both documents committed under
+`plugins/pandects/docs/withdrawal-batch-fee-law/`, carrying no
+marketplace-context block. That follows the closest precedent in this
+repository: a first frontier run puts its study at the top of `docs/` and
+carries the block, and the one earlier second run puts its study in a named
+subdirectory and does not. The prose gate skips a document without the block, so
+`python3 -m unittest discover -s tests` stays green and step 4 has two fewer
+surfaces to reconcile.
+
+**Files.** `plugins/pandects/docs/withdrawal-batch-fee-law/study.md`,
+`plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md`.
+
+**Tests.** None added. The repository prose suite is the gate.
+
+## Step 2: The law, both corrections, and the specimen
+
+**Goal.** Add `claims/pooled-claims-cover-open-batches/v1` with all six parts, and
+correct the two models so they hold it.
+
+**Entry.** Step 1's exit state.
+
+**Exit.** `pandects.py check` reports ten laws with every part present;
+`forge test` green; the diagonals in `test/Corpus.t.sol` and `test/Pairs.t.sol`
+still exact, so the new specimen breaks this law and no other and no existing
+specimen breaks this one; the counterexample replays with no fuzzer and asserts
+the intermediate quantities.
+
+**Files.**
+
+- `src/laws/PooledClaimsCoverOpenBatches.sol`, new. Single-state `Law`, reads the
+  queue by casting the target as its two siblings do, sums unchecked with the
+  overflow returned as a violation, skips a claim paid beyond what it was owed
+  rather than subtracting into an underflow, and says so in a comment naming
+  `reserves-cover-payable` as the law that leaves that defect uncovered.
+- `specimens/Sound.sol`, corrected twice. `reserve` caps a new claim against the
+  pooled claim not already queued, matching what `requestWithdrawal` already does
+  in the Wildcat model. `accrueFee` caps the fee against the pooled claim not
+  already queued rather than against `reserved`.
+- `integrations/wildcat/WildcatMarketModel.sol`, corrected once, in `accrueFee`,
+  the same way.
+- `specimens/FeeFromQueued.sol`, new. Inherits `Sound`, overrides `accrueFee`
+  alone to restore the cap at `claims - reserved`, and carries the deliberately
+  broken header the checker requires.
+- `catalogue/pandects.json`, one entry: family `claims`, bounds `exact`,
+  applicability naming the accounting model, the assumptions that would make the
+  law false, and the four observables it requires.
+- `docs/catalogue.md`, the rendering for that entry.
+- `test/counterexamples/Claims.t.sol`, extended.
+- `test/Corpus.t.sol`, the new law and specimen added to the corpus tables the
+  diagonal walks.
+
+**Tests.** One counterexample asserting `claims`, the queue total, `reserved` and
+`held` at the violating state, not only the verdict. The diagonal grows from 9x9
+to 10x10 over the single-state half. Expect the plugin catalogue suite to rise
+above 106 by the entries the new law adds, and `forge test` to rise above 72.
+
+**Watch.** The study's first risk. Around twenty existing call sites drive
+`reserve` and `accrueFee`, including repeated `reserve(1); reserve(1)` pairs in
+`test/Corpus.t.sol`, `test/Adapters.t.sol` and the counterexamples. A tighter cap
+can turn one of those into a no-op and leave a passing test asserting a state it
+no longer reaches. Read every one of them against the new caps rather than
+trusting a green suite.
+
+## Step 3: Reach the specimen from both engines
+
+**Goal.** Make the new specimen reachable in a campaign and record what the
+engines found.
+
+**Entry.** Step 2's exit state.
+
+**Exit.** Echidna and Medusa both drive the new specimen and both report the
+violation; the harness exposes it under `echidna_` and `property_`; a search
+record for each run states engine, configuration digest, sequence length and
+corpus digest, with Echidna's seed recorded and Medusa's stated as unavailable
+rather than invented.
+
+**Files.** `src/campaigns/Specimens.sol`, extended. `adapters/echidna/CorpusEchidna.sol`
+and `adapters/medusa/CorpusMedusa.sol` where the new property needs an entry
+point. A run record beside the existing campaign evidence.
+
+**Tests.** `test/Corpus.t.sol` or `test/Adapters.t.sol` extended so the new
+entry point is exercised without an engine, the way the existing prefixed entry
+points already are. Engine runs are evidence, not tests, and are recorded as
+campaigns.
+
+**Watch.** A campaign that reaches the specimen but never reaches the illiquid
+state proves nothing. The violation needs `held` below what the queue is owed, so
+check the corpus coverage rather than accepting a failure report at face value.
+
+## Step 4: Reconcile the prose, demonstrate, and close the frontier
+
+**Goal.** Make every first-party document say what is now true, run the demo path,
+and advance the ledger once.
+
+**Entry.** Step 3's exit state.
+
+**Exit.** The demo path from the study's problem statement runs green:
+
+```bash
+forge test
+python3 scripts/pandects.py laws
+python3 scripts/pandects.py check
+```
+
+Every claim of "nine laws" reconciled; the twelve documents carrying the frontier
+sentence updated; `python3 -m unittest discover -s tests` green, which is the gate
+on the marketplace-context blocks; the ledger advanced exactly once under
+`plugins/hexaemeron/skills/VERSIONING.md`.
+
+**Files.** `README.md` at the repository root, and inside the plugin
+`README.md`, `AGENTS.md`, `docs/applicability.md`, `docs/design.md`,
+`docs/writing-a-law.md`, `docs/catalogue.md`, `adapters/medusa/README.md`,
+`integrations/wildcat/APPLICABILITY.md`, `audit/AUDIT.md` for its
+marketplace-context block only, `skills/pandects/SKILL.md`,
+`skills/pandects/EVOLUTION.md`, and the `.agents/skills/pandects/SKILL.md` mirror.
+
+**Tests.** No new tests. The repository prose suite and `pandects.py check` are
+the gates.
+
+**Watch.** Three things, each a way to leave the record wrong.
+
+The Wildcat applicability document opens on "Nine laws. Six apply without
+qualification. Three do not." The new law belongs with neither group as written:
+the model holds it only because `accrueFee` was corrected in step 2. Say that,
+rather than counting it among the laws that always held.
+
+`audit/AUDIT.md` records past audit rounds. Those are history and stay as
+written, including their nine-law counts. Only its marketplace-context block is
+mutable.
+
+The ledger advances once: evolution increments, generation and epoch stay, and
+either one evidenced next job is recorded or the frontier is set to `mature` with
+`Next Fiat job` reading `None -- mature`. The frontier is not mature here. Seven
+property families remain deferred from the original design, so the next job comes
+from that list with evidence, not from a wish to keep the loop busy.

--- a/plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md
+++ b/plugins/pandects/docs/withdrawal-batch-fee-law/runbook.md
@@ -69,7 +69,10 @@ the intermediate quantities.
 - `catalogue/pandects.json`, one entry: family `claims`, bounds `exact`,
   applicability naming the accounting model, the assumptions that would make the
   law false, and the four observables it requires.
-- `docs/catalogue.md`, the rendering for that entry.
+- `docs/catalogue.md`, regenerated with `python3 scripts/pandects.py render`
+  rather than edited. It is a rendering of the catalogue, `tests/test_documents.py`
+  checks it against the renderer, and a hand-edit either fails that check or
+  makes a real drift invisible by matching it.
 - `test/counterexamples/Claims.t.sol`, extended.
 - `test/Corpus.t.sol`, the new law and specimen added to the corpus tables the
   diagonal walks.
@@ -133,13 +136,14 @@ python3 scripts/pandects.py check
 ```
 
 Every claim of "nine laws" reconciled; the twelve documents carrying the frontier
-sentence updated; `python3 -m unittest discover -s tests` green, which is the gate
-on the marketplace-context blocks; the ledger advanced exactly once under
+sentence updated; `docs/catalogue.md` regenerated rather than edited;
+`python3 -m unittest discover -s tests` green, which is the gate on the
+marketplace-context blocks; the ledger advanced exactly once under
 `plugins/hexaemeron/skills/VERSIONING.md`.
 
 **Files.** `README.md` at the repository root, and inside the plugin
 `README.md`, `AGENTS.md`, `docs/applicability.md`, `docs/design.md`,
-`docs/writing-a-law.md`, `docs/catalogue.md`, `adapters/medusa/README.md`,
+`docs/writing-a-law.md`, `adapters/medusa/README.md`,
 `integrations/wildcat/APPLICABILITY.md`, `audit/AUDIT.md` for its
 marketplace-context block only, `skills/pandects/SKILL.md`,
 `skills/pandects/EVOLUTION.md`, and the `.agents/skills/pandects/SKILL.md` mirror.
@@ -157,6 +161,11 @@ rather than counting it among the laws that always held.
 `audit/AUDIT.md` records past audit rounds. Those are history and stay as
 written, including their nine-law counts. Only its marketplace-context block is
 mutable.
+
+This run's own study and runbook are records on the same footing, and they are
+not reconciled either. Both say Pandects ships nine laws, which is what was true
+when the spec was written and is the whole reason the run exists. Rewriting them
+to say ten would leave a spec describing work nobody needed to do.
 
 The ledger advances once: evolution increments, generation and epoch stay, and
 either one evidenced next job is recorded or the frontier is set to `mature` with

--- a/plugins/pandects/docs/withdrawal-batch-fee-law/study.md
+++ b/plugins/pandects/docs/withdrawal-batch-fee-law/study.md
@@ -31,9 +31,9 @@ over the same span by different routes, so a single system's before and after is
 not the comparison it describes.
 
 This is a finding about the reduced model in `integrations/wildcat/`, and about
-the corpus being silent on the state it reaches. It is not a claim about the
-deployed Wildcat market contracts, which are not read here and whose fee
-accounting this study does not establish either way.
+the corpus being silent on the state it reaches. Nothing here is a claim about the
+deployed Wildcat market contracts. They are not read, and this study establishes
+nothing either way about how they account for fees.
 
 The sound reference does the same thing on a shorter path: `deposit(100)`,
 `borrow(50)`, `reserve(100)`, `reserve(100)`, `accrueFee` lands on claims 50
@@ -65,8 +65,8 @@ locally.
 
 ## Why nine laws miss it
 
-Each of the three that come closest misses for a different reason, and the reasons
-are worth separating because two of them constrain the design.
+Three come close. Each misses for a different reason, and separating them matters,
+because two of those reasons constrain the design.
 
 `conservation/value-conserved/v1` cannot see it by construction. A fee moves value
 from claims to fees, both on the right-hand side of the equality, so the sums agree
@@ -150,8 +150,9 @@ withdrawal batches.** `totalLenderClaims() >= sum over recorded claims of
 (owed - paid)`, exact, needing the queue extension. **Chosen.** A single state is
 enough to see the violation -- claims 200 against 1000 owed is already evidence, and
 no history is needed to say so -- which is the corpus's own test for which shape a
-law takes. It is the cheapest of the four to comprehend: a sum and a comparison,
-the same shape as `reserves-cover-payable` with the two quantities changed.
+law takes. Of the four it is also the cheapest to comprehend: a sum and a
+comparison, the same shape as `reserves-cover-payable` with two quantities
+changed.
 
 **B. A `PairLaw` over the fall in pooled claims.** Bound the fall by payments
 recorded against the queue plus whatever was unqueued at the earlier observation.

--- a/plugins/pandects/docs/withdrawal-batch-fee-law/study.md
+++ b/plugins/pandects/docs/withdrawal-batch-fee-law/study.md
@@ -1,0 +1,313 @@
+# Study: a law that stops a fee eating queued withdrawals
+
+Topic: `Pandects: withdrawal-batch-fee law`. Base: `loop/2026-08-18-kronos` at
+`9ad3c59`.
+
+## Problem statement
+
+Pandects ships nine laws. None of them notices when a fee takes value that has
+already been promised to a lender who asked to leave.
+
+That is not a reading of the code. It is a state, reached in five calls against
+the plugin's own Wildcat model:
+
+| | claims | owed on open batches | reserved | held | fees |
+| --- | --- | --- | --- | --- | --- |
+| deposit 1000, borrow 1000, request 1000 | 1000 | 1000 | 200 | 200 | 0 |
+| then `accrueFee` | **200** | **1000** | 200 | 200 | 800 |
+
+The market is delinquent, holds 200 because the borrow left the twenty per cent
+required reserve, and owes 1000 on one open batch. The fee takes 800 of it. Every
+one of the five single-state laws returns `held = true` in the second row, and the
+four pair laws hold across the transition: the accrual pair reads debt, which a fee
+does not touch, and `claims/recorded-claim-never-shrinks/v1` reads each batch's own
+`owed` and `paid`, which a fee does not touch either. The protocol has taken four
+fifths of what a departing lender is owed and the corpus has no opinion.
+
+The sound reference does the same thing on a shorter path: `deposit(100)`,
+`borrow(50)`, `reserve(100)`, `reserve(100)`, `accrueFee` lands on claims 50
+against 100 owed, with all five single-state laws holding.
+
+**Working prototype.** A tenth law, `claims/pooled-claims-cover-open-batches/v1`,
+carrying all six parts, and both models corrected so they hold it. It works when
+this runs offline and green:
+
+```bash
+forge test                        # every law against every specimen
+python3 scripts/pandects.py laws  # ten laws with their applicability
+python3 scripts/pandects.py check # the six parts, enforced
+```
+
+with the new specimen caught by the new law and by no other, the diagonals in
+`test/Corpus.t.sol` and `test/Pairs.t.sol` still exact, and the counterexample
+replaying with no fuzzer. The demo is not that the law passes. It is that the
+specimen written to break it does break it, and that nothing else in the corpus
+fires on the same state.
+
+**Baseline, measured on `9ad3c59` before any change.** `forge test`: 72 passed,
+0 failed, across 10 suites. `python3 -m unittest discover -s plugins/pandects/tests
+-t plugins/pandects`: 106 passed. Repository suite `-s tests`: 20 passed.
+`pandects.py check`: nine laws, every part present. `forge 1.7.1`, `solc 0.8.28`,
+Echidna 2.3.3, Medusa 1.5.1, Slither 0.11.6, crytic-compile 0.4.2, all present
+locally.
+
+## Why nine laws miss it
+
+Each of the three that come closest misses for a different reason, and the reasons
+are worth separating because two of them constrain the design.
+
+`conservation/value-conserved/v1` cannot see it by construction. A fee moves value
+from claims to fees, both on the right-hand side of the equality, so the sums agree
+before and after. Conservation says value went somewhere, not that it was allowed
+to go there.
+
+`conservation/reserves-backed-by-claims/v1` bounds reserved from above by pooled
+claims. `claims/reserves-cover-payable/v1` bounds reserved from below by what is
+outstanding on the payable prefix. Composed, they give `claims >= outstanding on
+the payable prefix`. That is strictly weaker than what is needed, and the gap is
+exactly where the money goes: `payableThrough` is derived in both models from what
+has actually been set aside, so an illiquid system declares fewer batches payable
+rather than more, and the prefix shrinks to match the reserves while the batches
+behind it stay owed. In the table above the payable prefix covers 200 and the
+other 800 sits outside every existing bound.
+
+`claims/recorded-claim-never-shrinks/v1` is the interesting one, because its
+docstring has already ruled out the pooled total: claims fall legitimately every
+time a fee is taken, so a *pair* law over `totalLenderClaims` either admits fees
+and restates conservation, or refuses them and fails against every correct system.
+That argument is correct and it is about pair laws. It says nothing about a
+single-state lower bound, and the frontier names precisely the bound it leaves
+open.
+
+## Prior art
+
+**In this plugin.** The five laws above, `src/Law.sol` for the returning shape,
+`src/IWithdrawalQueueObservables.sol` for the queue extension, and
+`specimens/Sound.sol` as the reference each specimen inherits. `docs/writing-a-law.md`
+fixes the seven-step method this study follows, including the instruction to check a
+statement against the reference before writing Solidity, which is what caught the
+first draft below.
+
+Two comments already in the tree describe the defect without a law behind them.
+`Sound.accrueFee` says that value earmarked against a recorded withdrawal has been
+promised to a lender who asked for it, and that a protocol taking its fee out of it
+is taking money it already owed. `WildcatMarketModel.delinquent` says that
+`reserved` and `unpaidBatches` differ exactly when the market is in trouble. Put
+together those two comments are the bug: the fee is capped against `reserved`, and
+`reserved` falls below what is owed precisely when the market is delinquent.
+
+**In this repository.** `plugins/ariadne` carries the search record for any campaign
+this produces. `tests/test_marketplace_prose.py` gates the prose reconciliation the
+held job asks for, so that half of the job is machine-checked rather than eyeballed.
+
+**Outside.** `crytic/properties` covers ERC-20 and ERC-4626 and has no withdrawal
+queue, so there is no upstream property to adopt or contribute back to here.
+The a16z and OpenZeppelin ERC-4626 suites bound redemption against shares rather
+than against a recorded queue, which is a different fact about a different design.
+
+## Constraints and non-goals
+
+**Starting point.** `loop/2026-08-18-kronos` at `9ad3c59`. Every pull request in
+this run targets that branch and not `main`.
+
+**Toolchain.** Solidity 0.8.28 under `forge 1.7.1`, no external Solidity
+dependency. Python 3.9 through 3.13, standard library only. Both fixed by the
+existing CI matrix in `.github/workflows/pandects.yml`.
+
+**No new observable.** `ICreditObservables` does not grow. Everything the law needs
+is already readable through it and the queue extension, and adding a fee-history
+observable for one law would put a quantity in the interface that only one law can
+use.
+
+**Ruled out.** Per-lender accounting inside a batch, which the Wildcat integration
+already declares out of model. The seven deferred property families. The
+"claim paid beyond what it was owed" defect that `reserves-cover-payable` names and
+deliberately leaves uncovered; folding it in here would make this law broader than
+its statement, which is what the diagonal exists to fail.
+
+## Design options
+
+**A. A single-state `Law`: pooled lender claims cover everything still owed on open
+withdrawal batches.** `totalLenderClaims() >= sum over recorded claims of
+(owed - paid)`, exact, needing the queue extension. **Chosen.** A single state is
+enough to see the violation -- claims 200 against 1000 owed is already evidence, and
+no history is needed to say so -- which is the corpus's own test for which shape a
+law takes. It is the cheapest of the four to comprehend: a sum and a comparison,
+the same shape as `reserves-cover-payable` with the two quantities changed.
+
+**B. A `PairLaw` over the fall in pooled claims.** Bound the fall by payments
+recorded against the queue plus whatever was unqueued at the earlier observation.
+Rejected. It answers a question nobody needs: what is wrong is the state, not the
+transition into it, and a pair law would hold on a system that was already in the
+bad state when first observed. It also inherits the difficulty
+`recorded-claim-never-shrinks` documents, and it would need the earlier observation
+to be trustworthy about a queue the harness may not have read.
+
+**C. Narrow the bound to the payable prefix.** Rejected, and this is the option that
+looks right and is not. `claims >= outstanding on the payable prefix` is implied by
+the conjunction of two shipped laws, as shown above. A law implied by laws already
+in the corpus has no specimen of its own: anything breaking it breaks one of them
+first, and the diagonal fails. Being unable to write a specimen for it is the proof
+that it is not a law.
+
+**D. Add a fee-history observable and name the fee directly.** Rejected. It widens
+the interface for one law, and it is unnecessary: the state after the fee is
+evidence enough, which is what option A uses.
+
+## The first draft was false of the reference
+
+`docs/writing-a-law.md` says to check the statement against the sound reference
+before writing any Solidity, on the grounds that two accrual laws were written,
+checked, and found false of a correct system. The same thing happened here, and it
+changed the work.
+
+The statement in option A, tested against `Sound` as shipped, fails on a path that
+has nothing to do with fees. `deposit(100)`, `reserve(100)`, `reserve(100)` leaves
+claims at 100 and the queue owed 200, because `Sound.reserve` caps a new claim at
+`min(claims, held)` rather than against the pooled claim not already queued. The
+same pool is queued twice.
+
+So the law is not the whole job. Both models need correcting before either can hold
+it, and the corrections are the interesting part of the change:
+
+1. **`Sound.reserve`** must cap a new claim against the pooled claim not already
+   queued. The Wildcat model already does this correctly in `requestWithdrawal`,
+   which caps at `claims - unpaidBatches()`, so the fix is to bring the reference
+   into line with the integration rather than to invent anything.
+2. **`Sound.accrueFee` and `WildcatMarketModel.accrueFee`** must cap the fee at the
+   pooled claim not already queued, rather than at `claims - reserved`. `reserved`
+   is `min(outstanding, claims, held)`, so it equals what is outstanding only while
+   the system holds enough to earmark the whole queue. In the illiquid case -- the
+   undercollateralised case the corpus exists for -- it sits below, and the cap
+   leaks by exactly the difference.
+
+Both corrections are tightenings: they shrink the set of reachable states and
+neither weakens an existing law. `reserved <= claims` survives because the new cap
+is at or below the old one.
+
+The consequence worth stating plainly: **the specimen for this law is the current
+behaviour of the reference and of the shipped Wildcat model.** The specimen
+reinstates as its single deliberate defect what both files do today.
+
+## The build
+
+**The law.** `src/laws/PooledClaimsCoverOpenBatches.sol`, id
+`claims/pooled-claims-cover-open-batches/v1`, family `claims`, exact. Reads the
+queue by casting the target, as its two siblings do. Sums unchecked with the
+overflow reported as a violation, because a revert carries no verdict under
+`fail_on_revert = false`. Traversal is unbounded and the applicability says so, in
+the same words the two sibling queue laws already use.
+
+**The specimen.** `specimens/FeeFromQueued.sol`, inheriting `Sound`, overriding
+`accrueFee` alone to restore the cap at `claims - reserved`. One function, so the
+defect is the diff. It must break this law and no other, and the state above is the
+evidence that it does: five single-state laws holding, debt untouched, each batch's
+`owed` and `paid` untouched. Reachable in five calls, which is well inside a
+fuzzer's depth.
+
+**The counterexample.** A deterministic replay added to
+`test/counterexamples/Claims.t.sol`, asserting the intermediate quantities and not
+only the verdict, then checked against Echidna to see whether it shrinks smaller.
+
+**The catalogue.** An entry in `catalogue/pandects.json` and a rendering in
+`docs/catalogue.md`. `pandects.py check` refuses either one alone.
+
+**The campaign.** `src/campaigns/Specimens.sol` extended so the new specimen is
+reachable under both the `echidna_` and `property_` prefixes, then both engines run.
+Echidna reports its seed and Medusa does not, so a Medusa record states the engine,
+configuration digest, sequence length and corpus digest and says the seed is
+unavailable.
+
+**The prose.** Twelve files carry the frontier sentence and around ten places claim
+"nine laws". `tests/test_marketplace_prose.py` gates the marketplace-context blocks.
+`integrations/wildcat/APPLICABILITY.md` needs the most care: it opens on "Nine laws.
+Six apply without qualification. Three do not", and the new law arrives as one the
+model holds only after the fee cap is corrected, which is a fact about the model and
+belongs in that document. The audit log's historical rounds are records and stay as
+written; only its marketplace-context block is mutable.
+
+## Risk register seed
+
+What the audit loop should look hardest at, in the order they are most likely to
+bite:
+
+1. **The reference corrections changing reachable states under existing tests.**
+   Around twenty call sites drive `reserve` and `accrueFee`, including repeated
+   `reserve(1); reserve(1)` pairs in `test/Corpus.t.sol`, `test/Adapters.t.sol` and
+   the counterexamples. A tighter cap can silently turn one of those into a no-op
+   and leave a test asserting a state it no longer reaches. Every existing
+   counterexample must still replay for the reason it was written.
+2. **A specimen that breaks two laws.** The diagonal is the check, and the state
+   above says the specimen is clean, but it says so at one point. The specimen has
+   to break only this law across everything the campaign reaches, not only at the
+   state derived by hand.
+3. **`Sound` no longer reaching states other laws need.** The corrections remove the
+   double-queue path. If any existing specimen depended on it to exhibit its own
+   defect, that specimen stops proving its law and the loss is invisible: the test
+   still passes.
+4. **The law reverting instead of judging.** Arithmetic in the sum, a read past the
+   end of the queue, an underflow on `owed - paid` where a claim was paid beyond
+   what it was owed. That last case is real: `reserves-cover-payable` skips such
+   claims deliberately, and this law must make the same choice explicitly rather
+   than subtract and revert.
+5. **Overflow in the sum.** Reported as a violation, never reverted, for the reason
+   `ValueConserved` gives.
+6. **A tolerance appearing.** There is none. The law is a sum and a comparison, and
+   any epsilon that shows up is a defect being hidden.
+7. **The Wildcat applicability claim.** The document will say the model holds ten
+   laws. It must say so because the fee cap was corrected, not by quietly counting
+   the new law among the six that always held.
+8. **Unbounded traversal.** The same limit the sibling queue laws carry, stated in
+   the applicability and not worked around in the law.
+9. **Prose drifting from the catalogue.** A law count in one document and not
+   another is the failure `test_marketplace_prose.py` exists to catch; the ten-vs-nine
+   claims sit outside the gated blocks and need reading by hand.
+
+## Glossary seeds
+
+- **Open batch.** A recorded withdrawal claim still owed something: `paid < owed`.
+- **Outstanding on the queue.** The sum of `owed - paid` over every recorded claim.
+- **Pooled lender claim.** What `totalLenderClaims()` reports: everything lenders
+  may eventually withdraw, including amounts already queued and not yet paid.
+- **Unqueued claim.** The part of the pooled claim not owed on any open batch, and
+  the only part a fee may take.
+- **Payable prefix.** The claims at indices below `payableThrough`, which the system
+  declares it can settle now.
+- **Earmark.** What a model sets aside against the queue, bounded by what it holds,
+  and therefore below what is outstanding whenever it is illiquid.
+- **Delinquent.** A market holding less than what its open batches are owed plus its
+  required reserve.
+
+## Recorded readings
+
+Where the held job left a choice, this is the reading taken.
+
+- **"Open withdrawal batches" means every recorded claim still owed something**,
+  not the payable prefix. The prefix reading is option C, and it is not a law.
+- **"Fees cannot reduce" is enforced as a state bound rather than a fee bound.** The
+  law never mentions fees. A fee is what puts a system into the state, and the state
+  is what is checkable through the observables; a law that named the fee would need
+  the harness to tell it a fee happened, and a law that trusts the harness is a law
+  about the harness.
+- **Both models get corrected in this run.** The alternative was to add the law,
+  qualify the Wildcat applicability to say the model does not hold it, and leave the
+  reference broken. That fails on its own terms: the reference must hold every law,
+  or no specimen means anything.
+- **The specimen restores the reference's current fee cap.** It is the honest
+  specimen, it is one line of diff, and it is a defect a real system has had.
+
+## Sources
+
+- `plugins/pandects/docs/design.md` and `docs/writing-a-law.md`, for the method and
+  the six parts.
+- `plugins/pandects/src/laws/*.sol` and `catalogue/pandects.json`, for the nine
+  shipped laws and the entry shape.
+- `plugins/pandects/specimens/Sound.sol` and
+  `integrations/wildcat/WildcatMarketModel.sol`, for the two models corrected here.
+- `plugins/pandects/integrations/wildcat/APPLICABILITY.md`, for the six-and-three
+  split this run changes.
+- `tests/test_marketplace_prose.py` and `.github/workflows/pandects.yml`, for what
+  is gated and what CI runs.
+- `crytic/properties`, `a16z/erc4626-tests`, at `github.com/`, checked for a
+  withdrawal-queue property to adopt. There is none.
+- Local toolchain, versions recorded in the baseline above.

--- a/plugins/pandects/docs/withdrawal-batch-fee-law/study.md
+++ b/plugins/pandects/docs/withdrawal-batch-fee-law/study.md
@@ -17,16 +17,28 @@ the plugin's own Wildcat model:
 | then `accrueFee` | **200** | **1000** | 200 | 200 | 800 |
 
 The market is delinquent, holds 200 because the borrow left the twenty per cent
-required reserve, and owes 1000 on one open batch. The fee takes 800 of it. Every
-one of the five single-state laws returns `held = true` in the second row, and the
-four pair laws hold across the transition: the accrual pair reads debt, which a fee
-does not touch, and `claims/recorded-claim-never-shrinks/v1` reads each batch's own
-`owed` and `paid`, which a fee does not touch either. The protocol has taken four
-fifths of what a departing lender is owed and the corpus has no opinion.
+required reserve, and owes 1000 on one open batch. The fee takes 800 of it. The
+protocol has taken four fifths of what a departing lender is owed and the corpus
+has no opinion.
+
+Every law was executed against that pair rather than argued about. The five
+single-state laws each return `held = true` on the second row.
+`claims/recorded-claim-never-shrinks/v1` holds, because a fee touches neither
+`owed` nor `paid` on any batch. Both accrual pair laws hold, because they read
+debt and a fee does not move it. `accrual/path-independent/v1` also returns held,
+and that verdict carries no weight either way: it compares two systems advanced
+over the same span by different routes, so a single system's before and after is
+not the comparison it describes.
+
+This is a finding about the reduced model in `integrations/wildcat/`, and about
+the corpus being silent on the state it reaches. It is not a claim about the
+deployed Wildcat market contracts, which are not read here and whose fee
+accounting this study does not establish either way.
 
 The sound reference does the same thing on a shorter path: `deposit(100)`,
 `borrow(50)`, `reserve(100)`, `reserve(100)`, `accrueFee` lands on claims 50
-against 100 owed, with all five single-state laws holding.
+against 100 owed, with all five single-state laws and all four pair laws holding,
+again by execution.
 
 **Working prototype.** A tenth law, `claims/pooled-claims-cover-open-batches/v1`,
 carrying all six parts, and both models corrected so they hold it. It works when
@@ -99,6 +111,12 @@ together those two comments are the bug: the fee is capped against `reserved`, a
 **In this repository.** `plugins/ariadne` carries the search record for any campaign
 this produces. `tests/test_marketplace_prose.py` gates the prose reconciliation the
 held job asks for, so that half of the job is machine-checked rather than eyeballed.
+
+The frontier is also not a fresh idea. `plugins/pandects/audit/AUDIT.md` closes its
+last round carrying, among its leads not pursued, the fee that can drop pooled
+claims below what is owed on open batches. The defect was seen during the original
+delivery's audit loop, judged not worth another round then, and written down instead
+of dropped. This run is that lead being taken up.
 
 **Outside.** `crytic/properties` covers ERC-20 and ERC-4626 and has no withdrawal
 queue, so there is no upstream property to adopt or contribute back to here.


### PR DESCRIPTION
Step 1 of four. The spec for a tenth Pandects law, and the runbook the rest of the
run follows.

Pandects ships nine laws and none of them notices when a fee takes value already
promised to a lender who asked to leave. That is a state, not a reading. On the
plugin's own Wildcat model, a lender deposits 1000, the borrower takes 1000, the
lender asks for all of it back, and the market is left delinquent holding 200
against one open batch owed 1000. A fee then takes 800 of that batch's value. All
nine laws were executed against the pair and all nine hold.

The study records two experiments that changed the design. Its chosen statement is
false of the sound reference as shipped, because `Sound.reserve` caps a new claim
against the pooled claim rather than against the part of it not already queued, so
one pool can be queued twice. And the fee cap in both `Sound` and the Wildcat model
is taken against reserved assets instead of against what the open batches are owed.
Reserved assets fall below that figure exactly when the system is illiquid, which is
the case the corpus exists for, so the cap leaks by the difference.

The consequence is worth stating plainly: the specimen for the new law is the
current behaviour of the reference and of the shipped integration model. Both get
corrected in step 2, and the specimen reinstates the leak as its single deliberate
defect.

This step ships only the two documents. No law, no specimen, no correction.

The audit record is in `audit/AUDIT.md` under "Withdrawal batch fee law, step 1":
five rounds, six findings, all fixed, clean on round 5. The fixes are stacked in
#82. No Solidity in this step, so the Pashov suite had nothing to read and every
round says so instead of recording a zero.

One thing to know about the history. The six commits made before the push phase
lacked the provenance trailers this repository requires, and nothing had been
pushed, so they were rebuilt with the trailers added. Trees are unchanged. The
controller's step 1 implement receipt and audit rounds 1 to 4 name the old SHAs; a
`commit_rewrite` receipt maps each old SHA to its replacement.

Proof:

```bash
python3 -m unittest discover -s tests
python3 -m unittest discover -s plugins/pandects/tests -t plugins/pandects
python3 plugins/pandects/scripts/pandects.py check
cd plugins/pandects && forge test
```

<!-- wildcat-origin: shoggoth -->
