### PR TITLE
docs(lemma): compress chunking prose

### DIFF
--- a/.agents/skills/lemma/SKILL.md
+++ b/.agents/skills/lemma/SKILL.md
@@ -6,7 +6,7 @@ description: Route Solidity or Markdown chunking to Lemma. Use it for validated,
 # Lemma portable entrypoint
 
 <!-- marketplace-context:start -->
-## Where this sits
+## Scope
 
 Lemma turns Solidity compiler input or Markdown trees into validated, source-linked JSONL chunks, keeping quotation text separate from model and embedding text.
 
@@ -15,11 +15,12 @@ Lemma turns Solidity compiler input or Markdown trees into validated, source-lin
 **Current frontier.** Callable-surface ABI validation does not independently check return types or state mutability.
 <!-- marketplace-context:end -->
 
-Read [the Lemma runtime contract](../../../plugins/lemma/AGENTS.md), then read
-[the canonical `chunk` skill](../../../plugins/lemma/skills/chunk/SKILL.md) in
-full and follow it. Resolve every relative path from the canonical skill's
-directory. The canonical file is authoritative if this entrypoint and it ever
-disagree.
+## Authority
 
-`/lemma:chunk` is the plugin-qualified invocation. `$lemma` remains the
-host-neutral entrypoint for agents that discover this portable skill.
+Read [the runtime contract](../../../plugins/lemma/AGENTS.md), then read and follow
+[the canonical `chunk` skill](../../../plugins/lemma/skills/chunk/SKILL.md) in full.
+Resolve relative paths from its directory. It wins if the two files disagree.
+
+## Invocation
+
+Use `/lemma:chunk` through the plugin or `$lemma` through host-neutral discovery.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -884,3 +884,11 @@ The Hermes prose diff has no open finding. Status: clean.
 The review compared six files with entry ref `a7d001009e7e2a7e63343e206ef10ecabc2cab42`. It retained Gates 1 through 6, exits `0`, `10`, `20`, `30`, `40`, `50`, and `60`, all storage-layout and unchecked-arithmetic refusals, and frontier digest `7d5489a979e01a2ac5f27ad9dbc70811375104a76482f218b72b559bf6298f40`. No live Wildcat gas result or candidate was established.
 
 Root `22/22`, Hermes `14/14`, two Agent Skills validations, six Imprimatur and Brevitas `--source` checks, protected SHA verification, and `git diff --check` pass. The security suite remains waived because only Markdown changed.
+
+## Repository-wide Brevitas pass, step 5, round 1 -- 2026-08-18
+
+The Lemma prose diff has no open finding. Status: clean.
+
+The review compared 17 files with entry ref `a7d001009e7e2a7e63343e206ef10ecabc2cab42`. It retained the quotation, model and embedding fields, source-location rules, fatal validation conditions, baseline entry figures, frontier digest `2d4f0d7948208fefdca52f4380b3f4c83261917a282256571a2ee611c5d9d36c`, and protected licence passage.
+
+Root `22/22`, Markdown `126` assertions, Solidity `142` assertions with pinned solc `0.8.25`, two Agent Skills validations, 17 Imprimatur and Brevitas `--source` checks, protected SHA verification, and `git diff --check` pass. Regeneration produced `49` chunks, `9/9` placed, `44` placed through `SUMMARY.md`, median `143`, and p99/max `589`. The security suite remains waived because only Markdown changed.

--- a/plugins/lemma/AGENTS.md
+++ b/plugins/lemma/AGENTS.md
@@ -5,31 +5,28 @@
 <!-- marketplace-context:end -->
 
 Lemma contains one Agent Skill, `chunk`. Its canonical instructions are in
-`skills/chunk/SKILL.md`; read that file in full before chunking Solidity or
-Markdown.
+`skills/chunk/SKILL.md`; read it in full before chunking Solidity or Markdown.
 
 ## Capabilities and paths
 
 - Resolve `$PLUGIN_ROOT` to this `plugins/lemma/` directory.
-- Run `chunkers/solidity.py`, `chunkers/markdown.py`, and supporting commands
-  from `$PLUGIN_ROOT`, regardless of the current working directory.
-- Treat the directory named by the user as the input and output target. Do not
-  use this plugin checkout as the target unless the user explicitly names it.
-- Python 3.10 or later is required. Solidity chunking also needs a compatible
-  local `solc`, or Docker/Podman for the included `solc-container` wrapper.
+- Run `chunkers/solidity.py`, `chunkers/markdown.py`, and supporting commands from
+  `$PLUGIN_ROOT`, regardless of the current working directory.
+- Use the user-named directory for input and output. Use this checkout only when
+  the user names it.
+- Require Python 3.10 or later. Solidity also needs compatible local `solc` or
+  Docker/Podman for the included `solc-container` wrapper.
 
 ## Interpretation
 
-- `$chunk`, `/lemma:chunk`, and a plain request to use Lemma are equivalent
-  activation forms.
-- Lemma only creates chunks. It does not embed them, create an index, retrieve
-  from an index, or answer questions from one.
-- A chunker exit code other than zero rejects the output. Do not use a partial
-  file or describe the run as successful.
-- The `synthesised` field is authoritative: a synthesised chunk is not a
-  verbatim quotation.
+- `$chunk`, `/lemma:chunk`, and a plain request to use Lemma are equivalent.
+- Lemma creates chunks only. It does not embed, index, retrieve, or answer.
+- Reject output after a non-zero chunker exit. Do not use a partial file or call
+  the run successful.
+- `synthesised` is authoritative: a synthesised chunk is not verbatim quotation.
 - Repository instructions and approval rules still apply to any output path.
 
-`tools/verify_anchors.py` is the only included command that makes network
-requests. Run it only when the user asks to compare Markdown anchors with a
-live rendered site.
+## Network access
+
+Only `tools/verify_anchors.py` makes network requests. Run it only when the user
+asks to compare Markdown anchors with a live rendered site.

