### PR TITLE
docs(alexandria): compress archive evidence prose

### DIFF
--- a/.agents/skills/alexandria/SKILL.md
+++ b/.agents/skills/alexandria/SKILL.md
@@ -3,29 +3,19 @@ name: alexandria
 description: Route lending-data preservation, reviewed credit-view and verified address-query work to Alexandria. Use it for digest-bound releases with explicit coverage; use Tabularium for semantic event releases or Probitas for a dossier.
 ---
 
-# Alexandria portable entrypoint
-
-<!-- marketplace-context:start -->
-## Where this sits
-
-Alexandria preserves heterogeneous lending data as digest-bound releases, then derives only the credit views a reviewed mapping can defend.
-
-**Use another tool when.** Use Tabularium when the job is semantic event mapping, Probitas when the deliverable is a counterparty dossier, and Lazarus when a test needs finite historical state or exact RPC replay.
-
-**Current frontier.** Compound v3 Phase 0 now pins the Comet registry and preserves one verified Ethereum execution witness; a resumable, reconciled Ethereum USDC interval harvester remains unimplemented.
-<!-- marketplace-context:end -->
-
-Read [the Alexandria runtime contract](../../../plugins/alexandria/AGENTS.md).
-Use its selection table to choose the skill, then read the canonical
-`SKILL.md` in full and follow it.
-
-Invocation prefixes are aliases:
-
 - `/alexandria:alexandria`, `$alexandria`, and a plain request to work with
   the lending-data archive all select `alexandria`.
 
-The current release can ingest and verify raw releases, derive registered
-Goldfinch and Clearpool credit views, rebuild a disposable address index and
-query it for Probitas. It also builds and checks the bounded Compound v3 Phase
-0 method release. The canonical skill and runtime contract are authoritative
-if this entrypoint disagrees with them.
+Alexandria portable entrypoint
+
+Read [the runtime contract](../../../plugins/alexandria/AGENTS.md), select its
+sole skill, and follow the canonical `SKILL.md` in full.
+
+<!-- marketplace-context:start -->
+> **Marketplace context: Alexandria.** Alexandria preserves heterogeneous lending data as digest-bound releases, then derives only the credit views a reviewed mapping can defend. Use Tabularium when the job is semantic event mapping, Probitas when the deliverable is a counterparty dossier, and Lazarus when a test needs finite historical state or exact RPC replay. **Current frontier:** Compound v3 Phase 0 now pins the Comet registry and preserves one verified Ethereum execution witness; a resumable, reconciled Ethereum USDC interval harvester remains unimplemented.
+<!-- marketplace-context:end -->
+
+The release ingests and verifies raw releases, derives registered Goldfinch
+and Clearpool credit views, rebuilds a disposable address index, queries it for
+Probitas, and builds and checks the bounded Compound v3 Phase 0 method release.
+The canonical skill and runtime contract prevail over this entrypoint.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -908,3 +908,11 @@ The Lazarus prose diff has no open finding. Status: clean.
 The review compared seven mutable files with entry ref `a7d001009e7e2a7e63343e206ef10ecabc2cab42`. It retained proof-backed, header-bound and recorded-RPC evidence classes, exact-request miss behaviour `-32070`, offline verification, and frontier digest `94c0f87fc8dd14562e948fb5b523c9248ffa6fd21849cc433d4a5bc47966daf5`. The manifest-bound Goldfinch README remains byte-identical at `b8a0441746fdd8feb6657bcc78f13ff199c94b081a6462981e8e8a233ae0c09b`.
 
 The fresh `requirements.lock` environment passed root `22/22`, Lazarus `144/144`, two Agent Skills validations, seven Imprimatur and Brevitas `--source` checks, protected SHA verification, and `git diff --check`. No live capture, external RPC, canonical-chain provenance, or publisher identity was established. The security suite remains waived because only Markdown changed.
