### PR TITLE
Reconcile the prose and close the withdrawal-batch-fee frontier

### DIFF
--- a/.agents/skills/pandects/SKILL.md
+++ b/.agents/skills/pandects/SKILL.md
@@ -12,7 +12,7 @@ Pandects supplies executable laws for credit contracts, each paired with a delib
 
 **Use another tool when.** Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release.
 
-**Current frontier.** No law prevents fees from reducing pooled lender claims below amounts owed on open withdrawal batches.
+**Current frontier.** The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records.
 <!-- marketplace-context:end -->
 
 Read [the Pandects runtime contract](../../../plugins/pandects/AGENTS.md). Use

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ contract it is proven to catch, a reduced counterexample, and a statement of
 the accounting model and observables it requires.
 
 The catalogue holds ten laws across conservation, accrual and withdrawal
-claims. Eight are exact. The path-independence law carries a bound derived from
+claims. Nine are exact. The path-independence law carries a bound derived from
 the rounding performed by linear accrual, and its tests assert the figures on
 both the sound reference and the compounding specimen.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ build.
 | [Hexaemeron](./plugins/hexaemeron) | Running an explicit, receipted delivery loop, ranking frontier work with Kronos, or using its fuzzing, audit and prose skills separately. | A named bundled skill when the controller is unnecessary. | The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery. |
 | [Lemma](./plugins/lemma) | Producing source-linked chunks from Solidity compiler inputs or Markdown. | An embedding, index, retrieval or answering system for every later stage. | Callable-surface ABI validation does not independently check return types or state mutability. |
 | [Lazarus](./plugins/lazarus) | Capturing a finite fixed-block Ethereum fixture, checking proof-backed state and replaying exact requests without fallback. | Alexandria for a lending archive; Tabularium for event interpretation. | Preservation-pipeline integration and an Ariadne state-fixture predicate remain unimplemented. |
-| [Pandects](./plugins/pandects) | Supplying executable credit laws, broken specimens and reduced counterexamples. | Fizz for a protocol-specific fuzz harness. | No law prevents fees from reducing pooled lender claims below amounts owed on open withdrawal batches. |
+| [Pandects](./plugins/pandects) | Supplying executable credit laws, broken specimens and reduced counterexamples. | Fizz for a protocol-specific fuzz harness. | The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records. |
 | [Probitas](./plugins/probitas) | Building a sourced counterparty dossier from declared addresses, without identity inference or a Wildcat verdict. | Alexandria for archived inputs. | Euler v1/v2 now ship; Morpho Midnight fixed-maturity coverage and curation remain unimplemented. |
 | [Sapheneia](./plugins/sapheneia) | Shaping the agent's own replies so an AuDHD reader can see the action, boundaries, state and evidence. | Imprimatur for prose linting; Vulgate or another voice mask for register. | Cross-model behaviour has not yet been held against a published AuDHD task corpus. |
 | [Tabularium](./plugins/tabularium) | Mapping preserved venue-native records into reproducible, venue-qualified credit events. | Alexandria for raw harvesting; Probitas for a dossier. | Compound v3 Phase 0 now rebuilds ordered calls and signed-principal transitions from one verified Alexandria witness; the Phase 1 canonical adapter and Ethereum USDC specimen remain unimplemented. |
@@ -241,7 +241,7 @@ contracts. Each law is a Solidity component with a deliberately broken
 contract it is proven to catch, a reduced counterexample, and a statement of
 the accounting model and observables it requires.
 
-The catalogue holds nine laws across conservation, accrual and withdrawal
+The catalogue holds ten laws across conservation, accrual and withdrawal
 claims. Eight are exact. The path-independence law carries a bound derived from
 the rounding performed by linear accrual, and its tests assert the figures on
 both the sound reference and the compounding specimen.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -808,3 +808,34 @@ drift.
 
 Leads not pursued: the four accepted at the close of step 2, and the Medusa coverage
 asymmetry stated in step 3 round 6.