--- a/plugins/lemma/INVARIANTS.md
+++ b/plugins/lemma/INVARIANTS.md
@@ -4,28 +4,23 @@
 > **Marketplace context: Lemma.** Lemma turns Solidity compiler input or Markdown trees into validated, source-linked JSONL chunks, keeping quotation text separate from model and embedding text. It does not embed, index, retrieve or answer; Berean is the adjacent unbuilt release discipline for a grounded protocol agent. **Current frontier:** Callable-surface ABI validation does not independently check return types or state mutability.
 <!-- marketplace-context:end -->
 
-This document states the current chunker guarantees, the classes of defect
-adversarial review has found in them, and the residual weak points. A past
-finding is recorded where it explains a non-obvious design decision or a
-regression fixture that would otherwise look arbitrary, and dropped where it
-does not.
+This records chunker guarantees, defects that explain design choices or fixtures,
+and residual weak points. It omits past findings that explain neither.
 
-The central risk is a citation that looks verified while pointing at the wrong
-bytes, source, contract, or rendered fragment. A crash is safer because the build
-stops.
+The central risk is a verified-looking citation to the wrong bytes, source,
+contract, or fragment. A crash stops the build and is safer.
 
 ## Current invariants
 
 ### Shared schema and citation invariants
 
-**I1: display text is byte-exact source.** For every chunk with
-`synthesised: false`, `display_text` is sliced from the source bytes and decoded
-after slicing. Source offsets from solc are byte offsets, not Python character
-offsets.
+**I1: display text is byte-exact source.** For `synthesised: false`, slice
+`display_text` from source bytes before decoding. Solc offsets are bytes, not
+Python characters.
 
 **I2: assembled chunks are labeled.** Contract headers, callable surfaces, and
-document indexes combine multiple source regions. They carry
-`synthesised: true` and cannot be rendered as verbatim quotes.
+document indexes combine regions and carry `synthesised: true`; never render them
+as verbatim quotes.
 
 **I3: IDs are unique after source namespacing.** Solidity IDs include path,
 contract, signature, and canonical parameter types. Markdown duplicate headings
@@ -35,9 +30,9 @@ are disambiguated. The merged pipeline rejects collisions across sources.
 `model_text`; it never changes `display_text`. `embed_text` is composed from
 structured state rather than parsed back from a previous rendered string.
 
-**I5: schema validation is fatal.** Empty required fields, invalid source types
-or tiers, duplicate IDs, incorrect synthesized flags, empty visible model text,
-and oversize model or embedding text stop the build.
+**I5: schema validation is fatal.** Empty required fields or visible model text,
+invalid source types or tiers, duplicate IDs, wrong synthesized flags, and
+oversize model or embedding text stop the build.
 
 **I6: provenance is pipeline-owned.** Chunkers emit source-local facts. The
 calling pipeline applies corpus build ID, resolved source ref, tier, protocol
@@ -47,14 +42,13 @@ version, deployment status, and per-document legal metadata, via
 ### Solidity invariants
 
 **S1: deployed inputs define the corpus.** The chunker consumes every configured
-deployment `standard-input.json`. Compilation errors, unexpected solc
-versions when `--expect-solc` is used, invalid source-unit paths, and empty
-selections are fatal.
+deployment `standard-input.json`. Compilation errors, unexpected solc under
+`--expect-solc`, invalid source-unit paths, and empty selections are fatal.
 
-**S2: comment removal preserves code.** Strings containing comment delimiters,
-Unicode and hex literals, escaped quotes, division, and CR line endings survive.
-Only the documentation range attached by solc is retained as natspec; mid-body
-`///` and `/** */` comments are ordinary comments.
+**S2: comment removal preserves code.** Keep strings with comment delimiters,
+Unicode and hex literals, escaped quotes, division, and CR line endings. Retain
+only solc-attached documentation as natspec; mid-body `///` and `/** */` are
+ordinary comments.
 
 **S3: signatures distinguish semantic types.** Canonical signatures preserve
 struct, enum, contract, fully qualified type, array, and payable-address
@@ -65,9 +59,8 @@ distinctions while removing data-location syntax.
 state-variable getters occupy their signature slot, derived overrides shadow
 bases, and constructors are not inherited.
 
-**S5: compilation-unit merging only adds evidence.** Exposure is unioned across units
-and override state is ORed. Absence from a separately deployed unit does not
-erase evidence from another unit.
+**S5: compilation-unit merging only adds evidence.** Union exposure and OR
+override state across units. Absence from one unit does not erase another.
 
 **S6: callable surfaces agree with the ABI.** Public and external functions and
 getters are compared with the compiler ABI by full input signature. A divergence
@@ -83,10 +76,9 @@ detail and embedding text.
 HTML comments, raw HTML blocks, inline code, lazy list continuation, and lazy
 blockquote continuation do not become section boundaries.
 
-**M2: hidden comments do not enter model text.** Comment bytes are removed while
-visible text on the same line survives. Comment syntax inside a valid code span
-remains visible. An unmatched or escaped backtick is literal text rather than an
-unbounded hiding delimiter.
+**M2: hidden comments do not enter model text.** Remove comment bytes but retain
+visible same-line text. Keep comment syntax in valid code spans. Treat unmatched
+or escaped backticks as literal, not unbounded hiding delimiters.
 
 **M3: anchors follow renderer behavior.** Inline markup is reduced to rendered
 text before slugging. Duplicate suffixes count every parsed heading, including
@@ -106,14 +98,11 @@ filenames.
 **M6: pinned refs determine all bytes.** Symlinked documents, symlinked
 navigation, paths outside the root, and unreadable sources are rejected.
 