+
+## Repository-wide Brevitas pass, step 8, round 1 -- 2026-08-18
+
+The Alexandria prose diff has no open finding. Status: clean.
+
+The review compared 13 changed files with entry ref `a7d001009e7e2a7e63343e206ef10ecabc2cab42`. It retained the `522/31/11/11` fixture counts, 28 Compound v3 deployments, two Ethereum USDC transactions, 100,000-row and 64 MiB limits, and frontier digest `d5afa30db4e5769dccded9f28be061dc623e119b328dbbcd87b729567b7eaeff`.
+
+Root `22/22`, Alexandria `255/255`, two Agent Skills validations, 16 Imprimatur and Brevitas `--source` checks, 24 local-link checks, protected SHA verification, and `git diff --check` pass. No publisher identity, provider completeness, canonical finality, interval history, address identity, default, repayment, or current balance was established. The security suite remains waived because only Markdown changed.

--- a/plugins/alexandria/AGENTS.md
+++ b/plugins/alexandria/AGENTS.md
@@ -4,25 +4,22 @@
 > **Marketplace context: Alexandria.** Alexandria preserves heterogeneous lending data as digest-bound releases, then derives only the credit views a reviewed mapping can defend. Use Tabularium when the job is semantic event mapping, Probitas when the deliverable is a counterparty dossier, and Lazarus when a test needs finite historical state or exact RPC replay. **Current frontier:** Compound v3 Phase 0 now pins the Comet registry and preserves one verified Ethereum execution witness; a resumable, reconciled Ethereum USDC interval harvester remains unimplemented.
 <!-- marketplace-context:end -->
 
-Alexandria contains one Agent Skill. Select it from this table, then read the
-chosen `SKILL.md` in full.
+Alexandria contains one Agent Skill:
 
-| Skill | Canonical instructions | Select when |
-| --- | --- | --- |
-| `alexandria` | `skills/alexandria/SKILL.md` | Build or verify a digest-bound lending-data release, or inspect the archive contract |
+- `alexandria`: read `skills/alexandria/SKILL.md` in full when building or
+  verifying a digest-bound lending-data release or inspecting the archive
+  contract.
 
 `skills/alexandria/SKILL.md` is the only canonical instruction document. Do
 not add a sibling browsing README.
 
 ## Translate tool names by capability
 
-| Instruction term | Required capability |
-| --- | --- |
-| `Read` | Read the named file completely or at the stated range |
-| `Write` or `Edit` | Create or patch the named file |
-| `Bash` | Execute the command in a shell and inspect its exit status |
-| `Glob`, `Grep`, or `find` | Enumerate or search files with the stated pattern |
-| `AskUserQuestion` | Ask the stated question through structured UI or concise text |
+- `Read`: read the named file completely or at the stated range.
+- `Write` or `Edit`: create or patch the named file.
+- `Bash`: execute the command and inspect its exit status.
+- `Glob`, `Grep`, or `find`: enumerate or search the stated pattern.
+- `AskUserQuestion`: ask through structured UI or concise text.
 
 Tool names describe capabilities, not mandatory API identifiers. Preserve the
 arguments, ordering, output files and exit codes when using an equivalent

--- a/plugins/alexandria/README.md
+++ b/plugins/alexandria/README.md
@@ -14,10 +14,10 @@ Alexandria preserves heterogeneous lending data as digest-bound releases, then d
 
 An offline tool for digest-bound lending-data releases.
 
-Alexandria keeps heterogeneous lending-protocol captures unchanged. It binds
-each capture to explicit scope and coverage, derives a narrow Tabularium credit
-view and supplies that view to Probitas through a disposable index. Alexandria
-is an archive and data source, not a lending venue or underwriting system.
+Alexandria keeps heterogeneous lending-protocol captures unchanged, binds each
+to explicit scope and coverage, derives a narrow Tabularium credit view, and
+supplies it to Probitas through a disposable index. It is an archive and data
+source, not a lending venue or underwriting system.
 
 ## Complete prototype
 
