### PR TITLE
Add Brevitas structural prose skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -123,6 +123,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Research"
+    },
+    {
+      "name": "brevitas",
+      "source": {
+        "source": "local",
+        "path": "./plugins/brevitas"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
     }
   ]
 }

--- a/.agents/skills/brevitas/SKILL.md
+++ b/.agents/skills/brevitas/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: brevitas
+description: Route evidence-preserving volume and structure budgets for audit findings, security reviews, gas analysis, invariant discussion, diff review and protocol commentary to Brevitas.
+---
+
+# Brevitas portable entrypoint
+
+<!-- marketplace-context:start -->
+## Where this sits
+
+Brevitas enforces mechanical volume and structure budgets on engineering review prose while preserving evidence.
+
+**Use another tool when.** Use Imprimatur for banned vocabulary, Vulgate for register, and Sapheneia for AuDHD interaction shape. Brevitas does not own any of those jobs.
+
+**Current frontier.** The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked.
+<!-- marketplace-context:end -->
+
+Read [the Brevitas runtime contract](../../../plugins/brevitas/AGENTS.md), then
+read [the canonical Brevitas skill](../../../plugins/brevitas/skills/brevitas/SKILL.md)
+in full and follow it.
+
+Apply the canonical rules to substantive chat answers as well as written
+reports. The canonical skill and runtime contract are authoritative if this
+entrypoint ever disagrees with them.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -221,6 +221,28 @@
         "preservation",
         "diligence"
       ]
+    },
+    {
+      "name": "brevitas",
+      "displayName": "Brevitas",
+      "source": "./plugins/brevitas",
+      "description": "Evidence-preserving budgets for engineering prose.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Wildcat Labs",
+        "url": "https://wildcat.finance"
+      },
+      "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/brevitas",
+      "repository": "https://github.com/wildcat-finance/skills",
+      "category": "Developer Tools",
+      "tags": [
+        "audit",
+        "security-review",
+        "engineering-prose",
+        "lint",
+        "evidence",
+        "brevity"
+      ]
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ the canonical `SKILL.md` it names.
 
 ## Marketplace boundaries
 
-The ten plugins form one marketplace, not ten competing descriptions of the
+The eleven plugins form one marketplace, not eleven competing descriptions of the
 same job. Alexandria preserves lending inputs; Tabularium interprets preserved
 venue records; Probitas assembles a counterparty dossier. Lazarus preserves the
 finite historical Ethereum state and exact RPC traffic a test needs, while
@@ -15,9 +15,10 @@ Ariadne binds a released artefact digest to its evidence. Pandects supplies
 reviewed credit laws, Hermes measures a single gas-optimisation class,
 Hexaemeron controls a receipted delivery loop and Lemma stops after producing
 source-linked chunks. Sapheneia shapes the agent's own replies for AuDHD
-readers without changing another skill's facts or gates. If a request crosses
-one of those boundaries, hand it to the named sibling rather than broadening
-the selected skill.
+readers without changing another skill's facts or gates. Brevitas controls the
+volume and structure of engineering prose after vocabulary and register passes.
+If a request crosses one of those boundaries, hand it to the named sibling
+rather than broadening the selected skill.
 
 ## Repository map
 
@@ -26,6 +27,8 @@ the selected skill.
   plugin.
 - Ariadne is under `plugins/ariadne/`. Read `plugins/ariadne/AGENTS.md` before
   running its skill or changing that plugin.
+- Brevitas is under `plugins/brevitas/`. Read `plugins/brevitas/AGENTS.md`
+  before running its skill or changing that plugin.
 - Hermes is under `plugins/hermes/`. Read `plugins/hermes/AGENTS.md` before
   running its skill or changing that plugin.
 - Hexaemeron is under `plugins/hexaemeron/`. Read
@@ -71,6 +74,7 @@ Run the checks that cover every changed area:
 python3 -m unittest discover -s tests
 python3 -m unittest discover -s plugins/alexandria/tests -t plugins/alexandria
 python3 -m unittest discover -s plugins/ariadne/tests -t plugins/ariadne
+python3 -m unittest discover -s plugins/brevitas/tests -t plugins/brevitas
 python3 plugins/hermes/skills/hermes/scripts/test_hermes.py
 python3 plugins/hexaemeron/tests/run_tests.py
 python3 plugins/hexaemeron/skills/imprimatur/tests/run_tests.py

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ build.
 | --- | --- | --- | --- |
 | [Alexandria](./plugins/alexandria) | Preserving heterogeneous lending-source bytes, then deriving and querying reviewed credit views. | Tabularium for semantic event mapping; Probitas for a dossier. | Compound v3 Phase 0 now pins the Comet registry and preserves one verified Ethereum execution witness; a resumable, reconciled Ethereum USDC interval harvester remains unimplemented. |
 | [Ariadne](./plugins/ariadne) | Binding an artefact digest to build, test, review and deployment evidence. | An external Sigstore or cosign verifier for signatures. | The dataset predicate is the first unimplemented predicate; state-fixture and grounded-agent predicates also remain unimplemented. |
+| [Brevitas](./plugins/brevitas) | Enforcing mechanical volume and structure budgets on engineering review prose while preserving evidence. | Imprimatur for vocabulary; Vulgate for register; Sapheneia for AuDHD interaction shape. | The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked. |
 | [Hermes](./plugins/hermes) | Measuring one Solidity gas-optimisation class through fail-closed Foundry checks. | Pandects or the audit skills for broader behavioural and security work. | No complete, reproducible live Wildcat evidence bundle is published. |
 | [Hexaemeron](./plugins/hexaemeron) | Running an explicit, receipted delivery loop, ranking frontier work with Kronos, or using its fuzzing, audit and prose skills separately. | A named bundled skill when the controller is unnecessary. | The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery. |
 | [Lemma](./plugins/lemma) | Producing source-linked chunks from Solidity compiler inputs or Markdown. | An embedding, index, retrieval or answering system for every later stage. | Callable-surface ABI validation does not independently check return types or state mutability. |
@@ -108,6 +109,39 @@ Ariadne includes:
 **Developers.** A release goes out, and six months later somebody asks which commit the deployed bytecode came from and whether the audit covered it. `capture` reads that out of the build you already ran, and the statement answers from its own contents rather than from a changelog nobody updated.
 
 **Security and audit.** An attestation arrives with a release. `verify` says which gates hold, which went unchecked and why, and states plainly that it checked no signature. `replay` re-runs the deterministic half and compares the artefacts, so the recorded digests are something you can test rather than something you accept.
+
+### Brevitas
+
+[Brevitas](./plugins/brevitas) is the final structural pass for audit findings,
+security reviews, gas analysis, invariant discussion, diff review and protocol
+commentary. It controls line count, finding shape, headings, tables, code fences
+and connective prose. Imprimatur still owns vocabulary, Vulgate owns register,
+and Sapheneia owns AuDHD interaction shape.
+
+Evidence outranks every budget. Addresses, transaction hashes, `file:line`
+references, numbers, counterexamples, reproduction steps and statements of what
+could not be established survive compression. The linter accepts a draft from a
+file or stdin, rejects mechanical breaches with line-numbered diagnostics, and
+can compare a compressed draft with its source. A marked evidence exception keeps
+an irreducible finding intact when the evidence itself needs more than five lines.
+
+Brevitas includes:
+
+- the standard-library [`brevitas.py`](./plugins/brevitas/skills/brevitas/scripts/brevitas.py) linter;
+- Make targets for written reports and source-preservation checks;
+- three audit-derived before/after cases with pinned fixture digests; and
+- tests for finding, heading, table, fence and banned-structure failures.
+
+#### Day to day
+
+**Developers.** A diff review has two defects buried under setup and a repeated
+summary. Brevitas keeps each defect to claim, location, mechanism, impact and fix,
+then rejects the draft if its structure drifts.
+
+**Security and audit.** A finding carries addresses, exact locations, numeric
+traces and reproduction steps. Brevitas cuts connective prose first, checks the
+machine-readable evidence against the source, and permits a marked exception when
+the protected evidence needs more than five lines.
 
 ### Hermes
 
@@ -408,14 +442,14 @@ economic meaning attached.
 
 Scored out of 10 for doing the job, not for reading the output. A marketer can quote a verified gas number without having any use for Hermes itself.
 
