### PR TITLE
docs(brevitas): compress skill prose

### DIFF
--- a/.agents/skills/brevitas/SKILL.md
+++ b/.agents/skills/brevitas/SKILL.md
@@ -1,13 +1,11 @@
 ---
 name: brevitas
-description: Route evidence-preserving volume and structure budgets for audit findings, security reviews, gas analysis, invariant discussion, diff review and protocol commentary to Brevitas.
+description: Route evidence-preserving volume and structure budgets for audit findings, security reviews, gas analysis, `invariant` discussion, diff review and protocol commentary to Brevitas.
 ---
 
-# Brevitas portable entrypoint
+Brevitas portable entrypoint
 
 <!-- marketplace-context:start -->
-## Where this sits
-
 Brevitas enforces mechanical volume and structure budgets on engineering review prose while preserving evidence.
 
 **Use another tool when.** Use Imprimatur for banned vocabulary, Vulgate for register, and Sapheneia for AuDHD interaction shape. Brevitas does not own any of those jobs.
@@ -15,10 +13,7 @@ Brevitas enforces mechanical volume and structure budgets on engineering review 
 **Current frontier.** The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked.
 <!-- marketplace-context:end -->
 
-Read [the Brevitas runtime contract](../../../plugins/brevitas/AGENTS.md), then
-read [the canonical Brevitas skill](../../../plugins/brevitas/skills/brevitas/SKILL.md)
-in full and follow it.
-
-Apply the canonical rules to substantive chat answers as well as written
-reports. The canonical skill and runtime contract are authoritative if this
-entrypoint ever disagrees with them.
+Read [the Brevitas runtime contract](../../../plugins/brevitas/AGENTS.md) and
+[the canonical Brevitas skill](../../../plugins/brevitas/skills/brevitas/SKILL.md)
+in full. Apply them to substantive chat answers and written reports. They are
+authoritative if this entrypoint disagrees.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -860,3 +860,11 @@ The round re-read the historical mechanism at `audit/AUDIT.md:20`, both compact-
 parsers, their fixtures, and the full protected-state proof. Root `22/22`, Hexaemeron
 `62/62`, Imprimatur, Brevitas `--source`, protected SHA verification, and
 `git diff --check` pass. No further lead was established.
+
+## Repository-wide Brevitas pass, step 2, round 1 -- 2026-08-18
+
+The Brevitas prose diff has no open finding. Status: clean.
+
+The review compared five changed files with entry ref `a7d001009e7e2a7e63343e206ef10ecabc2cab42`, checked the compact history parser, and recomputed frontier digest `dcff4f6b1397570468dedb18a1ebaa5f45377272bcd2f71cd69ad6818eeb0b62`. It also verified the three refusal digests: `08e534ff9fd8005778e2224f374bd1e42a4bb129c2504e8aa54549f8621f0494`, `2cdd9bb04532ec278184d2a3290a0b0b72c02be47ca634911428440ddbed6d58`, and `ed8fbcf14186a1c79f9db8f971796d192969ec729edeb2bba0fc78f30ff75e48`.
+
+Root `22/22`, Brevitas `13/13`, evals `3/3`, Agent Skills validation, Imprimatur, Brevitas `--source`, protected SHA verification, and `git diff --check` pass. The security suite remains waived because only Markdown changed.

--- a/plugins/brevitas/AGENTS.md
+++ b/plugins/brevitas/AGENTS.md
@@ -1,4 +1,4 @@
-# Brevitas runtime contract
+Brevitas runtime contract
 
 <!-- marketplace-context:start -->
 > **Marketplace context: Brevitas.** Brevitas enforces mechanical volume and structure budgets on engineering review prose while preserving evidence. Use Imprimatur for banned vocabulary, Vulgate for register, and Sapheneia for AuDHD interaction shape. Brevitas does not own any of those jobs. **Current frontier:** The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked.
@@ -7,16 +7,11 @@
 Brevitas contains one Agent Skill. Read `skills/brevitas/SKILL.md` in full
 before applying it. The canonical skill is the only behaviour contract.
 
-## Subject and order
-
 - Apply Brevitas to the agent's substantive chat answer and to engineering prose written to disk.
 - Run it after Imprimatur, Vulgate, or another word-choice or register pass.
 - Keep evidence precedence above every line, heading, table, and code-fence budget.
 - Do not apply it to code comments, commit messages, or specifications whose completeness is the point.
 - System, safety, harness, and target-repository rules still take precedence.
-
-## Invocation and paths
-
 - `$brevitas`, `/brevitas:brevitas`, `use Brevitas`, and any audit, security-review, gas, invariant, diff-review, or protocol-commentary answer select the skill.
 - Resolve relative paths from `skills/brevitas/`.
 - Run `scripts/brevitas.py` on a file or stdin. A non-zero exit rejects the draft.

--- a/plugins/brevitas/README.md
+++ b/plugins/brevitas/README.md
@@ -9,11 +9,13 @@ Brevitas puts mechanical volume and structure limits on engineering review prose
 
 **Current frontier.** The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked.
 
