### PR TITLE
docs(lazarus): compress historical fixture prose

### DIFF
--- a/.agents/skills/lazarus/SKILL.md
+++ b/.agents/skills/lazarus/SKILL.md
@@ -2,31 +2,18 @@
 name: lazarus
 description: Route finite historical Ethereum fixture work to Lazarus. Use it for proof-checked fixed-block state and exact-request replay without fallback; use Alexandria for lending archives.
 ---
-
-# Lazarus portable entrypoint
-
-<!-- marketplace-context:start -->
-## Where this sits
-
-Lazarus captures the finite fixed-block Ethereum state and RPC evidence an application test needs, verifies the proof-backed part and replays only exact recorded requests.
-
-**Use another tool when.** Use Alexandria for a lending-data archive, Tabularium for event interpretation and Ariadne to bind a released fixture to its evidence.
-
-**Current frontier.** Preservation-pipeline integration and an Ariadne state-fixture predicate remain unimplemented.
-<!-- marketplace-context:end -->
-
-Read [the Lazarus runtime contract](../../../plugins/lazarus/AGENTS.md). Use its
-selection table to choose the skill, then read that canonical `SKILL.md` in
-full and follow it.
-
-Invocation prefixes are aliases:
-
 - `/lazarus:lazarus`, `$lazarus`, and a plain request for a proof-checked
   historical Ethereum fixture all select `lazarus`.
 
-The canonical skill implements capture, offline verification and exact-request
-loopback replay. Keep its evidence classes separate: a recorded RPC response is
-not a proof-backed state claim.
+Lazarus portable entrypoint
 
-The canonical skill and runtime contract are authoritative if this entrypoint
-disagrees with them.
+Read [the runtime contract](../../../plugins/lazarus/AGENTS.md), select its sole
+skill, and follow that canonical `SKILL.md` in full.
+
+<!-- marketplace-context:start -->
+> **Marketplace context: Lazarus.** Lazarus captures finite fixed-block Ethereum state and RPC evidence, verifies the proof-backed part, and replays only exact recorded requests. Use Alexandria for a lending-data archive, Tabularium for event interpretation, and Ariadne to bind a released fixture to its evidence. **Current frontier:** Preservation-pipeline integration and an Ariadne state-fixture predicate remain unimplemented.
+<!-- marketplace-context:end -->
+
+The canonical skill covers capture, offline verification, and exact-request
+loopback replay. A recorded RPC response is not proof-backed state. The
+canonical skill and runtime contract prevail over this entrypoint.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -900,3 +900,11 @@ The Ariadne prose and link-test diff has no open finding. Status: clean.
 The review compared 12 files with entry ref `a7d001009e7e2a7e63343e206ef10ecabc2cab42`. It retained digest matching, seven gate outcomes, exit codes `0/1/2`, external signature verification, replay consent, and frontier digest `0c0310a503de564b892e7206d6b8e88ec3acd4ad99a62d02f3f83cd16991bc20`. The link test permits only the normalized `plugins/hexaemeron/skills/VERSIONING.md` target outside Ariadne.
 
 Root `22/22`, Ariadne `310/310`, two Agent Skills validations, 12 Imprimatur and Brevitas `--source` checks, protected SHA verification, and `git diff --check` pass. No signature identity, network activity, or replay execution was established. The security suite remains waived because only Markdown and one test changed.
+
+## Repository-wide Brevitas pass, step 7, round 1 -- 2026-08-18
+
+The Lazarus prose diff has no open finding. Status: clean.
+
+The review compared seven mutable files with entry ref `a7d001009e7e2a7e63343e206ef10ecabc2cab42`. It retained proof-backed, header-bound and recorded-RPC evidence classes, exact-request miss behaviour `-32070`, offline verification, and frontier digest `94c0f87fc8dd14562e948fb5b523c9248ffa6fd21849cc433d4a5bc47966daf5`. The manifest-bound Goldfinch README remains byte-identical at `b8a0441746fdd8feb6657bcc78f13ff199c94b081a6462981e8e8a233ae0c09b`.
+
+The fresh `requirements.lock` environment passed root `22/22`, Lazarus `144/144`, two Agent Skills validations, seven Imprimatur and Brevitas `--source` checks, protected SHA verification, and `git diff --check`. No live capture, external RPC, canonical-chain provenance, or publisher identity was established. The security suite remains waived because only Markdown changed.

--- a/plugins/lazarus/AGENTS.md
+++ b/plugins/lazarus/AGENTS.md
@@ -4,71 +4,62 @@
 > **Marketplace context: Lazarus.** Lazarus captures the finite fixed-block Ethereum state and RPC evidence an application test needs, verifies the proof-backed part and replays only exact recorded requests. Use Alexandria for a lending-data archive, Tabularium for event interpretation and Ariadne to bind a released fixture to its evidence. **Current frontier:** Preservation-pipeline integration and an Ariadne state-fixture predicate remain unimplemented.
 <!-- marketplace-context:end -->
 
-Lazarus contains one Agent Skill. Select it from this table, then read the
-chosen `SKILL.md` in full.
+Lazarus has one Agent Skill:
 
-| Skill | Canonical instructions | Select when |
-| --- | --- | --- |
-| `lazarus` | `skills/lazarus/SKILL.md` | Capture, verify or replay a finite historical Ethereum fixture |
+- `lazarus`: read `skills/lazarus/SKILL.md` in full to capture, verify or
+  replay a finite historical Ethereum fixture.
 
-`skills/lazarus/SKILL.md` is the only canonical instruction document. Do not
-add a sibling browsing README.
+That `SKILL.md` is the only canonical instruction document. Do not add a
+sibling browsing README.
 
 ## Translate tool names by capability
 
-The canonical skill may name host tools. A local agent must map them to
-equivalent capabilities:
+Map canonical tool names to these local capabilities:
 
-| Instruction term | Required capability |
-| --- | --- |
-| `Read` | Read the named file completely or at the stated range |
-| `Write` or `Edit` | Create or patch the named file |
-| `Bash` | Execute the command in a shell and inspect its exit status |
-| `Glob`, `Grep`, or `find` | Enumerate or search files with the stated pattern |
-| `AskUserQuestion` | Ask the stated question through structured UI or concise text |
+- `Read`: read the named file completely or at the stated range.
+- `Write` or `Edit`: create or patch the named file.
+- `Bash`: run the command and inspect its exit status.
+- `Glob`, `Grep`, or `find`: enumerate or search the stated pattern.
+- `AskUserQuestion`: ask through structured UI or concise text.
 
-Tool names describe capabilities, not mandatory API identifiers. Preserve the
-arguments, ordering, output files and exit codes when using an equivalent
-local tool. A non-zero exit means the requested operation did not succeed.
+Tool names are capabilities, not required API identifiers. Preserve arguments,
+ordering, output files, and exit codes. A non-zero exit means failure.
 
 ## Resolve placeholders
 
-- `$SKILL_DIR` means the directory containing the active `SKILL.md`, unless
-  that file defines it differently.
+- `$SKILL_DIR` is the active `SKILL.md` directory unless it says otherwise.
 - `$PLUGIN_ROOT` means this `plugins/lazarus/` directory.
-- The command path is `$PLUGIN_ROOT/scripts/lazarus.py`. The current build
-  implements format validation, finite capture, manifest construction and
-  offline verification and exact loopback replay.
-- Names such as `lazarus:lazarus`, `/lazarus:lazarus` and `$lazarus` are
-  logical aliases. Load the canonical path from the table above.
+- `$PLUGIN_ROOT/scripts/lazarus.py` implements format validation, finite
+  capture, manifest construction, offline verification, and exact loopback replay.
+- `lazarus:lazarus`, `/lazarus:lazarus`, and `$lazarus` are aliases for the
+  canonical skill above.
 
 ## Network and side effects
 
-`capture` is the only networked command. It uses only the explicit RPC URL,
-brackets one fixed block, verifies proofs before atomically finalising output
-and discards provider error prose. Format validation, manifest construction
-and fixture verification reach no network. `build-manifest` writes only
-`manifest.json` beneath its explicit fixture root. `verify` checks schemas,
-safe paths, canonical manifest bytes, component sizes and SHA-256 digests,
-then verifies the header, EIP-1186 account and storage proofs, proved response
-fields and captured code. `replay` verifies before binding loopback.
-It has no provider, proxy or fallback.
+Only `capture` uses the network, and only through the explicit RPC URL. It
+brackets one fixed block, verifies proofs before atomic finalisation, and drops
+provider error prose. Format validation, manifest construction, and fixture
+verification stay offline. `build-manifest` writes only `manifest.json` under
+the explicit fixture root. `verify` checks schemas, safe paths, canonical
+manifest bytes, sizes, SHA-256 digests, the header, EIP-1186 account and storage
+proofs, proved fields, and captured code. `replay` verifies before binding
+loopback and has no provider, proxy or fallback.
 
 ## What this skill must refuse
 
-- No moving block in an effective plan. `latest` and `pending` are resolved or
-  rejected before the stored plan is written.
-- No proof claim for an ordinary RPC result. Logs, receipts, calls and traces
+- No moving block: resolve or reject `latest` and `pending` before writing the
+  effective plan.
+- No proof claim for ordinary RPC results; logs, receipts, calls, and traces
   remain recorded evidence.
 - No silent live fallback. An uncaptured replay request is a visible miss.
-- No secret persistence. Provider URLs, headers, credentials and raw provider
+- No secret persistence. Provider URLs, headers, credentials, and raw provider
   errors do not enter a fixture or its diagnostics.
 - No unsafe fixture path. Absolute paths, parent traversal and symlinks are
   rejected.
-- No canonical-chain claim from a self-consistent header alone. The expected
-  block hash needs an external provenance record.
+- No canonical-chain claim from a self-consistent header; the expected block
+  hash needs external provenance.
 - No proof claim for an account, storage slot or code blob unless the current
   `verify` command checked it against the captured header state root.
 
-If capture, verification, replay or a test did not run, say so plainly and do
-not describe its result as successful.
+If capture, verification, replay, or a test did not run, say so and do not
+describe it as successful.

--- a/plugins/lazarus/README.md
+++ b/plugins/lazarus/README.md
@@ -12,36 +12,26 @@ Lazarus captures the finite fixed-block Ethereum state and RPC evidence an appli
 **Next Fiat job.** Use /hexaemeron:fiat to bind a Lazarus fixture through an Ariadne state-fixture predicate in the first end-to-end Goldfinch preservation release without upgrading recorded RPC evidence into proof-backed state. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
 <!-- marketplace-context:end -->
 