-| Role | Alexandria | Ariadne | Hermes | Hexaemeron | Lemma | Lazarus | Pandects | Probitas | Sapheneia | Tabularium |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Developers | 8 | 8 | 9 | 9 | 6 | 8 | 8 | 4 | 8 | 7 |
-| Security and audit | 8 | 9 | 7 | 8 | 4 | 8 | 9 | 5 | 7 | 7 |
-| Marketing | 1 | 1 | 3 | 6 | 1 | 1 | 1 | 1 | 3 | 1 |
-| Business development | 6 | 2 | 2 | 5 | 1 | 2 | 2 | 9 | 4 | 3 |
-| Finance | 8 | 1 | 3 | 4 | 1 | 2 | 2 | 7 | 4 | 7 |
-| Legal | 3 | 3 | 1 | 4 | 1 | 2 | 2 | 4 | 4 | 2 |
+| Role | Alexandria | Ariadne | Brevitas | Hermes | Hexaemeron | Lemma | Lazarus | Pandects | Probitas | Sapheneia | Tabularium |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Developers | 8 | 8 | 8 | 9 | 9 | 6 | 8 | 8 | 4 | 8 | 7 |
+| Security and audit | 8 | 9 | 10 | 7 | 8 | 4 | 8 | 9 | 5 | 7 | 7 |
+| Marketing | 1 | 1 | 1 | 3 | 6 | 1 | 1 | 1 | 1 | 3 | 1 |
+| Business development | 6 | 2 | 2 | 2 | 5 | 1 | 2 | 2 | 9 | 4 | 3 |
+| Finance | 8 | 1 | 2 | 3 | 4 | 1 | 2 | 2 | 7 | 4 | 7 |
+| Legal | 3 | 3 | 2 | 1 | 4 | 1 | 2 | 2 | 4 | 4 | 2 |
 
 Five is the barrier. At or above it, the plugin's entry carries a worked example of what that role would use it for. Below it there is no example, because there is no honest one to give. These are engineering tools, and a 2 means we could not find a reason for that desk to open the plugin rather than read what it produced.
 
@@ -448,6 +482,7 @@ Add the same marketplace and install a plugin from inside Claude Code:
 /plugin marketplace add wildcat-finance/skills
 /plugin install alexandria@wildcat-labs
 /plugin install ariadne@wildcat-labs
+/plugin install brevitas@wildcat-labs
 /plugin install hermes@wildcat-labs
 /plugin install hexaemeron@wildcat-labs
 /plugin install lemma@wildcat-labs
@@ -468,6 +503,12 @@ Ariadne is:
 
 ```text
 /ariadne:ariadne
+```
+
+Brevitas is:
+
+```text
+/brevitas:brevitas
 ```
 
 Hermes is:
@@ -522,7 +563,7 @@ See Anthropic's [skills](https://code.claude.com/docs/en/skills) and [plugin mar
 
 ### Local agents
 
-Agents that support the open Agent Skills convention can discover the ten
+Agents that support the open Agent Skills convention can discover the eleven
 host-neutral entries under [`.agents/skills`](./.agents/skills). Point the
 agent at this repository and include that directory in its project skill
 search path. Keep the repository layout intact: each entry routes to the