-**M7: template chrome does not enter model text.** GitBook `{% … %}` tag bytes
-are removed from model text wherever they sit on a line, including after visible
-prose. The visible prose they wrap survives. A live corpus chunk
-carried `{% hint style="info" %}` sharing a line with prose into a delivered
-answer. Tag syntax inside fenced code or a valid code span remains visible
-example markup, and an unclosed `{%` is literal text rather than an unbounded
-hiding delimiter. Display text still quotes the file byte-for-byte: the strip
-happens in span selection for model text, never in citation bytes.
+**M7: template chrome does not enter model text.** Remove GitBook `{% … %}` bytes
+even beside prose, while keeping wrapped text. A live chunk once carried
+`{% hint style="info" %}` beside prose into an answer. Keep tags in fences or
+valid code spans, and treat unclosed `{%` as literal. Display text stays
+byte-exact because only model-text span selection strips tags.
 
 ## Why the implementation has these shapes
 
@@ -122,11 +111,10 @@ Each fix has a regression fixture in the current suites.
 
 ### Byte and character offsets diverge
 
-Solc reports byte offsets. Slicing decoded Python strings corrupted Solidity
-after non-ASCII text while still producing plausible code. A later variant used
-a byte length as a character length when preserving natspec and could extend the
-trusted documentation range into a function body. Source and documentation
-slicing now remain in bytes until the selected region is decoded.
+Solc byte offsets once sliced decoded Python strings, corrupting Solidity after
+non-ASCII text while leaving plausible code. A later variant treated a byte
+length as characters and could extend natspec into a function body. Source and
+documentation stay in bytes until the selected region is decoded.
 
 ### Self-derived checks can certify the wrong object
 
@@ -144,11 +132,10 @@ signatures, emitted document paths, and production entry points.
 
 ### Re-parsing generated text creates attacker-controlled delimiters
 
-Embedding text once reconstructed its base by splitting on a human-readable
-marker that natspec could contain. Text after the marker disappeared from
-retrieval while the citation remained intact. Embedding text is now composed
-from the chunk's model text, breadcrumb, exposure, and alias fields on every
-update.
+Embedding text once split its base on a human-readable marker that natspec could
+contain. Later text vanished from retrieval while its citation survived. Each
+update now composes embedding text from model text, breadcrumb, exposure, and
+aliases.
 
 ### Handwritten syntax approximations need fail-safe direction
 
@@ -161,10 +148,8 @@ reader-hidden instructions.
 
 ### Compiler facts should replace lexical guesses
 
-Natspec was initially identified by `///` or `/** */` syntax. That preserved
-documentation-shaped comments in function bodies. Solc has already decided
-which documentation attaches to a declaration, so the chunker now preserves
-only the compiler-reported documentation range.
+Recognizing natspec by `///` or `/** */` preserved documentation-shaped function
+body comments. The chunker now keeps only solc's attached documentation range.
 
 The same principle applies to inheritance order and ABI surfaces: compiler
 linearization and ABI output are stronger evidence than a parallel source-level
@@ -179,21 +164,17 @@ corpus is not a warning condition.
 
 ## Recorded baseline
 
-Produced by `baseline/regenerate` over the synthetic corpus in `baseline/`, with
-solc 0.8.25, the version `solc-container`'s pinned digest resolves to. The
-corpus is invented and small; the point is that these numbers can be reproduced
-from a clone rather than taken on trust.
+`baseline/regenerate` produced this from the small, invented `baseline/` corpus
+with solc 0.8.25, resolved by the `solc-container` digest. These numbers reproduce
+from a clone.
 
-The Solidity figures depend on the compiler, because the AST is the compiler's
-output. `regenerate` therefore passes `--expect-solc`, so a compiler change
-fails the run rather than quietly printing different numbers (S1). As it
-happens this corpus produces byte-identical chunks on 0.8.25 and 0.8.26, which
-says the corpus does not exercise a difference between those two releases, not
-that the output is compiler-independent.
+Solidity figures depend on the compiler AST. `regenerate` passes `--expect-solc`,
+so a change fails instead of printing new numbers (S1). This corpus happens to
+produce byte-identical chunks on 0.8.25 and 0.8.26; it does not exercise a
+difference between those releases and does not prove compiler independence.
 
 ```text
-Solidity
-  25 chunks from 1 compilation unit
+Solidity: 25 chunks from 1 compilation unit
   0 duplicate bodies folded; 0 alias IDs retained
   5 synthesised chunks
   13 chunks attributed to a concrete contract
@@ -202,25 +183,22 @@ Solidity
   by kind: Enum 1, Error 3, Event 2, Function 12, Modifier 1, Struct 1,
            contract 2, interface 1, library 1, surface 1
 
-Markdown
-  38 chunks from 9 documents
-  9/9 emitted documents placed
-  9 synthesised document indexes
-  34 chunks placed in the SUMMARY hierarchy
-  median 141 characters; p99 568; maximum 568
+Markdown entry ref: 38 chunks from 9 documents; 9/9 placed; 9 indexes
+  34 chunks in SUMMARY; median 141 characters; p99 568; maximum 568
+Markdown current: 49 chunks from 9 documents; 9/9 placed; 9 indexes
+  44 chunks in SUMMARY; median 143 characters; p99 589; maximum 589
 ```
 
-A change that moves these figures should move the recorded baseline in the same
-commit. A change that moves them unexpectedly is what the corpus is for.
+The entry-ref Markdown figures retain the source evidence tokens for this prose
+pass. The current figures reproduce from the rewritten corpus. Move the current
+baseline with intentional chunker or corpus changes; investigate unexpected ones.
 
 ## A note on numbering
 