-Lazarus preserves the finite part of historical Ethereum state and RPC
-evidence that one application test needs. A fixture binds an explicit capture
-plan, a fixed block header, exact JSON-RPC records and EIP-1186 account and
-storage proofs into deterministic files. Replay answers only requests present
-in that fixture and fails closed on a miss.
-
-The current build implements finite capture and offline verification for the
-versioned plan, header, RPC record, proof record and manifest formats. It
-writes canonical JSON and JSONL, confines fixture paths, derives exact request
-keys, verifies component digests, recomputes the header hash, traverses
-EIP-1186 proofs, checks captured code and serves exact requests over loopback.
+Each deterministic fixture binds a capture plan, fixed block header, exact
+JSON-RPC records, and EIP-1186 account and storage proofs. The current build
+captures and verifies versioned plan, header, RPC record, proof record, and
+manifest formats. It writes canonical JSON and JSONL, confines paths, derives
+exact request keys, checks digests, header hashes, EIP-1186 proofs, and captured
+code, then serves only captured requests over loopback. A miss fails closed.
 
 ## Evidence boundary
 
-- **Proof-backed state** is checked through an EIP-1186 proof against the
-  captured header's `stateRoot`. Captured code is checked against the proved
-  `codeHash`.
-- **Header-bound data** is internally consistent with the named header. That
-  does not prove on its own that the header belongs to Ethereum's canonical
-  chain.
-- **Recorded RPC evidence** preserves an exact response, receipt, log query,
-  call or trace without describing it as a state proof.
+- Proof-backed state uses EIP-1186 against the header's `stateRoot`; captured
+  code is checked against the proved `codeHash`.
+- Header-bound data is internally consistent with the named header, which alone
+  does not establish Ethereum canonical-chain membership.
+- Recorded RPC evidence preserves an exact response, receipt, log query, call,
+  or trace without claiming a state proof.
 
-The [study](./docs/study.md) records the prior-art research and selected exact
-request cassette design. The [runbook](./docs/runbook.md) divides the prototype
-into six reviewable steps.
+The [study](./docs/study.md) records prior art and the selected exact-request
+cassette. The [runbook](./docs/runbook.md) splits the prototype into six steps.
 
 ## Capture and offline commands
-
-The implemented entrypoints are:
 
 ```bash
 python3 scripts/lazarus.py capture \
@@ -55,28 +45,26 @@ python3 scripts/lazarus.py verify <fixture>
 python3 scripts/lazarus.py replay <fixture>
 ```
 
-`capture` is the only command that receives a provider URL. It brackets one
-fixed block, verifies the captured proofs and code, removes provider error
-prose and atomically finalises a deterministic fixture. `verify` repeats all
-format, digest, header, trie and code checks without a network. `replay` is the
-local exact-request server: it verifies before binding, returns a
-stable capture-plan fragment for a miss and has no provider fallback.
+Only `capture` receives a provider URL. It brackets one fixed block, checks
+proofs and code, removes provider error prose, and atomically finalises the
+fixture. `verify` repeats format, digest, header, trie, and code checks offline.
+`replay` verifies before binding, returns a stable capture-plan fragment for a
+miss, and has no provider fallback.
 
 ## Goldfinch demonstration
 
-[`examples/goldfinch-v0`](./examples/goldfinch-v0) is a checked-in Ethereum
-mainnet fixture for a Goldfinch market at block `0xc7da16`. It carries a
-proof-backed account, contract code and storage slot, plus the named receipt
-and a five-log query as recorded RPC evidence. Run the complete test without a
-provider:
+[`examples/goldfinch-v0`](./examples/goldfinch-v0) is an Ethereum mainnet
+fixture for a Goldfinch market at block `0xc7da16`: a proof-backed account,
+contract code and storage slot, plus the named receipt and a five-log query as
+recorded RPC evidence. Run it without a provider:
 
 ```bash
 python3 plugins/lazarus/examples/goldfinch-v0/demo.py
 ```
 
-The demo verifies before replay, reads the four committed results through
-ordinary loopback JSON-RPC, observes a `-32070` miss for slot `0x1`, rejects a
-one-nibble proof mutation and rebuilds the same manifest bytes.
+The demo verifies before replay, reads four committed results through loopback
+JSON-RPC, observes a `-32070` miss for slot `0x1`, rejects a one-nibble proof
+mutation, and rebuilds the same manifest bytes.
 
 ## Tests
 
@@ -87,5 +75,5 @@ python3 -m unittest discover -s tests
 python3 -m unittest discover -s plugins/lazarus/tests -t plugins/lazarus
 ```
 
-The CI job installs the fully resolved `requirements.lock` environment under
-supported Python versions before running both suites.
+CI installs the resolved `requirements.lock` under supported Python versions
+before running both suites.

--- a/plugins/lazarus/docs/runbook.md
+++ b/plugins/lazarus/docs/runbook.md
@@ -4,26 +4,22 @@
 > **Marketplace context: Lazarus.** Lazarus captures the finite fixed-block Ethereum state and RPC evidence an application test needs, verifies the proof-backed part and replays only exact recorded requests. Use Alexandria for a lending-data archive, Tabularium for event interpretation and Ariadne to bind a released fixture to its evidence. **Current frontier:** Preservation-pipeline integration and an Ariadne state-fixture predicate remain unimplemented.
 <!-- marketplace-context:end -->
 
-This runbook builds the proof-checked, exact-request historical Ethereum
-fixture selected in the Lazarus study. Branches stack in order under Fiat's
-`chain` setting. Each step leaves the full repository test suite green and is
-reviewed in its own pull request.
+Build the study's proof-checked, exact-request Ethereum fixture in stacked
+Fiat `chain` branches. Each pull request leaves all repository tests green.
 
 ## Step 1: Scaffold the Lazarus plugin
 
-**Goal.** Add the complete repository-facing plugin shell, pinned Python
-toolchain, CI job and reviewed design documents without implementing capture
-or replay.
+**Goal.** Add the plugin shell, pinned Python toolchain, CI, and reviewed design
+documents without capture or replay.
 
 **Entry.** `main` at `83fef6634a560860b930a532861dbfff8cbb3442`.
 
-**Exit.** `plugins/lazarus/` has its runtime contract, canonical skill, host
-manifests, agent metadata, MIT licence, package
-shell, dependency pins and committed copies of this study and runbook. The
-portable entrypoint, both marketplace manifests, root plugin inventory, root
-instructions and a Lazarus CI workflow include the new plugin. `python3 -m
-unittest discover -s tests` and `python3 -m unittest discover -s
-plugins/lazarus/tests -t plugins/lazarus` pass.
+**Exit.** `plugins/lazarus/` contains its runtime contract, canonical skill,
+host manifests, agent metadata, MIT licence, package shell, dependency pins,
+study, and runbook. The portable entrypoint, both marketplace manifests, root
+inventory and instructions, and Lazarus CI include it. `python3 -m unittest
+discover -s tests` and `python3 -m unittest discover -s plugins/lazarus/tests
+-t plugins/lazarus` pass.
 
 **Files.** `plugins/lazarus/{AGENTS.md,LICENSE,README.md,requirements.txt}`,
 `plugins/lazarus/.claude-plugin/plugin.json`,
@@ -36,126 +32,115 @@ plugins/lazarus/tests -t plugins/lazarus` pass.
 `.claude-plugin/marketplace.json`, `.github/workflows/lazarus.yml`,
 `AGENTS.md`, `README.md` and `tests/test_portable_skills.py`.
 
-**Tests.** Add scaffold tests for manifest parsing, skill/readme identity,
-portable routing, documented entrypoints and version pins. Extend the root
-portable-skill inventory to cover Lazarus.
+**Tests.** Cover manifest parsing, skill/readme identity, portable routing,
+documented entrypoints, version pins, and Lazarus in the root portable inventory.
 
 ## Step 2: Define deterministic fixtures and manifests
 
-**Goal.** Implement the versioned plan, header, RPC-record, proof-record and
-manifest formats with deterministic encoding, safe paths and digest checking.
+**Goal.** Implement versioned plan, header, RPC-record, proof-record, and
+manifest formats with deterministic encoding, safe paths, and digest checks.
 
 **Entry.** The pushed tip of `step-1-scaffold-the-lazarus-plugin`.
 
-**Exit.** The library validates the built-in JSON Schemas, rejects duplicate
-keys and unsafe paths, writes canonical JSON and JSONL, derives exact request
-keys, builds a manifest from confined components and verifies every component
-length and SHA-256 digest. `python3 -m unittest discover -s
-plugins/lazarus/tests -t plugins/lazarus` passes without network access.
+**Exit.** The library validates built-in JSON Schemas; rejects duplicate keys
+and unsafe paths; writes canonical JSON and JSONL; derives exact request keys;
+builds a confined manifest; and verifies every length and SHA-256 digest.
+`python3 -m unittest discover -s plugins/lazarus/tests -t plugins/lazarus`
+passes offline.
 
 **Files.** `plugins/lazarus/schemas/{plan-v1.json,header-v1.json,rpc-record-v1.json,proof-record-v1.json,manifest-v1.json}`,
 `plugins/lazarus/scripts/lazarus_lib/{canonical.py,errors.py,paths.py,schemas.py,records.py,manifest.py}`,
 `plugins/lazarus/scripts/lazarus.py`, and
 `plugins/lazarus/tests/{test_canonical.py,test_paths.py,test_schemas.py,test_records.py,test_manifest.py}`.
 
-**Tests.** Cover stable bytes across insertion order and repeated builds,
-request-key exactness, quantity and address validation, duplicate-key
-rejection, traversal, absolute paths, symlinks, digest and size mismatches,
-unknown schema versions, extra files and resource limits.
+**Tests.** Cover stable bytes across insertion order and rebuilds, exact request
+keys, quantities, addresses, duplicate keys, traversal, absolute paths,
+symlinks, digest and size mismatches, unknown schemas, extra files, and limits.
 
 ## Step 3: Verify headers, accounts, storage and code
 
-**Goal.** Add offline Ethereum block-header and EIP-1186 account/storage proof
-verification with explicit proof-backed and recorded-evidence boundaries.
+**Goal.** Add offline Ethereum header and EIP-1186 account/storage proof checks
+with explicit proof-backed and recorded-evidence boundaries.
 
 **Entry.** The pushed tip of `step-2-define-deterministic-fixtures-and-manifests`.
 