+
+## Withdrawal batch fee law, step 4, round 2 -- 2026-08-18
+
+Reviewed: the tree with round 1 applied, then every count and claim in browsing prose
+that the run had touched or should have. One it had not touched.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S4-R2-01 | medium | `README.md` | The repository README says how many of the corpus's laws carry no tolerance, and it still said eight. Nine of the ten are exact; only `accrual/path-independent/v1` carries a bound. Step 4 had corrected the same claim in the plugin's own README and missed this one, so the two documents disagreed with each other and one of them disagreed with the catalogue. | Fixed in this round: nine, taken from the catalogue's `bounds` field rather than counted by eye. |
+| S4-R2-02 | medium | `tests/test_marketplace_prose.py` | Nothing held either README's corpus counts to the catalogue. The rendered document derives both of its counts, the adapters are held to theirs by the plugin's suite, and these two were hand-written sentences that a frontier run adding a law simply has to remember. This run corrected five of them and missed the sixth, which is the whole argument. | Fixed in this round: `test_pandects_prose_counts_the_laws_the_catalogue_holds` derives the total, the exact count and the family count from the catalogue and requires both documents to state them. Each of the three anchored claims was made to fail on its own before the test was kept. |
+
+**The mirror, checked and clean.** `.agents/skills/pandects/SKILL.md` was compared with
+the canonical skill in case the version bump had left them disagreeing. It is a
+deliberately different document, a short routing entrypoint with its own description
+and no frontmatter version, and no other plugin's mirror carries a version either. The
+frontier sentence is the part they share and the prose gate already holds it.
+
+**The ledger, machine-checked rather than read.** `tests/test_evolution_contract.py`
+holds every governed ledger to the versioning contract, and it passes on this entry:
+the frontmatter version matches the ledger, the recorded SHA-256 matches the digest of
+the current status line, and the axis rules allow an evolution entry to move the
+frontier revision where a generation entry may not. The reading in round 1 was right
+and this is the part of it that did not depend on my reading.
+
+**What ran.** The repository's 21 tests, up from 20 by the count gate, 116 plugin
+tests, 79 Solidity tests under forge 1.7.1, and the demo path: ten laws printed, ten
+laws with every part present, no catalogue drift. No Solidity in this step, so the
+Pashov pair and `fizz` had nothing to read and did not run.
+
+Leads not pursued: the four accepted at the close of step 2, and the Medusa coverage
+asymmetry from step 3 round 6.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -839,3 +839,29 @@ Pashov pair and `fizz` had nothing to read and did not run.
 
 Leads not pursued: the four accepted at the close of step 2, and the Medusa coverage
 asymmetry from step 3 round 6.
+
+## Withdrawal batch fee law, step 4, round 3 -- 2026-08-18
+
+Reviewed: whether the frontier this step declares is visible where a reader would meet
+it. The ledger names a gap in the search-record runner. Two documents describe that
+runner and neither said the gap existed.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S4-R3-01 | medium | `plugins/pandects/README.md` | "Saying how it was searched" opens with "A campaign result without its settings is an anecdote" and then hands the reader `pandects run`, without saying that the command emits the Foundry campaign and nothing else. A reader who has just run Echidna or Medusa, which this plugin ships adapters and a configuration for, would look for a record the tool cannot produce. The section names `foundry.toml` and so is not false; it is silent exactly where the corpus's own held frontier says the gap is. | Fixed in this round: the section says `run` knows one engine, that an engine which did not run is absent rather than empty, that a campaign under either fuzzer is not recorded by the command, and that widening it is the held frontier. |
+| S4-R3-02 | medium | `plugins/pandects/adapters/medusa/README.md` | The adapter document says "A Medusa record therefore carries the engine, the configuration, the sequence length and the corpus digest", which describes such records as things this plugin produces. Nothing produces them. It is the document somebody reads to learn how to run Medusa here, so it is the worst place for that to be implied. | Fixed in this round: the record is described as written by hand, with `pandects run` named as emitting Foundry and no other engine, and the widening named as the frontier. |
+
+**Why these count as reconciliation rather than new work.** The held job asks for a
+cold read of mutable first-party marketplace prose, and the step had read it for law
+counts and the frontier sentence. It had not read it against the frontier it was
+about to declare. A ledger that names a gap while the two documents describing that
+tool imply it is filled is a record disagreeing with itself, which is the same defect
+class as a count written twice.
+
+**What ran.** The repository's 21 tests, 116 plugin tests, 79 Solidity tests under
+forge 1.7.1, and the demo path: ten laws printed, ten laws with every part present, no
+catalogue drift. No Solidity in the diff, so the Pashov pair and `fizz` had nothing to
+read and did not run.
+
+Leads not pursued: the four accepted at the close of step 2, and the Medusa coverage
+asymmetry from step 3 round 6.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -766,3 +766,45 @@ searched them.
 Leads not pursued: the four accepted at the close of step 2, none of them touched by
 this step, and the Medusa coverage asymmetry above, which is a stated limit rather
 than a defect.