-The `S*` and `M*` identifiers above number the *invariants* in this document.
-They are not the same scheme as the case identifiers the test suites print:
-`test_solidity.py` prints `I4` through `I29`; `test_markdown.py` prints `M1`
-through `M24`.
-The Markdown prefix collides by accident. An invariant is usually covered by
-several cases rather than one, so do not read `M3` here as `M3` there.
+`S*` and `M*` name these invariants, not suite cases: `test_solidity.py` prints
+`I4` through `I29`; `test_markdown.py` prints `M1` through `M24`. The Markdown
+prefix collision is accidental. Several cases usually cover one invariant, so
+`M3` here does not mean suite case `M3`.
 
 Both suites print a per-run assertion total. Treat it as a regression signal;
 adding source legitimately changes it.
@@ -267,8 +245,5 @@ python3 tests/test_markdown.py
 python3 tests/test_solidity.py --solc ./solc-container
 ```
 
-Run the renderer fit after a docs or platform change:
-
-```bash
-python3 tools/verify_anchors.py --help
-```
+After a docs or platform change, inspect the renderer fit with
+`python3 tools/verify_anchors.py --help`.

--- a/plugins/lemma/README.md
+++ b/plugins/lemma/README.md
@@ -12,19 +12,16 @@ Lemma turns Solidity compiler input or Markdown trees into validated, source-lin
 **Next Fiat job.** Use /hexaemeron:fiat to make callable-surface ABI validation cover return types and state mutability as well as names and input types, with any divergence rejecting the output. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
 <!-- marketplace-context:end -->
 
-Lemma turns Solidity compiler inputs and Markdown documents into JSONL chunks.
-Each chunk uses the same schema and records enough source information for a
-downstream system to distinguish quoted source text from assembled text.
+Lemma turns Solidity compiler inputs and Markdown documents into one JSONL
+schema with source data that separates quotation from assembled text.
 
-It does not embed, index, retrieve, or answer from the chunks. Python 3.10 or
-later is the only runtime dependency. Solidity chunking also needs `solc`; the
-included wrapper can run the pinned compiler with Docker or Podman.
+It does not embed, index, retrieve, or answer. Python 3.10 or later is the only
+runtime dependency. Solidity also needs `solc`; Docker or Podman can run the
+pinned compiler through the included wrapper.
 
-The plugin is Lemma; its skill is `chunk`, giving the qualified name
-`lemma:chunk` (`/lemma:chunk` in Claude Code). The name states the operation
-instead of repeating the plugin name in the call.
-`lemmatise` was avoided because it already means reducing words to dictionary
-forms in natural-language processing, which this plugin does not do.
+The `chunk` skill is `lemma:chunk` (`/lemma:chunk` in Claude Code). It names the
+operation. `lemmatise` already means reducing words to dictionary forms in
+natural-language processing, which Lemma does not do.
 
 ## Solidity
 
@@ -38,8 +35,8 @@ python3 chunkers/solidity.py \
   --out chunks.jsonl
 ```
 
-Use `--solc solc` to call a local compiler. Add `--expect-solc 0.8.25` when the
-build must refuse another compiler version.
+Use `--solc solc` for a local compiler. Add `--expect-solc 0.8.25` to reject any
+other version.
 
 ## Markdown
 
@@ -53,23 +50,19 @@ python3 chunkers/markdown.py \
   --out chunks.jsonl
 ```
 
-Pass `--summary ''` for a tree without GitBook navigation. Use `--exclude`
-for agent instructions, generated pages, or other files that should not enter
-the corpus.
+Pass `--summary ''` without GitBook navigation. Use `--exclude` for agent
+instructions, generated pages, or anything else outside the corpus.
 
-Both commands validate their output before writing it. A non-zero exit means no
-JSONL file should be used.
+Both commands validate before writing. Reject the JSONL after a non-zero exit.
 
 ## Output
 
-[`schema.py`](schema.py) defines the shared `Chunk` type. The main text fields
-are:
+[`schema.py`](schema.py) defines `Chunk` and its text fields:
 
 - `display_text`: source text used for quotation;
 - `model_text`: text prepared for model context;
 - `embed_text`: text prepared for embedding; and
-- `synthesised`: true when `display_text` was assembled and must not be treated
-  as a verbatim quotation.
+- `synthesised`: true for assembled `display_text`, which is not verbatim.
 
 The calling pipeline can add build provenance with `schema.stamp()`.
 
@@ -82,14 +75,11 @@ python3 tests/test_markdown.py
 python3 tests/test_solidity.py
 ```
 
-Compiler-dependent Solidity tests are opt-in:
+Compiler-dependent tests are opt-in with
+`python3 tests/test_solidity.py --solc ./solc-container`.
 
-```bash
-python3 tests/test_solidity.py --solc ./solc-container
-```
-
-[`INVARIANTS.md`](INVARIANTS.md) records the guarantees, known limitations,
-and reproducible baseline. `baseline/regenerate` rebuilds that baseline.
+[`INVARIANTS.md`](INVARIANTS.md) records guarantees, limits, and the reproducible
+baseline. `baseline/regenerate` rebuilds it.
 
 ## Licence
 

--- a/plugins/lemma/baseline/README.md
+++ b/plugins/lemma/baseline/README.md
@@ -4,52 +4,42 @@
 > **Marketplace context: Lemma.** Lemma turns Solidity compiler input or Markdown trees into validated, source-linked JSONL chunks, keeping quotation text separate from model and embedding text. It does not embed, index, retrieve or answer; Berean is the adjacent unbuilt release discipline for a grounded protocol agent. **Current frontier:** Callable-surface ABI validation does not independently check return types or state mutability.
 <!-- marketplace-context:end -->
 
-A small invented corpus, used to produce the numbers recorded in
-[`../INVARIANTS.md`](../INVARIANTS.md).
+A small invented corpus produces the numbers in
+[`../INVARIANTS.md`](../INVARIANTS.md). An unreproducible baseline is not evidence.
 