-**Exit.** `lazarus verify <fixture>` recomputes the fork-appropriate header
-hash, verifies account inclusion and absence against `stateRoot`, verifies
-storage inclusion and absence against each proved storage root, compares
-response fields with decoded leaves, and checks captured code against the
-proved `codeHash`. The command reports evidence counts separately and fails
-on any mutation. The plugin test suite passes offline.
+**Exit.** `lazarus verify <fixture>` recomputes the fork-appropriate header hash;
+checks account inclusion or absence against `stateRoot`, storage inclusion or
+absence against each proved root, response fields against decoded leaves, and
+code against `codeHash`; reports evidence counts separately; and rejects any
+mutation. The plugin suite passes offline.
 
 **Files.** `plugins/lazarus/scripts/lazarus_lib/{hexvalue.py,rlp.py,trieproof.py,header.py,proofs.py,verifier.py}`,
 `plugins/lazarus/tests/fixtures/execution-api/`, and
 `plugins/lazarus/tests/{test_hexvalue.py,test_rlp.py,test_trieproof.py,test_header.py,test_proofs.py,test_verifier.py}`.
 
-**Tests.** Import compact EIP-1186 vectors and add mutations for every proof
-node, malformed and overlong RLP, bad compact paths, embedded versus hashed
-nodes, empty accounts, zero slots, mismatched keys, values wider than 256 bits,
-wrong state roots, wrong block hashes and code substitutions.
+**Tests.** Import compact EIP-1186 vectors. Mutate every proof node, malformed
+or overlong RLP, compact paths, embedded or hashed nodes, empty accounts, zero
+slots, mismatched keys, values wider than 256 bits, roots, hashes, and code.
 
 ## Step 4: Capture a finite plan safely
 
-**Goal.** Implement the capture CLI which resolves one fixed block, records
-declared RPC calls, verifies required proofs before writing and excludes
-provider secrets.
+**Goal.** Capture one fixed block, declared RPC calls, and required proofs
+without persisting provider secrets.
 
 **Entry.** The pushed tip of `step-3-verify-headers-accounts-storage-and-code`.
 
 **Exit.** `lazarus capture --plan <plan> --rpc-url <url> --out <directory>`
-resolves and brackets the named block, prefers EIP-1898 hash selectors, records
-required and optional requests, verifies proofs and code, sanitises failures,
-writes one deterministic fixture and fails without leaving a valid-looking
-partial result. A local fake RPC integration test proves the complete path;
-the plugin test suite passes offline.
+brackets the named block, prefers EIP-1898 hash selectors, records required and
+optional requests, checks proofs and code, sanitises failures, and atomically
+writes one deterministic fixture. A fake local RPC covers the path; the plugin
+suite passes offline.
 
 **Files.** `plugins/lazarus/scripts/lazarus_lib/{rpc.py,capture.py,scrub.py,limits.py}`,
 `plugins/lazarus/tests/{fake_rpc.py,test_rpc.py,test_capture.py,test_scrub.py,test_limits.py}`,
 and the Step 2 schemas where capture-only constraints require an additive
 clarification.
 
-**Tests.** Cover fixed number and expected-hash resolution, rejected effective
-tags, header equivocation, EIP-1898 fallback, required and optional failures,
-proof rejection before finalisation, out-of-order responses, time and byte
-limits, interrupted writes, URL userinfo, query keys, bearer headers, cookies
-and provider errors containing secrets.
+**Tests.** Cover fixed number and expected-hash resolution, effective-tag
+rejection, equivocation, EIP-1898 fallback, required and optional failures,
+proof rejection before finalisation, response order, limits, interrupted
+writes, URL userinfo, query keys, bearer headers, cookies, and secret errors.
 
 ## Step 5: Replay exact requests and fail closed
 
-**Goal.** Serve a verified fixture over loopback JSON-RPC with exact matching,
-no provider client and a stable miss protocol.
+**Goal.** Serve a verified fixture over loopback JSON-RPC with exact matches, no
+provider client, and a stable miss.
 
 **Entry.** The pushed tip of `step-4-capture-a-finite-plan-safely`.
 
-**Exit.** `lazarus replay <fixture>` verifies before binding, answers captured
-single and batch requests with each caller's own JSON-RPC identifier, handles
-notifications, rejects write methods and returns error `-32070` plus a capture
-plan fragment for an exact miss. The process has no provider or fallback
-configuration. Socket-blocked tests prove a miss cannot leave loopback, and
-the plugin suite passes offline.
+**Exit.** `lazarus replay <fixture>` verifies before binding; answers captured
+single and batch requests with caller JSON-RPC identifiers; handles
+notifications; rejects writes; and returns `-32070` plus a capture-plan
+fragment on a miss. It has no provider or fallback. Socket-blocked tests prove
+a miss stays on loopback; the plugin suite passes offline.
 
 **Files.** `plugins/lazarus/scripts/lazarus_lib/{replay.py,server.py}`,
 `plugins/lazarus/tests/{test_replay.py,test_server.py,test_no_network.py}`, and
 `plugins/lazarus/README.md` for the verified local replay command.
 
-**Tests.** Cover request-object key reordering, exact value preservation,
-caller IDs, notifications, mixed batches, malformed JSON-RPC, unsupported and
-write methods, fixtures that fail verification, stable miss payloads,
-concurrent reads, loopback binding and blocked outbound sockets.
+**Tests.** Cover reordered request-object keys, exact values, caller IDs,
+notifications, mixed batches, malformed JSON-RPC, unsupported and write
+methods, invalid fixtures, stable miss payloads, concurrency, loopback, and
+blocked outbound sockets.
 
 ## Step 6: Ship and run the Goldfinch demonstration
 
-**Goal.** Prove the prototype with a checked-in, offline-verifiable Goldfinch
-fixture and an application test using ordinary JSON-RPC.
+**Goal.** Prove the prototype with an offline-verifiable Goldfinch fixture and
+an application test using ordinary JSON-RPC.
 
 **Entry.** The pushed tip of `step-5-replay-exact-requests-and-fail-closed`.
 
 **Exit.** `plugins/lazarus/examples/goldfinch-v0/` contains the fixed plan,
-captured header, proof-backed account/code/slot data, the named transaction
-receipt, a small log query, schemas and manifest. Its demo script verifies the
-fixture, starts replay, reads the committed code, slot, receipt and logs,
-observes a miss for slot `0x1`, rejects a one-nibble proof mutation and rebuilds
-the same manifest bytes and digests. `python3
-plugins/lazarus/examples/goldfinch-v0/demo.py` and every repository check named
-in root `AGENTS.md` pass.
+header, proof-backed account/code/slot data, named receipt, small log query,
+schemas, and manifest. The demo verifies, starts replay, reads the committed
+code, slot, receipt, and logs, observes a miss for `0x1`, rejects a one-nibble
+proof mutation, and rebuilds identical manifest bytes and digests. `python3
+plugins/lazarus/examples/goldfinch-v0/demo.py` and every root `AGENTS.md` check pass.
 
 **Files.** `plugins/lazarus/examples/goldfinch-v0/{README.md,plan.json,header.json,rpc.jsonl,proofs.jsonl,manifest.json,demo.py}`,
 `plugins/lazarus/examples/goldfinch-v0/schemas/`,
 `plugins/lazarus/tests/test_goldfinch.py`, `plugins/lazarus/README.md`,
 `README.md` and `specs/lazarus.md`.
 
-**Tests.** Add the end-to-end demo test, byte-for-byte rebuild check, replay
-miss assertion, proof mutation failure, no-network guard and repository-wide
-regression run. Record exact test totals at implementation time.
+**Tests.** Add the end-to-end demo, byte-for-byte rebuild, replay miss, proof
+mutation, no-network guard, and repository regression. Record exact totals.

--- a/plugins/lazarus/docs/study.md
+++ b/plugins/lazarus/docs/study.md
@@ -4,501 +4,332 @@
 > **Marketplace context: Lazarus.** Lazarus captures the finite fixed-block Ethereum state and RPC evidence an application test needs, verifies the proof-backed part and replays only exact recorded requests. Use Alexandria for a lending-data archive, Tabularium for event interpretation and Ariadne to bind a released fixture to its evidence. **Current frontier:** Preservation-pipeline integration and an Ariadne state-fixture predicate remain unimplemented.
 <!-- marketplace-context:end -->
 
-## Problem statement
+## Problem and evidence boundary
 
-Lazarus captures the finite part of historical Ethereum state that one
-application test reads, verifies every claim that can be checked against the
-named block, and serves the captured JSON-RPC responses from a local process.
-It is for protocol engineers, researchers and security reviewers whose tests
-currently depend on an archive RPC URL and a block number. The fixture must
-remain useful when that endpoint, credential or protocol front end no longer
-exists.
+Lazarus preserves the finite historical Ethereum state and JSON-RPC responses
+one application test reads after its archive endpoint, credential, or protocol
+front end disappears. It serves protocol engineers, researchers, and security
+reviewers without overstating what the named block establishes.
 
-The central distinction is between three evidence classes:
+1. Proof-backed state is an account or storage value checked through an
+   `eth_getProof` Merkle Patricia proof against the header `stateRoot`; code
+   is checked against the proved `codeHash`.
+2. Header-bound data has locally checked fields, encoding, and hash. That does
+   not establish that the header belongs to Ethereum's canonical chain.
+3. Recorded RPC evidence preserves the exact `eth_call`, `eth_getLogs`,
+   receipt, or client-trace response under its request without calling it a
+   state proof.
 
-1. **Proof-backed state:** an account or storage value checked through an
-   `eth_getProof` Merkle Patricia proof against the `stateRoot` in the captured
-   block header. Contract code is checked against the proved `codeHash`.
-2. **Header-bound data:** block fields whose encoding and hash are checked
-   locally. This proves internal consistency with the named header, but not by
-   itself that the header belongs to Ethereum's canonical chain.
-3. **Recorded RPC evidence:** a provider response such as `eth_call`,
-   `eth_getLogs`, a receipt or a client trace. Lazarus preserves and replays
-   these bytes under the exact request that produced them without upgrading
-   them into a state-proof claim.
+The `plugins/lazarus` prototype accepts an Ethereum mainnet capture plan for
+one finalised block, exact requests, accounts, and slots. It resolves the block
+once; excludes `latest` and `pending` from the effective plan; stores the
+header, number, hash, parent hash, and state root; records exact method,
+parameters, result or sanitised error; checks declared `eth_getProof` account,
+storage, absence, and code claims offline; writes schema-checked deterministic
+files bound by component SHA-256 digests; serves exact requests locally with a
+documented miss containing method and parameters; and verifies and replays
+without network access or the capture URL.
 