+
+## Withdrawal batch fee law, step 4, round 1 -- 2026-08-18
+
+Reviewed: every document the step touched, the ledger against the versioning
+contract, and the branch the step was built on. This step ships prose and a ledger
+entry, so `x-ray`, `solidity-auditor` and `fizz` had no Solidity to read and none of
+them ran. Saying so rather than recording a zero, for the reason step 3 round 5 gave.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S4-R1-01 | medium | `plugins/pandects/audit/AUDIT.md` | The plugin's own audit log records this run's whole subject as a lead not pursued, closing with "No law covers it. It is a real gap and a new law rather than a fix to this one." A law covers it now, and nothing in that log said so. Its historical rounds stay as written, which is right, but that left a reader of the plugin's own record meeting an open gap that had been closed in another file. The same log also carries the `slither_results.json` lead, which this run closed in step 2 round 2. | Fixed in this round: a "Leads closed since" section says what became of both, names the law, the specimen, the reduced counterexample and where the run is recorded, and states which leads remain untouched. No historical round was edited. |
+| S4-R1-02 | medium | this log | The step was branched from a stale `origin/loop/2026-08-18-kronos`, taken before step 3's pull request merged, so the tree it was verified against did not contain step 3. The demo path caught it: `forge test` reported 77 where step 3 had closed at 79. Merging would not have reverted step 3, because the merge base was below it, but every number in the step's receipt would have described a tree that was never going to ship. | Fixed before the step was committed: the branch was reset to the current tip and the twelve-file change reapplied, which it did cleanly because step 3 and step 4 share no file. Re-verified after replanting: 79 Solidity tests, ten laws, no catalogue drift. Recorded here rather than left in the reflog, because the receipt would have carried the wrong evidence and only a count nobody was checking on purpose revealed it. |
+
+**The ledger, against the contract.** `pandects-v0.1.0` becomes `pandects-v1.1.0`:
+the evolution counter moves once for a completed frontier job, generation and epoch
+are retained, and `SKILL.md` frontmatter matches the ledger. The frontier revision
+moves from `withdrawal-batch-fee-law` to `search-record-engine-coverage`, which an
+evolution entry is allowed to do and a generation entry is not. The recorded SHA-256
+was recomputed from the four ledger fields as written, including the trailing
+newline, and matches the digest in the history row.
+
+**The new frontier, and why it is not mature.** The contract asks whether another
+pass has a concrete evidenced chance of material improvement. It does, and the
+evidence is this run's own log: rounds in steps 2 and 3 recorded Echidna and Medusa
+results as prose because `pandects run` emits one engine, `foundry`, and nothing
+else. A corpus whose argument is that a campaign result means nothing without its
+search record can machine-record one of the three engines it uses. That is a gap
+this run demonstrated rather than one chosen from a list.
+
+**What was reconciled.** Twelve documents carried the old frontier sentence and all
+twelve carry the new one. Five prose law counts said nine and say ten. Two others say
+nine and are right: one counts the laws other than this one, and one is about a
+lexicon. `docs/catalogue.md` was regenerated rather than edited and produced no
+diff, because it already counted ten from the catalogue.
+
+**What ran.** The repository's 20 tests including the marketplace prose gate, 116
+plugin tests, 79 Solidity tests under forge 1.7.1, `pandects laws` printing ten with
+their applicability, `pandects check` over ten laws, and `pandects render` with no
+drift.
+
+Leads not pursued: the four accepted at the close of step 2, and the Medusa coverage
+asymmetry stated in step 3 round 6.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -865,3 +865,38 @@ read and did not run.
 
 Leads not pursued: the four accepted at the close of step 2, and the Medusa coverage
 asymmetry from step 3 round 6.