-It exists because a baseline you cannot reproduce is not evidence. Everything
-here is fabricated for the purpose: four Solidity sources describing a registry
-that does not exist, and nine Markdown documents describing how to use it. None
-of it corresponds to a deployed system, and the prose is written to be chunked
-rather than to be read.
+Everything here is fabricated: four Solidity sources describe a nonexistent
+registry and nine Markdown documents describe its use. Nothing corresponds to a
+deployed system. The prose exists for chunking, not reading.
 
 ```bash
 baseline/regenerate --solc /path/to/solc
 ```
 
-`standard-input.json` is built from `solidity/src/` on each run rather than
-committed, because that file embeds a copy of every source. A committed copy
-would sit next to `src/` with nothing keeping the two in agreement, and the
-failure is silent: you edit a contract, the chunker reads the stale copy, and
-every chunk cites bytes no longer in the file it names. `standard_input.py`
-does the build, and doubles as the shortest worked example of the input format
-the Solidity chunker consumes.
+Each run builds `standard-input.json` from `solidity/src/`; committing its copied
+sources would permit silent drift. The chunker could then read stale code and
+cite bytes absent from the named file. `standard_input.py` builds the input and
+serves as the shortest example of its format.
 
 ## What it is chosen to exercise
 
-The Solidity side covers an interface, an abstract base, a concrete contract
-inheriting from it, and a library: natspec on declarations and on parameters,
-custom errors, an event, an enum, a struct, a modifier, public immutables and a
-public constant that compile to getters, an `@inheritdoc` override, and a
-`using ... for` directive. That is enough for the surface chunk, the inheritance
-attribution and the ABI cross-check to all have something to do.
+Solidity covers an interface, abstract base, concrete inheritor, and library;
+natspec on declarations and parameters; custom errors, event, enum, struct,
+modifier, public immutable and constant getters; an `@inheritdoc` override; and
+`using ... for`. These exercise surface chunks, inheritance, and ABI checks.
 
-The Markdown side is shaped like a GitBook: a `SUMMARY.md` with three nav
-sections and a nested entry, headings at several levels, a fenced code block, an
-HTML comment, a table, and a troubleshooting page written as standalone bold
-paragraphs rather than headings. `SUMMARY.md` is excluded from the chunked set,
-because it is navigation rather than content.
+Markdown is a GitBook-shaped tree: `SUMMARY.md` has three nav sections and a
+nested entry; documents include varied headings, fenced code, an HTML comment,
+a table, and standalone bold troubleshooting boundaries. `SUMMARY.md` is
+navigation and remains outside the chunked set.
 
 ## The compiler is gated
 
-The figures in `INVARIANTS.md` were recorded with solc 0.8.25, which is
-what `solc-container`'s pinned digest resolves to. `regenerate` passes
-`--expect-solc 0.8.25` by default, so a compiler that is not the pinned one
-fails the run with a non-zero exit rather than quietly printing different
-numbers.
+The `INVARIANTS.md` figures use solc 0.8.25, the version resolved by the
+`solc-container` digest. `regenerate` defaults to `--expect-solc 0.8.25`, so any
+other compiler fails non-zero instead of printing different numbers.
 
-If you change the digest in `solc-container`, change the default in
-`regenerate` in the same commit, and re-record the figures.
+Change the `regenerate` default and recorded figures in the same commit as the
+`solc-container` digest.
 
 ```bash
 baseline/regenerate --expect 0.8.26   # record against a different compiler
@@ -58,6 +48,5 @@ baseline/regenerate --no-expect       # see what an ungated run produces
 
 ## Regenerating after a change
 
-If a change to either chunker moves these numbers, that is expected and the
-recorded baseline should move with it in the same commit. If a change moves them
-and you did not expect it, that is the signal this corpus exists to give you.
+Move the baseline in the same commit when a chunker intentionally changes its
+numbers. An unexpected change is the signal this corpus provides.

--- a/plugins/lemma/baseline/docs/README.md
+++ b/plugins/lemma/baseline/docs/README.md
@@ -4,18 +4,18 @@
 > **Marketplace context: Lemma.** Lemma turns Solidity compiler input or Markdown trees into validated, source-linked JSONL chunks, keeping quotation text separate from model and embedding text. It does not embed, index, retrieve or answer; Berean is the adjacent unbuilt release discipline for a grounded protocol agent. **Current frontier:** Callable-surface ABI validation does not independently check return types or state mutability.
 <!-- marketplace-context:end -->
 
-The registry stores entries against identifiers. An entry records an owner, an
-amount, a creation timestamp, and a status. Only the admin may create entries;
-only the owner of an entry may retire it.
+## Registry state
+
+The registry maps identifiers to entries holding an owner, amount, creation
+timestamp, and status. Only the admin creates entries; only their owner retires
+them.
 
 ## What the registry is not
 
-The registry does not hold funds, does not price anything, and does not decide
-who may become an owner. Those decisions sit outside it, and this document does
-not describe them.
+It does not hold funds, set prices, or decide who may become an owner. Those
+decisions are outside this document.
 
 ## Reading this documentation
 
-Concepts explain why the system behaves as it does. The user guide describes the
-operations available day to day. The reference sections are generated from the
-deployed contracts and are the authority where the two disagree.
+Concepts explain behavior; the user guide covers daily operations. Generated
+contract references are authoritative if they disagree.

--- a/plugins/lemma/baseline/docs/concepts/entries.md
+++ b/plugins/lemma/baseline/docs/concepts/entries.md
@@ -4,15 +4,13 @@
 > **Marketplace context: Lemma.** Lemma turns Solidity compiler input or Markdown trees into validated, source-linked JSONL chunks, keeping quotation text separate from model and embedding text. It does not embed, index, retrieve or answer; Berean is the adjacent unbuilt release discipline for a grounded protocol agent. **Current frontier:** Callable-surface ABI validation does not independently check return types or state mutability.
 <!-- marketplace-context:end -->
 
-An entry is the unit of state in the registry. Every entry has an identifier
-that is unique for the lifetime of the deployment, and identifiers are never
-reused after retirement.
+An entry is the registry's unit of state. Its identifier is unique for the
+deployment's lifetime and is never reused after retirement.
 
 ## Identifier assignment
 
-Identifiers are supplied by the caller rather than derived, because deriving
-them would make the registry responsible for a namespace it does not own. The
-creation call reverts with `DuplicateEntry` if the identifier is taken.
+Callers supply identifiers because the registry does not own their namespace.
+Creation reverts with `DuplicateEntry` when an identifier is taken.
 
 ## Status transitions
 
@@ -24,12 +22,10 @@ An entry moves through three states.
 | `Active` | Usable | `create` |
 | `Retired` | Permanently closed | `retire` |
 
-Transitions are one-way. There is no path from `Retired` back to `Active`, and
-the absence of that path is deliberate.
+Transitions are deliberately one-way; `Retired` cannot return to `Active`.
 
 ## Capacity
 
-Capacity is immutable and fixed at construction. A deployment that reaches
-capacity cannot be extended; a new deployment is required. This trades
-flexibility for a guarantee that the entry count cannot grow without a new
-address to point at.
+Capacity is immutable and fixed at construction. This trades extension
+flexibility for a guarantee: growth after capacity requires a new deployment
+and address.

--- a/plugins/lemma/baseline/docs/concepts/fixed-point.md
+++ b/plugins/lemma/baseline/docs/concepts/fixed-point.md
@@ -4,12 +4,14 @@
 > **Marketplace context: Lemma.** Lemma turns Solidity compiler input or Markdown trees into validated, source-linked JSONL chunks, keeping quotation text separate from model and embedding text. It does not embed, index, retrieve or answer; Berean is the adjacent unbuilt release discipline for a grounded protocol agent. **Current frontier:** Callable-surface ABI validation does not independently check return types or state mutability.
 <!-- marketplace-context:end -->
 
-All proportional values are fixed-point with eighteen decimals. The scaling
-factor is exposed as `ONE`.
+## Scale
+
+All proportional values use eighteen-decimal fixed point. `ONE` exposes the
+scaling factor.
 
 ## Rounding direction is explicit
 
-Every multiplication names its rounding direction at the call site:
+Every multiplication names its rounding direction:
 
 ```solidity
 uint256 charged = amount.mulUp(fee);