-A working prototype will ship as `plugins/lazarus` and will:
-
-- accept an explicit capture plan naming Ethereum mainnet, one finalised block,
-  exact JSON-RPC requests, accounts and storage slots;
-- resolve the block once, reject `latest` and `pending` in the effective plan,
-  and store its full header, number, hash, parent hash and state root;
-- record exact method, parameter, result or sanitised error triples;
-- request `eth_getProof` for every declared account and slot, verify account,
-  storage and non-existence proofs offline, and verify captured code against
-  the proved code hash;
-- write deterministic, schema-checked files whose component SHA-256 digests
-  are bound by a manifest;
-- start a local JSON-RPC replay server that answers only exact captured
-  requests and returns a documented error containing the missing method and
-  parameters for every miss; and
-- verify and replay with network access disabled and without the capture URL.
-
-The demonstration lives at `plugins/lazarus/examples/goldfinch-v0/`. Its plan
-uses the Ethereum mainnet Goldfinch market
-`0x8bbd80f88e662e56b918c353da635e210ece93c6`, already named by the first row
-of Tabularium's checked-in Goldfinch release. It captures the account proof,
-contract code, storage slot `0x0`, the cited transaction receipt
+The demonstration at `plugins/lazarus/examples/goldfinch-v0/` uses Ethereum
+mainnet Goldfinch market `0x8bbd80f88e662e56b918c353da635e210ece93c6`,
+the first row in Tabularium's checked-in release. It captures the account,
+code, slot `0x0`, receipt
 `0xa46a744d6d52528a660c1d99a4edde403504fe7a308118c7cc947819583ce699`,
-and a small log query at the fixed fixture block. The demo check is:
+and a small log query at one fixed block.
 
-1. verify the checked-in fixture offline;
-2. start the replay server;
-3. run an application test which reads the captured code, slot, receipt and
-   logs through ordinary JSON-RPC and obtains the committed answers;
-4. request slot `0x1` and observe a Lazarus miss rather than `0x0` or a network
-   request;
-5. change one proof nibble and observe verification fail; and
-6. rebuild the manifest from the same captured files and obtain identical
-   bytes and digests.
+1. Verify the fixture offline.
+2. Start replay.
+3. Read its code, slot, receipt, and logs through ordinary JSON-RPC and obtain
+   the committed answers.
+4. Request `0x1` and receive a Lazarus miss, not `0x0` or a network result.
+5. Change one proof nibble and observe verification fail.
+6. Rebuild identical manifest bytes and digests from the captured files.
 
-The Goldfinch address is a concrete replay subject, not a claim that slot
-`0x0` has a particular business meaning. Interpreting Goldfinch storage is
-outside this first test. The chosen reading of "replay" is exact request replay,
-not arbitrary EVM execution from a partial world state. Exact replay is enough
-to remove the original RPC from an application test and makes the finite
-coverage boundary observable. Flexible local execution can follow once the
-fixture format and proof verifier are stable.
+The market is a replay subject, not evidence that `0x0` has a business
+meaning. This first test does not interpret Goldfinch storage or execute an
+arbitrary EVM against partial state. Exact-request replay removes the original
+RPC and exposes finite coverage; flexible execution can follow once the format
+and proof verifier are stable.
 
 ## Prior art
 
-### In this repository
+### Repository and organisation
 
-- `specs/lazarus.md` defines the intended gates: declared capture scope,
-  block-hash identity, exact proof claims, missing-data failure, secret
-  removal, deterministic rebuilding and finite coverage. Lazarus is still an
-  unbuilt specification on the starting ref.
+- `specs/lazarus.md` requires declared scope, block-hash identity, exact proof
+  claims, missing-data failure, secret removal, deterministic rebuilding, and
+  finite coverage. Lazarus was unbuilt on the starting ref.
 - `specs/preservation-runbook.md` places Lazarus between an archive node and a
-  published preservation release. It says state-derived values need
-  `eth_getProof` while events remain source records. It names Goldfinch as the
-  first preservation case.
-- `plugins/tabularium/examples/goldfinch-v0/` is a complete offline-verifiable
-  event release with 34 borrow rows and 477 repay rows. Its
-  `coverage.json` names the exact gap Lazarus should close: block 25,764,670 is
-  reported by a hosted indexer, individual events lack independently checked
-  block identities, and no state proof accompanies derived values. Its
-  deterministic JSONL, relative-path confinement, component digests and
-  coverage reporting are the local format precedent.
-- `plugins/ariadne/scripts/ariadne_lib/` supplies local precedents for safe
-  JSON handling, path confinement, SHA-256 subjects, scrubbing and offline
-  verification. `specs/ariadne.md` reserves a future state-fixture predicate
-  with the block hash, ancestry, accounts, slots and a separation between
-  proof-backed and merely recorded values. Lazarus should produce the subject
-  that predicate will later bind; it should not implement signing itself.
-- `plugins/probitas/` shows the repository's failure and coverage style. Its
-  live adapters never turn an unavailable source into a clean record, while
-  its tests use network-free fixtures. The Lazarus replay miss should be just
-  as visible.
-- Root `AGENTS.md` and `tests/test_portable_skills.py` define the plugin shape:
-  a canonical `SKILL.md`, portable entrypoint, plugin
-  contract, Claude and Codex manifests, marketplace entries and tests.
+  preservation release: state-derived values need `eth_getProof`, events stay
+  source records, and Goldfinch is the first case.
+- `plugins/tabularium/examples/goldfinch-v0/` contains 34 borrow rows and 477
+  repay rows. Its `coverage.json` says block 25,764,670 came from a hosted
+  indexer, events lack independently checked block identities, and derived
+  values lack state proofs. Its JSONL, confined paths, component digests, and
+  coverage reports are the local format precedent.
+- `plugins/ariadne/scripts/ariadne_lib/` supplies safe JSON, path confinement,
+  SHA-256 subjects, scrubbing, and offline verification. `specs/ariadne.md`
+  reserves a state-fixture predicate for block hash, ancestry, accounts, slots,
+  and separate proof-backed and recorded values. Lazarus produces its subject;
+  signing stays elsewhere.
+- `plugins/probitas/` keeps unavailable sources visible and tests live
+  adapters with offline fixtures. Lazarus misses must be equally visible.
+- Root `AGENTS.md` and `tests/test_portable_skills.py` require a canonical
+  `SKILL.md`, portable entrypoint, plugin contract, Claude and Codex manifests,
+  marketplace entries, and tests.
 
-The branch `codex/mnemosyne-synthesis` at `0d929a0` contains
-`specs/mnemosyne.md`, an unmerged integration draft. It keeps Lazarus,
-Tabularium and Ariadne as separate verifiers and says a combined release must
-retain each component's claim boundary. The draft is useful prior art but is
-not part of `main` and is not a dependency of this build.
+Unmerged branch `codex/mnemosyne-synthesis` at `0d929a0` contains
+`specs/mnemosyne.md`. It keeps Lazarus, Tabularium, and Ariadne as separate
+verifiers whose claim boundaries survive composition. It is prior art, not a
+`main` dependency. The recovered OpenCode session
+`ses_ff5057204ffe26V8p4QM5Kh9PL`, “Lazarus prior-art spike research,” had no
+final report; each technical conclusion used here was rechecked against its
+named source.
 
-The recovered OpenCode archive session
-`ses_ff5057204ffe26V8p4QM5Kh9PL`, titled "Lazarus prior-art spike research",
-contains the unfinished research run shown by the user. It had collected much
-of the Foundry, EELS, tracing, proof and Goldfinch evidence below but had not
-produced a final report. Every technical conclusion from that archive was
-checked again against the named source before inclusion here.
+The prototype began in `laurenceday/wildcat-skills-todo` before review and
+publication in `wildcat-finance/skills`. Wildcat's Foundry fork tests need a
+small application-specific set of calls and storage reads, not an Ethereum
+database. Goldfinch's wind-down also exposed endpoint loss: Tabularium's source
+was a served Graph deployment and its release records the hosted indexer's
+block as a limitation. Lazarus preserves state that logs cannot derive.
 
-### In the wider organisation
+### Ethereum and client tools
 
-- The prototype was built in `laurenceday/wildcat-skills-todo` before being
-  reviewed and published here in `wildcat-finance/skills`.
-- Wildcat protocol tests use Foundry forks for historical integration. Their
-  practical need is the application boundary Lazarus serves: a small set of
-  calls and storage reads, not an exported Ethereum database.
-- Tabularium and Probitas already expose the cost of endpoint loss. Goldfinch
-  wound down, its checked-in source came from a served Graph deployment, and
-  the release records that hosted indexer's block as a limitation. Lazarus can
-  preserve the state reads a later release cannot derive from logs.
+EIP-1186 and `ethereum/execution-apis` define `eth_getProof` fields:
+`address`, `accountProof`, `balance`, `codeHash`, `nonce`,
+`storageHash`, and `storageProof`; each storage entry has `key`, `value`,
+and `proof`. Account and storage paths are `keccak256(address)` under
+`stateRoot` and `keccak256(left_pad_32(slot))` under the proved storage
+root. Hex RLP-node lists prove inclusion or non-existence; absence cannot be
+inferred from a missing object.
 
-### Outside the organisation
+The execution API's `tests/eth_getProof/` vectors include
+`get-account-proof-with-storage.io` and a block-hash request. They test
+interoperability better than the EIP example but do not promise historical
+retention. Capture records a capability failure rather than assuming public
+RPC archive access. EIP-1898 hash selectors, including `requireCanonical`,
+are preferred where supported; otherwise fixed-number calls are bracketed by
+matching expected-hash header reads.
 
-#### EIP-1186 and the execution API
+At Foundry commit `3c16e2361f18f2cecc975e1d5a8d17330d92ced7` and
+`foundry-core` commit `8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f`, fork
+caches live under `~/.foundry/cache/rpc/<chain>/<block>/`. Their JSON holds
+`meta`, `accounts`, `storage`, and `block_hashes`, with newer zstd
+output. Storage maps addresses to hex slot/value pairs. Recent Anvil also uses
+`storage-<keccak256(rpc-url)>.json`, resolves a fork block hash at startup,
+and retains block hashes.
 
-EIP-1186 and `ethereum/execution-apis` define `eth_getProof`. The result has
-`address`, `accountProof`, `balance`, `codeHash`, `nonce`, `storageHash` and
-`storageProof`. Each storage entry has `key`, `value` and `proof`.
-`accountProof` and each storage proof are lists of hex-encoded RLP trie nodes.
-The account path is `keccak256(address)` under the block's state root. A
-storage path is `keccak256(left_pad_32(slot))` under the account's proved
-storage root. Non-existence is a proof result too; it must not be inferred
-from a missing object.
+This remains a cache. On an account, slot, or block-hash miss,
+`SharedBackend` fetches and writes provider data. Metadata contains the block
+environment and hosts, but account and slot values lack EIP-1186 proofs.
+Completeness is implicit, a new read reaches the provider, and Anvil dump/load
+describes local state rather than a finite proof-labelled capture. Lazarus may
+borrow the ergonomics without calling the cache verified or complete.
 