+
+## Withdrawal batch fee law, step 4, round 4 -- 2026-08-18
+
+Reviewed: the fixed tree, the gates the earlier rounds added, and one last read for
+anything still describing the closed frontier as open.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| None | - | - | The fixed tree has no open finding. | clean |
+
+**Nothing still calls the gap open.** No document or contract outside the audit logs
+and this run's own spec describes a fee reducing pooled claims below what open batches
+are owed as uncovered. `src/laws/ReservesCoverPayableClaims.sol` still says no law
+covers a claim paid beyond what it was owed, which remains true and is a different
+defect. `docs/applicability.md` names two laws as examples of qualified applicability,
+and both readings still hold.
+
+**The frontier agrees everywhere.** The new sentence appears once per surface across
+all twelve documents that carry a marketplace-context block, and matches the row in the
+repository README's selection table. The other nine plugins' frontiers are untouched.
+
+**The gates, re-proved.** Setting the repository README's exact count back to eight
+fails the count gate. Desyncing the ledger label from the frontmatter fails two
+evolution-contract checks at once, which is the right answer: the label and the digest
+are separate claims.
+
+**What ran.** The repository's 21 tests, 116 plugin tests, 79 Solidity tests across ten
+suites under forge 1.7.1 and solc 0.8.28, and the demo path from the study's problem
+statement: `pandects laws` printing ten with their applicability, `pandects check` over
+ten laws with every part present, and `pandects render` producing no drift. No Solidity
+in this step at any round, so `x-ray`, `solidity-auditor` and `fizz` had nothing to read
+and none of them ran; the reading passes are these four rounds.
+
+Leads not pursued: the four accepted at the close of step 2, unchanged and none of them
+touched by this step, and the Medusa coverage asymmetry stated in step 3 round 6.

--- a/plugins/pandects/AGENTS.md
+++ b/plugins/pandects/AGENTS.md
@@ -1,7 +1,7 @@
 # Pandects runtime contract
 
 <!-- marketplace-context:start -->
-> **Marketplace context: Pandects.** Pandects supplies executable laws for credit contracts, each paired with a deliberately broken specimen and a reduced counterexample. Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release. **Current frontier:** No law prevents fees from reducing pooled lender claims below amounts owed on open withdrawal batches.
+> **Marketplace context: Pandects.** Pandects supplies executable laws for credit contracts, each paired with a deliberately broken specimen and a reduced counterexample. Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release. **Current frontier:** The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records.
 <!-- marketplace-context:end -->
 
 Pandects contains one Agent Skill. Select from this table, then read the chosen

--- a/plugins/pandects/README.md
+++ b/plugins/pandects/README.md
@@ -177,7 +177,13 @@ python3 scripts/pandects.py run --out search-record.json
 
 The record names the engine, the argv, the determinism class, the
 configuration read out of `foundry.toml` rather than restated, the sequence
-length, and a digest of the corpus that was searched. It is shaped as an
+length, and a digest of the corpus that was searched.
+
+`run` knows one engine, and it is Foundry. It emits no entry for Echidna or
+Medusa, and an engine that did not run is absent from a record rather than
+present and empty, so a campaign under either of those is not recorded by this
+command at all. Write it down where the run is reported. That gap is the corpus's
+held frontier, stated at the top of this file. It is shaped as an
 `ariadne` command entry, so a result drops into a release statement without
 translation -- shaped as, not built by: the two plugins share no code and a
 test pins the shape from this side.

--- a/plugins/pandects/README.md
+++ b/plugins/pandects/README.md
@@ -7,9 +7,9 @@ Pandects supplies executable laws for credit contracts, each paired with a delib
 
 **Try something else when.** Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release.
 
-**Current frontier.** No law prevents fees from reducing pooled lender claims below amounts owed on open withdrawal batches.
+**Current frontier.** The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records.
 
-**Next Fiat job.** Use /hexaemeron:fiat to add and prove the missing law that fees cannot reduce pooled lender claims below amounts owed on open withdrawal batches, including its specimen, reduced counterexample and applicability. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
+**Next Fiat job.** Use /hexaemeron:fiat to widen the search-record runner to the Echidna and Medusa campaigns, so every engine result ships as a record carrying its engine, configuration, sequence length and corpus digest, with a seed where the engine exposes one and a stated absence where it does not. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
 <!-- marketplace-context:end -->
 
 Executable laws for credit contracts.
@@ -52,7 +52,7 @@ setting a revert carries no verdict, so a law using `require` to mean
 
 ## What is in the catalogue
 
-Nine laws in three families. Each says what it means, where it means it, and
+Ten laws in three families. Each says what it means, where it means it, and
 which contract it is proven to catch.
 
 | Law | Statement | Caught in |
@@ -93,7 +93,7 @@ have meant is a mistake by whoever built it, so refuse and say why.
 
 ## The one tolerance
 