@@ -32,6 +32,9 @@ python3 scripts/alexandria.py derive release --output derived-release
 python3 scripts/alexandria.py verify derived-release
 python3 scripts/alexandria.py index derived-release --output alexandria.sqlite
 python3 scripts/alexandria.py query --index alexandria.sqlite --address 0x...
+output="$(mktemp -d)/credit-history-v0"
+python3 examples/credit-history-v0/demo.py build --output "$output"
+python3 examples/credit-history-v0/demo.py verify "$output"
 ```
 
 Ingest copies the declared raw bytes into SHA-256-derived paths and writes one
@@ -58,14 +61,8 @@ observation and per-venue coverage JSON. Probitas opts into the archive with
 `--alexandria-index`; its normal fixture and live adapter route is unchanged.
 
 The checked-in [`credit-history-v0`](examples/credit-history-v0/README.md)
-demonstration runs that complete path from the existing Goldfinch and Clearpool
-source files through Probitas's five gates without network access:
-
-```bash
-output="$(mktemp -d)/credit-history-v0"
-python3 examples/credit-history-v0/demo.py build --output "$output"
-python3 examples/credit-history-v0/demo.py verify "$output"
-```
+demonstration runs that path from the existing Goldfinch and Clearpool sources
+through Probitas's five gates without network access.
 
 Its expected receipts bind 522 derived events, 31 observations, an 11-event
 Clearpool address query and 11 Probitas records. Goldfinch remains partial for
@@ -90,17 +87,13 @@ python3 scripts/compound_v3_phase0.py registry \
 python3 scripts/compound_v3_phase0.py build \
   --input <captured-input> --output <release>
 python3 scripts/compound_v3_phase0.py check <release>
-```
-
-Live capture is a separate, explicit network boundary. It reads the endpoint
-only from `ALEXANDRIA_COMPOUND_RPC_URL` and does not preserve that URL or its
-headers:
-
-```bash
 python3 scripts/compound_v3_phase0.py capture \
   --registry registry.json --corpus corpus.json \
   --comet-repository <comet-checkout> --output <captured-input>
 ```
+
+Live capture is a separate network boundary. It reads the endpoint only from
+`ALEXANDRIA_COMPOUND_RPC_URL` and preserves neither the URL nor its headers.
 
 This is a fixed method proof from one RPC provider, not an interval harvester,
 independent finality evidence or a canonical Compound event release.

--- a/plugins/alexandria/docs/address-index.md
+++ b/plugins/alexandria/docs/address-index.md
@@ -7,6 +7,8 @@
 Alexandria rebuilds a disposable SQLite index from one or more verified
 derived releases:
 
+## Index boundary
+
 ```bash
 python3 plugins/alexandria/scripts/alexandria.py index derived-release \
   --output alexandria.sqlite
@@ -21,10 +23,10 @@ release IDs, component digests, capture IDs and evidence classes. It is an
 index of release truth, not release truth itself, and can be deleted and
 rebuilt at any time.
 
-The builder verifies every input before writing through a temporary sibling
-file and refuses an output path inside any input release. The reader opens
-SQLite read-only, runs its integrity check and
-re-verifies every release at its recorded path. It reconstructs and compares
+The builder verifies every input, writes through a temporary sibling file, and
+refuses an output path inside an input release. The reader opens SQLite
+read-only, runs its integrity check, and re-verifies every release at its
+recorded path. It reconstructs and compares
 one release partition at a time, so a multi-release catalogue does not retain
 every parsed JSONL row in memory together. This check binds the rows and the
 active correction set to release content instead of trusting a digest stored

--- a/plugins/alexandria/docs/credit-view.md
+++ b/plugins/alexandria/docs/credit-view.md
@@ -8,6 +8,8 @@ Alexandria derives a narrow credit view from a verified raw release. The raw
 release stays unchanged. Derivation writes a new release containing the same
 digest-keyed objects, two deterministic JSONL files and a new manifest.
 
+## Release contract
+
 ```bash
 python3 plugins/alexandria/scripts/alexandria.py derive raw-release \
   --output derived-release