-The execution API repository carries runnable vectors at
-`tests/eth_getProof/`, including `get-account-proof-with-storage.io` and a
-block-hash request. These are better interoperability tests than the original
-EIP's illustrative example. Historical availability remains a node or
-provider capability: the API specifies the request shape, not how long a node
-retains old state. Capture should probe the chosen block and record a
-capability failure rather than describe every public RPC as archive-capable.
+Execution-specification state tests carry an execution environment, full
+pre-allocation, transaction, expected post-state roots, and log hashes.
+Blockchain tests carry pre-allocation, genesis RLP and header, blocks, last
+block hash, and post-allocation. Clients can reconstruct tries and check
+consensus-critical execution. Ordinary fixtures do not carry EIP-1186 proofs
+for arbitrary historical reads. Optional `--witness` output remains
+test-block execution input, so these formats are vectors rather than a capture
+plan.
 
-EIP-1898 permits block-hash selectors, including `requireCanonical`, for
-state-query methods. Lazarus should prefer a block-hash selector where the
-provider implements it. Providers vary, so the fallback is a fixed block
-number bracketed by header reads that must return the same expected hash.
+Geth's struct logger reports program counter, opcode, remaining gas, gas cost,
+call depth, and optional memory, stack, return data, and storage. `callTracer`
+emits call frames; `prestateTracer` emits touched accounts and slots, with a
+diff mode for changes. Those are trie leaves, not cryptographic proofs.
+`debug_traceCall` may regenerate historical state; `reexec` defaults to 128
+and documented regeneration can take minutes. Trace namespaces, names,
+defaults, and encodings vary by client. Lazarus records client, version,
+tracer, options, and exact response without claiming cross-client canonical
+output or proof for every value.
 
-#### Foundry fork caches and Anvil state
+Reth's `debug_executionWitness` and `debug_executionWitnessByBlockHash` map
+hashed trie nodes to preimages for re-executing a whole block and recomputing
+its state root. This may become an importer, but it is broader than Geth
+`prestateTracer` and does not describe arbitrary application calls, receipts,
+or log ranges. The first prototype should not add a second completeness model.
 
-Foundry is the closest practical neighbour. At Foundry commit
-`3c16e2361f18f2cecc975e1d5a8d17330d92ced7` and `foundry-core` commit
-`8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f`, fork cache paths are rooted at
-`~/.foundry/cache/rpc/<chain>/<block>/`. The JSON database serialises
-`meta`, `accounts`, `storage` and `block_hashes`; newer builds can write the
-JSON through zstd. Storage is an address map whose entries are hex slot-to-hex
-value pairs. Recent Anvil code also supports endpoint-specific files named
-`storage-<keccak256(rpc-url)>.json`, resolves a fork block hash during startup,
-and keeps block hashes in the database.
+Tenderly virtual testnets, simulations, archive RPC products, Anvil forks,
+Reth databases, and Erigon snapshots preserve historical state but keep a
+service dependency or large client-specific artefact. None combines a declared
+finite request set, EIP-1186 labels, deterministic release bytes, and an exact
+local miss. They are capture sources and comparisons, not the format.
 
-This is a cache, not a released proof bundle. `foundry-fork-db` documents and
-implements the decisive behaviour: on an account, slot or block-hash miss,
-`SharedBackend` schedules a request to the provider and writes the response
-back to the cache. The cache metadata carries a block environment and hosts,
-but cached account and slot values are not accompanied by EIP-1186 proofs
-against the header state root. A warmed cache may let a particular test run
-without fetching, but completeness is implicit and a new read follows the
-provider path. Anvil's dump/load state is useful for reproducible local nodes,
-but it likewise represents local state rather than a finite, proof-labelled
-application capture. Lazarus should borrow the ergonomics, not declare a
-Foundry cache verified or complete.
+## Constraints and design
 
-#### Execution-specification fixtures
-
-`ethereum/execution-specs` and the associated execution test releases are
-client-conformance material. State-test fixtures contain an execution
-environment, a full pre-allocation, a transaction and expected post-state
-roots and log hashes. Blockchain-test fixtures contain a pre-allocation,
-genesis RLP and header, blocks, the last block hash and a post-allocation.
-They let a client reconstruct tries from allocations and check consensus-
-critical execution.
-
-Those ordinary fixtures do not package EIP-1186 account and storage inclusion
-proofs for an arbitrary historical application read. Newer fixture tooling
-can optionally add an execution witness with `--witness`, but that witness is
-generated for executing the test block and remains client-conformance input.
-The formats and their release discipline are worth reusing as vectors; their
-scope is not a replacement for an application capture plan.
-
-#### Geth traces and prestate capture
-
-Geth's default struct logger emits program counter, opcode, remaining gas, gas
-cost, call depth and optionally memory, stack, return data and storage at each
-step. `callTracer` emits nested call frames. `prestateTracer` records the
-accounts and slots touched during execution and its diff mode records changed
-state. Geth's own documentation says the prestate result contains trie leaves,
-not cryptographic proofs.
-
-`debug_traceCall` runs a call in a selected block context and returns the same
-family of output as transaction tracing. Historical tracing may regenerate
-state by re-executing blocks; Geth's `reexec` setting defaults to 128 and its
-documentation shows historical regeneration taking minutes. Trace namespaces,
-tracer names, defaults and encodings are not part of the stable `eth_` API and
-can differ across clients. For the prototype, a trace is an exact recorded RPC
-response carrying the client name, version, tracer and options. It cannot be
-used as a cross-client canonical response or as proof of every value it
-mentions.
-
-#### Reth execution witnesses
-
-Reth exposes `debug_executionWitness` and
-`debug_executionWitnessByBlockHash`. Its documentation describes a map from
-hashed trie nodes to the preimages needed to re-execute a whole block and
-recompute its state root. This is stronger and broader than Geth's
-`prestateTracer`, and it may later supply an import format. It is still a
-block-execution witness, not a capture plan for an arbitrary set of
-application calls, receipts and log ranges. Importing it in the first
-prototype would add a second completeness model before the simpler one is
-tested.
-
-#### Hosted forks and node snapshots
-
-Tenderly virtual testnets, provider simulations, archive RPC products, Anvil
-forks, Reth databases and Erigon snapshots all preserve or expose historical
-state in some form. Hosted forks retain an account and service dependency.
-Client databases and snapshots are large, implementation-specific node
-artefacts. Neither class gives the prototype's combination of a declared
-finite request set, EIP-1186 proof labels, deterministic release bytes and an
-exact local miss. They are capture sources and comparison targets, not the
-fixture format.
-
-## Constraints and non-goals
-
-The original implementation started from `main` at
+The original implementation started from clean `main` at
 `83fef6634a560860b930a532861dbfff8cbb3442` in
-`laurenceday/wildcat-skills-todo`. The worktree was clean when the study began,
-and no Lazarus plugin existed on that ref.
+`laurenceday/wildcat-skills-todo`, where no Lazarus plugin existed.
 
-The implementation must follow the target repository's plugin layout and
-tests. Python should own the CLI, deterministic file writing and local HTTP
-server, matching Ariadne, Probitas and Tabularium. Use Python 3.11 or newer.
-The proof checker may use a small pinned Ethereum trie stack (`eth-hash` with a
-Keccak backend, `rlp` and `trie`) rather than writing a new Keccak or Merkle
-Patricia implementation. Pin and lock those packages, keep the verifier API
-behind one module, and run all repository tests without a network once
-dependencies are installed. Do not add Web3 merely to make JSON-RPC calls;
-the standard library can send those requests.
+Python 3.11 or newer owns the CLI, deterministic writer, and local HTTP server,
+matching Ariadne, Probitas, and Tabularium. A pinned Ethereum trie stack
+(`eth-hash` with Keccak, `rlp`, and `trie`) may sit behind one verifier
+module; do not write new Keccak or Merkle Patricia code or add Web3 just for
+JSON-RPC. Once dependencies are installed, every repository test runs offline.
 
-Canonical output follows the existing repository convention: UTF-8, ASCII
-schema keys, lexicographically sorted object keys, compact separators, no
-floating-point values and one trailing newline for JSONL. Quantities are
-validated as Ethereum hex quantities and converted to integers only for
-bounded comparison. SHA-256 identifies fixture files and the fixture as a
-release artefact; Keccak-256 remains the Ethereum trie and code hash.
+Canonical output uses UTF-8, ASCII schema keys, lexicographically sorted object
+keys, compact separators, no floating point, and one trailing newline for
+JSONL. Ethereum hex quantities become integers only for bounded comparisons.
+SHA-256 identifies fixture files and releases; Keccak-256 remains the trie and
+code hash.
 
-The capture URL and headers are runtime inputs. They never enter the fixture,
-diagnostics or digest material. Provider identity is limited to explicitly
-safe metadata such as client family and version returned by an allowed probe.
-URL user information, query strings, API keys, cookies and arbitrary provider
-error text are scrubbed before anything is written.
+Capture URLs and headers are runtime inputs, never fixture, diagnostic, or
+digest material. Only safe metadata such as an allowed client-family/version
+probe may persist. Scrub URL user information, query strings, API keys,
+cookies, and arbitrary provider errors.
 
-The fixture accepts only a fixed block number and expected block hash in its
-effective plan. Capture from a tag is allowed only as a convenience before
-resolution; the stored plan contains neither `latest` nor `pending`. The
-prototype supports Ethereum mainnet's current Merkle Patricia state trie. L2
-state roots, Verkle-state formats, pre-Byzantium receipt differences and
-chain-specific RPC extensions need separate profiles and are deferred.
+The effective plan has a fixed block number and expected hash; tags may be
+resolved before storage, but `latest` and `pending` never persist. The first
+profile covers Ethereum mainnet's current Merkle Patricia trie. L2 roots,
+Verkle state, pre-Byzantium receipt differences, and chain-specific extensions
+need separate profiles.
 
 The prototype does not:
 
-- replace an archive node or capture unbounded state;
-- execute arbitrary `eth_call` locally from partial state;
-- infer which slots a dynamic call might read;
-- prove logs or receipts against `receiptsRoot`;
-- claim a block is canonical or final solely because its header hash is
-  internally consistent;
-- normalise one client's `debug_` or `trace_` result into another's;
-- capture pending state, mempool contents, subscriptions or write methods;
-- collect private keys, sign transactions or hold a signing key;
-- silently use a live provider during replay;
-- publish, sign or merge a Mnemosyne release;
-- rewrite Tabularium's existing Goldfinch release; or
-- provide a Foundry state backend in the first step.
+- replace an archive node, capture unbounded state, execute arbitrary local
+  `eth_call`, or infer dynamic slots;
+- prove logs or receipts against `receiptsRoot`, or infer canonicality or
+  finality from an internally consistent header;
+- normalise `debug_` or `trace_` clients, capture pending state, mempool,
+  subscriptions, or writes;
+- collect keys, sign transactions, use a live provider during replay, publish,
+  sign, or merge a Mnemosyne release;
+- rewrite Tabularium's Goldfinch release or provide a Foundry state backend.
 