@@ -18,13 +20,10 @@ uint256 credited = amount.mulDown(share);
 
 <!-- Reviewers: the asymmetry below is intentional, do not "fix" it. -->
 
-The asymmetry is deliberate. Amounts owed to the registry round up; amounts owed
-to a user round down. A single rounding helper used in both directions would
-make the residue accumulate in whichever direction the last caller happened to
-choose.
+Amounts owed to the registry round up; amounts owed to users round down. One
+helper for both would make residue follow the last caller's chosen direction.
 
 ## Saturating subtraction
 
-`subFloor` returns zero rather than reverting on underflow. It is used only
-where a negative result is meaningless rather than exceptional, and every such
-call site is expected to document which of the two it is.
+`subFloor` returns zero instead of reverting on underflow. Use it only when a
+negative result is meaningless, not exceptional, and document that choice.

--- a/plugins/lemma/baseline/docs/reference/contracts.md
+++ b/plugins/lemma/baseline/docs/reference/contracts.md
@@ -6,11 +6,11 @@
 
 ## Registry
 
-The concrete deployment. Inherits everything on `RegistryBase`.
+Concrete deployment inheriting `RegistryBase`.
 
 ### create
 
-Creates an entry. Admin only. Reverts on a duplicate identifier or at capacity.
+Creates an entry. Admin only; reverts on duplicate identifiers or capacity.
 
 ### retire
 
@@ -18,15 +18,15 @@ Retires an entry. Owner only.
 
 ### setFee
 
-Sets the creation fee. Admin only. Takes effect from the next creation.
+Sets the creation fee. Admin only; applies to the next creation.
 
 ## RegistryBase
 
-Abstract. Holds storage and access control, and is not deployed on its own.
+Abstract storage and access control; never deployed alone.
 
 ### entry
 
-Returns the stored entry for an identifier, or a zeroed entry if none exists.
+Returns an identifier's entry, or a zeroed entry when none exists.
 
 ### total
 

--- a/plugins/lemma/baseline/docs/reference/errors.md
+++ b/plugins/lemma/baseline/docs/reference/errors.md
@@ -4,18 +4,17 @@
 > **Marketplace context: Lemma.** Lemma turns Solidity compiler input or Markdown trees into validated, source-linked JSONL chunks, keeping quotation text separate from model and embedding text. It does not embed, index, retrieve or answer; Berean is the adjacent unbuilt release discipline for a grounded protocol agent. **Current frontier:** Callable-surface ABI validation does not independently check return types or state mutability.
 <!-- marketplace-context:end -->
 
-Every revert in the registry is a custom error. There are no string reverts.
+Every registry revert uses a custom error, never a string.
 
 ## DuplicateEntry
 
-Raised by `create` when the identifier is already in use.
+`create` raises this for an identifier already in use.
 
 ## AtCapacity
 
-Raised by `create` when the total has reached the immutable capacity.
+`create` raises this at immutable capacity.
 
 ## NotAdmin
 
-Raised by the `onlyAdmin` modifier, and also by `retire` when the caller is not
-the entry owner. The reuse is a known wart and is documented in the
-troubleshooting guide.
+`onlyAdmin` raises this, as does `retire` when its caller is not the entry owner.
+The troubleshooting guide documents this known reuse.