--- a/plugins/alexandria/docs/data-dictionary.md
+++ b/plugins/alexandria/docs/data-dictionary.md
@@ -10,15 +10,16 @@ coordinates remain decimal strings where their schemas require exact values.
 
 ## Raw release
 
-| Field | Meaning |
-| --- | --- |
-| `release_id` | SHA-256 identity of the canonical manifest with this field omitted |
-| `components[].sha256` | SHA-256 of the unchanged object bytes |
-| `components[].object_path` | Confined digest-derived path inside the release |
-| `captures[].source` | Non-secret source kind, locator class and reference |
-| `captures[].scope` | Venue, chain, deployment, subjects and snapshot or block interval |
-| `captures[].coverage` | Counted collections, status, gaps and unsupported collections |
-| `supersedes` | Earlier release corrected by this release; it does not mutate the earlier bytes |
+- `release_id`: SHA-256 identity of the canonical manifest with this field
+  omitted.
+- `components[].sha256`: SHA-256 of the unchanged object bytes.
+- `components[].object_path`: confined digest-derived release path.
+- `captures[].source`: non-secret source kind, locator class and reference.
+- `captures[].scope`: venue, chain, deployment, subjects and snapshot or
+  block interval.
+- `captures[].coverage`: counted collections, status, gaps and unsupported
+  collections.
+- `supersedes`: earlier release corrected without mutating its bytes.
 
 `complete` applies only to the declared scope and collections. A digest match
 does not establish publisher identity, provider completeness or canonical-chain
@@ -26,17 +27,21 @@ finality.
 
 ## Derived release
 
-| Field | Meaning |
-| --- | --- |
-| `derivation.source_release_id` | Verified raw release used by every mapping |
-| `derivation.mappings[]` | Venue, adapter version, mapping revision and reconciliation counts |
-| `credit-events.jsonl` | Canonical, deterministically ordered venue-qualified credit events |
-| `credit-observations.jsonl` | Canonical position readings at named observation boundaries |
-| `id` | Hash of stable native identity, row kind and mapping rule; exposed as `row_id` by queries |
-| `provenance.component_sha256` | Raw object containing the selected source record |
-| `provenance.source_selector` | Exact native record selector |
-| `provenance.context_selectors` | Other native records needed to interpret the row |
-| `provenance.mapping_rule` | Registered rule which assigned the row meaning |
+- `derivation.source_release_id`: verified raw release used by every mapping.
+- `derivation.mappings[]`: venue, adapter version, mapping revision and
+  reconciliation counts.
+- `credit-events.jsonl`: canonical, deterministically ordered,
+  venue-qualified credit events.
+- `credit-observations.jsonl`: canonical position readings at named
+  observation boundaries.
+- `id`: hash of stable native identity, row kind and mapping rule; queries
+  expose it as `row_id`.
+- `provenance.component_sha256`: raw object containing the selected source
+  record.
+- `provenance.source_selector`: exact native record selector.
+- `provenance.context_selectors`: other native records needed to interpret
+  the row.
+- `provenance.mapping_rule`: registered rule which assigned the row meaning.
 
 Events do not imply a current balance, default or complete repayment.
 Observations apply only at their recorded boundary.

--- a/plugins/alexandria/docs/study.md
+++ b/plugins/alexandria/docs/study.md
@@ -578,46 +578,46 @@ truthfulness and query provenance.
 
 ## Glossary seeds
 
-- **Alexandria:** the raw-object archive, release catalogue and query boundary
+- `Alexandria`: the raw-object archive, release catalogue and query boundary
   described here; also the name of its operator plugin.