-The supported replay allowlist should begin with `eth_chainId`,
-`eth_getBlockByHash`, `eth_getBlockByNumber`, `eth_getBalance`,
-`eth_getTransactionCount`, `eth_getCode`, `eth_getStorageAt`, `eth_getProof`,
-`eth_call`, `eth_getLogs`, `eth_getTransactionByHash` and
-`eth_getTransactionReceipt`. A plan can store another read-only method as
-recorded evidence, but the schema must label it unproved and preserve its exact
-method and parameters. Write methods and subscriptions are rejected.
+Replay begins with `eth_chainId`, `eth_getBlockByHash`,
+`eth_getBlockByNumber`, `eth_getBalance`, `eth_getTransactionCount`,
+`eth_getCode`, `eth_getStorageAt`, `eth_getProof`, `eth_call`,
+`eth_getLogs`, `eth_getTransactionByHash`, and
+`eth_getTransactionReceipt`. Other read-only methods may be recorded as
+unproved exact method/parameter evidence. Writes and subscriptions are rejected.
 
-## Design options
+Four options were considered:
 
-### Option 1: bless the Foundry fork cache
-
-Package a warmed `storage.json` with a wrapper that launches Forge or Anvil.
-This is the shortest route to local EVM execution and matches the tests Wildcat
-already runs. Completeness remains accidental, cache misses use the provider
-path, values lack state proofs, the format follows Foundry internals and the
-capture plan is not reviewable. Fixing those gaps would amount to building a
-new layer around the cache.
-
-### Option 2: deterministic RPC cassette with a proof bundle
-
-Store an explicit plan, checked header, exact request-response records,
-EIP-1186 proofs and a digest manifest. Verify the bundle offline and replay by
-exact method-plus-parameters lookup. A miss is a JSON-RPC error and a suggested
-plan entry; it never fetches. `eth_call`, logs, receipts and traces remain
-labelled recorded evidence.
-
-This is the selected construction. It has the lowest comprehension cost that
-meets every prototype requirement. One format explains capture, evidence,
-coverage and replay. A reviewer can inspect it with ordinary JSON tools. It
-does less than a forked EVM, which is an advantage at this stage: the tool
-cannot imply that uncaptured state was present.
-
-The fixture layout should be:
-
-```text
-fixture/
-  manifest.json       component digests, schema/tool versions, evidence counts
-  plan.json           requested chain, block, methods, accounts and slots
-  header.json         full header plus recomputed hash and state root
-  rpc.jsonl           canonical exact request and result/error records
-  proofs.jsonl        account/storage proofs and local verification results
-  schemas/            pinned JSON Schemas used by this fixture version
-```
-
-The request key is SHA-256 over canonical JSON containing only `method` and
-`params`; the caller's JSON-RPC `id` is never part of it. Replay copies the
-caller's `id` into the response. JSON object member order is irrelevant after
-canonicalisation, while array order, quantities, addresses, block selectors
-and omitted fields remain exact. There is no convenience coercion between
-`0x0`, `0x00`, decimal zero or `latest`.
-
-### Option 3: rebuild a partial state database and execute calls in revm
-
-Convert proved accounts, code and slots into a revm database and run arbitrary
-calls against it. This gives useful Foundry-like behaviour and discovers a
-miss when the EVM touches an absent slot. It also introduces hardfork
-selection, block environment, precompiles, call overrides, block-hash history,
-dynamic dependencies and client parity. A replay result becomes a new
-calculation rather than the captured provider result. Build this later as a
-consumer of the selected fixture, not as its first storage format.
-
-### Option 4: package a client execution witness or node snapshot
-
-Import a Reth execution witness, Erigon snapshot or other client database and
-run a local execution client. This can support wider execution and stronger
-block-level completeness. It is much larger, tied to a client and aimed at
-block execution rather than one application's declared calls. It should be an
-optional importer after Lazarus has a stable evidence model.
+1. A warmed Foundry `storage.json` is short and supports local execution, but
+   completeness is accidental, misses reach the provider, values lack proofs,
+   internals own the format, and scope is not reviewable.
+2. The selected deterministic cassette stores an explicit plan, checked
+   header, exact responses, EIP-1186 proofs, and digest manifest. It verifies
+   offline; exact method-plus-parameters misses return JSON-RPC errors and plan
+   entries; calls, logs, receipts, and traces stay recorded evidence. Ordinary
+   JSON tools can inspect it, and uncaptured state cannot be implied.
+3. A revm database could execute arbitrary calls and expose absent slots, but
+   adds hardfork, environment, precompile, override, block-history, dynamic
+   dependency, and client-parity questions. It can consume a stable fixture
+   later; its results would be new calculations.
+4. A Reth witness, Erigon snapshot, or client database supports wider
+   execution and block completeness but is large, client-bound, and aimed at
+   blocks rather than application calls. It can become an optional importer.
 
 ## Selected format and verification details
 
-`plan.json` is both input and coverage contract. Each request has a stable
-name, exact method and parameters, `required` flag and expected evidence class.
-Proof targets are separate objects with an address and sorted unique 32-byte
-slots. The effective plan records the resolved chain ID, block number and block
-hash. Capture fails if two reads of the header disagree, if a required method
-fails, if a returned object names another block, or if a proof does not verify.
-An optional method failure is preserved as a sanitised error and counted in
-the manifest.
+The selected layout is:
 
-For each account proof, verification must:
+```text
+fixture/
+  manifest.json  component digests, versions, and evidence counts
+  plan.json      chain, block, methods, accounts, and slots
+  header.json    full header, recomputed hash, and state root
+  rpc.jsonl      canonical exact requests and results or errors
+  proofs.jsonl   account/storage proofs and verification results
+  schemas/       pinned JSON Schemas for this fixture version
+```
 
-1. recompute the block header hash from its fork-appropriate RLP fields and
-   compare it with the expected block hash;
-2. traverse `accountProof` from the header `stateRoot` using
-   `keccak256(address)`;
-3. RLP-decode the account leaf as nonce, balance, storage root and code hash;
-4. compare those values with the response fields;
-5. traverse every storage proof from the proved storage root using
-   `keccak256(slot32)` and compare its decoded value; and
-6. Keccak-hash captured code and compare it with the proved code hash.
+The request key is SHA-256 of canonical JSON containing only `method` and
+`params`; caller `id` is excluded then copied to the response. Object member
+order is canonicalised, while arrays, values, omitted fields, quantities,
+addresses, and selectors stay exact. Do not coerce `0x0`, `0x00`, decimal
+zero, or `latest`.
 
-Proofs of absence must terminate according to trie rules and produce the
-documented empty account or zero slot result. A missing proof node is an error,
-not an absent account. Duplicate RLP nodes, malformed compact paths, overlong
-RLP, values wider than 256 bits and a response whose `key` differs from the
-planned slot all fail.
+Each request has a name, exact method and parameters, `required`, and expected
+evidence class. Proof targets have an address and sorted unique 32-byte slots.
+The effective plan records chain ID, block number, and hash. Capture fails on
+header disagreement, required-method failure, a returned object naming another
+block, or an invalid proof. Optional failure persists as a sanitised error and
+manifest count.
 
-`manifest.json` records schema version, tool version, plan and block identity,
-component byte lengths and SHA-256 digests, counts by evidence class, failed
-optional requests and the overall fixture digest. It cannot hash itself.
-Define the fixture digest as SHA-256 over canonical JSON containing the
-manifest's versioned identity fields and the sorted list of component path,
-byte length and digest triples. All paths are relative, slash-normalised,
-confined beneath the fixture root and forbidden from being symlinks.
+For each account proof:
 
-The replay server reads only a fixture that has passed verification in the
-same process. It binds loopback by default. It has no capture URL, proxy or
-fallback configuration. On an exact miss it returns a stable server error,
-for example code `-32070`, whose data contains canonical `method` and `params`
-plus the plan fragment needed for a later recapture. Batch requests are
-answered item by item; notifications produce no response. The server refuses
-write methods even if a malformed fixture contains one.
+1. Recompute the fork-appropriate RLP header hash and compare the expected hash.
+2. Traverse `accountProof` from `stateRoot` with `keccak256(address)`.
+3. RLP-decode nonce, balance, storage root, and code hash.
+4. Compare response fields with the leaf.
+5. Traverse each storage proof with `keccak256(slot32)` and compare its value.
+6. Keccak-hash captured code and compare the proved code hash.
 
-## Risk register seed
+Absence must terminate under trie rules and yield the documented empty account
+or zero slot. Missing nodes are errors. Duplicate RLP nodes, malformed compact
+paths, overlong RLP, values wider than 256 bits, and response keys different
+from planned slots fail.
 