--- a/plugins/lemma/baseline/docs/user-guide/day-to-day-usage/README.md
+++ b/plugins/lemma/baseline/docs/user-guide/day-to-day-usage/README.md
@@ -4,6 +4,14 @@
 > **Marketplace context: Lemma.** Lemma turns Solidity compiler input or Markdown trees into validated, source-linked JSONL chunks, keeping quotation text separate from model and embedding text. It does not embed, index, retrieve or answer; Berean is the adjacent unbuilt release discipline for a grounded protocol agent. **Current frontier:** Callable-surface ABI validation does not independently check return types or state mutability.
 <!-- marketplace-context:end -->
 
-The two operations available in normal running are creating an entry and
-retiring one. Both are single transactions and neither requires a prior
-approval.
+## Create
+
+Creating an entry is one transaction and needs no prior approval.
+
+## Retire
+
+Retiring an entry is one transaction and needs no prior approval.
+
+## Scope
+
+These are the only normal operations.

--- a/plugins/lemma/baseline/docs/user-guide/day-to-day-usage/creating.md
+++ b/plugins/lemma/baseline/docs/user-guide/day-to-day-usage/creating.md
@@ -4,17 +4,17 @@
 > **Marketplace context: Lemma.** Lemma turns Solidity compiler input or Markdown trees into validated, source-linked JSONL chunks, keeping quotation text separate from model and embedding text. It does not embed, index, retrieve or answer; Berean is the adjacent unbuilt release discipline for a grounded protocol agent. **Current frontier:** Callable-surface ABI validation does not independently check return types or state mutability.
 <!-- marketplace-context:end -->
 
-Creation is admin-only. The admin supplies an identifier and an amount, and the
-call returns the fee charged.
+## Call
+
+Creation is admin-only. The admin supplies an identifier and amount; the call
+returns the charged fee.
 
 ## Before you start
 
-Check that the identifier is unused and that the deployment is below capacity.
-Both conditions revert rather than returning a status, so a failed simulation is
-the cheapest way to find out.
+Check that the identifier is unused and capacity remains. Both failures revert
+instead of returning status, so simulation is the cheapest check.
 
 ## What the fee depends on
 
-The fee is a proportion of the amount, rounded up. Changing the fee affects
-subsequent creations only; entries already created are unaffected, because the
-charged amount is computed once and not stored.
+The fee is a rounded-up proportion of the amount. Changes affect later creations
+only because the charge is computed once and not stored.

--- a/plugins/lemma/baseline/docs/user-guide/day-to-day-usage/retiring.md
+++ b/plugins/lemma/baseline/docs/user-guide/day-to-day-usage/retiring.md
@@ -4,17 +4,16 @@
 > **Marketplace context: Lemma.** Lemma turns Solidity compiler input or Markdown trees into validated, source-linked JSONL chunks, keeping quotation text separate from model and embedding text. It does not embed, index, retrieve or answer; Berean is the adjacent unbuilt release discipline for a grounded protocol agent. **Current frontier:** Callable-surface ABI validation does not independently check return types or state mutability.
 <!-- marketplace-context:end -->
 
-Retirement is available to the owner of an entry and to nobody else, including
-the admin.
+## Access
+
+Only the entry owner may retire it. The admin cannot.
 
 ## Effect
 
-Retiring sets the status to `Retired` and emits `EntryRetired`. It does not
-free the identifier, does not reduce the total, and does not refund the creation
-fee.
+Retirement sets `Retired` and emits `EntryRetired`. It does not free the
+identifier, reduce the total, or refund the creation fee.
 
 ## Why the total does not decrease
 
-The total counts entries ever created rather than entries currently active,
-because a decreasing total would make capacity a moving target and let a
-deployment exceed its stated bound over time.
+The total counts all created entries. Decreasing it would move the capacity
+target and let the deployment exceed its stated lifetime bound.

--- a/plugins/lemma/baseline/docs/user-guide/troubleshooting.md
+++ b/plugins/lemma/baseline/docs/user-guide/troubleshooting.md
@@ -4,18 +4,15 @@
 > **Marketplace context: Lemma.** Lemma turns Solidity compiler input or Markdown trees into validated, source-linked JSONL chunks, keeping quotation text separate from model and embedding text. It does not embed, index, retrieve or answer; Berean is the adjacent unbuilt release discipline for a grounded protocol agent. **Current frontier:** Callable-surface ABI validation does not independently check return types or state mutability.
 <!-- marketplace-context:end -->
 
-**My creation call reverts with DuplicateEntry**
+## `DuplicateEntry`
 
-The identifier is already in use. Identifiers are never released, so this is
-permanent for that value. Choose another.
+The identifier is already used and never released. Choose another.
 
-**My creation call reverts with AtCapacity**
+## `AtCapacity`
 
-The deployment has reached its immutable capacity. Nothing can be done on this
-deployment; a new one is required.
+The deployment has reached immutable capacity. Use a new deployment.
 
-**My retire call reverts with NotAdmin**
+## `NotAdmin`
 
-The error name is misleading here. `NotAdmin` is reused for the ownership check
-in `retire`, so this means you are not the owner of that entry, not that you are
-not the admin.
+The name is misleading: `retire` reuses `NotAdmin` for ownership checks. It means
+the caller does not own the entry, not that the caller is not admin.

--- a/plugins/lemma/skills/chunk/EVOLUTION.md
+++ b/plugins/lemma/skills/chunk/EVOLUTION.md
@@ -1,4 +1,4 @@
-# Chunk evolution ledger
+Chunk evolution ledger
 
 Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
 
@@ -8,8 +8,4 @@ Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VE
 - Current frontier: Callable-surface ABI validation does not independently check return types or state mutability.
 - Next Fiat job: Make callable-surface ABI validation cover return types and state mutability as well as names and input types, with any divergence rejecting the output. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
 
-## History
-
-| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
-| --- | --- | --- | --- | --- | --- |
-| `chunk-v0.1.0` | baseline | `abi-return-and-mutability` | `2d4f0d7948208fefdca52f4380b3f4c83261917a282256571a2ee611c5d9d36c` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |
+- `chunk-v0.1.0` | baseline | `abi-return-and-mutability` | `2d4f0d7948208fefdca52f4380b3f4c83261917a282256571a2ee611c5d9d36c` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged.