-- **Raw object:** unchanged bytes received from a chain reader, indexer,
+- `Raw object`: unchanged bytes received from a chain reader, indexer,
   provider export or other declared source.
-- **Object digest:** `sha256:<hex>` over the exact raw object bytes.
-- **Component descriptor:** a manifest entry naming a component's role, media
+- `Object digest`: `sha256:<hex>` over the exact raw object bytes.
+- `Component descriptor`: a manifest entry naming a component's role, media
   type, byte count, digest and safe local path or publication locations.
-- **Release manifest:** the canonical document that binds components to
+- `Release manifest`: the canonical document that binds components to
   capture scope, coverage, mapping versions and supersession history.
-- **Release ID:** SHA-256 of the canonical manifest body, excluding the ID
+- `Release ID`: SHA-256 of the canonical manifest body, excluding the ID
   field itself.
-- **Capture scope:** the network, deployment or subject set, interval,
+- `Capture scope`: the network, deployment or subject set, interval,
   selectors, source capability and evidence boundary a harvest attempted.
-- **Coverage:** the machine-readable result of that attempt, including counts,
+- `Coverage`: the machine-readable result of that attempt, including counts,
   omissions, failures and unsupported parts.
-- **Coverage status:** `complete`, `partial`, `failed` or `unsupported` within
+- `Coverage status`: `complete`, `partial`, `failed` or `unsupported` within
   the declared capture scope.
-- **Negative space:** the distinction among a checked empty result, an
+- `Negative space`: the distinction among a checked empty result, an
   uncovered venue, a failed capture and an unsupported record family.
-- **Credit event:** a venue-qualified occurrence such as borrowing, repayment
+- `Credit event`: a venue-qualified occurrence such as borrowing, repayment
   or liquidation, backed by a raw record.
-- **Position observation:** a value established for a credit position at a
+- `Position observation`: a value established for a credit position at a
   named capture boundary, such as principal outstanding or maturity.
-- **Amount leg:** one exact asset quantity with a role; a liquidation may have
+- `Amount leg`: one exact asset quantity with a role; a liquidation may have
   separate debt-repaid and collateral-seized legs.
-- **Subject account:** the chain-qualified address whose conduct or position a
+- `Subject account`: the chain-qualified address whose conduct or position a
   derived row describes.
-- **Source selector:** a deterministic pointer from a derived row to one record
+- `Source selector`: a deterministic pointer from a derived row to one record
   inside a raw object.
-- **Mapping rule:** a versioned Tabularium identifier for the economic and
+- `Mapping rule`: a versioned Tabularium identifier for the economic and
   structural transformation from a source record to a derived row.
-- **Evidence class:** the declared support for a boundary or value, such as
+- `Evidence class`: the declared support for a boundary or value, such as
   provider-reported, recorded RPC, header-bound or proof-backed.
-- **Address index:** a disposable SQLite projection rebuilt from verified
+- `Address index`: a disposable SQLite projection rebuilt from verified
   manifests and derived rows.
-- **Publication location:** one place from which component bytes may be
+- `Publication location`: one place from which component bytes may be
   obtained; it is not the component identity or a promise of availability.
-- **Supersession:** a new immutable release that names an earlier release it
+- `Supersession`: a new immutable release that names an earlier release it
   corrects or extends.
-- **Retention receipt:** later evidence that an operator undertook to keep a
+- `Retention receipt`: later evidence that an operator undertook to keep a
   copy for a named period; not implemented in the prototype.
 
 ## Sources

--- a/plugins/alexandria/examples/README.md
+++ b/plugins/alexandria/examples/README.md
@@ -1,15 +1,15 @@
-# Alexandria examples
+Alexandria examples
 
 <!-- marketplace-context:start -->
 > **Marketplace context: Alexandria.** Alexandria preserves heterogeneous lending data as digest-bound releases, then derives only the credit views a reviewed mapping can defend. Use Tabularium when the job is semantic event mapping, Probitas when the deliverable is a counterparty dossier, and Lazarus when a test needs finite historical state or exact RPC replay. **Current frontier:** Compound v3 Phase 0 now pins the Comet registry and preserves one verified Ethereum execution witness; a resumable, reconciled Ethereum USDC interval harvester remains unimplemented.
 <!-- marketplace-context:end -->
 