-- **False chain identity.** A provider can supply a self-consistent header and
-  proof for a non-canonical fork. Recompute the header hash, require the user or
-  plan to name the expected hash, record how it was obtained, and state that
-  consensus finality remains external.
-- **Provider equivocation during capture.** Number-based calls may cross a
-  reorganisation or reach inconsistent backends. Resolve once, prefer
-  EIP-1898 block-hash selectors, and bracket capture with the same header hash.
-- **Proof-verifier errors.** RLP length handling, hex-prefix paths, embedded
-  versus hashed trie nodes, empty accounts and zero slots are easy to get
-  wrong. Use a pinned trie library, execution-apis proof vectors, independent
-  negative vectors and mutation tests over every proof node.
-- **Code substituted for a proved hash.** `eth_getProof` proves `codeHash`, not
-  code bytes. Always hash `eth_getCode` locally and fail on a mismatch.
-- **Recorded evidence described as proof.** Logs, receipts, calls and traces do
-  not become state proofs because they share a fixture with one. Evidence class
-  is required on every record and the verifier reports counts separately.
-- **Request-key collision or over-normalisation.** Address case, omitted
-  parameters, quantity encoding and block tags can change method semantics.
-  Canonicalise JSON syntax only, keep values exact, store the canonical request
-  beside its digest and compare both on lookup.
-- **Silent provider access.** A library proxy, environment variable or replay
-  helper could route a miss to the network. The replay process has no provider
-  client, tests run with sockets blocked except loopback, and a miss test
-  asserts no outbound connection was attempted.
-- **Incomplete dynamic calls.** Exact `eth_call` replay says nothing about a
-  different calldata value or a later implementation which tries to execute
-  from partial state. Keep call replay exact and defer EVM execution until a
-  state-access discovery and miss protocol exists.
-- **Client-dependent traces.** Geth, Reth, Erigon and hosted providers may emit
-  different trace shapes or defaults. Record client, version, method and full
-  options; treat the response as opaque recorded evidence.
-- **Secret disclosure.** RPC URLs and provider errors may contain credentials.
-  Use an allowlist for persisted metadata, scrub error strings, test userinfo,
-  query, header and bearer-token cases, and scan every output file before
-  finalisation.
-- **Path and parser attacks.** A downloaded fixture is untrusted. Reject
-  absolute paths, traversal, symlinks, duplicate JSON keys, oversized fields,
-  excessive nesting, invalid UTF-8 and unexpected files before reading proof
-  material.
-- **Resource exhaustion.** Logs, traces and proof arrays can be large. Plans
-  declare request and component byte limits; capture streams JSONL; verification
-  applies limits before allocation.
-- **Arithmetic and encoding drift.** Ethereum quantities are unsigned 256-bit
-  values, while JSON numbers and Python integers have different rules. Accept
-  canonical hex quantities at the boundary, reject negative or over-wide
-  values, never use floating point, and test leading-zero rejection.
-- **Nondeterminism.** Wall-clock time, request completion order, dictionary
-  order, host paths and server-generated IDs can change bytes. Sort all records
-  by request key or proof target, keep capture time outside deterministic
-  identity or require it as explicit input, and own every serialisation rule.
-- **Schema substitution.** A fixture could carry a permissive schema chosen by
-  an attacker. The verifier selects schemas by a built-in version registry and
-  then checks that bundled schema bytes match the registered digest.
-- **Correction and upgrade confusion.** A new schema or verifier could reinterpret
-  an old fixture. Unknown major versions fail; old verifiers remain available;
-  corrections produce new fixture IDs and name the superseded digest.
-- **Key custody.** The prototype holds no signing or transaction key. Future
-  Ariadne signing stays an external operation, and an unsigned fixture receives
-  no publisher identity claim.
+`manifest.json` records schema and tool versions, plan and block identity,
+component lengths and SHA-256 digests, evidence counts, optional failures, and
+the fixture digest. It cannot hash itself. The fixture digest hashes canonical
+JSON of the versioned identity and sorted component path/length/digest triples.
+Paths are relative, slash-normalised, confined, and not symlinks.
 
-## Glossary seeds
+Replay verifies in-process, binds loopback, and has no capture URL, proxy, or
+fallback. An exact miss returns `-32070` with canonical `method`, `params`,
+and a recapture plan fragment. Batches are per-item, notifications have no
+response, and writes fail even if a malformed fixture contains one.
 
-- **Capture plan:** the versioned list of chain, block, requests, proof targets,
-  limits and allowed omissions fixed before collection.
-- **Effective plan:** the capture plan after a tag has been resolved to one
-  block number and expected hash.
-- **Fixture:** the complete digest-bound directory containing plan, header,
-  records, proofs, schemas and manifest.
-- **Request record:** one exact JSON-RPC method-plus-parameters pair and its
-  result or sanitised error.
-- **Request key:** SHA-256 of the canonical JSON object containing a method and
-  its exact parameters.
-- **Proof target:** one account address and the finite set of storage slots
-  whose EIP-1186 proofs the plan requires.
-- **Proof-backed state:** a value whose trie proof verifies against the captured
-  header's state root.
-- **Header-bound data:** data checked against the captured header without an
-  external proof that the header is canonical.
-- **Recorded RPC evidence:** an exact provider response preserved without a
-  stronger cryptographic claim.
-- **Replay:** serving an exact recorded result for an exact captured request.
-- **Replay miss:** the explicit error returned when no exact request key exists.
-- **Coverage:** the set of requests and proof targets answered, failed or
-  omitted relative to the plan.
-- **Capability failure:** a sanitised record that the provider did not support
-  or could not serve a planned optional method at the chosen block.
-- **Fixture digest:** the SHA-256 identity derived from versioned manifest
-  fields and the sorted component digest list.
-- **Chain anchor:** evidence outside the fixture used to decide whether its
-  internally checked block hash belongs to the intended canonical chain.
-- **State witness:** the trie nodes and state needed to execute a transition;
-  broader than Lazarus's first exact-request fixture.
+## Risks and terms
+
+- False chain identity: recompute the header hash, require and provenance the
+  expected hash, and leave consensus finality external.
+- Provider equivocation: resolve once, prefer EIP-1898 hash selectors, and
+  bracket number fallback with the same header.
+- Proof-verifier errors: pin trie code and use execution-apis vectors,
+  independent negatives, and every-node mutations for RLP lengths, hex-prefix
+  paths, embedded/hashed nodes, empty accounts, and zero slots.
+- Code substitution: `eth_getProof` proves `codeHash`, so hash
+  `eth_getCode` locally and reject mismatch.
+- Evidence inflation: require an evidence class per record and report
+  proof-backed state separately from calls, logs, receipts, and traces.
+- Request-key drift: canonicalise syntax only; preserve address case,
+  omissions, quantities, tags, canonical request bytes, and digest.
+- Silent provider access: ship no provider client in replay; block non-loopback
+  sockets and assert misses make no outbound attempt.
+- Dynamic calls and client traces: keep calls exact, defer EVM execution until
+  access discovery has a miss protocol, and store client/version/method/options
+  with opaque trace results from Geth, Reth, Erigon, or hosted providers.
+- Secret disclosure: allowlist metadata, scrub errors, test userinfo, query,
+  headers, bearer tokens, and scan every output before finalisation.
+- Parser and resource attacks: reject absolute paths, traversal, symlinks,
+  duplicate keys, oversized fields, excessive nesting, invalid UTF-8, and
+  unexpected files before proofs; apply request/component limits before
+  allocation and stream logs, traces, and proof arrays as JSONL.
+- Arithmetic drift: accept canonical unsigned 256-bit hex quantities, reject
+  negative, over-wide, and leading-zero values, and never use floating point.
+- Nondeterminism: sort by request key or proof target; keep wall time outside
+  identity or explicit; exclude completion order, dictionary order, host paths,
+  and generated IDs from uncontrolled bytes.
+- Schema substitution and upgrades: select a built-in version and check bundled
+  schema digests; reject unknown majors; retain old verifiers; give corrections
+  new fixture IDs naming the superseded digest.
+- Key custody: hold no signing or transaction key. Ariadne signing remains
+  external, and unsigned fixtures receive no publisher claim.
+
+Terms:
+
+- Capture plan: versioned chain, block, requests, proof targets, limits, and
+  omissions fixed before collection.
+- Effective plan: the plan after resolving one block number and expected hash.
+- Fixture: the digest-bound plan, header, records, proofs, schemas, and manifest.
+- Request record: exact JSON-RPC method/parameters with result or sanitised error.
+- Request key: SHA-256 of canonical `method` and exact `params`.
+- Proof target: an account address and finite slots required by EIP-1186.
+- Proof-backed state: a value checked against the header state root.
+- Header-bound data: data checked against the header without a canonical anchor.
+- Recorded RPC evidence: an exact provider response without a stronger claim.
+- Replay and replay miss: an exact result, or the explicit absent-key error.
+- Coverage: planned requests and proof targets answered, failed, or omitted.
+- Capability failure: a sanitised unsupported/unserved optional method record.
+- Fixture digest: SHA-256 of versioned fields and sorted component digests.
+- Chain anchor: external evidence for canonical membership of the checked hash.
+- State witness: transition-execution trie nodes and state, broader than the
+  first Lazarus exact-request fixture.
 
 ## Sources
 
@@ -508,50 +339,42 @@ write methods even if a malformed fixture contains one.
   `83fef6634a560860b930a532861dbfff8cbb3442`: `specs/lazarus.md`,
   `specs/preservation-runbook.md`, `specs/ariadne.md`,
   `plugins/tabularium/examples/goldfinch-v0/`, `plugins/ariadne/`,
-  `plugins/probitas/`, root `AGENTS.md` and `tests/test_portable_skills.py`.
-- Unmerged local/remote branch `codex/mnemosyne-synthesis`, commit `0d929a0`:
+  `plugins/probitas/`, root `AGENTS.md`, and `tests/test_portable_skills.py`.
+- Unmerged local/remote `codex/mnemosyne-synthesis` at `0d929a0`:
   `specs/mnemosyne.md` and `mnemosyne/README.md`.
-- OpenCode database session `ses_ff5057204ffe26V8p4QM5Kh9PL`, "Lazarus
-  prior-art spike research". It is a research trail, not an authority; the
-  sources it identified are listed below.
+- OpenCode session `ses_ff5057204ffe26V8p4QM5Kh9PL`, “Lazarus prior-art
+  spike research,” is a trail rather than an authority.
 
 ### Ethereum specifications and vectors
 
-- EIP-1186, `eth_getProof`:
-  `https://eips.ethereum.org/EIPS/eip-1186`.
-- EIP-1898, block-hash selectors:
-  `https://eips.ethereum.org/EIPS/eip-1898`.
-- Ethereum execution APIs, state methods and account-proof schema:
-  `https://github.com/ethereum/execution-apis/blob/main/src/eth/state.yaml`
+- EIP-1186, `eth_getProof`: `https://eips.ethereum.org/EIPS/eip-1186`.
+- EIP-1898 selectors: `https://eips.ethereum.org/EIPS/eip-1898`.
+- Execution APIs: `https://github.com/ethereum/execution-apis/blob/main/src/eth/state.yaml`
   and `src/schemas/state.yaml`.
-- Execution API proof vectors:
-  `https://github.com/ethereum/execution-apis/tree/main/tests/eth_getProof`,
+- Proof vectors: `https://github.com/ethereum/execution-apis/tree/main/tests/eth_getProof`,
   especially `get-account-proof-with-storage.io` and
   `get-account-proof-blockhash.io`.
-- Ethereum execution-specification fixture documentation:
+- Execution-specification fixture docs:
   `https://github.com/ethereum/execution-specs/blob/forks/amsterdam/docs/running_tests/test_formats/state_test.md`
   and `blockchain_test.md`.
-- Execution-specification release and generation entrypoints:
+- Release and generation:
   `https://github.com/ethereum/execution-specs` and
   `docs/library/execution_testing_fixtures.md`.
 - JSON-RPC 2.0: `https://www.jsonrpc.org/specification`.
 - JSON Schema 2020-12: `https://json-schema.org/draft/2020-12`.
-- RFC 8785, JSON Canonicalization Scheme, consulted as comparison material:
-  `https://www.rfc-editor.org/rfc/rfc8785`.
+- RFC 8785 comparison: `https://www.rfc-editor.org/rfc/rfc8785`.
 
 ### Clients and developer tools
 