--- a/plugins/lemma/skills/chunk/SKILL.md
+++ b/plugins/lemma/skills/chunk/SKILL.md
@@ -9,10 +9,9 @@ metadata:
 
 ## Frontier
 
-Chunk owns its own chunking and validation frontier, not Hexaemeron's delivery or
-Solidity frontier. Its version, held target, next job, and maturity
-state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run
-another frontier pass after that ledger becomes mature.
+Chunk owns its chunking and validation frontier, not Hexaemeron's delivery or
+Solidity frontier. [EVOLUTION.md](EVOLUTION.md) holds its version, target, next
+job, and maturity. Do not run or recommend another pass once it is mature.
 
 <!-- marketplace-context:start -->
 ## Where this sits
@@ -24,27 +23,24 @@ Lemma turns Solidity compiler input or Markdown trees into validated, source-lin
 **Current frontier.** Callable-surface ABI validation does not independently check return types or state mutability.
 <!-- marketplace-context:end -->
 
-Use Lemma to create chunks. Stop at the JSONL output unless the user separately
-asks for another system to consume it.
+Create chunks and stop at JSONL unless the user separately asks another system
+to consume it.
 
-`$SKILL_DIR` is the directory containing this file. Resolve `$PLUGIN_ROOT` as
-`$SKILL_DIR/../..` and run the bundled commands from there.
+Set `$PLUGIN_ROOT` to `$SKILL_DIR/../..` and run bundled commands there.
 
 ## Choose the chunker
 
 - Use `chunkers/solidity.py` for one or more solc standard JSON input files.
 - Use `chunkers/markdown.py` for a directory of Markdown documents.
-- If the request is only to inspect or validate an existing JSONL file, read
-  `schema.py` and apply its `Chunk` and `validate()` contract. Do not rerun a
-  chunker without its source input.
+- To inspect or validate existing JSONL, read `schema.py` and apply `Chunk` and
+  `validate()`. Do not rerun a chunker without source input.
 
-Read the target repository's instructions before writing output. Keep generated
-JSONL outside the plugin directory unless the plugin repository itself is the
-named target.
+Read target-repository instructions before writing. Keep generated JSONL outside
+the plugin unless that repository is the named target.
 
 ## Chunk Solidity
 
-Prefer the included pinned compiler wrapper when Docker or Podman is available:
+With Docker or Podman, prefer the pinned compiler wrapper:
 
 ```bash
 cd "$PLUGIN_ROOT"
@@ -55,14 +51,11 @@ python3 chunkers/solidity.py \
   --out /absolute/path/to/chunks.jsonl
 ```
 
-Repeat `--input` to merge compilation units and repeat `--include` for more
-source patterns. Use `--expect-solc VERSION` when the requested corpus pins a
-compiler version. Use `--solc solc` only when the user asks for a local compiler
-or the container runtime is unavailable and the local compiler version is
-acceptable.
+Repeat `--input` for compilation units and `--include` for source patterns. Use
+`--expect-solc VERSION` for a pinned corpus. Use `--solc solc` only by request,
+or when no container runtime exists and the local version is acceptable.
 
-The first container run may fetch the pinned image. The compiler process itself
-runs without network access.
+The first container run may fetch the image; the compiler itself has no network.
 
 ## Chunk Markdown
 
@@ -77,27 +70,24 @@ python3 chunkers/markdown.py \
   --out /absolute/path/to/chunks.jsonl
 ```
 
-Pass `--summary ''` when the tree has no GitBook navigation. Add an `--exclude`
-for every instruction file, generated directory, or unrelated subtree that
-must not enter the corpus. When a compatible manifest already declares the
-exclusions, pass it with `--manifest` and select its source with `--source`.
+Pass `--summary ''` without GitBook navigation. Add `--exclude` for every
+instruction file, generated directory, or unrelated subtree outside the corpus.
+For compatible manifest exclusions, pass `--manifest` and choose `--source`.
 
-Markdown anchors follow GitBook behavior. Do not claim that they match another
-renderer without checking that renderer separately.
+Markdown anchors follow GitBook. Check another renderer before claiming parity.
 
 ## Accept the result
 
-Both chunkers validate before writing. Accept the JSONL only when the command
-exits zero and reports that it wrote the requested file. On failure, report the
-named error and do not use an earlier or partial output.
+Both chunkers validate before writing. Accept JSONL only after exit zero and a
+report that the requested file was written. Otherwise report the named error;
+do not use earlier or partial output.
 
 Preserve these distinctions downstream:
 
 - `display_text` holds source text used for quotation;
 - `model_text` holds text prepared for model context;
 - `embed_text` holds text prepared for embedding; and
-- `synthesised: true` means the chunk is assembled and is not a verbatim quote.
+- `synthesised: true` marks assembled, non-verbatim text.
 
-Read [`INVARIANTS.md`](../../INVARIANTS.md) when changing the chunkers, judging a
-guarantee, or investigating unexpected output. Run the two bundled test files
-after any code change.
+Read [`INVARIANTS.md`](../../INVARIANTS.md) before changing chunkers, judging a
+guarantee, or investigating output. Run both test files after code changes.


### PR DESCRIPTION
Compresses Lemma plugin, baseline documentation, and portable prose without changing chunk schemas or source guarantees.
Pinned solc `0.8.25` and baseline regeneration reproduce `49` chunks, `9/9` placed, `44` through `SUMMARY.md`, median `143`, and p99/max `589`.
Audit: `audit/AUDIT.md`, repository-wide Brevitas pass, step 5, round 1.
Proof: root `22/22`, Markdown `126`, Solidity `142`, two validators, 17 source checks, protected SHA verification, and `git diff --check`.
<!-- wildcat-origin: shoggoth -->