-[`credit-history-v0`](credit-history-v0/README.md) runs the checked-in offline
-path from existing Goldfinch and Clearpool source bytes through raw release,
-derived credit view, address index and Probitas's five dossier gates. Its plan
-pins the original repository files rather than duplicating them.
+- [`credit-history-v0`](credit-history-v0/README.md) runs the checked-in offline
+  path from existing Goldfinch and Clearpool source bytes through raw release,
+  derived credit view, address index and Probitas's five dossier gates. Its plan
+  pins the original repository files rather than duplicating them.
 
-[`compound-v3-phase0-v0`](compound-v3-phase0-v0/README.md) preserves the
-pinned Comet registry and exact RPC corpus for one old and one recent Ethereum
-USDC transaction. It rebuilds and checks the raw release offline; it is a
-method proof, not an interval history.
+- [`compound-v3-phase0-v0`](compound-v3-phase0-v0/README.md) preserves the
+  pinned Comet registry and exact RPC corpus for one old and one recent Ethereum
+  USDC transaction. It rebuilds and checks the raw release offline; it is a
+  method proof, not an interval history.

--- a/plugins/alexandria/examples/compound-v3-phase0-v0/README.md
+++ b/plugins/alexandria/examples/compound-v3-phase0-v0/README.md
@@ -1,15 +1,18 @@
-# Compound v3 Phase 0 method proof
+Compound v3 Phase 0 method proof
 
 <!-- marketplace-context:start -->
 > **Marketplace context: Alexandria.** Alexandria preserves heterogeneous lending data as digest-bound releases, then derives only the credit views a reviewed mapping can defend. Use Tabularium when the job is semantic event mapping, Probitas when the deliverable is a counterparty dossier, and Lazarus when a test needs finite historical state or exact RPC replay. **Current frontier:** Compound v3 Phase 0 now pins the Comet registry and preserves one verified Ethereum execution witness; a resumable, reconciled Ethereum USDC interval harvester remains unimplemented.
 <!-- marketplace-context:end -->
 
-This release pins Compound's 28 production Comet deployments at commit
-`f766f51583c23acc33b2a7824654ef2029a96804` and preserves the raw JSON-RPC
-requests and responses for two Ethereum USDC transactions. The 2022
-transaction tests old-state and old-trace access. The 2026 transaction tests
-the pinned deployment, nested calls, transaction-start storage and ordered
-`SSTORE` output below a provider-reported finalized boundary.
+The fixed release records:
+
+- Compound's 28 production Comet deployments at commit
+  `f766f51583c23acc33b2a7824654ef2029a96804`;
+- raw JSON-RPC requests and responses for two Ethereum USDC transactions;
+- a 2022 transaction testing old-state and old-trace access; and
+- a 2026 transaction testing the pinned deployment, nested calls,
+  transaction-start storage, and ordered `SSTORE` output below a
+  provider-reported finalized boundary.
 
 The capture came from one public Hinterlight endpoint reporting
 `reth/v1.11.3-d6324d6`. It is recorded RPC evidence, not chain proof or an

--- a/plugins/alexandria/examples/credit-history-v0/README.md
+++ b/plugins/alexandria/examples/credit-history-v0/README.md
@@ -1,16 +1,18 @@
-# `credit-history-v0`
+`credit-history-v0`
 
 <!-- marketplace-context:start -->
 > **Marketplace context: Alexandria.** Alexandria preserves heterogeneous lending data as digest-bound releases, then derives only the credit views a reviewed mapping can defend. Use Tabularium when the job is semantic event mapping, Probitas when the deliverable is a counterparty dossier, and Lazarus when a test needs finite historical state or exact RPC replay. **Current frontier:** Compound v3 Phase 0 now pins the Comet registry and preserves one verified Ethereum execution witness; a resumable, reconciled Ethereum USDC interval harvester remains unimplemented.
 <!-- marketplace-context:end -->
 