-**Next Fiat job.** Use /hexaemeron:fiat to Forward-test Brevitas across held x-ray, Solidity-auditor, gas, invariant and diff-review outputs, then add every confirmed structural bypass to the corpus without weakening evidence precedence. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
+**Next Fiat job.** Use /hexaemeron:fiat to Forward-test Brevitas across held x-ray, Solidity-auditor, gas, `invariant` and diff-review outputs, then add every confirmed structural bypass to the corpus without weakening evidence precedence. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
 <!-- marketplace-context:end -->
 
+## Contract
+
 Brevitas is the last structural pass for audit findings, security reviews, gas
-analysis, invariant discussion, diff review and protocol commentary. It does
+analysis, `invariant` discussion, diff review and protocol commentary. It does
 not choose words or voice. It controls line count, finding shape, headings,
 tables, code fences and the prose between points.
 
@@ -23,15 +25,18 @@ what could not be established survive every rewrite. `--source` checks the
 machine-readable subset. An explicit evidence exception keeps longer material
 when the five-line finding form cannot hold it.
 
-Brevitas includes:
-
 - one canonical [`SKILL.md`](skills/brevitas/SKILL.md) shared by Codex, Claude Code and portable agents;
 - the standard-library [`brevitas.py`](skills/brevitas/scripts/brevitas.py) linter for files and stdin;
 - a Make target for written reports and source-preservation checks; and
 - three audit-derived corpus cases, including one that must retain the original finding rather than compress it.
 
-#### Day to day
+## Examples
 
-**Developers.** A diff review has two real defects buried under setup, transitions and a repeated summary. Brevitas keeps each defect to claim, location, mechanism, impact and fix, then rejects the draft if its line budget or structure drifts.
+A diff review can hide two real defects under setup, transitions and a repeated
+summary. Brevitas keeps each defect to claim, location, mechanism, impact and
+fix, then rejects line-budget or structure drift.
 
-**Security and audit.** A finding carries addresses, exact locations, numeric traces and a reproduction sequence. Brevitas cuts connective prose first, checks the machine-readable evidence against the source, and permits a marked exception when the remaining evidence needs more than five lines.
+For security and audit work, Brevitas cuts connective prose before addresses,
+exact locations, numeric traces or reproduction steps. It checks machine-readable
+evidence against the source and permits a marked exception when evidence needs
+more than five lines.

--- a/plugins/brevitas/skills/brevitas/EVOLUTION.md
+++ b/plugins/brevitas/skills/brevitas/EVOLUTION.md
@@ -1,4 +1,4 @@
-# Brevitas evolution ledger
+Brevitas evolution ledger
 
 Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
 
@@ -6,10 +6,6 @@ Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VE
 - Frontier status: `open`
 - Frontier revision: `held-engineering-corpus`
 - Current frontier: The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked.
-- Next Fiat job: Forward-test Brevitas across held x-ray, Solidity-auditor, gas, invariant and diff-review outputs, then add every confirmed structural bypass to the corpus without weakening evidence precedence. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
+- Next Fiat job: `Forward-test Brevitas across held x-ray, Solidity-auditor, gas, invariant and diff-review outputs, then add every confirmed structural bypass to the corpus without weakening evidence precedence. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.`
 
-## History
-
-| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
-| --- | --- | --- | --- | --- | --- |
-| `brevitas-v0.1.0` | baseline | `held-engineering-corpus` | `dcff4f6b1397570468dedb18a1ebaa5f45377272bcd2f71cd69ad6818eeb0b62` | [README marketplace-context](../../README.md) | Versioning starts with the executable linter and three audit-derived corpus cases. |
+- `brevitas-v0.1.0` | baseline | `held-engineering-corpus` | `dcff4f6b1397570468dedb18a1ebaa5f45377272bcd2f71cd69ad6818eeb0b62` | [README marketplace-context](../../README.md) | Versioning starts with the executable linter and three audit-derived corpus cases.

--- a/plugins/brevitas/skills/brevitas/SKILL.md
+++ b/plugins/brevitas/skills/brevitas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brevitas
-description: Enforce evidence-preserving structural output budgets on engineering prose. Apply automatically to chat answers and written drafts containing audit findings, security or diff review, gas analysis, invariant discussion, protocol analysis, or specification commentary, and on explicit $brevitas invocation. Govern volume, structure, and connective prose only. Do not apply to code comments, commit messages, or completeness-oriented specification documents.
+description: Enforce evidence-preserving structural output budgets on engineering prose. Apply automatically to chat answers and written drafts containing audit findings, security or diff review, gas analysis, `invariant` discussion, protocol analysis, or specification commentary, and on explicit $brevitas invocation. Govern volume, structure, and connective prose only. Do not apply to code comments, commit messages, or completeness-oriented specification documents.
 metadata:
   version: "0.1.0"
 ---
@@ -9,10 +9,10 @@ metadata:
 
 ## Frontier
 