-- Foundry commit `3c16e2361f18f2cecc975e1d5a8d17330d92ced7`:
+- Foundry `3c16e2361f18f2cecc975e1d5a8d17330d92ced7`:
   `crates/config/src/lib.rs`, `crates/evm/core/src/fork/database.rs`,
-  `crates/evm/core/src/fork/multi.rs` and `crates/anvil/src/config.rs`.
-- `foundry-core` commit `8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f`:
+  `crates/evm/core/src/fork/multi.rs`, and `crates/anvil/src/config.rs`.
+- `foundry-core` `8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f`:
   `crates/fork-db/src/cache.rs` and `crates/fork-db/src/backend.rs`.
-- Foundry Anvil overview and state-management pointer:
-  `https://getfoundry.sh/anvil/`.
-- Geth built-in tracers:
+- Anvil: `https://getfoundry.sh/anvil/`.
+- Geth tracers:
   `https://geth.ethereum.org/docs/developers/evm-tracing/built-in-tracers`.
-- Geth debug namespace, `debug_traceCall` and `reexec`:
+- Geth `debug_traceCall` and `reexec`:
   `https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug`.
-- Reth debug RPC, execution witnesses:
-  `https://reth.rs/jsonrpc/debug/` and
+- Reth witnesses: `https://reth.rs/jsonrpc/debug/` and
   `https://reth.rs/docs/reth_rpc_api/clients/trait.DebugApiClient.html`.

--- a/plugins/lazarus/skills/lazarus/EVOLUTION.md
+++ b/plugins/lazarus/skills/lazarus/EVOLUTION.md
@@ -1,4 +1,4 @@
-# Lazarus evolution ledger
+Lazarus evolution ledger
 
 Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
 
@@ -8,8 +8,4 @@ Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VE
 - Current frontier: Preservation-pipeline integration and an Ariadne state-fixture predicate remain unimplemented.
 - Next Fiat job: Bind a Lazarus fixture through an Ariadne state-fixture predicate in the first end-to-end Goldfinch preservation release without upgrading recorded RPC evidence into proof-backed state. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
 
-## History
-
-| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
-| --- | --- | --- | --- | --- | --- |
-| `lazarus-v0.1.0` | baseline | `ariadne-state-fixture-binding` | `94c0f87fc8dd14562e948fb5b523c9248ffa6fd21849cc433d4a5bc47966daf5` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |
+- `lazarus-v0.1.0` | baseline | `ariadne-state-fixture-binding` | `94c0f87fc8dd14562e948fb5b523c9248ffa6fd21849cc433d4a5bc47966daf5` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged.

--- a/plugins/lazarus/skills/lazarus/SKILL.md
+++ b/plugins/lazarus/skills/lazarus/SKILL.md
@@ -14,10 +14,9 @@ metadata:
 
 ## Frontier
 
-Lazarus owns its own state-fixture preservation frontier, not Hexaemeron's delivery or
-Solidity frontier. Its version, held target, next job, and maturity
-state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run
-another frontier pass after that ledger becomes mature.
+Lazarus owns the state-fixture preservation frontier, not Hexaemeron's delivery
+or Solidity frontier. [EVOLUTION.md](EVOLUTION.md) holds its version, target,
+next job, and maturity. Do not run another frontier pass once it is mature.
 
 <!-- marketplace-context:start -->
 ## Where this sits
@@ -30,32 +29,18 @@ Lazarus captures the finite fixed-block Ethereum state and RPC evidence an appli
 <!-- marketplace-context:end -->
 
 Lazarus turns a finite historical Ethereum capture plan into a deterministic
-fixture and calls its exact JSON-RPC answers back into a local test after the
-original provider is gone.
+fixture whose exact JSON-RPC answers survive the original provider.
 
-`$SKILL_DIR` is the directory holding this file. The command lives at
-`$SKILL_DIR/../../scripts/lazarus.py`; resolve it from where you loaded this
-skill. This build implements finite capture plus the offline format, manifest
-and proof-verification layer, with exact verified replay over loopback.
-
-## Day to day
-
-**Protocol engineering.** A fork test depends on a paid archive endpoint and
-one old block. Its declared reads become a reviewable fixture, and an
-unexpected read becomes a visible miss instead of a hidden provider call.
-
-**Research.** A closed venue's state needs to remain inspectable after its
-front end and hosted data disappear. The fixture keeps the block, finite
-coverage and evidence classes together.
-
-**Security.** An incident test needs stable historical inputs. Account and
-storage values are checked against the captured state root, while calls,
-receipts, logs and client traces remain labelled as recorded evidence.
+`$SKILL_DIR` is this file's directory. Resolve the command at
+`$SKILL_DIR/../../scripts/lazarus.py`. It implements finite capture, offline
+formats, manifests, proof verification, and exact verified loopback replay.
 
 ## Available offline commands
 
-The current build validates versioned documents and binds their bytes in a
-manifest:
+Declared fork-test reads become a reviewable fixture; unexpected reads become
+visible misses. The fixture keeps a closed venue's block, finite coverage, and
+evidence classes together. Incident tests get stable historical inputs while
+calls, receipts, logs, and traces remain recorded evidence.
 
 ```bash
 python3 scripts/lazarus.py capture \
@@ -69,47 +54,43 @@ python3 scripts/lazarus.py verify <fixture-directory>
 python3 scripts/lazarus.py replay <fixture-directory>
 ```
 
-`verify` checks schema versions, safe paths, canonical manifest bytes and every
-declared component length and SHA-256 digest. It then recomputes the
-fork-appropriate header hash; verifies EIP-1186 account and storage inclusion
-or absence against the header state root; checks response fields against the
-decoded leaves; and hashes captured code against the proved `codeHash`. It
-reports separate proof-backed, header-bound and recorded-RPC evidence counts.
-Read the checked-in
-[study](../../docs/study.md) for the selected design and the
-[runbook](../../docs/runbook.md) for implementation status.
+`verify` checks schema versions, safe paths, canonical manifest bytes, and every
+component length and SHA-256 digest. It recomputes the fork-appropriate header
+hash; verifies EIP-1186 account and storage inclusion or absence against the
+state root; compares response fields with decoded leaves; hashes code against
+the proved `codeHash`; and reports proof-backed, header-bound, and recorded-RPC
+counts. The [study](../../docs/study.md) explains the design; the
+[runbook](../../docs/runbook.md) records implementation.
 
-`capture` resolves and brackets the plan's fixed number and expected hash. It
-prefers EIP-1898 hash selectors for proofs and code, safely falls back to the
-fixed number, checks the closing header, verifies the complete fixture and
-only then atomically finalises the output directory. Required request or proof
-failures leave no fixture. Optional provider failures retain only a stable
-sanitised error. URL credentials, query values, bearer tokens, cookies and raw
-provider errors are not fixture material.
+`capture` brackets the plan's fixed number and expected hash, prefers EIP-1898
+hash selectors, safely falls back to the fixed number, checks the closing
+header, verifies the fixture, then atomically finalises it. Required request or
+proof failures leave no fixture. Optional failures retain only a stable
+sanitised error. URL credentials, query values, bearer tokens, cookies, and raw
+provider errors never enter the fixture.
 
-`replay` verifies the fixture in the same process before binding to
-`127.0.0.1`. It answers only exact method-and-parameter matches, preserves the
-caller's identifier, handles single requests, batches and notifications, and
-returns error `-32070` with a capture-plan fragment on a miss. It rejects
-write and unsupported methods and has no provider client or fallback setting.
+`replay` verifies before binding `127.0.0.1`. It answers exact method-and-
+parameter matches, preserves caller identifiers, handles single requests,
+batches, and notifications, and returns `-32070` with a capture-plan fragment
+on a miss. It rejects write and unsupported methods and has no provider client
+or fallback.
 
 ## Fixture boundary
 
-A fixture separates three classes rather than lending one class the strength
-of another:
+A fixture keeps three evidence classes separate:
 
-1. **Proof-backed state.** Account and storage values verify through EIP-1186
+1. Proof-backed state. Account and storage values verify through EIP-1186
    against the captured header's `stateRoot`; code verifies against the proved
    `codeHash`.
-2. **Header-bound data.** The header hash and fields are checked internally.
+2. Header-bound data. The header hash and fields are checked internally.
    An external chain anchor is still required to call that header canonical.
-3. **Recorded RPC evidence.** Exact method, parameters and result or sanitised
+3. Recorded RPC evidence. Exact method, parameters and result or sanitised
    error bytes are preserved for calls, receipts, logs and traces without a
    trie-proof claim.
 
-Replay is exact request replay, not arbitrary EVM execution from a partial
-world state. Object member order is canonicalised for a request key; values,
-array order, omitted fields, quantities and block selectors remain exact.
+Replay is exact-request replay, not arbitrary EVM execution from partial state.
+Request keys canonicalise object member order only; values, array order,
+omissions, quantities, and block selectors remain exact.
 
 ## What capture must require
 
@@ -121,7 +102,7 @@ array order, omitted fields, quantities and block selectors remain exact.
 - Limits for requests, components, time and bytes.
 - A second matching header read when number-based provider fallback is used.
 
-Provider credentials are runtime inputs. They never enter output, diagnostics
+Provider credentials are runtime inputs and never enter output, diagnostics,
 or digest material.
 
 ## What verify must establish
@@ -133,16 +114,15 @@ or digest material.
   root, response values against decoded leaves and code against `codeHash`.
 - Separate counts for proof-backed, header-bound and recorded evidence.
 
-A self-consistent header is not proof that it belongs to Ethereum's canonical
-chain. Report the expected hash and its external provenance without upgrading
+A self-consistent header does not establish Ethereum canonical-chain
+membership. Report the expected hash and external provenance without upgrading
 the local check.
 
 ## What replay must guarantee
 
-Replay verifies the fixture in the same process before binding to loopback. It
-has no capture URL and no fallback provider. A request absent from the fixture
-returns the stable Lazarus miss error and a capture-plan fragment. It never
-invents a zero value or leaves loopback to answer a miss.
+Replay verifies in-process before binding loopback. It has no capture URL or
+fallback provider. An absent request returns the stable Lazarus miss and a
+capture-plan fragment; replay never invents zero or leaves loopback.
 
 ## What this never does
 


### PR DESCRIPTION
Compresses seven Lazarus Markdown surfaces while retaining proof classes, exact replay, offline verification, and held frontier.
The manifest-bound Goldfinch README remains byte-identical at SHA-256 `b8a0441746fdd8feb6657bcc78f13ff199c94b081a6462981e8e8a233ae0c09b`.
Audit: `audit/AUDIT.md`, repository-wide Brevitas pass, step 7, round 1.
Proof: fresh locked environment, root `22/22`, Lazarus `144/144`, two validators, seven source checks, protected SHA verification, and `git diff --check`.
<!-- wildcat-origin: shoggoth -->