-This demonstration runs the complete Alexandria prototype without reaching
-the network. It reads the existing Goldfinch source at
-`plugins/tabularium/examples/goldfinch-v0/source.json` and the existing
-Clearpool source stored with this example at
-`plugins/alexandria/examples/credit-history-v0/sources/clearpool.json`. The
-plan pins both SHA-256 values and materializes them only in the temporary demo
-output.
+This offline demonstration reads:
+
+- Goldfinch source
+  `plugins/tabularium/examples/goldfinch-v0/source.json`; and
+- Clearpool source
+  `plugins/alexandria/examples/credit-history-v0/sources/clearpool.json`.
+
+The plan pins both SHA-256 values and materializes them only in the temporary
+demo output.
 
 From the repository root:
 

--- a/plugins/alexandria/schemas/README.md
+++ b/plugins/alexandria/schemas/README.md
@@ -1,4 +1,4 @@
-# Alexandria schemas
+Alexandria schemas
 
 <!-- marketplace-context:start -->
 > **Marketplace context: Alexandria.** Alexandria preserves heterogeneous lending data as digest-bound releases, then derives only the credit views a reviewed mapping can defend. Use Tabularium when the job is semantic event mapping, Probitas when the deliverable is a counterparty dossier, and Lazarus when a test needs finite historical state or exact RPC replay. **Current frontier:** Compound v3 Phase 0 now pins the Comet registry and preserves one verified Ethereum execution witness; a resumable, reconciled Ethereum USDC interval harvester remains unimplemented.

--- a/plugins/alexandria/skills/alexandria/EVOLUTION.md
+++ b/plugins/alexandria/skills/alexandria/EVOLUTION.md
@@ -1,4 +1,4 @@
-# Alexandria evolution ledger
+Alexandria evolution ledger
 
 Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
 
@@ -8,8 +8,4 @@ Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VE
 - Current frontier: Compound v3 Phase 0 now pins the Comet registry and preserves one verified Ethereum execution witness; a resumable, reconciled Ethereum USDC interval harvester remains unimplemented.
 - Next Fiat job: Build the first resumable Ethereum USDC interval collector with implementation-epoch discovery, bounded shards, a second-provider reconciliation path, explicit finality and offline raw-release verification. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
 
-## History
-
-| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
-| --- | --- | --- | --- | --- | --- |
-| `alexandria-v0.2.0` | baseline | `usdc-interval-collector` | `d5afa30db4e5769dccded9f28be061dc623e119b328dbbcd87b729567b7eaeff` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |
+- `alexandria-v0.2.0` | baseline | `usdc-interval-collector` | `d5afa30db4e5769dccded9f28be061dc623e119b328dbbcd87b729567b7eaeff` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged.

--- a/plugins/alexandria/skills/alexandria/SKILL.md
+++ b/plugins/alexandria/skills/alexandria/SKILL.md
@@ -68,6 +68,17 @@ boundary and counted coverage or a stated gap. Then ingest it:
 ```bash
 python3 "$SKILL_DIR/../../scripts/alexandria.py" ingest \
   --plan capture-plan.json --output release
+python3 "$SKILL_DIR/../../scripts/alexandria.py" verify release
+python3 "$SKILL_DIR/../../scripts/alexandria.py" derive raw-release \
+  --output derived-release
+python3 "$SKILL_DIR/../../scripts/alexandria.py" verify derived-release
+python3 "$SKILL_DIR/../../scripts/alexandria.py" index derived-release \
+  --output alexandria.sqlite
+python3 "$SKILL_DIR/../../scripts/alexandria.py" query \
+  --index alexandria.sqlite --address 0x...
+output="$(mktemp -d)/credit-history-v0"
+python3 plugins/alexandria/examples/credit-history-v0/demo.py build --output "$output"
+python3 plugins/alexandria/examples/credit-history-v0/demo.py verify "$output"
 ```
 
 Ingest reads only the plan and its confined local source files. It copies raw