@@ -539,6 +580,7 @@ Plain-text activation works alongside host syntax:
 ```text
 Use Alexandria to preserve this lending-data capture and query its source-bound credit view.
 Use Ariadne to capture this release in an evidence statement, run its gates, and report its signature state without checking signatures.
+Use Brevitas to enforce evidence-preserving structural budgets on this engineering review.
 Use Hermes to optimise gas in this Foundry repository.
 Use Hexaemeron Fiat to take "<topic>" through the delivery loop.
 Use Hexaemeron Fizz to generate a stateful fuzz suite.
@@ -573,6 +615,15 @@ Use $ariadne to capture this release in an evidence statement, run its gates, an
 ```
 
 The gates, the predicate and the refusals live in [Ariadne's `SKILL.md`](./plugins/ariadne/skills/ariadne/SKILL.md).
+
+Brevitas needs Python 3 and no third-party package. Ask:
+
+```text
+Use $brevitas to compress this engineering review without dropping addresses, transaction hashes, file:line references, numbers, counterexamples or reproduction steps.
+```
+
+The budgets, evidence precedence and exception rule live in
+[Brevitas's `SKILL.md`](./plugins/brevitas/skills/brevitas/SKILL.md).
 
 Hermes needs Python 3, Git and [Foundry](https://getfoundry.sh/) available in the target repository. Start Codex from a clean Foundry worktree, then ask:
 
@@ -665,6 +716,13 @@ plugins/
 │   ├── tests/
 │   └── skills/
 │       └── ariadne/
+├── brevitas/
+│   ├── .claude-plugin/plugin.json
+│   ├── .codex-plugin/plugin.json
+│   ├── AGENTS.md
+│   ├── tests/
+│   └── skills/
+│       └── brevitas/
 ├── hermes/
 │   ├── .claude-plugin/plugin.json
 │   ├── .codex-plugin/plugin.json

--- a/plugins/brevitas/.claude-plugin/plugin.json
+++ b/plugins/brevitas/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "brevitas",
+  "displayName": "Brevitas",
+  "version": "0.1.0",
+  "description": "Evidence-preserving budgets for engineering prose.",
+  "author": {
+    "name": "Wildcat Labs",
+    "url": "https://wildcat.finance"
+  },
+  "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/brevitas",
+  "repository": "https://github.com/wildcat-finance/skills",
+  "keywords": [
+    "audit",
+    "security-review",
+    "engineering-prose",
+    "lint",
+    "evidence",
+    "brevity"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/brevitas/.codex-plugin/plugin.json
+++ b/plugins/brevitas/.codex-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "brevitas",
+  "version": "0.1.0",
+  "description": "Evidence-preserving budgets for engineering prose.",
+  "author": {
+    "name": "Wildcat Labs",
+    "url": "https://wildcat.finance"
+  },
+  "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/brevitas",
+  "repository": "https://github.com/wildcat-finance/skills",
+  "keywords": [
+    "audit",
+    "security-review",
+    "engineering-prose",
+    "lint",
+    "evidence",
+    "brevity"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Brevitas",
+    "shortDescription": "Evidence-preserving budgets for engineering prose.",
+    "longDescription": "Checks audit findings, security reviews, gas analysis, invariant discussion, diff review and protocol commentary against mechanical structure limits while preserving source evidence.",
+    "developerName": "Wildcat Labs",
+    "category": "Developer Tools",
+    "capabilities": [],
+    "defaultPrompt": "Use $brevitas to compress this engineering review without losing evidence."
+  }
+}

--- a/plugins/brevitas/AGENTS.md
+++ b/plugins/brevitas/AGENTS.md
@@ -1,0 +1,24 @@
+# Brevitas runtime contract
+
+<!-- marketplace-context:start -->
+> **Marketplace context: Brevitas.** Brevitas enforces mechanical volume and structure budgets on engineering review prose while preserving evidence. Use Imprimatur for banned vocabulary, Vulgate for register, and Sapheneia for AuDHD interaction shape. Brevitas does not own any of those jobs. **Current frontier:** The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked.
+<!-- marketplace-context:end -->
+
+Brevitas contains one Agent Skill. Read `skills/brevitas/SKILL.md` in full
+before applying it. The canonical skill is the only behaviour contract.
+
+## Subject and order
+
+- Apply Brevitas to the agent's substantive chat answer and to engineering prose written to disk.
+- Run it after Imprimatur, Vulgate, or another word-choice or register pass.
+- Keep evidence precedence above every line, heading, table, and code-fence budget.
+- Do not apply it to code comments, commit messages, or specifications whose completeness is the point.
+- System, safety, harness, and target-repository rules still take precedence.
+
+## Invocation and paths
+
+- `$brevitas`, `/brevitas:brevitas`, `use Brevitas`, and any audit, security-review, gas, invariant, diff-review, or protocol-commentary answer select the skill.
+- Resolve relative paths from `skills/brevitas/`.
+- Run `scripts/brevitas.py` on a file or stdin. A non-zero exit rejects the draft.
+- When compressing existing prose, pass `--source`; missing addresses, transaction hashes, `file:line` references, or numeric tokens reject the draft.
+- The checker needs Python 3 and no third-party package.

--- a/plugins/brevitas/README.md
+++ b/plugins/brevitas/README.md
@@ -1,0 +1,37 @@
+# Brevitas
+
+<!-- marketplace-context:start -->
+## In one line
+
+Brevitas puts mechanical volume and structure limits on engineering review prose without cutting its evidence.
+
+**Try something else when.** Use Imprimatur for banned vocabulary, Vulgate for register, and Sapheneia for AuDHD interaction shape. Brevitas does not own any of those jobs.
+
+**Current frontier.** The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked.
+
+**Next Fiat job.** Use /hexaemeron:fiat to Forward-test Brevitas across held x-ray, Solidity-auditor, gas, invariant and diff-review outputs, then add every confirmed structural bypass to the corpus without weakening evidence precedence. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
+<!-- marketplace-context:end -->
+
+Brevitas is the last structural pass for audit findings, security reviews, gas
+analysis, invariant discussion, diff review and protocol commentary. It does
+not choose words or voice. It controls line count, finding shape, headings,
+tables, code fences and the prose between points.
+
+The evidence rule comes first. Addresses, transaction hashes, `file:line`
+references, numbers, counterexamples, reproduction steps and statements of
+what could not be established survive every rewrite. `--source` checks the
+machine-readable subset. An explicit evidence exception keeps longer material
+when the five-line finding form cannot hold it.
+
+Brevitas includes:
+
+- one canonical [`SKILL.md`](skills/brevitas/SKILL.md) shared by Codex, Claude Code and portable agents;
+- the standard-library [`brevitas.py`](skills/brevitas/scripts/brevitas.py) linter for files and stdin;
+- a Make target for written reports and source-preservation checks; and
+- three audit-derived corpus cases, including one that must retain the original finding rather than compress it.
+
+#### Day to day
+
+**Developers.** A diff review has two real defects buried under setup, transitions and a repeated summary. Brevitas keeps each defect to claim, location, mechanism, impact and fix, then rejects the draft if its line budget or structure drifts.
+
+**Security and audit.** A finding carries addresses, exact locations, numeric traces and a reproduction sequence. Brevitas cuts connective prose first, checks the machine-readable evidence against the source, and permits a marked exception when the remaining evidence needs more than five lines.

--- a/plugins/brevitas/skills/brevitas/EVOLUTION.md
+++ b/plugins/brevitas/skills/brevitas/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Brevitas evolution ledger
+
+Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
+
+- Current version: `brevitas-v0.1.0`
+- Frontier status: `open`
+- Frontier revision: `held-engineering-corpus`
+- Current frontier: The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked.
+- Next Fiat job: Forward-test Brevitas across held x-ray, Solidity-auditor, gas, invariant and diff-review outputs, then add every confirmed structural bypass to the corpus without weakening evidence precedence. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `brevitas-v0.1.0` | baseline | `held-engineering-corpus` | `dcff4f6b1397570468dedb18a1ebaa5f45377272bcd2f71cd69ad6818eeb0b62` | [README marketplace-context](../../README.md) | Versioning starts with the executable linter and three audit-derived corpus cases. |

--- a/plugins/brevitas/skills/brevitas/Makefile
+++ b/plugins/brevitas/skills/brevitas/Makefile
@@ -1,0 +1,18 @@
+PYTHON ?= python3
+FILE ?=
+MODE ?= auto
+SOURCE ?=
+
+.PHONY: lint test unit evals
+
+lint:
+	@test -n "$(FILE)" || { echo "usage: make lint FILE=report.md [SOURCE=original.md] [MODE=report]" >&2; exit 2; }
+	$(PYTHON) scripts/brevitas.py "$(FILE)" --mode "$(MODE)" $(if $(SOURCE),--source "$(SOURCE)",)
+
+unit:
+	$(PYTHON) -m unittest discover -s ../../tests -t ../.. -v
+
+evals:
+	$(PYTHON) scripts/run_evals.py
+
+test: unit evals

--- a/plugins/brevitas/skills/brevitas/SKILL.md
+++ b/plugins/brevitas/skills/brevitas/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: brevitas
+description: Enforce evidence-preserving structural output budgets on engineering prose. Apply automatically to chat answers and written drafts containing audit findings, security or diff review, gas analysis, invariant discussion, protocol analysis, or specification commentary, and on explicit $brevitas invocation. Govern volume, structure, and connective prose only. Do not apply to code comments, commit messages, or completeness-oriented specification documents.
+metadata:
+  version: "0.1.0"
+---
+
+# Brevitas
+
+## Frontier
+
+Brevitas owns the engineering-prose structure frontier, not Hexaemeron's
+delivery or Solidity frontier. Its version, held target, next job, and maturity
+state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run another
+frontier pass after that ledger becomes mature.
+
+<!-- marketplace-context:start -->
+## Where this sits
+
+Brevitas enforces mechanical volume and structure budgets on engineering review prose while preserving evidence.
+
+**Use another tool when.** Use Imprimatur for banned vocabulary, Vulgate for register, and Sapheneia for AuDHD interaction shape. Brevitas does not own any of those jobs.
+
+**Current frontier.** The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked.
+<!-- marketplace-context:end -->
+
+Apply this as the final structural pass after any lexicon or register skill such as
+imprimatur or vulgate. Do not alter word choice, voice, or AuDHD presentation.
+
+## Precedence
+
+Preserve evidence before satisfying any budget. Never delete or weaken:
+
+- addresses or transaction hashes;
+- `file:line` references or numeric claims;
+- concrete counterexamples or reproduction steps; or
+- an explicit statement that a fact, property, or conclusion could not be established.
+
+If evidence does not fit, let the budget yield and cut prose further. Never trade
+evidence for brevity. If the irreducible evidence still exceeds a finding budget,
+retain it and use the evidence-exception mechanism below.
+
+## Compose
+
+1. Answer immediately. Do not restate the request or introduce the answer.
+2. Apply these physical-line budgets:
+   - Direct answer: at most 6 nonblank lines before the first list or code fence.
+   - Finding: at most 5 prose lines: claim, location, mechanism, impact, fix.
+   - Code: at most one fence per point and 15 content lines per fence.
+3. Give each finding this checkable shape:
+
+   ```text
+   [High] Claim.
+   Location: `src/Contract.sol:42`
+   Mechanism: Concrete causal path.
+   Impact: Concrete consequence.
+   Fix: Smallest correction.
+   ```
+
+   Use only the severity word; do not add a severity-justification paragraph.
+4. Put findings adjacent. Add no transition, preamble, or summary between them.
+5. Use a table only with at least 3 data rows and 3 real-data columns.
+6. Use headings only when the draft has at least 3 sections. A document title does
+   not count as a section.
+7. Use at most one qualifier per claim.
+
+For an irreducible finding, place this immediately before it:
+
+```html
+<!-- brevitas: evidence-exception reason="counterexample requires ordered steps" -->
+```
+
+Use the exception only when compression would remove protected evidence. Keep any
+extra lines as evidence, counterexample, reproduction, or establishment-limit
+statements; do not use the exception to retain connective prose.
+
+## Delete
+
+Delete request restatements, list preambles, post-list summaries, process narration,
+bold-label-colon items, trailing offers, unrequested next-step menus, stacked hedges,
+and confidence theatre such as "importantly", "notably", or "it's worth noting".
+Do not reprint visible code. Quote only the lines that carry the defect.
+
+## Lint
+
+Run the checker before sending substantive chat prose or saving a report. Pipe chat
+drafts through stdin; pass a file for written work:
+
+```bash
+python3 scripts/brevitas.py - < draft.md
+python3 scripts/brevitas.py report.md
+python3 scripts/brevitas.py report.md --source uncompressed.md
+make -C /path/to/brevitas lint FILE=/path/to/report.md
+```
+
+Use `--mode answer` for direct answers and `--mode report` for reports. `auto`
+infers a report from findings or at least 3 sections. When compressing existing
+material, always pass `--source`; the checker then fails if an address, transaction
+hash, `file:line` reference, or numeric token disappears. Fix every diagnostic and
+rerun until exit status 0.
+
+Host-required status commentary is outside the draft lint boundary. Do not suppress
+status messages required by the execution environment.
+
+## Evals
+
+Run `make test`. The corpus in `evals/cases/` contains preserved audit, x-ray,
+and security-review excerpts with source paths, ranges, and pinned fixture
+digests. `scripts/run_evals.py` verifies fixture integrity, target structure,
+evidence-token survival, actual compression for positive cases, and exact
+retention for the evidence-exception case.
+
+## Exclusions
+
+Do not apply this skill to code comments, commit messages, or specification documents
+where completeness is the point. Do not perform lexicon, tone, register, or
+accessibility transformations.

--- a/plugins/brevitas/skills/brevitas/agents/openai.yaml
+++ b/plugins/brevitas/skills/brevitas/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Brevitas"
+  short_description: "Evidence-preserving budgets for engineering prose."
+  default_prompt: "Use $brevitas to compress this engineering review without losing evidence."

--- a/plugins/brevitas/skills/brevitas/evals/cases/fund-safety-evidence-exception/case.json
+++ b/plugins/brevitas/skills/brevitas/evals/cases/fund-safety-evidence-exception/case.json
@@ -1,0 +1,7 @@
+{
+  "expectation": "retain-evidence",
+  "mode": "report",
+  "origin_artifact_path": "outputs/t0-rc3-1/sol56/artifacts/redteam/raw/database-enforcement-agent.md",
+  "origin_ranges": [[1, 19]],
+  "origin_sha256": "08e534ff9fd8005778e2224f374bd1e42a4bb129c2504e8aa54549f8621f0494"
+}

--- a/plugins/brevitas/skills/brevitas/evals/cases/fund-safety-evidence-exception/original.md
+++ b/plugins/brevitas/skills/brevitas/evals/cases/fund-safety-evidence-exception/original.md
@@ -1,0 +1,19 @@
+FINDING
+title: Fund-safety claim trusts an unaudited bypass pointer
+stage: T0
+severity: high
+disposition: SPEC_DEFECT
+claim: DB-055 permits a FUND_SAFETY event to pass an earlier event only after the hard deadline, only when the named predecessor is QUARANTINED, and only when the same transaction inserts an immutable validated work.outbox_order_bypasses row.
+claim_source: source-bundle.md:31902
+invariants: [DB-055]
+gate_axes: [Objective validation]
+owner: inferrex_worker / work
+counterexample: In the executable reference schema, create predecessor P at aggregate sequence n with delivery_state PENDING or LEASED, create later candidate S at n+1 with ordering_class FUND_SAFETY and bypass_predecessor_event_id=P, insert no work.outbox_order_bypasses row, and call work.claim_next_outbox_v1 after S becomes available. The NOT EXISTS predicate exempts P solely because S names P, so S is leased even though P is not quarantined, no deadline fact was checked, no exact reason was checked, and no audit row exists.
+trace: work.claim_next_outbox_v1 at source-bundle.md:30556 excludes a predecessor when candidate.ordering_class='FUND_SAFETY' and candidate.bypass_predecessor_event_id equals the predecessor ID. It neither joins nor requires work.outbox_order_bypasses. The validator at source-bundle.md:30612 checks the required predicates only if an audit row is inserted; there is no reverse constraint making that row mandatory before claim. The reference checker case NEG-DB-055-INVALID-FUND-SAFETY-BYPASS attempts a malformed audit-row insert, not a claim with no audit row. The T0.9 checker evaluates an independent auditRecord boolean vector, while its SQL check at source-bundle.md:33352 only searches for the table name.
+evidence_present: PGlite executes the reference DDL and rejects a malformed bypass audit row; deterministic T0.9 vectors include all seven intended predicates.
+evidence_independence: The PGlite case, model mapping, SQL substring checks, and deterministic vectors are all source-tier evidence from the same packet. None executes the missing-audit-row claim schedule, and no pinned real-PostgreSQL result is present at T0.
+smallest_correction: Make work.claim_next_outbox_v1 exempt a predecessor only under an EXISTS subquery for work.outbox_order_bypasses matching candidate event, predecessor event, reservation, exact reason, and validated deadline facts; lock the matched rows consistently. Add a database constraint or constrained append procedure that prevents a non-null bypass pointer from existing without its validated audit row.
+closure_evidence: Add a PGlite negative case that inserts the pointer without an audit row and proves claim returns no row, plus cases for a non-quarantined predecessor and mismatched audit pair. At T1, provide the migration, worker-role privilege-negative test, and a pinned real-PostgreSQL T1-CONC-SAFETY-006 interleaving proving only the validated audited path can publish.
+confidence: 99
+group_key: T0|DB-055 audited fund-safety bypass|claim predicate requires validated audit row
+END

--- a/plugins/brevitas/skills/brevitas/evals/cases/fund-safety-evidence-exception/target.md
+++ b/plugins/brevitas/skills/brevitas/evals/cases/fund-safety-evidence-exception/target.md
@@ -1,0 +1,20 @@
+<!-- brevitas: evidence-exception reason="ordered counterexample, trace, independence limit, and closure evidence are irreducible" -->
+FINDING
+title: Fund-safety claim trusts an unaudited bypass pointer
+stage: T0
+severity: high
+disposition: SPEC_DEFECT
+claim: DB-055 permits a FUND_SAFETY event to pass an earlier event only after the hard deadline, only when the named predecessor is QUARANTINED, and only when the same transaction inserts an immutable validated work.outbox_order_bypasses row.
+claim_source: source-bundle.md:31902
+invariants: [DB-055]
+gate_axes: [Objective validation]
+owner: inferrex_worker / work
+counterexample: In the executable reference schema, create predecessor P at aggregate sequence n with delivery_state PENDING or LEASED, create later candidate S at n+1 with ordering_class FUND_SAFETY and bypass_predecessor_event_id=P, insert no work.outbox_order_bypasses row, and call work.claim_next_outbox_v1 after S becomes available. The NOT EXISTS predicate exempts P solely because S names P, so S is leased even though P is not quarantined, no deadline fact was checked, no exact reason was checked, and no audit row exists.
+trace: work.claim_next_outbox_v1 at source-bundle.md:30556 excludes a predecessor when candidate.ordering_class='FUND_SAFETY' and candidate.bypass_predecessor_event_id equals the predecessor ID. It neither joins nor requires work.outbox_order_bypasses. The validator at source-bundle.md:30612 checks the required predicates only if an audit row is inserted; there is no reverse constraint making that row mandatory before claim. The reference checker case NEG-DB-055-INVALID-FUND-SAFETY-BYPASS attempts a malformed audit-row insert, not a claim with no audit row. The T0.9 checker evaluates an independent auditRecord boolean vector, while its SQL check at source-bundle.md:33352 only searches for the table name.
+evidence_present: PGlite executes the reference DDL and rejects a malformed bypass audit row; deterministic T0.9 vectors include all seven intended predicates.
+evidence_independence: The PGlite case, model mapping, SQL substring checks, and deterministic vectors are all source-tier evidence from the same packet. None executes the missing-audit-row claim schedule, and no pinned real-PostgreSQL result is present at T0.
+smallest_correction: Make work.claim_next_outbox_v1 exempt a predecessor only under an EXISTS subquery for work.outbox_order_bypasses matching candidate event, predecessor event, reservation, exact reason, and validated deadline facts; lock the matched rows consistently. Add a database constraint or constrained append procedure that prevents a non-null bypass pointer from existing without its validated audit row.
+closure_evidence: Add a PGlite negative case that inserts the pointer without an audit row and proves claim returns no row, plus cases for a non-quarantined predecessor and mismatched audit pair. At T1, provide the migration, worker-role privilege-negative test, and a pinned real-PostgreSQL T1-CONC-SAFETY-006 interleaving proving only the validated audited path can publish.
+confidence: 99
+group_key: T0|DB-055 audited fund-safety bypass|claim predicate requires validated audit row
+END

--- a/plugins/brevitas/skills/brevitas/evals/cases/solidity-partial-recovery/case.json
+++ b/plugins/brevitas/skills/brevitas/evals/cases/solidity-partial-recovery/case.json
@@ -1,0 +1,7 @@
+{
+  "expectation": "compress",
+  "mode": "report",
+  "origin_artifact_path": "credit-default-swaps/audit/AUDIT.md",
+  "origin_ranges": [[80, 80], [92, 99]],
+  "origin_sha256": "2cdd9bb04532ec278184d2a3290a0b0b72c02be47ca634911428440ddbed6d58"
+}

--- a/plugins/brevitas/skills/brevitas/evals/cases/solidity-partial-recovery/original.md
+++ b/plugins/brevitas/skills/brevitas/evals/cases/solidity-partial-recovery/original.md
@@ -1,0 +1,10 @@
+| S3-R1-02 | medium | `src/CoveredCDSFacility.sol` | A small partial default claim could round recovery down to zero, pay cash and leave all debt for later redemption. | fixed; non-final cumulative recovery rounds up against the claimant and a low-share regression covers the split |
+
+Evidence:
+
+- `audit/X-RAY.md`
+- `audit/FIZZ.md`
+- 36 Foundry tests, including directed regressions for all four fixed defects
+- five stateful accounting properties at 128,000 calls each under the default profile
+- CI fuzz properties at 1,000 runs and stateful properties at 32,768 calls each
+- `script/release-gate.sh`: passed, including dependency, Markdown, raster, arithmetic and size checks

--- a/plugins/brevitas/skills/brevitas/evals/cases/solidity-partial-recovery/target.md
+++ b/plugins/brevitas/skills/brevitas/evals/cases/solidity-partial-recovery/target.md
@@ -1,0 +1,5 @@
+[Medium] A small partial default claim could pay cash while rounding recovery debt to zero.
+Location: `src/CoveredCDSFacility.sol:249-264`
+Mechanism: Per-claim floor rounding let split claims leave debt for later redemption; non-final cumulative recovery must round up against the claimant.
+Impact: Claim splitting could change debt recovery despite equal total cash payouts.
+Fix: Use cumulative rounded-up allocation and keep the low-share regression; `audit/X-RAY.md`, `audit/FIZZ.md`, 36 Foundry tests, 128,000 calls per stateful accounting property, CI fuzz at 1,000 runs, stateful checks at 32,768 calls, and `script/release-gate.sh` passed.

--- a/plugins/brevitas/skills/brevitas/evals/cases/xray-replay-authority/case.json
+++ b/plugins/brevitas/skills/brevitas/evals/cases/xray-replay-authority/case.json
@@ -1,0 +1,7 @@
+{
+  "expectation": "compress",
+  "mode": "report",
+  "origin_artifact_path": "outputs/t0-rc3-1/sol56/artifacts/x-ray/attack-surfaces.md",
+  "origin_ranges": [[3, 19]],
+  "origin_sha256": "ed8fbcf14186a1c79f9db8f971796d192969ec729edeb2bba0fc78f30ff75e48"
+}

--- a/plugins/brevitas/skills/brevitas/evals/cases/xray-replay-authority/original.md
+++ b/plugins/brevitas/skills/brevitas/evals/cases/xray-replay-authority/original.md
@@ -1,0 +1,17 @@
+## AS-1: Signed replay identity and authority
+
+- **Stage:** T0; later enforcement T1/T4.
+- **Adversary control:** signer address, nonce, cancellation timing, delegated scope.
+- **Trust boundary:** seller/buyer signer to intake and database authority.
+- **Authoritative clock / identity:** environment-scoped cryptographic identity;
+  separately revocable purpose/object/scope/owner authority.
+- **Normative claims at risk:** SYS-005, SYS-012.
+- **Artifacts / locations:** `inferrex-t0.3-signed-protocol-objects-spec.md:411`,
+  `inferrex-t0.8-database-model-invariants-spec.md:194`.
+- **Counterexample class:** two grants share a replay identity or revocation
+  fails to serialize against intake.
+- **Ambiguity / terminal disposition:** acceptance and revocation snapshots must
+  resolve under the specified lock order.
+- **Existing evidence:** schemas, signing vectors and source checkers; T1 real
+  revocation concurrency is later.
+- **Priority:** high.

--- a/plugins/brevitas/skills/brevitas/evals/cases/xray-replay-authority/target.md
+++ b/plugins/brevitas/skills/brevitas/evals/cases/xray-replay-authority/target.md
@@ -1,0 +1,5 @@
+[High] Signed replay identity can collide or survive revocation at intake.
+Location: `inferrex-t0.3-signed-protocol-objects-spec.md:411`; `inferrex-t0.8-database-model-invariants-spec.md:194`
+Mechanism: Two grants can share one environment-scoped signer/nonce identity, or acceptance can race revocation without the specified lock order across T0 and T1/T4.
+Impact: SYS-005 and SYS-012 can admit replay or revoked authority; T1 real revocation concurrency could not be established from the schemas, vectors, and source checkers.
+Fix: Serialize acceptance and revocation under one lock order keyed by environment, signer, nonce, purpose, object, scope, and owner.

--- a/plugins/brevitas/skills/brevitas/scripts/brevitas.py
+++ b/plugins/brevitas/skills/brevitas/scripts/brevitas.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""Fail-closed structural linter for Brevitas engineering prose."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+SEVERITIES = r"critical|high|medium|low|informational|info"
+CANONICAL_FINDING_RE = re.compile(
+    rf"^\s*(?:#{{1,6}}\s+)?(?:\[(?:{SEVERITIES})\]|(?:{SEVERITIES})\s+[\u2014-])\s+\S",
+    re.IGNORECASE,
+)
+SENTINEL_FINDING_RE = re.compile(r"^\s*FINDING\s*$")
+SENTINEL_END_RE = re.compile(r"^\s*END\s*$")
+EXCEPTION_RE = re.compile(
+    r'^\s*<!--\s*brevitas:\s*evidence-exception\s+reason="([^"]+)"\s*-->\s*$'
+)
+HEADING_RE = re.compile(r"^(#{1,6})\s+\S")
+LIST_RE = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)")
+TOP_LIST_RE = re.compile(r"^(?:[-*+]\s+|\d+[.)]\s+)")
+FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})(.*)$")
+TABLE_SEPARATOR_RE = re.compile(
+    r"^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$"
+)
+BOLD_LABEL_COLON_RE = re.compile(
+    r"^\s*(?:[-*+]\s+)?\*\*[^*:\n]{1,60}(?::\*\*|\*\*:)\s*\S"
+)
+CONFIDENCE_THEATRE_RE = re.compile(
+    r"\b(?:importantly|notably|it(?:'|\u2019)s worth noting|it is worth noting)\b",
+    re.IGNORECASE,
+)
+PROCESS_RE = re.compile(
+    r"^\s*(?:let me|i(?:'|\u2019)ll now|i will now|i(?:'|\u2019)m going to|"
+    r"i am going to|first,? i(?:'|\u2019)ll|first,? i will|reading|checking|"
+    r"reviewing|looking at)\b",
+    re.IGNORECASE,
+)
+REQUEST_RE = re.compile(
+    r"^\s*(?:you asked(?: me)? to|you(?:'|\u2019)ve asked|as requested|"
+    r"per your request|your request is|the task is to)\b",
+    re.IGNORECASE,
+)
+LIST_PREAMBLE_RE = re.compile(
+    r"^\s*(?:here (?:are|is)|the following|i found|these are)\b.*:\s*$",
+    re.IGNORECASE,
+)
+SUMMARY_RE = re.compile(
+    r"^\s*(?:in summary|to summari[sz]e|overall|taken together|in conclusion)\b",
+    re.IGNORECASE,
+)
+TRAILING_OFFER_RE = re.compile(
+    r"^\s*(?:let me know if|i can also|if you(?:'|\u2019)d like|happy to|"
+    r"would you like me to|feel free to ask)\b",
+    re.IGNORECASE,
+)
+QUALIFIER_RE = re.compile(
+    r"\b(?:may|might|could|possibly|probably|likely|apparently|appears?|seems?|"
+    r"suggests?|arguably|potentially|perhaps)\b",
+    re.IGNORECASE,
+)
+TX_HASH_RE = re.compile(r"\b0x[a-fA-F0-9]{64}\b")
+ADDRESS_RE = re.compile(r"\b0x[a-fA-F0-9]{40}\b")
+FILE_LINE_RE = re.compile(
+    r"(?<![A-Za-z0-9_])(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_.-]+\."
+    r"[A-Za-z0-9]+:\d+(?:-\d+)?"
+)
+NUMBER_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])(?:\d{1,3}(?:,\d{3})+(?:\.\d+)?|\d+(?:\.\d+)?)"
+    r"(?:%|[xX])?(?![A-Za-z0-9_-])"
+)
+
+
+@dataclass(frozen=True, order=True)
+class Issue:
+    line: int
+    code: str
+    message: str
+    source: str = "draft"
+
+
+@dataclass
+class Finding:
+    start: int
+    end: int
+    canonical: bool
+    exception_line: int | None = None
+
+
+def protected_tokens(text: str) -> dict[str, set[str]]:
+    """Return evidence tokens whose literal survival can be checked mechanically."""
+    tx_hashes = set(TX_HASH_RE.findall(text))
+    addresses = {token for token in ADDRESS_RE.findall(text) if token not in tx_hashes}
+    return {
+        "transaction hash": tx_hashes,
+        "address": addresses,
+        "file:line reference": set(FILE_LINE_RE.findall(text)),
+        "numeric token": set(NUMBER_RE.findall(text)),
+    }
+
+
+def _code_fences(lines: Sequence[str]) -> tuple[list[tuple[int, int, int]], set[int], list[Issue]]:
+    fences: list[tuple[int, int, int]] = []
+    code_lines: set[int] = set()
+    issues: list[Issue] = []
+    opener: tuple[int, str] | None = None
+    for index, line in enumerate(lines, start=1):
+        match = FENCE_RE.match(line)
+        if opener is None:
+            if match:
+                opener = (index, match.group(1))
+                code_lines.add(index)
+        else:
+            code_lines.add(index)
+            marker = opener[1]
+            if re.match(rf"^\s*{re.escape(marker[0])}{{{len(marker)},}}\s*$", line):
+                content_length = index - opener[0] - 1
+                fences.append((opener[0], index, content_length))
+                if content_length > 15:
+                    issues.append(
+                        Issue(opener[0], "B006", f"code fence has {content_length} lines; maximum is 15")
+                    )
+                opener = None
+    if opener is not None:
+        issues.append(Issue(opener[0], "B007", "unclosed code fence"))
+    return fences, code_lines, issues
+
+
+def _find_findings(lines: Sequence[str], code_lines: set[int]) -> list[Finding]:
+    starts: list[tuple[int, bool]] = []
+    sentinel_ranges: dict[int, int] = {}
+    index = 1
+    while index <= len(lines):
+        if index in code_lines:
+            index += 1
+            continue
+        line = lines[index - 1]
+        if SENTINEL_FINDING_RE.match(line):
+            starts.append((index, False))
+            end = index
+            while end <= len(lines) and not SENTINEL_END_RE.match(lines[end - 1]):
+                end += 1
+            sentinel_ranges[index] = min(end, len(lines))
+            index = end + 1
+            continue
+        if CANONICAL_FINDING_RE.match(line):
+            starts.append((index, True))
+        index += 1
+
+    findings: list[Finding] = []
+    for position, (start, canonical) in enumerate(starts):
+        if start in sentinel_ranges:
+            end = sentinel_ranges[start]
+        else:
+            end = starts[position + 1][0] - 1 if position + 1 < len(starts) else len(lines)
+        previous = start - 1
+        while previous >= 1 and not lines[previous - 1].strip():
+            previous -= 1
+        exception_line = previous if previous >= 1 and EXCEPTION_RE.match(lines[previous - 1]) else None
+        findings.append(Finding(start, end, canonical, exception_line))
+    return findings
+
+
+def _finding_issues(
+    lines: Sequence[str], findings: Sequence[Finding], code_lines: set[int]
+) -> list[Issue]:
+    issues: list[Issue] = []
+    used_exceptions: set[int] = set()
+    for finding in findings:
+        prose: list[tuple[int, str]] = []
+        for line_number in range(finding.start, finding.end + 1):
+            if line_number in code_lines:
+                continue
+            stripped = lines[line_number - 1].strip()
+            if not stripped or stripped.startswith("<!--"):
+                continue
+            if not finding.canonical and (
+                SENTINEL_FINDING_RE.match(stripped) or SENTINEL_END_RE.match(stripped)
+            ):
+                continue
+            prose.append((line_number, stripped))
+
+        if finding.exception_line is not None:
+            used_exceptions.add(finding.exception_line)
+            if len(prose) <= 5:
+                issues.append(
+                    Issue(finding.exception_line, "B005", "evidence exception is unnecessary")
+                )
+            if finding.canonical:
+                evidence_prefixes = (
+                    "evidence:",
+                    "counterexample:",
+                    "reproduction:",
+                    "establishment limit:",
+                    "could not establish:",
+                    "address:",
+                    "transaction:",
+                    "numeric evidence:",
+                )
+                for line_number, value in prose[5:]:
+                    if not value.lower().startswith(evidence_prefixes):
+                        issues.append(
+                            Issue(
+                                line_number,
+                                "B009",
+                                "evidence exception retains non-evidence prose",
+                            )
+                        )
+        elif len(prose) > 5:
+            issues.append(
+                Issue(
+                    prose[5][0],
+                    "B002",
+                    f"finding has {len(prose)} prose lines; maximum is 5",
+                )
+            )
+
+        if finding.canonical:
+            required = ("Location:", "Mechanism:", "Impact:", "Fix:")
+            values = [text for _, text in prose]
+            for label in required:
+                if not any(value.lower().startswith(label.lower()) for value in values[1:]):
+                    issues.append(Issue(finding.start, "B003", f"canonical finding is missing {label}"))
+
+    for line_number, line in enumerate(lines, start=1):
+        match = EXCEPTION_RE.match(line)
+        if match and line_number not in used_exceptions:
+            issues.append(
+                Issue(line_number, "B004", "evidence exception must immediately precede a finding")
+            )
+    return issues
+
+
+def _section_issues(lines: Sequence[str], code_lines: set[int]) -> tuple[list[Issue], list[int]]:
+    headings = [
+        index
+        for index, line in enumerate(lines, start=1)
+        if index not in code_lines and HEADING_RE.match(line)
+    ]
+    sections = headings[:]
+    if headings:
+        first = headings[0]
+        prior_content = any(lines[index - 1].strip() for index in range(1, first))
+        if not prior_content and lines[first - 1].startswith("# "):
+            sections = headings[1:]
+    issues: list[Issue] = []
+    if headings and len(sections) < 3:
+        issues.append(
+            Issue(headings[0], "B010", f"draft has {len(sections)} section headings; minimum is 3")
+        )
+    return issues, sections
+
+
+def _split_table_row(line: str) -> list[str]:
+    stripped = line.strip()
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    return [cell.strip() for cell in re.split(r"(?<!\\)\|", stripped)]
+
+
+def _table_issues(lines: Sequence[str], code_lines: set[int]) -> list[Issue]:
+    issues: list[Issue] = []
+    index = 1
+    while index < len(lines):
+        if index in code_lines or index + 1 in code_lines:
+            index += 1
+            continue
+        if "|" in lines[index - 1] and TABLE_SEPARATOR_RE.match(lines[index]):
+            start = index
+            rows = [lines[index - 1], lines[index]]
+            cursor = index + 2
+            while cursor <= len(lines) and "|" in lines[cursor - 1] and lines[cursor - 1].strip():
+                rows.append(lines[cursor - 1])
+                cursor += 1
+            column_counts = [_split_table_row(row) for row in rows]
+            real_columns = min((sum(bool(cell) for cell in row) for row in column_counts), default=0)
+            data_rows = max(0, len(rows) - 2)
+            if real_columns < 3 or data_rows < 3:
+                issues.append(
+                    Issue(
+                        start,
+                        "B011",
+                        f"table has {data_rows} data rows and {real_columns} real-data columns; minimum is 3x3",
+                    )
+                )
+            index = cursor
+        else:
+            index += 1
+    return issues
+
+
+def _point_for_line(
+    line_number: int, findings: Sequence[Finding], headings: Sequence[int], list_points: Sequence[int]
+) -> str:
+    for position, finding in enumerate(findings):
+        if finding.start <= line_number <= finding.end:
+            return f"finding:{position}"
+    candidates = [(line, f"heading:{line}") for line in headings if line < line_number]
+    candidates += [(line, f"list:{line}") for line in list_points if line < line_number]
+    return max(candidates, default=(0, "document"), key=lambda item: item[0])[1]
+
+
+def _fence_count_issues(
+    lines: Sequence[str], fences: Sequence[tuple[int, int, int]], findings: Sequence[Finding]
+) -> list[Issue]:
+    headings = [index for index, line in enumerate(lines, start=1) if HEADING_RE.match(line)]
+    list_points = [index for index, line in enumerate(lines, start=1) if TOP_LIST_RE.match(line)]
+    owners: dict[str, list[int]] = defaultdict(list)
+    for start, _, _ in fences:
+        owners[_point_for_line(start, findings, headings, list_points)].append(start)
+    return [
+        Issue(starts[1], "B008", "point contains more than one code fence")
+        for starts in owners.values()
+        if len(starts) > 1
+    ]
+
+
+def _structural_move_issues(lines: Sequence[str], code_lines: set[int]) -> list[Issue]:
+    issues: list[Issue] = []
+    nonblank = [index for index, line in enumerate(lines, start=1) if line.strip()]
+    first_six = set(nonblank[:6])
+    last_five = set(nonblank[-5:])
+    saw_list = False
+    for index, line in enumerate(lines, start=1):
+        if index in code_lines:
+            continue
+        if LIST_RE.match(line) or TABLE_SEPARATOR_RE.match(line):
+            saw_list = True
+        if index in first_six and REQUEST_RE.search(line):
+            issues.append(Issue(index, "B020", "request restatement"))
+        if index in first_six and LIST_PREAMBLE_RE.search(line):
+            issues.append(Issue(index, "B021", "list preamble"))
+        if PROCESS_RE.search(line):
+            issues.append(Issue(index, "B022", "process narration"))
+        if BOLD_LABEL_COLON_RE.search(line):
+            issues.append(Issue(index, "B023", "bold-label-colon item"))
+        if CONFIDENCE_THEATRE_RE.search(line):
+            issues.append(Issue(index, "B024", "confidence theatre"))
+        if saw_list and SUMMARY_RE.search(line):
+            issues.append(Issue(index, "B025", "summary after list"))
+        if index in last_five and TRAILING_OFFER_RE.search(line):
+            issues.append(Issue(index, "B026", "trailing offer"))
+        qualifiers = QUALIFIER_RE.findall(line)
+        if len(qualifiers) > 1:
+            issues.append(
+                Issue(index, "B027", f"claim stacks {len(qualifiers)} qualifiers; maximum is 1")
+            )
+    return issues
+
+
+def _direct_answer_issues(
+    lines: Sequence[str], code_lines: set[int], mode: str, findings: Sequence[Finding], sections: Sequence[int]
+) -> list[Issue]:
+    is_report = mode == "report" or (mode == "auto" and (findings or len(sections) >= 3))
+    if is_report:
+        return []
+    prose_lines: list[int] = []
+    for index, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("<!--"):
+            continue
+        if index in code_lines or LIST_RE.match(line) or FENCE_RE.match(line):
+            break
+        prose_lines.append(index)
+    if len(prose_lines) > 6:
+        return [
+            Issue(
+                prose_lines[6],
+                "B001",
+                f"direct answer has {len(prose_lines)} lines before a list or code fence; maximum is 6",
+            )
+        ]
+    return []
+
+
+def _evidence_issues(source_text: str, draft_text: str, source_name: str) -> list[Issue]:
+    source_tokens = protected_tokens(source_text)
+    draft_tokens = protected_tokens(draft_text)
+    source_lines = source_text.splitlines()
+    issues: list[Issue] = []
+    for category, tokens in source_tokens.items():
+        missing = sorted(tokens - draft_tokens[category])
+        for token in missing:
+            line = next(
+                (index for index, text in enumerate(source_lines, start=1) if token in text),
+                1,
+            )
+            issues.append(
+                Issue(line, "B030", f"missing protected {category}: {token}", source_name)
+            )
+    return issues
+
+
+def lint_text(
+    text: str,
+    *,
+    mode: str = "auto",
+    source_text: str | None = None,
+    source_name: str = "source",
+) -> list[Issue]:
+    lines = text.splitlines()
+    fences, code_lines, issues = _code_fences(lines)
+    findings = _find_findings(lines, code_lines)
+    section_issues, sections = _section_issues(lines, code_lines)
+    issues.extend(section_issues)
+    issues.extend(_finding_issues(lines, findings, code_lines))
+    issues.extend(_table_issues(lines, code_lines))
+    issues.extend(_fence_count_issues(lines, fences, findings))
+    issues.extend(_structural_move_issues(lines, code_lines))
+    issues.extend(_direct_answer_issues(lines, code_lines, mode, findings, sections))
+    if source_text is not None:
+        issues.extend(_evidence_issues(source_text, text, source_name))
+    return sorted(set(issues))
+
+
+def _read(path: str) -> tuple[str, str]:
+    if path == "-":
+        return sys.stdin.read(), "stdin"
+    file_path = Path(path)
+    return file_path.read_text(encoding="utf-8"), str(file_path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("draft", nargs="?", default="-", help="draft file or - for stdin")
+    parser.add_argument("--source", help="uncompressed source whose evidence must survive")
+    parser.add_argument("--mode", choices=("auto", "answer", "report"), default="auto")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        draft_text, draft_name = _read(args.draft)
+        source_text = source_name = None
+        if args.source:
+            source_text, source_name = _read(args.source)
+    except OSError as error:
+        print(f"brevitas: {error}", file=sys.stderr)
+        return 2
+
+    issues = lint_text(
+        draft_text,
+        mode=args.mode,
+        source_text=source_text,
+        source_name=source_name or "source",
+    )
+    for issue in issues:
+        name = draft_name if issue.source == "draft" else issue.source
+        print(f"{name}:{issue.line}: {issue.code} {issue.message}", file=sys.stderr)
+    return 1 if issues else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/brevitas/skills/brevitas/scripts/run_evals.py
+++ b/plugins/brevitas/skills/brevitas/scripts/run_evals.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Run Brevitas provenance, compression, structure, and evidence evals."""
+
+from __future__ import annotations
+
+import json
+import hashlib
+from pathlib import Path
+
+from brevitas import lint_text
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CASES = ROOT / "evals" / "cases"
+
+
+def run_case(case_dir: Path) -> list[str]:
+    manifest = json.loads((case_dir / "case.json").read_text(encoding="utf-8"))
+    original = (case_dir / "original.md").read_text(encoding="utf-8")
+    target = (case_dir / "target.md").read_text(encoding="utf-8")
+    failures: list[str] = []
+
+    digest = hashlib.sha256(original.encode("utf-8")).hexdigest()
+    if digest != manifest["origin_sha256"]:
+        failures.append("fixture no longer matches its pinned origin digest")
+
+    issues = lint_text(
+        target,
+        mode=manifest.get("mode", "report"),
+        source_text=original,
+        source_name="original.md",
+    )
+    failures.extend(f"lint {issue.code} at {issue.source}:{issue.line}: {issue.message}" for issue in issues)
+
+    expectation = manifest["expectation"]
+    if expectation == "compress":
+        if len(target.splitlines()) >= len(original.splitlines()):
+            failures.append("target is not physically shorter than original")
+    elif expectation == "retain-evidence":
+        lines = target.splitlines()
+        if not lines or "brevitas: evidence-exception" not in lines[0]:
+            failures.append("retention case lacks an evidence exception")
+        retained = "\n".join(lines[1:]).rstrip() + "\n"
+        if retained != original:
+            failures.append("retention case changed irreducible evidence")
+    else:
+        failures.append(f"unknown expectation: {expectation}")
+    return failures
+
+
+def main() -> int:
+    failures = 0
+    for case_dir in sorted(path for path in CASES.iterdir() if path.is_dir()):
+        case_failures = run_case(case_dir)
+        if case_failures:
+            failures += len(case_failures)
+            for failure in case_failures:
+                print(f"FAIL {case_dir.name}: {failure}")
+        else:
+            print(f"PASS {case_dir.name}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/brevitas/tests/test_brevitas.py
+++ b/plugins/brevitas/tests/test_brevitas.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+import unittest
+from pathlib import Path
+
+
+PLUGIN = Path(__file__).resolve().parents[1]
+ROOT = PLUGIN.parents[1]
+SCRIPT = PLUGIN / "skills" / "brevitas" / "scripts" / "brevitas.py"
+SPEC = importlib.util.spec_from_file_location("brevitas", SCRIPT)
+assert SPEC and SPEC.loader
+brevitas = importlib.util.module_from_spec(SPEC)
+sys.modules["brevitas"] = brevitas
+SPEC.loader.exec_module(brevitas)
+
+
+VALID_FINDING = """[High] Claim.
+Location: `src/Foo.sol:42`
+Mechanism: Exact causal path.
+Impact: Funds can be lost.
+Fix: Reject the state.
+"""
+
+
+class BrevitasTests(unittest.TestCase):
+    def codes(self, text: str, **kwargs) -> set[str]:
+        return {issue.code for issue in brevitas.lint_text(text, **kwargs)}
+
+    def test_valid_finding(self) -> None:
+        self.assertEqual(self.codes(VALID_FINDING), set())
+
+    def test_over_budget_finding(self) -> None:
+        self.assertIn("B002", self.codes(VALID_FINDING + "Evidence: extra.\n"))
+
+    def test_evidence_exception_allows_retention(self) -> None:
+        text = (
+            '<!-- brevitas: evidence-exception reason="six ordered reproduction steps" -->\n'
+            + VALID_FINDING
+            + "Reproduction: Step 1.\n"
+        )
+        self.assertNotIn("B002", self.codes(text))
+
+    def test_evidence_exception_rejects_connective_prose(self) -> None:
+        text = (
+            '<!-- brevitas: evidence-exception reason="six ordered reproduction steps" -->\n'
+            + VALID_FINDING
+            + "This is a transition.\n"
+        )
+        self.assertIn("B009", self.codes(text))
+
+    def test_evidence_exception_must_be_needed(self) -> None:
+        text = '<!-- brevitas: evidence-exception reason="not needed" -->\n' + VALID_FINDING
+        self.assertIn("B005", self.codes(text))
+
+    def test_code_fence_limit(self) -> None:
+        text = "```solidity\n" + "\n".join("x" for _ in range(16)) + "\n```\n"
+        self.assertIn("B006", self.codes(text))
+
+    def test_small_table(self) -> None:
+        text = "| a | b | c |\n|---|---|---|\n| 1 | 2 | 3 |\n"
+        self.assertIn("B011", self.codes(text))
+
+    def test_two_sections(self) -> None:
+        text = "# Title\n## One\nx\n## Two\ny\n"
+        self.assertIn("B010", self.codes(text, mode="report"))
+
+    def test_direct_answer_limit(self) -> None:
+        text = "\n".join(f"line {index}" for index in range(7))
+        self.assertIn("B001", self.codes(text, mode="answer"))
+
+    def test_structural_openers_and_closers(self) -> None:
+        text = "Here are the issues:\n- defect\nLet me know if you want more.\n"
+        codes = self.codes(text)
+        self.assertIn("B021", codes)
+        self.assertIn("B026", codes)
+
+    def test_missing_source_evidence(self) -> None:
+        source = "At `src/Foo.sol:42`, 17 calls reach 0x1111111111111111111111111111111111111111."
+        codes = self.codes("The path is unsafe.\n", source_text=source)
+        self.assertIn("B030", codes)
+
+    def test_host_descriptions_remain_identical(self) -> None:
+        claude = json.loads(
+            (PLUGIN / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )
+        codex = json.loads(
+            (PLUGIN / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(claude["description"], codex["description"])
+        self.assertEqual(codex["description"], codex["interface"]["shortDescription"])
+        self.assertGreaterEqual(len(codex["description"]), 25)
+        self.assertLessEqual(len(codex["description"]), 64)
+
+    def test_portable_entrypoint_routes_to_canonical_contract(self) -> None:
+        portable = ROOT / ".agents" / "skills" / "brevitas" / "SKILL.md"
+        links = re.findall(r"\[[^]]+\]\(([^)]+)\)", portable.read_text(encoding="utf-8"))
+        self.assertEqual(len(links), 2)
+        for link in links:
+            self.assertTrue((portable.parent / link).resolve().is_file(), link)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_marketplace_prose.py
+++ b/tests/test_marketplace_prose.py
@@ -11,6 +11,7 @@ MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
 PLUGINS = (
     "alexandria",
     "ariadne",
+    "brevitas",
     "hermes",
     "hexaemeron",
     "lemma",
@@ -23,6 +24,7 @@ PLUGINS = (
 CANONICAL_SKILLS = {
     "alexandria": ROOT / "plugins" / "alexandria" / "skills" / "alexandria" / "SKILL.md",
     "ariadne": ROOT / "plugins" / "ariadne" / "skills" / "ariadne" / "SKILL.md",
+    "brevitas": ROOT / "plugins" / "brevitas" / "skills" / "brevitas" / "SKILL.md",
     "hermes": ROOT / "plugins" / "hermes" / "skills" / "hermes" / "SKILL.md",
     "hexaemeron": ROOT / "plugins" / "hexaemeron" / "skills" / "fiat" / "SKILL.md",
     "lemma": ROOT / "plugins" / "lemma" / "skills" / "chunk" / "SKILL.md",
@@ -125,7 +127,7 @@ class MarketplaceProseTests(unittest.TestCase):
     def test_plugin_landing_readmes_publish_unique_rolling_fiat_jobs(self):
         landings = plugin_landing_readmes()
         self.assertEqual(set(landings), set(PLUGINS))
-        self.assertEqual(len(landings), 10)
+        self.assertEqual(len(landings), 11)
 
         topics = {}
         for name, path in landings.items():

--- a/tests/test_portable_skills.py
+++ b/tests/test_portable_skills.py
@@ -32,6 +32,7 @@ class PortableSkillTests(unittest.TestCase):
         for name in (
             "alexandria",
             "ariadne",
+            "brevitas",
             "hermes",
             "hexaemeron",
             "lazarus",
@@ -66,6 +67,11 @@ class PortableSkillTests(unittest.TestCase):
         for relative in re.findall(r"`(skills/[^`]+/SKILL\.md)`", contract):
             self.assertTrue((ariadne / relative).is_file(), relative)
 
+        brevitas = ROOT / "plugins" / "brevitas"
+        contract = (brevitas / "AGENTS.md").read_text(encoding="utf-8")
+        for relative in re.findall(r"`(skills/[^`]+/SKILL\.md)`", contract):
+            self.assertTrue((brevitas / relative).is_file(), relative)
+
         lemma = ROOT / "plugins" / "lemma"
         contract = (lemma / "AGENTS.md").read_text(encoding="utf-8")
         for relative in re.findall(r"`(skills/[^`]+/SKILL\.md)`", contract):
@@ -96,6 +102,7 @@ class PortableSkillTests(unittest.TestCase):
     def test_skill_names_match_canonical_parent_directories(self):
         skills = list((ROOT / "plugins" / "alexandria" / "skills").glob("*/SKILL.md"))
         skills += list((ROOT / "plugins" / "ariadne" / "skills").glob("*/SKILL.md"))
+        skills += list((ROOT / "plugins" / "brevitas" / "skills").glob("*/SKILL.md"))
         skills += list((ROOT / "plugins" / "hermes" / "skills").glob("*/SKILL.md"))
         skills += list((ROOT / "plugins" / "hexaemeron" / "skills").glob("*/SKILL.md"))
         skills += list(


### PR DESCRIPTION
## What changed

- Add the canonical Brevitas skill and Claude, Codex and portable-agent entrypoints.
- Add a fail-closed structural linter, Make targets, 13 unit tests and three audit-derived evals.
- Register Brevitas in both marketplaces, the repository catalogue and its contract tests.

## Why

Engineering reviews need mechanical limits on volume, finding shape and connective prose. Brevitas applies those limits after vocabulary and register passes while preserving addresses, transaction hashes, source locations, numbers, counterexamples, reproduction steps and explicit limits on what could be established.

## Checks

- `make -C plugins/brevitas/skills/brevitas test`
- `python3 -m unittest discover -s tests -v`
- Plugin packaging validator
- Agent Skill validator
- Clean-checkout patch and overlay verification

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