-Brevitas owns the engineering-prose structure frontier, not Hexaemeron's
-delivery or Solidity frontier. Its version, held target, next job, and maturity
-state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run another
-frontier pass after that ledger becomes mature.
+Brevitas owns the engineering-prose structure frontier, not Hexaemeron's delivery
+or Solidity frontier. [EVOLUTION.md](EVOLUTION.md) records its version, held target,
+next job and maturity state. Do not run or recommend another frontier pass once
+that ledger is mature.
 
 <!-- marketplace-context:start -->
 ## Where this sits
@@ -24,8 +24,8 @@ Brevitas enforces mechanical volume and structure budgets on engineering review 
 **Current frontier.** The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked.
 <!-- marketplace-context:end -->
 
-Apply this as the final structural pass after any lexicon or register skill such as
-imprimatur or vulgate. Do not alter word choice, voice, or AuDHD presentation.
+Apply this after a lexicon or register skill such as Imprimatur or Vulgate. Do not
+alter word choice, voice or AuDHD presentation.
 
 ## Precedence
 
@@ -36,9 +36,8 @@ Preserve evidence before satisfying any budget. Never delete or weaken:
 - concrete counterexamples or reproduction steps; or
 - an explicit statement that a fact, property, or conclusion could not be established.
 
-If evidence does not fit, let the budget yield and cut prose further. Never trade
-evidence for brevity. If the irreducible evidence still exceeds a finding budget,
-retain it and use the evidence-exception mechanism below.
+If evidence does not fit, the budget yields. Cut prose, never evidence. Mark an
+irreducible over-budget finding with the evidence exception below.
 
 ## Compose
 
@@ -64,11 +63,7 @@ retain it and use the evidence-exception mechanism below.
    not count as a section.
 7. Use at most one qualifier per claim.
 
-For an irreducible finding, place this immediately before it:
-
-```html
-<!-- brevitas: evidence-exception reason="counterexample requires ordered steps" -->
-```
+For an irreducible finding, place `<!-- brevitas: evidence-exception reason="counterexample requires ordered steps" -->` immediately before it.
 
 Use the exception only when compression would remove protected evidence. Keep any
 extra lines as evidence, counterexample, reproduction, or establishment-limit
@@ -77,14 +72,19 @@ statements; do not use the exception to retain connective prose.
 ## Delete
 
 Delete request restatements, list preambles, post-list summaries, process narration,
-bold-label-colon items, trailing offers, unrequested next-step menus, stacked hedges,
-and confidence theatre such as "importantly", "notably", or "it's worth noting".
-Do not reprint visible code. Quote only the lines that carry the defect.
+bold-label-colon items, trailing offers, unrequested next-step menus and stacked
+hedges. Delete confidence theatre, including:
+
+```text
+importantly; notably; it's worth noting
+```
+
+Do not reprint visible code. Quote only the lines carrying the defect.
 
 ## Lint
 
 Run the checker before sending substantive chat prose or saving a report. Pipe chat
-drafts through stdin; pass a file for written work:
+drafts through stdin; pass written work as a file:
 
 ```bash
 python3 scripts/brevitas.py - < draft.md
@@ -94,24 +94,21 @@ make -C /path/to/brevitas lint FILE=/path/to/report.md
 ```
 
 Use `--mode answer` for direct answers and `--mode report` for reports. `auto`
-infers a report from findings or at least 3 sections. When compressing existing
-material, always pass `--source`; the checker then fails if an address, transaction
-hash, `file:line` reference, or numeric token disappears. Fix every diagnostic and
-rerun until exit status 0.
+infers a report from findings or at least 3 sections. For existing material, always
+pass `--source`; the checker fails if an address, transaction hash, `file:line`
+reference or numeric token disappears. Fix every diagnostic and rerun for exit 0.
 
 Host-required status commentary is outside the draft lint boundary. Do not suppress
 status messages required by the execution environment.
 
 ## Evals
 
-Run `make test`. The corpus in `evals/cases/` contains preserved audit, x-ray,
-and security-review excerpts with source paths, ranges, and pinned fixture
-digests. `scripts/run_evals.py` verifies fixture integrity, target structure,
-evidence-token survival, actual compression for positive cases, and exact
-retention for the evidence-exception case.
+Run `make test`. `evals/cases/` contains preserved audit, x-ray and security-review
+excerpts with source paths, ranges and pinned fixture digests. `scripts/run_evals.py`
+checks fixture integrity, target structure, evidence-token survival, positive-case
+compression and exact retention for the evidence-exception case.
 
 ## Exclusions
 
-Do not apply this skill to code comments, commit messages, or specification documents
-where completeness is the point. Do not perform lexicon, tone, register, or
-accessibility transformations.
+Do not apply this skill to code comments, commit messages or specifications where
+completeness is the point. Do not change lexicon, tone, register or accessibility.


### PR DESCRIPTION
Compresses Brevitas canonical, runtime, README, ledger, and portable prose without changing its evidence precedence or held frontier.
The three digest-bound `original.md` fixtures remain byte-identical; eight mutable surfaces pass source preservation.
Audit: `audit/AUDIT.md`, repository-wide Brevitas pass, step 2, round 1.
Proof: root `22/22`, Brevitas `13/13`, evals `3/3`, Agent Skills validation, protected SHA checks, Imprimatur, Brevitas `--source`, and `git diff --check`.
<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