-Eight of the nine laws are exact. `path-independent` is not, and its bound is
+Nine of the ten laws are exact. `path-independent` is not, and its bound is
 derived rather than chosen: linear accrual on principal truncates once per
 step, so `n` small steps and one long step over the same span differ by at most
 `n - 1` units.
@@ -253,7 +253,7 @@ forge test
 python3 scripts/pandects.py run --out search-record.json
 ```
 
-`laws` prints nine laws with their applicability. `check` reports every part
+`laws` prints ten laws with their applicability. `check` reports every part
 present. `forge test` runs both diagonals, the counterexamples, the adapters and
 the Wildcat model. `run` searches and writes the record.
 

--- a/plugins/pandects/adapters/medusa/README.md
+++ b/plugins/pandects/adapters/medusa/README.md
@@ -1,7 +1,7 @@
 # Medusa, over an adapter you wrote
 
 <!-- marketplace-context:start -->
-> **Marketplace context: Pandects.** Pandects supplies executable laws for credit contracts, each paired with a deliberately broken specimen and a reduced counterexample. Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release. **Current frontier:** No law prevents fees from reducing pooled lender claims below amounts owed on open withdrawal batches.
+> **Marketplace context: Pandects.** Pandects supplies executable laws for credit contracts, each paired with a deliberately broken specimen and a reduced counterexample. Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release. **Current frontier:** The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records.
 <!-- marketplace-context:end -->
 
 `medusa.json` carries the settings and leaves `targetContracts` empty, because

--- a/plugins/pandects/adapters/medusa/README.md
+++ b/plugins/pandects/adapters/medusa/README.md
@@ -42,10 +42,15 @@ than a name somebody preferred.
 Two things differ, and both reach the search record.
 
 **Medusa exposes no seed.** Echidna takes one and reports the one it used, so a
-campaign under it can be reproduced call for call. A Medusa record therefore
-carries the engine, the configuration, the sequence length and the corpus
-digest, and says nothing about a seed -- rather than carrying a null, which
-would read as a run that had no seed instead of one nobody can read.
+campaign under it can be reproduced call for call. A record of a Medusa run
+therefore carries the engine, the configuration, the sequence length and the
+corpus digest, and says nothing about a seed -- rather than carrying a null,
+which would read as a run that had no seed instead of one nobody can read.
+
+That record is written by hand today. `pandects run` emits the Foundry campaign
+and no other engine, so nothing here produces a Medusa entry, and a Medusa
+result belongs wherever the run is reported until that changes. Widening the
+runner is the corpus's held frontier.
 
 **Medusa reports the sequence it found; Echidna shrinks it first.** Turning a
 Medusa failure into a deterministic replay is work that turning an Echidna one

--- a/plugins/pandects/audit/AUDIT.md
+++ b/plugins/pandects/audit/AUDIT.md
@@ -667,3 +667,30 @@ Leads not pursued: whether the claim law should be relaxed and the fee that can
 drop pooled claims below what is owed on open batches, both from round 1;
 `slither_results.json` still tracked, from round 2; and the nine carried from
 earlier steps. Each is recorded in the round that found it.
+
+## Leads closed since
+
+The rounds above stay as they were written. This section is what became of two of
+the leads they left open, so a reader meeting them does not have to guess whether
+anybody went back.
+
+**A fee can drop pooled claims below what is owed on open batches**, from step 5
+round 1, which closes with "No law covers it. It is a real gap and a new law rather
+than a fix to this one." One does now.
+`claims/pooled-claims-cover-open-batches/v1` was added in the
+`withdrawal-batch-fee-law` frontier run, with `specimens/FeeFromQueued.sol`, a
+four-call counterexample reduced by Echidna, and a campaign both engines drive. The
+lead's own reading was right on both counts: the cap against the earmark was the
+defect, and it needed a law rather than a change to the one it sat beside. Both
+`Sound` and `WildcatMarketModel` were corrected, and the study, the runbook and that
+run's rounds are in `docs/withdrawal-batch-fee-law/` and the repository's
+`audit/AUDIT.md`.
+
+**`slither_results.json` still tracked**, from step 5 round 2. Closed in the same
+run. The ignore rules for it and two sibling artefacts were written one directory too
+shallow, so an engine invoked from a subdirectory wrote past them. The patterns are
+depth-independent now and the three files are untracked.
+
+The other leads those rounds left open are untouched, including whether
+`claims/recorded-claim-never-shrinks/v1` should be relaxed, which still wants a
+second integration to decide.

--- a/plugins/pandects/audit/AUDIT.md
+++ b/plugins/pandects/audit/AUDIT.md
@@ -1,7 +1,7 @@
 # Pandects audit log
 
 <!-- marketplace-context:start -->
-> **Record status.** This is a historical audit record; findings and dispositions below are preserved as evidence. Pandects supplies executable laws for credit contracts, each paired with a deliberately broken specimen and a reduced counterexample. Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release. **Current frontier:** No law prevents fees from reducing pooled lender claims below amounts owed on open withdrawal batches.
+> **Record status.** This is a historical audit record; findings and dispositions below are preserved as evidence. Pandects supplies executable laws for credit contracts, each paired with a deliberately broken specimen and a reduced counterexample. Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release. **Current frontier:** The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records.
 <!-- marketplace-context:end -->
 
 One section per round. A round with no findings is still a round and still gets

--- a/plugins/pandects/docs/applicability.md
+++ b/plugins/pandects/docs/applicability.md
@@ -1,7 +1,7 @@
 # Applicability
 
 <!-- marketplace-context:start -->
-> **Marketplace context: Pandects.** Pandects supplies executable laws for credit contracts, each paired with a deliberately broken specimen and a reduced counterexample. Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release. **Current frontier:** No law prevents fees from reducing pooled lender claims below amounts owed on open withdrawal batches.
+> **Marketplace context: Pandects.** Pandects supplies executable laws for credit contracts, each paired with a deliberately broken specimen and a reduced counterexample. Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release. **Current frontier:** The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records.
 <!-- marketplace-context:end -->
 
 The rules a law obeys, stated once here rather than nine times in nine

--- a/plugins/pandects/docs/design.md
+++ b/plugins/pandects/docs/design.md
@@ -1,7 +1,7 @@
 # Design: pandects, executable laws for credit contracts
 
 <!-- marketplace-context:start -->
-> **Marketplace context: Pandects.** Pandects supplies executable laws for credit contracts, each paired with a deliberately broken specimen and a reduced counterexample. Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release. **Current frontier:** No law prevents fees from reducing pooled lender claims below amounts owed on open withdrawal batches.
+> **Marketplace context: Pandects.** Pandects supplies executable laws for credit contracts, each paired with a deliberately broken specimen and a reduced counterexample. Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release. **Current frontier:** The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records.
 <!-- marketplace-context:end -->
 
 The specification is `specs/pandects.md` in the repository this was built in. This study fixes the

--- a/plugins/pandects/docs/writing-a-law.md
+++ b/plugins/pandects/docs/writing-a-law.md
@@ -1,7 +1,7 @@
 # Writing a law
 
 <!-- marketplace-context:start -->
-> **Marketplace context: Pandects.** Pandects supplies executable laws for credit contracts, each paired with a deliberately broken specimen and a reduced counterexample. Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release. **Current frontier:** No law prevents fees from reducing pooled lender claims below amounts owed on open withdrawal batches.
+> **Marketplace context: Pandects.** Pandects supplies executable laws for credit contracts, each paired with a deliberately broken specimen and a reduced counterexample. Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release. **Current frontier:** The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records.
 <!-- marketplace-context:end -->
 
 Six parts, in the order you meet them. A law with fewer is refused by

--- a/plugins/pandects/integrations/wildcat/APPLICABILITY.md
+++ b/plugins/pandects/integrations/wildcat/APPLICABILITY.md
@@ -1,7 +1,7 @@
 # The corpus against a Wildcat market
 
 <!-- marketplace-context:start -->
-> **Marketplace context: Pandects.** Pandects supplies executable laws for credit contracts, each paired with a deliberately broken specimen and a reduced counterexample. Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release. **Current frontier:** No law prevents fees from reducing pooled lender claims below amounts owed on open withdrawal batches.
+> **Marketplace context: Pandects.** Pandects supplies executable laws for credit contracts, each paired with a deliberately broken specimen and a reduced counterexample. Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release. **Current frontier:** The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records.
 <!-- marketplace-context:end -->
 
 `WildcatMarketModel.sol` is a reduced model, not a reimplementation. It keeps

--- a/plugins/pandects/skills/pandects/EVOLUTION.md
+++ b/plugins/pandects/skills/pandects/EVOLUTION.md
@@ -2,14 +2,15 @@
 
 Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
 
-- Current version: `pandects-v0.1.0`
+- Current version: `pandects-v1.1.0`
 - Frontier status: `open`
-- Frontier revision: `withdrawal-batch-fee-law`
-- Current frontier: No law prevents fees from reducing pooled lender claims below amounts owed on open withdrawal batches.
-- Next Fiat job: Add and prove the missing law that fees cannot reduce pooled lender claims below amounts owed on open withdrawal batches, including its specimen, reduced counterexample and applicability. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
+- Frontier revision: `search-record-engine-coverage`
+- Current frontier: The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records.
+- Next Fiat job: Widen the search-record runner to the Echidna and Medusa campaigns, so every engine result ships as a record carrying its engine, configuration, sequence length and corpus digest, with a seed where the engine exposes one and a stated absence where it does not. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
 
 ## History
 
 | Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
 | --- | --- | --- | --- | --- | --- |
 | `pandects-v0.1.0` | baseline | `withdrawal-batch-fee-law` | `c5156fb0e08112cd003f4baceb58c66856a5fee23f49e38d27ed73a458dda369` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |
+| `pandects-v1.1.0` | evolution | `search-record-engine-coverage` | `f8c17a1b872e93439fa85122d703565d880f3d70321305edae04abc51274a3de` | [the law](../../src/laws/PooledClaimsCoverOpenBatches.sol), [its specimen](../../specimens/FeeFromQueued.sol), [the study and runbook](../../docs/withdrawal-batch-fee-law/), [the audit record](../../../../audit/AUDIT.md) | The held frontier completed. `claims/pooled-claims-cover-open-batches/v1` ships with all six parts, and both models were corrected because both carried the defect it names: the fee was capped against assets set aside rather than against what the open batches are owed, and an earmark cannot exceed what a system holds, so the two part company exactly when the system is illiquid. On the Wildcat model a market holding 200 against a batch owed 1000 permitted a fee of 800 and now permits nothing. Both engines catch the specimen and neither catches another, across every campaign in the harness. The new frontier is evidenced by this run's own audit log, which had to record Echidna and Medusa results as prose because `pandects run` knows one engine. |

--- a/plugins/pandects/skills/pandects/SKILL.md
+++ b/plugins/pandects/skills/pandects/SKILL.md
@@ -9,7 +9,7 @@ description: >
   generate a harness for one repository; that is fizz. Never report a campaign
   under an engine that did not run.
 metadata:
-  version: "0.1.0"
+  version: "1.1.0"
 ---
 
 # Pandects
@@ -28,7 +28,7 @@ Pandects supplies executable laws for credit contracts, each paired with a delib
 
 **Use another tool when.** Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release.
 
-**Current frontier.** No law prevents fees from reducing pooled lender claims below amounts owed on open withdrawal batches.
+**Current frontier.** The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records.
 <!-- marketplace-context:end -->
 
 A fuzzer searches a state space. It cannot decide which economic facts must
@@ -119,7 +119,7 @@ the specimen written for it and holds against the others. The corpus takes no
 external Solidity dependency: there is no `lib/`, no submodule and nothing to
 fetch.
 
-The catalogue holds nine laws in three families. Conservation: value is
+The catalogue holds ten laws in three families. Conservation: value is
 conserved across held assets, debt, claims and fees; assets reserved never
 exceed the claims recorded; and reserved plus borrowable never exceed what is
 held. Accrual: debt falls only against assets arriving, rises at rest only

--- a/tests/test_marketplace_prose.py
+++ b/tests/test_marketplace_prose.py
@@ -207,6 +207,47 @@ class MarketplaceProseTests(unittest.TestCase):
                     "canonical skills must not carry shadow README.md mirrors",
                 )
 
+    def test_pandects_prose_counts_the_laws_the_catalogue_holds(self):
+        """Two documents state the corpus size in prose and neither derives it.
+
+        The rendered catalogue derives both of its counts and the adapters are held
+        to theirs by the plugin's own suite. These two are hand-written sentences in
+        browsing prose, and a frontier run that adds a law has to remember them. The
+        withdrawal-batch-fee run corrected five such counts and missed a sixth, which
+        is the argument for anchoring them here.
+        """
+        words = [
+            "Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven",
+            "Eight", "Nine", "Ten", "Eleven", "Twelve",
+        ]
+        catalogue = json.loads(
+            (ROOT / "plugins" / "pandects" / "catalogue" / "pandects.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        laws = catalogue["laws"]
+        total = words[len(laws)].lower()
+        exact = words[len([law for law in laws if law["bounds"] == "exact"])]
+        families = words[len({law["family"] for law in laws})].lower()
+
+        landing = (ROOT / "plugins" / "pandects" / "README.md").read_text(encoding="utf-8")
+        for claim in (
+            "%s laws in %s families." % (words[len(laws)], families),
+            "%s of the %s laws are exact." % (exact, total),
+            "`laws` prints %s laws with their applicability." % total,
+        ):
+            with self.subTest(document="plugins/pandects/README.md", claim=claim):
+                self.assertIn(claim, landing)
+
+        root = (ROOT / "README.md").read_text(encoding="utf-8")
+        for claim in (
+            "The catalogue holds %s laws across conservation, accrual and withdrawal"
+            % total,
+            "%s are exact." % exact,
+        ):
+            with self.subTest(document="README.md", claim=claim):
+                self.assertIn(claim, root)
+
     def test_lazarus_release_readme_remains_digest_bound(self):
         manifest = json.loads(
             (ROOT / "plugins" / "lazarus" / "examples" / "goldfinch-v0" / "manifest.json").read_text(encoding="utf-8")


### PR DESCRIPTION
Step 4 of four, and the close. The record now says what is true, and the frontier moves.

Twelve documents carried the old frontier sentence and all twelve carry the new one.
Six law counts written in prose said nine and say ten, including one the step missed on
its first pass and its own audit caught. Two others say nine and are right: one counts
the laws other than this one, and one is about a lexicon. `docs/catalogue.md` was
regenerated rather than edited and produced no diff, because it derives both its counts
from the catalogue.

**The ledger advances once.** `pandects-v0.1.0` becomes `pandects-v1.1.0` on the
evolution axis, generation and epoch retained, `SKILL.md` frontmatter matching. The
frontier revision moves from `withdrawal-batch-fee-law` to
`search-record-engine-coverage`, which an evolution entry may do and a generation entry
may not, and the SHA-256 of the new status line is recorded beside it.
`tests/test_evolution_contract.py` checks all of that rather than leaving it to a
reading.

**The new frontier came from this run rather than from a list.** Rounds in steps 2 and 3
had to record Echidna and Medusa results as prose, because `pandects run` emits one
engine. A corpus whose whole argument is that a campaign result means nothing without
its search record can machine-record one of the three engines it uses. The held job is
to widen the runner so every engine result ships as a record, with a seed where the
engine exposes one and a stated absence where it does not.

Two documents describing that runner implied the gap was already filled, and the audit
found both. The plugin README handed a reader `pandects run` after telling them a result
without its settings is an anecdote; the Medusa adapter described what "a Medusa record"
carries, as though such records are produced here. Both now say which engine the runner
knows and that a fuzzer's record is written by hand.

**The demo path from the study's problem statement runs green.**

```bash
forge test                        # 79 passed across ten suites
python3 scripts/pandects.py laws  # ten laws with their applicability
python3 scripts/pandects.py check # ten laws, every part present
```

**The audit.** Four rounds, six findings, all fixed, clean on round 4. No Solidity in
this step at any round, so `x-ray`, `solidity-auditor` and `fizz` had nothing to read
and none of them ran; the reading passes are the rounds.

The plugin's own audit log recorded this run's entire subject as a lead not pursued,
closing with "No law covers it. It is a real gap and a new law rather than a fix to this
one." A law covers it now and nothing in that log said so. Its historical rounds stay as
written; a "Leads closed since" section says what became of that lead and of the
`slither_results.json` one, and which remain untouched.

One finding is about this log rather than the tree, and it is worth reading. The step was
branched from a loop ref taken before step 3 merged, so the tree it was first verified
against did not contain step 3. The demo path caught it: `forge test` reported 77 where
step 3 had closed at 79. Merging would not have reverted anything, because the merge base
sat below step 3, but every number in the receipt would have described a tree that was
never going to ship. Replanted onto the current tip, reapplied cleanly because the two
steps share no file, and re-verified at 79.

| gate | before the run | now |
|---|---|---|
| `forge test` | 72 | 79 |
| plugin Python suite | 106 | 116 |
| repository suite | 20 | 21 |
| `pandects check` | 9 laws | 10 laws |

<!-- wildcat-origin: shoggoth -->