@@ -76,11 +87,7 @@ directory and installs the release atomically. It refuses absolute paths,
 traversal, symlinks and replacement of a different release. Record the
 `sha256:...` release ID printed on success.
 
-Verify before using or moving a release:
-
-```bash
-python3 "$SKILL_DIR/../../scripts/alexandria.py" verify release
-```
+Verify before using or moving a release.
 
 Verification is offline and read-only. It checks canonical manifest bytes,
 release identity, object paths, byte counts, digests, component access and
@@ -89,13 +96,7 @@ collection counts, declared gaps, correction links and exact release-tree
 membership. It does not establish publisher identity, source completeness or
 chain finality.
 
-Derive the narrow Tabularium view into a new release:
-
-```bash
-python3 "$SKILL_DIR/../../scripts/alexandria.py" derive raw-release \
-  --output derived-release
-python3 "$SKILL_DIR/../../scripts/alexandria.py" verify derived-release
-```
+Derive the narrow Tabularium view into a new release.
 
 Derivation first verifies the input and never changes it. Registered
 Goldfinch and Clearpool mappings emit deterministic credit events and, where
@@ -107,14 +108,7 @@ renames do not change row IDs, and repayment legs remain neutral source
 amounts unless the native record supplies a principal and interest split.
 Derivation stops above 100,000 rows or 64 MiB for either JSONL file.
 
-Rebuild the disposable address index and query it:
-
-```bash
-python3 "$SKILL_DIR/../../scripts/alexandria.py" index derived-release \
-  --output alexandria.sqlite
-python3 "$SKILL_DIR/../../scripts/alexandria.py" query \
-  --index alexandria.sqlite --address 0x...
-```
+Rebuild the disposable address index and query it.
 
 Indexing verifies every derived release, refuses to write inside one and
 retains the derived release, raw release, component, capture and row
@@ -133,14 +127,8 @@ evidence class, combines per-chain coverage conservatively and keeps registry
 venues absent from the archive visible as gaps. It does not infer people,
 defaults, full repayment or a current balance.
 
-To exercise the whole path without a network, run the fixed demonstration from
-the repository root:
-
-```bash
-output="$(mktemp -d)/credit-history-v0"
-python3 plugins/alexandria/examples/credit-history-v0/demo.py build --output "$output"
-python3 plugins/alexandria/examples/credit-history-v0/demo.py verify "$output"
-```
+The last three commands exercise the fixed demonstration without a network
+from the repository root.
 
 The plan pins existing Goldfinch and Clearpool files by digest. The result is a
 reproducibility fixture, not a production corpus. Its Goldfinch source remains


### PR DESCRIPTION
- Compresses 13 Alexandria Markdown files; runtime code, schemas, release bytes, and the held frontier are unchanged.
- Preserves `522/31/11/11`, 28 Compound v3 deployments, two Ethereum USDC transactions, the 100,000-row and 64 MiB limits, and frontier digest `d5afa30db4e5769dccded9f28be061dc623e119b328dbbcd87b729567b7eaeff`.
- Audit: `audit/AUDIT.md`, step 8 round 1, zero findings.
- Proof: root `22/22`; Alexandria `255/255`; validators `2/2`; prose checks `16/16`; local links `24/24`; protected proof `159/43/29/4`; `git diff --check`.
- No publisher identity, provider completeness, canonical finality, interval history, address identity, default, repayment, or current balance was established.

<!-- wildcat-origin: shoggoth -->
