### PR TITLE
docs(probitas): compress dossier evidence prose

### DIFF
--- a/.agents/skills/probitas/SKILL.md
+++ b/.agents/skills/probitas/SKILL.md
@@ -3,30 +3,20 @@ name: probitas
 description: Route sourced counterparty lending dossiers to Probitas. Use declared addresses and keep coverage gaps visible; do not infer identity or issue a Wildcat verdict.
 ---
 
-# Probitas portable entrypoint
-
-<!-- marketplace-context:start -->
-## Where this sits
-
-Probitas builds a sourced record of what a counterparty did across lending venues from addresses they declared, without identifying a person or issuing a Wildcat verdict.
-
-**Use another tool when.** Use Alexandria for archived lending inputs and Tabularium when the job is publishing a reusable credit-event release rather than assessing one counterparty.
-
-**Current frontier.** Euler v1/v2 now ship; Morpho Midnight fixed-maturity coverage and curation remain unimplemented.
-<!-- marketplace-context:end -->
-
-Read [the Probitas runtime contract](../../../plugins/probitas/AGENTS.md). Use
-its selection table to choose the skill, then read that canonical `SKILL.md` in
-full and follow it.
-
-Invocation prefixes are aliases:
-
 - `/probitas:probitas`, `$probitas`, and a plain request for a counterparty
   dossier all select `probitas`.
+
+Probitas portable entrypoint
+
+Read [the runtime contract](../../../plugins/probitas/AGENTS.md), select its
+sole skill, and follow that canonical `SKILL.md` in full.
+
+<!-- marketplace-context:start -->
+> **Marketplace context: Probitas.** Probitas builds a sourced record of what a counterparty did across lending venues from addresses they declared, without identifying a person or issuing a Wildcat verdict. Use Alexandria for archived lending inputs and Tabularium when the job is publishing a reusable credit-event release rather than assessing one counterparty. **Current frontier:** Euler v1/v2 now ship; Morpho Midnight fixed-maturity coverage and curation remain unimplemented.
+<!-- marketplace-context:end -->
 
 The tool reaches public venue APIs over the network when `--fixtures` is
 absent. Ask before running it against a live counterparty if the runtime or the
 target repository requires approval for outbound requests.
 
-The canonical skill and the runtime contract are authoritative if this
-entrypoint disagrees with them.
+The canonical skill and runtime contract prevail over this entrypoint.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -75,7 +75,7 @@
       "displayName": "Probitas",
       "source": "./plugins/probitas",
       "description": "Sourced counterparty lending dossiers from declared addresses, with coverage gaps kept visible.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -916,3 +916,11 @@ The Alexandria prose diff has no open finding. Status: clean.
 The review compared 13 changed files with entry ref `a7d001009e7e2a7e63343e206ef10ecabc2cab42`. It retained the `522/31/11/11` fixture counts, 28 Compound v3 deployments, two Ethereum USDC transactions, 100,000-row and 64 MiB limits, and frontier digest `d5afa30db4e5769dccded9f28be061dc623e119b328dbbcd87b729567b7eaeff`.
 
 Root `22/22`, Alexandria `255/255`, two Agent Skills validations, 16 Imprimatur and Brevitas `--source` checks, 24 local-link checks, protected SHA verification, and `git diff --check` pass. No publisher identity, provider completeness, canonical finality, interval history, address identity, default, repayment, or current balance was established. The security suite remains waived because only Markdown changed.
+
+## Repository-wide Brevitas pass, step 9, round 1 -- 2026-08-18
+
+The Probitas prose, renderer and version diff has no open finding. Status: clean.
+
+The review compared 12 Markdown files and seven renderer or version surfaces with entry ref `a7d001009e7e2a7e63343e206ef10ecabc2cab42`. Generation moved from `probitas-v0.1.0` to `probitas-v0.2.0`; frontier revision `morpho-midnight-coverage`, its Next Fiat job, and SHA-256 `5f66077a0c39a9ee647bd34233504b3891493f864fe4a16a9eb0c0337b3ee688` remain unchanged. It retained 15 venues, four adapters, 11 gaps, six adapter-only gaps, five gate outcomes, and the distinction between `empty`, `error`, `unimplemented`, and `unconfigured`.
+
+Root `22/22`, Probitas `276/276`, two Agent Skills validations, 12 Imprimatur and Brevitas `--source` checks, 21 local-link checks, protected SHA verification, and `git diff --check` pass. The fixture renderer produced nine records across four of 15 venues, named 11 gaps, passed gates 1 through 5, and matched the committed dossier byte-for-byte. No live venue call, chain-state claim, personal data, address attribution, or counterparty score was established. The security suite remains waived because no Solidity changed.

--- a/plugins/probitas/.claude-plugin/plugin.json
+++ b/plugins/probitas/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "probitas",
   "displayName": "Probitas",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Sourced counterparty lending dossiers from declared addresses, with coverage gaps kept visible.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/probitas/.codex-plugin/plugin.json
+++ b/plugins/probitas/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "probitas",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Sourced counterparty lending dossiers from declared addresses, with coverage gaps kept visible.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/probitas/AGENTS.md
+++ b/plugins/probitas/AGENTS.md
@@ -4,28 +4,23 @@
 > **Marketplace context: Probitas.** Probitas builds a sourced record of what a counterparty did across lending venues from addresses they declared, without identifying a person or issuing a Wildcat verdict. Use Alexandria for archived lending inputs and Tabularium when the job is publishing a reusable credit-event release rather than assessing one counterparty. **Current frontier:** Euler v1/v2 now ship; Morpho Midnight fixed-maturity coverage and curation remain unimplemented.
 <!-- marketplace-context:end -->
 
-Probitas contains one Agent Skill. Select from this table, then read the chosen
-`SKILL.md` in full.
+Probitas contains one Agent Skill:
 
-| Skill | Canonical instructions | Select when |
-| --- | --- | --- |
-| `probitas` | `skills/probitas/SKILL.md` | Build a sourced dossier on what a counterparty did across on-chain lending venues |
+- `probitas`: read `skills/probitas/SKILL.md` in full to build a sourced
+  dossier on a counterparty's actions across on-chain lending venues.
 
 `skills/probitas/SKILL.md` is the only canonical instruction document. Do not
 add a sibling browsing README.
 
 ## Translate tool names by capability
 
-The canonical skill was written for hosts that name their tools. A local agent
-must map those names to equivalent capabilities:
+Map host tool names to these capabilities:
 
-| Instruction term | Required capability |
-| --- | --- |
-| `Read` | Read the named file completely or at the stated range |
-| `Write` or `Edit` | Create or patch the named file |
-| `Bash` | Execute the command in a shell and inspect its exit status |
-| `Glob`, `Grep`, or `find` | Enumerate or search files with the stated pattern |
-| `AskUserQuestion` | Ask the stated question through structured UI or concise text |
+- `Read`: read the named file completely or at the stated range.
+- `Write` or `Edit`: create or patch the named file.
+- `Bash`: execute the command and inspect its exit status.
+- `Glob`, `Grep`, or `find`: enumerate or search the stated pattern.
+- `AskUserQuestion`: ask through structured UI or concise text.
 
 Tool names describe capabilities, not mandatory API identifiers. Preserve the
 arguments, ordering, output files and exit codes when using an equivalent local

--- a/plugins/probitas/README.md
+++ b/plugins/probitas/README.md
@@ -45,27 +45,24 @@ python3 scripts/probitas.py collect --entity "Acme Trading Ltd" \
   --fixtures tests/fixtures/demo --run-id demo --out evidence.json
 
 python3 scripts/probitas.py render evidence.json --out dossier.md
-
 python3 scripts/probitas.py verify dossier.md evidence.json
+python3 scripts/probitas.py collect --entity "Acme Trading Ltd" \
+  --address 0xa1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1 \
+  --alexandria-index alexandria.sqlite --out evidence.json
 ```
 
 Five gate lines and exit 0. `verify` exits 1 and names the gate when a dossier
 breaches one, which is the only exit code worth wiring into anything.
 
-That sequence produces [`docs/example-dossier.md`](docs/example-dossier.md)
+The first four commands produce [`docs/example-dossier.md`](docs/example-dossier.md)
 exactly. The test suite regenerates it and compares, so the committed example
 can't drift from what the tool actually does.
 
 Drop `--fixtures` to run against the live venues instead of a synthetic
 borrower.
 
-To use a verified Alexandria address index instead of live or fixture adapters:
-
-```bash
-python3 scripts/probitas.py collect --entity "Acme Trading Ltd" \
-  --address 0xa1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1 \
-  --alexandria-index alexandria.sqlite --out evidence.json
-```
+The final command uses a verified Alexandria address index instead of live or
+fixture adapters.
 
 This route keeps the original Goldfinch or Clearpool venue and the Alexandria
 release, capture, component and row identities on every record. Every registry
@@ -74,16 +71,16 @@ routes do not change unless this option is passed.
 
 ### Options
 
-| Flag | What it does |
-| --- | --- |
-| `--entity` | The counterparty's name. Required |
-| `--address` | An address they declared. Repeatable, required |
-| `--inferred` | An address suspected but neither declared nor provably linked. Kept in its own section, and gate 1 fails the dossier if a finding against one appears anywhere else |
-| `--fixtures` | Read venue responses from a directory instead of the network |
-| `--alexandria-index` | Read verified archive-backed evidence instead of live or fixture adapters |
-| `--run-id` | A label for the run, printed in the dossier |
-| `--timeout` | Seconds per request, default 30 |
-| `--out` | Where to write, or `-` for stdout |
+- `--entity`: required counterparty name.
+- `--address`: required, repeatable declared address.
+- `--inferred`: suspected address, kept in its own section; gate 1 fails if a
+  finding against it appears elsewhere.
+- `--fixtures`: read venue responses from a directory, not the network.
+- `--alexandria-index`: read verified archive evidence, not live or fixture
+  adapters.
+- `--run-id`: run label printed in the dossier.
+- `--timeout`: seconds per request; default 30.
+- `--out`: output path, or `-` for stdout.
 
 ### The fixtures
 
@@ -161,19 +158,19 @@ Fifteen in the registry, four with adapters. The other eleven appear in every
 coverage table saying nobody checked, which is gate 2 working rather than an
 omission.
 
-| Venue | Status |
-| --- | --- |
-| Wildcat | Shipped. Public Goldsky subgraph, no key |
-| Morpho Blue | Shipped. Borrowing on Blue markets, keyless public API |
-| Euler v1 | Shipped. Canonical proxy event log through a keyless archival RPC |
-| Euler v2 | Shipped. Keyless V3 event ledger and liquidation API; Goldsky is not used for history |
-| Centrifuge | Keyless GraphQL, introspects cleanly. The most build-ready of the gaps |
-| Aave v3, Aave v4 | Keyless first-party API. v4 went live on mainnet in March 2026 |
-| MetaMorpho vaults, Morpho Vaults V2, Morpho Midnight | Three further Morpho surfaces, all keyless, none collected |
-| Maple Finance | Answers, but disables introspection and publishes no schema |
-| Compound v3, Goldfinch | Need a paid Graph gateway key |
-| Clearpool | Live, behind a bot challenge. An agreement is the way in, not a workaround |
-| TrueFi | Restructured through a token migration; no public endpoint answered |
+- Wildcat: shipped; public Goldsky subgraph, no key.
+- Morpho Blue: shipped; Blue-market borrowing, keyless public API.
+- Euler v1: shipped; canonical proxy event log through a keyless archival RPC.
+- Euler v2: shipped; keyless V3 event ledger and liquidation API; Goldsky is
+  not the history source.
+- Centrifuge: keyless GraphQL with clean introspection; the most build-ready gap.
+- Aave v3 and Aave v4: keyless first-party API; v4 reached mainnet in March 2026.
+- MetaMorpho vaults, Morpho Vaults V2 and Morpho Midnight: three keyless,
+  uncollected Morpho surfaces.
+- Maple Finance: answers, but disables introspection and publishes no schema.
+- Compound v3 and Goldfinch: need a paid Graph gateway key.
+- Clearpool: live behind a bot challenge; access needs an agreement, not a workaround.
+- TrueFi: restructured through a token migration; no public endpoint answered.
 
 Six of the eleven gaps need only an adapter and nothing from anyone: Centrifuge,
 both Aave versions, and Morpho's three other surfaces. The rest wait on a key,

--- a/plugins/probitas/assets/dossier-template.md
+++ b/plugins/probitas/assets/dossier-template.md
@@ -6,10 +6,9 @@
 
 {{run_line}}
 
-This document was assembled by probitas from public sources. It carries no
-rating and no recommendation. Every assertion below cites a transaction, a URL
-or a document reference; anything that could not be sourced was dropped rather
-than softened.
+Probitas assembled this document from public sources without a rating or
+recommendation. Every assertion cites a transaction, URL or document reference;
+unsourced claims were dropped.
 
 ## Subject
 
@@ -17,9 +16,8 @@ than softened.
 
 ## Coverage
 
-What was checked, and what was not. A venue with no row here would be an
-omission; a venue with a row saying nobody checked is a gap, and a gap is not
-a clean record.
+A missing venue is an omission. A row saying nobody checked is a gap, not a
+clean record.
 
 {{coverage}}
 
@@ -39,8 +37,8 @@ Terms the counterparty set for themselves, and whether they held to them.
 
 ## Counterparty graph
 
-Limited to relationships the counterparty declared and relationships visible on
-chain between the declared addresses. No inference from off-chain association.
+Limited to declared relationships and those visible on chain between the
+declared addresses. Off-chain association is not used.
 
 {{graph}}
 
@@ -52,8 +50,8 @@ Insolvencies, exploits and enforcement actions, each with a source.
 
 ## Addresses not declared
 
-Addresses suspected but neither declared nor provably linked on chain. Findings
-here are held apart from everything above and feed no conclusion.
+Suspected addresses that were neither declared nor linked on chain. Their
+findings stay apart and feed no conclusion.
 
 {{inferred}}
 

--- a/plugins/probitas/audit/AUDIT.md
+++ b/plugins/probitas/audit/AUDIT.md
@@ -66,19 +66,27 @@ which is what was wanted. `marketplace_entry` is a helper rather than a test,
 since its name does not begin with `test_`, and the six tests still pass.
 Neither fix introduced anything.
 
-| id | severity | file | finding | status |
-| --- | --- | --- | --- | --- |
-| S1-R2-01 | info | audit/AUDIT.md | The audit log sat at the repository root. This repository will hold four plugins before long and a top-level `audit/` belongs to none of them. A plugin should carry its own log inside its own directory. | fixed in 3ef025f |
-| S1-R2-02 | low | .github/workflows/probitas.yml | The README and the study both claim Python 3.9 or later, and CI tested 3.11 alone. An untested compatibility claim is a claim that quietly stops being true. | fixed in 3ef025f |
+FINDING
+[Info] S1-R2-01: The audit log belonged inside its plugin.
+Location: `audit/AUDIT.md`
+Mechanism: The repository would hold four plugins, so a root `audit/` belonged to none.
+Impact: Ownership was unclear.
+Fix: fixed in `3ef025f`.
+END
+
+FINDING
+[Low] S1-R2-02: CI did not cover the documented interpreter floor.
+Location: `.github/workflows/probitas.yml`
+Mechanism: The README and study claimed Python 3.9 or later; CI tested only 3.11.
+Impact: Compatibility could regress without detection.
+Fix: fixed in `3ef025f`.
+END
 
 Leads not pursued: none.
 
 ## Step 1, round 3 -- 2026-08-15
 
 Reviewed: the tree with both rounds of fixes applied.
-
-| id | severity | file | finding | status |
-| --- | --- | --- | --- | --- |
 
 Nothing found. Checked this round:
 
@@ -134,10 +142,21 @@ attack, which is the threat that matters here. Recorded rather than deepened.
 Reviewed: the round 1 fixes, then the tree again. Round 1's third fix turned
 out to overreach, which is the case for running a second round.
 
-| id | severity | file | finding | status |
-| --- | --- | --- | --- | --- |
-| S2-R2-01 | medium | scripts/probitas_lib/evidence.py | The personal-key guard refused `market_name`, `token_name` and `market_age`. A market has a name and so does a token, and the Wildcat adapter in step 3 needs both. A guard that blocks the data the next step depends on gets loosened by whoever hits it, which is worse than a guard that never fired. | fixed in 4c377b1 |
-| S2-R2-02 | low | scripts/probitas_lib/evidence.py | A `doc:` reference could carry a pipe, which breaks out of a Markdown table cell. Round 1 refused the link metacharacters and missed the table one. | fixed in 4c377b1 |
+FINDING
+[Medium] S2-R2-01: The personal-key guard rejected valid entity fields.
+Location: `scripts/probitas_lib/evidence.py`
+Mechanism: It refused `market_name`, `token_name` and `market_age`, including fields needed by the Wildcat adapter in step 3.
+Impact: A later adapter would need to weaken the guard.
+Fix: fixed in `4c377b1` with an explicit non-person key list.
+END
+
+FINDING
+[Low] S2-R2-02: A document reference could break its table cell.
+Location: `scripts/probitas_lib/evidence.py`
+Mechanism: `doc:` allowed a pipe after round 1 blocked only link metacharacters.
+Impact: The reference could inject a Markdown column.
+Fix: fixed in `4c377b1`.
+END
 
 The fix for S2-R2-01 is an explicit list of keys that name a thing rather than
 a person, checked before the guard. The guard itself stays broad: a false
@@ -162,13 +181,24 @@ Reviewed: the tree with both rounds applied, plus a randomised sweep over the
 sanitiser and the source classifier. 20,000 generated strings drawn from
 printable ASCII plus a zero width space, a right-to-left override, a byte order
 mark, a non-breaking space, a null, an unassigned codepoint and every Markdown
-metacharacter. The sweep is what found both of these; neither was visible by
-reading.
+metacharacter. The sweep found both; neither was visible in a line-by-line
+inspection.
 
-| id | severity | file | finding | status |
-| --- | --- | --- | --- | --- |
-| S2-R3-01 | medium | scripts/probitas_lib/evidence.py | Round 1 excluded link syntax from a URL source and round 2 excluded a pipe from a document reference, and between them nobody excluded a pipe from a URL. Sources render inside a Markdown table, so `https://x/a|b` invents a column. | fixed in 7038d88 |
-| S2-R3-02 | medium | scripts/probitas_lib/evidence.py | A URL source could carry a control or format character. A right-to-left override inside a URL makes it display as a different address than the one it points at, in a document whose whole purpose is that a reader can check the citation. Nulls, byte order marks and zero-width spaces got through the same hole. | fixed in 7038d88 |
+FINDING
+[Medium] S2-R3-01: URL sources could inject a table column.
+Location: `scripts/probitas_lib/evidence.py`
+Mechanism: Rounds 1 and 2 blocked link syntax and document-reference pipes, but URL `https://x/a|b` remained valid.
+Impact: A network source could change the rendered table structure.
+Fix: fixed in `7038d88`.
+END
+
+FINDING
+[Medium] S2-R3-02: URL sources accepted deceptive control characters.
+Location: `scripts/probitas_lib/evidence.py`
+Mechanism: Right-to-left overrides, nulls, byte order marks and zero-width spaces survived.
+Impact: A citation could display a different address from its target.
+Fix: fixed in `7038d88` by refusing rather than rewriting the source.
+END
 
 The second is refused rather than stripped. Quietly rewriting a citation is
 worse than rejecting it: the operator finds out either way, and only one of
@@ -190,9 +220,6 @@ Leads not pursued: none.
 
 Reviewed: the tree with all three rounds of fixes, and the round 3 fixes for
 regressions.
-
-| id | severity | file | finding | status |
-| --- | --- | --- | --- | --- |
 
 Nothing found. Checked this round:
 
@@ -300,9 +327,13 @@ key in all three fixtures dropped in turn, then every scalar corrupted in turn,
 asking each time whether the adapter raised or quietly produced a different
 record set. 1,266 mutations. Fourteen changed the output without raising.
 
-| id | severity | file | finding | status |
-| --- | --- | --- | --- | --- |
-| S3-R3-01 | high | scripts/probitas_lib/adapters/wildcat.py | Every flag was read with `bool()`, which is true for any non-empty value the venue might send. A field turning from `false` into a string made a healthy market report as delinquent, a cure report as an entry, and, worst of the set, a withdrawal batch that expired unpaid report as settled and drop out of the dossier entirely. Eight of the fourteen silent mutations were this one bug. | fixed in be54fdd |
+FINDING
+[High] S3-R3-01: String flags inverted Wildcat findings.
+Location: `scripts/probitas_lib/adapters/wildcat.py`
+Mechanism: `bool()` treats every non-empty value as true; changing `false` to a string affected eight of fourteen silent mutations.
+Impact: Healthy markets appeared delinquent, cures became entries, and expired unpaid withdrawals disappeared as settled.
+Fix: fixed in `be54fdd`.
+END
 
 The remaining six are `name` and `asset.symbol` on each fixture. Both are free
 text, so a changed name changing the record is the adapter working. They are
@@ -324,9 +355,6 @@ Leads not pursued: none.
 
 Reviewed: the adapter with all three rounds applied, and the round 3 fix for
 regressions.
-
-| id | severity | file | finding | status |
-| --- | --- | --- | --- | --- |
 
 Nothing found. Checked this round:
 
@@ -419,10 +447,21 @@ which the fixtures do not cover. 22 records, three markets, two real
 delinquencies, one cured inside the grace period and one that ran past it. All
 five gates pass, and tampering with a real 18-decimal amount is caught.
 
-| id | severity | file | finding | status |
-| --- | --- | --- | --- | --- |
-| S4-R2-01 | low | scripts/probitas_lib/gates.py | Round 1's gate 2 fix looked for each venue anywhere in the Coverage section. A venue named in another venue's note would stand in for its own missing row. No note currently names another venue, so the hole was latent rather than open, but notes change. | fixed in 498ae55 |
-| S4-R2-02 | low | scripts/probitas_lib/render.py | `load` checked that each block was present, not that it was a list. An evidence file with `records` as an object would fail somewhere further in with an error about neither records nor evidence. | fixed in 498ae55 |
+FINDING
+[Low] S4-R2-01: A note could stand in for a missing coverage row.
+Location: `scripts/probitas_lib/gates.py`
+Mechanism: Round 1 gate 2 searched for venue names anywhere in Coverage; no note then named another venue.
+Impact: A later note could hide an omitted venue row.
+Fix: fixed in `498ae55` by requiring its own table row.
+END
+
+FINDING
+[Low] S4-R2-02: Evidence block types failed late and unclearly.
+Location: `scripts/probitas_lib/render.py`
+Mechanism: `load` checked block presence, not that `records` and its peers were lists.
+Impact: Object-shaped records failed later with an unrelated error.
+Fix: fixed in `498ae55`.
+END
 
 Gate 2 is now anchored to the first cell of a table row rather than to a
 substring of the section.
@@ -449,9 +488,6 @@ caught.
 
 Reviewed: the tree with both rounds applied, and the round 2 fixes for
 regressions.
-
-| id | severity | file | finding | status |
-| --- | --- | --- | --- | --- |
 
 Nothing found. Checked this round:
 
@@ -480,9 +516,13 @@ and is not numbered as a round: three rounds ran and three is what the list
 above says. Recorded because the fix is real and the reason for it is worth
 keeping.
 
-| id | severity | file | finding | status |
-| --- | --- | --- | --- | --- |
-| S4-R4-01 | low | plugins/probitas/tests/test_graphql.py | Round 2 silenced a `ResourceWarning` by closing a mocked `HTTPError`. On Python 3.9 an `HTTPError` built with no file object raises `KeyError` when closed, so the fix broke the oldest interpreter the README claims to support while passing on the newest. | fixed in 2bc32fc |
+FINDING
+[Low] S4-R4-01: A warning fix broke Python 3.9.
+Location: `plugins/probitas/tests/test_graphql.py`
+Mechanism: Round 2 closed a mocked `HTTPError`; without a file object, 3.9 raises `KeyError` while newer Python passes.
+Impact: The documented oldest interpreter failed.
+Fix: fixed in `2bc32fc`.
+END
 
 The error now carries a real empty file object, which closes cleanly on both.
 The suite also passes with `-W error::ResourceWarning`, so the warning is gone
@@ -550,9 +590,13 @@ protocol were not. Written up as issue 16.
 Reviewed: the round 1 fixes for regressions, then both adapters side by side,
 which is what a second venue makes possible.
 
-| id | severity | file | finding | status |
-| --- | --- | --- | --- | --- |
-| S5-R2-01 | medium | scripts/probitas_lib/adapters/wildcat.py | Round 1 made the Morpho coverage row say `ethereum mainnet only` and left the Wildcat row saying nothing about its chain. Wildcat is deployed on Plasma as well as mainnet, the adapter queries one of them, and a row reading `checked` invites a reader to take it for both. The fix that landed for one venue was needed for the other. | fixed in 02eca61 |
+FINDING
+[Medium] S5-R2-01: Wildcat coverage omitted its chain boundary.
+Location: `scripts/probitas_lib/adapters/wildcat.py`
+Mechanism: Round 1 labelled Morpho `ethereum mainnet only` but left Wildcat unqualified despite its Plasma deployment.
+Impact: A `checked` row could be read as covering both chains when the adapter queried one.
+Fix: fixed in `02eca61`.
+END
 
 Regenerating the committed example dossier was part of this: the demo test
 compares it against a fresh run, so a coverage note changing anywhere makes it
@@ -579,9 +623,6 @@ Reviewed: the tree with both rounds applied, with the CI matrix run first this
 time rather than after the close. That is the correction step 4 called for: an
 audit that closes before the oldest supported interpreter has seen the code
 closes early, and step 4 found that out the expensive way.
-
-| id | severity | file | finding | status |
-| --- | --- | --- | --- | --- |
 
 Nothing found. Checked this round:
 
@@ -649,8 +690,8 @@ Checked and clean:
   tree. The archive node discussed in issue 12 is named nowhere in the code.
 
 Leads not pursued: none. The Aave request shape was left unestablished on a
-first pass and then established properly, which is the better outcome and took
-reading the published schema rather than guessing at it. `aave/aave-v4-sdk`
+first pass and then established properly from the published schema rather than
+guessed. `aave/aave-v4-sdk`
 carries the whole thing at `packages/graphql/schema.graphql`. The working
 `activities` query is in the guide, verified against a live borrow returning an
 exact on-chain integer and a transaction hash, so the next person writing that
@@ -823,9 +864,13 @@ to give. Probitas scores 9 for business development, 7 for finance and 5 for
 security and audit, so three desks get examples. Marketing gets 1 and gets
 nothing, which is the correct outcome rather than a gap.
 
-| id | severity | file | finding | status |
-| --- | --- | --- | --- | --- |
-| PE-01 | low | plugins/probitas/skills/probitas/README.md | A copy of a file beside the original is a drift risk by construction. A shadow that has fallen behind is worse than no shadow, because a reader has no way to tell which of the two is current. | fixed |
+FINDING
+[Low] PE-01: The skill's shadow README could drift.
+Location: `plugins/probitas/skills/probitas/README.md`
+Mechanism: A copied instruction file could fall behind its canonical peer.
+Impact: Readers could not tell which version was current.
+Fix: removed the shadow and its drift surface.
+END
 
 Ten tests hold the shape. They check that the portable entrypoint's name
 matches its directory and its links resolve, that the runtime contract points

--- a/plugins/probitas/docs/adding-a-venue.md
+++ b/plugins/probitas/docs/adding-a-venue.md
@@ -27,13 +27,11 @@ of the value of the document.
 So every venue in the registry gets a row in every dossier, whether an adapter
 exists or not, and the row says which of five things happened:
 
-| Status | Meaning |
-| --- | --- |
-| `checked` | The adapter ran and returned what it found |
-| `empty` | The adapter ran and this counterparty has no history here |
-| `error` | The adapter ran and failed. This is not a clean record |
-| `unimplemented` | No adapter exists yet |
-| `unconfigured` | An adapter exists but no credential was supplied |
+- `checked`: the adapter ran and returned what it found.
+- `empty`: the adapter ran and found no history for this counterparty.
+- `error`: the adapter ran and failed; this is not a clean record.
+- `unimplemented`: no adapter exists.
+- `unconfigured`: an adapter exists, but no credential was supplied.
 
 `empty` is a finding. The last three are gaps, and they appear in the dossier's
 negative space section ahead of anything that reads like a conclusion. A run
@@ -88,20 +86,14 @@ query($user: EvmAddress!, $chains: [ChainId!]!) {
     types: [BORROW, REPAY, LIQUIDATED]
     pageSize: TEN
   }) {
-    items {
-      __typename
+    items { __typename
       ... on BorrowActivity {
-        timestamp
-        txHash
-        borrowed {
-          amount { onChainValue decimals }
-          token { info { symbol } }
-        }
+        timestamp txHash
+        borrowed { amount { onChainValue decimals } token { info { symbol } } }
       }
     }
     pageInfo { next }
-  }
-}
+  } }
 ```
 
 Two details that cost an hour of guessing, so they are written down here. `user`
@@ -116,8 +108,8 @@ venue the way it is on Wildcat.
 
 **Morpho's other three surfaces.** The shipped adapter covers borrowing on Blue
 markets. MetaMorpho vaults and Vaults V2 are separate surfaces on the same
-keyless API, where a counterparty may appear as a curator rather than a
-borrower, and a curator who allocated into a market that took bad debt made a
+keyless API, where a counterparty can appear as a curator, not a borrower. A
+curator who allocated into a market that took bad debt made a
 call that cost depositors money. Morpho Midnight is a fourth surface again:
 fixed-rate, fixed-maturity lending on its own keyless REST API at
 `api.morpho.org/v0/midnight`, on Base. Midnight is the most valuable of the
@@ -320,16 +312,13 @@ python3 scripts/probitas.py collect --entity "Acme Trading Ltd" \
 
 python3 scripts/probitas.py render evidence.json --out dossier.md
 python3 scripts/probitas.py verify dossier.md evidence.json
+python3 -m unittest discover -s plugins/probitas/tests -t plugins/probitas
 ```
 
 Five gate lines, exit 0. Drop `--fixtures` to run against the live venues.
 [`example-dossier.md`](example-dossier.md) is that command's real output.
 
-Tests, from the repository root:
-
-```bash
-python3 -m unittest discover -s plugins/probitas/tests -t plugins/probitas
-```
+The final command runs tests from the repository root.
 
 Python 3.9 or later, standard library only. No install step and no dependency
 tree, because someone deciding whether to trust a counterparty should not first

--- a/plugins/probitas/docs/euler-goldsky-discovery.md
+++ b/plugins/probitas/docs/euler-goldsky-discovery.md
@@ -47,15 +47,9 @@ query($prefix: Bytes!) {
     orderDirection: asc
     where: { addressPrefix: $prefix, debt_gt: 0 }
   ) {
-    id
-    vault
-    addressPrefix
-    account
-    balance
-    debt
-    blockNumber
-    blockTimestamp
-    transactionHash
+    id vault addressPrefix account
+    balance debt
+    blockNumber blockTimestamp transactionHash
   }
   _meta { block { number hash } deployment hasIndexingErrors }
 }
@@ -179,11 +173,8 @@ event Liquidation(
 );
 ```
 
-The mainnet address manifest binds those events to the canonical proxy:
-
-```text
-0x27182842E098f60e3D576794A5bFFb0777E025d3
-```
+The mainnet address manifest binds those events to canonical proxy
+`0x27182842E098f60e3D576794A5bFFb0777E025d3`.
 
 `https://mainnet.gateway.tenderly.co` accepted a keyless `eth_getLogs` query
 from block 0 through `latest`, filtered by that proxy and the indexed borrower.

--- a/plugins/probitas/docs/example-dossier.md
+++ b/plugins/probitas/docs/example-dossier.md
@@ -6,10 +6,9 @@
 
 Run `demo`.
 
-This document was assembled by probitas from public sources. It carries no
-rating and no recommendation. Every assertion below cites a transaction, a URL
-or a document reference; anything that could not be sourced was dropped rather
-than softened.
+Probitas assembled this document from public sources without a rating or
+recommendation. Every assertion cites a transaction, URL or document reference;
+unsourced claims were dropped.
 
 ## Subject
 
@@ -21,9 +20,8 @@ than softened.
 
 ## Coverage
 
-What was checked, and what was not. A venue with no row here would be an
-omission; a venue with a row saying nobody checked is a gap, and a gap is not
-a clean record.
+A missing venue is an omission. A row saying nobody checked is a gap, not a
+clean record.
 
 | Venue | Status | Range | Records | Note |
 | --- | --- | --- | --- | --- |
@@ -36,7 +34,7 @@ a clean record.
 | Euler v1 | empty | fixture | 0 | ethereum mainnet canonical Euler v1 proxy log; Borrow, Repay and Liquidation events checked through finalized block 18000000; no borrowing activity found for any subject address |
 | Goldfinch | unimplemented | -- | 0 | The protocol wound down in June 2026 after roughly 100 million dollars originated, with depositors reporting far heavier losses than the dashboard showed. The record stays on chain and is worth more to a dossier than most live venues, since it is a list of who did not repay. |
 | Maple Finance | unimplemented | -- | 0 | api.maple.finance responds but disables introspection, so the query shape could not be established. Undercollateralised, so worth the work. |
-| MetaMorpho vaults | unimplemented | -- | 0 | 450 vaults on mainnet, on the same keyless API. A counterparty may appear here as a curator rather than a borrower, and a curator who allocated into a market that took bad debt made a call that cost lenders money. Not collected yet. |
+| MetaMorpho vaults | unimplemented | -- | 0 | 450 vaults on mainnet, on the same keyless API. A counterparty can appear here as a curator, not a borrower; a curator who allocated into a market that took bad debt made a call that cost lenders money. Not collected yet. |
 | Morpho Blue | checked | fixture | 3 | ethereum mainnet only; 3 record(s) across 1 address(es) |
 | Morpho Midnight | unimplemented | -- | 0 | Fixed-rate, fixed-maturity lending on a separate keyless REST API at api.morpho.org/v0/midnight, not the GraphQL one. A maturity means there is a date by which the money was due, so this reads closer to Wildcat than Blue does. Base rather than mainnet. Not collected yet. |
 | Morpho Vaults V2 | unimplemented | -- | 0 | 474 vaults on mainnet, same API, separate surface from MetaMorpho with its own allocation transactions. Not collected yet. |
@@ -45,19 +43,17 @@ a clean record.
 
 ## What could not be established
 
-| Subject | Why |
-| --- | --- |
-| aave-v3 borrowing history | Reachable without a key after all, at api.aave.com/graphql. The `activities` query filtered by user returns borrows, repayments and liquidations, each with a txHash and an exact on-chain integer. Introspection is off; the schema is published in the aave-v4-sdk repository. The Graph gateway route needs a paid key; this does not. |
-| aave-v4 borrowing history | Live on Ethereum mainnet since March 2026, hub and spoke rather than one pool, keyless at api.v4.aave.com/graphql. A borrower on v3 and a borrower on v4 are the same counterparty and the dossier should say so. |
-| centrifuge borrowing history | Keyless GraphQL at api.centrifuge.io, introspects cleanly, 24 pools on mainnet. Carries pools, holdings, investor transactions and debt changes. The most build-ready of the unbuilt venues. |
-| clearpool borrowing history | Live, and the API sits behind a bot challenge that returns 403 to a plain request. Working around that is not something this tool should do; an agreement with them is the way in. |
-| compound-v3 borrowing history | No first-party API found. The Graph gateway rejects unauthenticated requests and the old hosted service is gone. |
-| goldfinch borrowing history | The protocol wound down in June 2026 after roughly 100 million dollars originated, with depositors reporting far heavier losses than the dashboard showed. The record stays on chain and is worth more to a dossier than most live venues, since it is a list of who did not repay. |
-| maple borrowing history | api.maple.finance responds but disables introspection, so the query shape could not be established. Undercollateralised, so worth the work. |
-| metamorpho borrowing history | 450 vaults on mainnet, on the same keyless API. A counterparty may appear here as a curator rather than a borrower, and a curator who allocated into a market that took bad debt made a call that cost lenders money. Not collected yet. |
-| morpho-midnight borrowing history | Fixed-rate, fixed-maturity lending on a separate keyless REST API at api.morpho.org/v0/midnight, not the GraphQL one. A maturity means there is a date by which the money was due, so this reads closer to Wildcat than Blue does. Base rather than mainnet. Not collected yet. |
-| morpho-vaults-v2 borrowing history | 474 vaults on mainnet, same API, separate surface from MetaMorpho with its own allocation transactions. Not collected yet. |
-| truefi borrowing history | Restructured through 2025 and into a token migration completing May 2026. No public API endpoint answered. Historical undercollateralised loans are still the interesting part. |
+- aave-v3 borrowing history: Reachable without a key after all, at api.aave.com/graphql. The `activities` query filtered by user returns borrows, repayments and liquidations, each with a txHash and an exact on-chain integer. Introspection is off; the schema is published in the aave-v4-sdk repository. The Graph gateway route needs a paid key; this does not.
+- aave-v4 borrowing history: Live on Ethereum mainnet since March 2026, hub and spoke rather than one pool, keyless at api.v4.aave.com/graphql. A borrower on v3 and a borrower on v4 are the same counterparty and the dossier should say so.
+- centrifuge borrowing history: Keyless GraphQL at api.centrifuge.io, introspects cleanly, 24 pools on mainnet. Carries pools, holdings, investor transactions and debt changes. The most build-ready of the unbuilt venues.
+- clearpool borrowing history: Live, and the API sits behind a bot challenge that returns 403 to a plain request. Working around that is not something this tool should do; an agreement with them is the way in.
+- compound-v3 borrowing history: No first-party API found. The Graph gateway rejects unauthenticated requests and the old hosted service is gone.
+- goldfinch borrowing history: The protocol wound down in June 2026 after roughly 100 million dollars originated, with depositors reporting far heavier losses than the dashboard showed. The record stays on chain and is worth more to a dossier than most live venues, since it is a list of who did not repay.
+- maple borrowing history: api.maple.finance responds but disables introspection, so the query shape could not be established. Undercollateralised, so worth the work.
+- metamorpho borrowing history: 450 vaults on mainnet, on the same keyless API. A counterparty can appear here as a curator, not a borrower; a curator who allocated into a market that took bad debt made a call that cost lenders money. Not collected yet.
+- morpho-midnight borrowing history: Fixed-rate, fixed-maturity lending on a separate keyless REST API at api.morpho.org/v0/midnight, not the GraphQL one. A maturity means there is a date by which the money was due, so this reads closer to Wildcat than Blue does. Base rather than mainnet. Not collected yet.
+- morpho-vaults-v2 borrowing history: 474 vaults on mainnet, same API, separate surface from MetaMorpho with its own allocation transactions. Not collected yet.
+- truefi borrowing history: Restructured through 2025 and into a token migration completing May 2026. No public API endpoint answered. Historical undercollateralised loans are still the interesting part.
 
 ## Borrowing history
 
@@ -82,8 +78,8 @@ Terms the counterparty set for themselves, and whether they held to them.
 
 ## Counterparty graph
 
-Limited to relationships the counterparty declared and relationships visible on
-chain between the declared addresses. No inference from off-chain association.
+Limited to declared relationships and those visible on chain between the
+declared addresses. Off-chain association is not used.
 
 No relationship between the declared addresses appears on chain in the venues checked, and none was declared.
 
@@ -95,8 +91,8 @@ _Nothing to report._
 
 ## Addresses not declared
 
-Addresses suspected but neither declared nor provably linked on chain. Findings
-here are held apart from everything above and feed no conclusion.
+Suspected addresses that were neither declared nor linked on chain. Their
+findings stay apart and feed no conclusion.
 
 _Nothing to report._
 

--- a/plugins/probitas/scripts/probitas_lib/__init__.py
+++ b/plugins/probitas/scripts/probitas_lib/__init__.py
@@ -1,3 +1,3 @@
 """Probitas: a sourced counterparty dossier for undercollateralised lending."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/plugins/probitas/scripts/probitas_lib/graphql.py
+++ b/plugins/probitas/scripts/probitas_lib/graphql.py
@@ -51,7 +51,7 @@ def post(endpoint, query, variables=None, timeout=DEFAULT_TIMEOUT):
         headers={
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "User-Agent": "probitas/0.1.0",
+            "User-Agent": "probitas/0.2.0",
         },
         method="POST",
     )

--- a/plugins/probitas/scripts/probitas_lib/registry.py
+++ b/plugins/probitas/scripts/probitas_lib/registry.py
@@ -83,8 +83,8 @@ VENUES = (
         "ethereum",
         False,
         "none",
-        "450 vaults on mainnet, on the same keyless API. A counterparty may "
-        "appear here as a curator rather than a borrower, and a curator who "
+        "450 vaults on mainnet, on the same keyless API. A counterparty can "
+        "appear here as a curator, not a borrower; a curator who "
         "allocated into a market that took bad debt made a call that cost "
         "lenders money. Not collected yet.",
     ),

--- a/plugins/probitas/scripts/probitas_lib/render.py
+++ b/plugins/probitas/scripts/probitas_lib/render.py
@@ -240,9 +240,9 @@ def _gaps(payload):
             "Nothing. Every venue in the registry was checked and every "
             "declared address resolved."
         )
-    lines = ["| Subject | Why |", "| --- | --- |"]
+    lines = []
     for gap in payload["gaps"]:
-        lines.append(f"| {gap['subject']} | {gap['reason']} |")
+        lines.append(f"- {gap['subject']}: {gap['reason']}")
     return "\n".join(lines)
 
 

--- a/plugins/probitas/skills/probitas/EVOLUTION.md
+++ b/plugins/probitas/skills/probitas/EVOLUTION.md
@@ -1,15 +1,12 @@
-# Probitas evolution ledger
+Probitas evolution ledger
 
 Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
 
-- Current version: `probitas-v0.1.0`
+- Current version: `probitas-v0.2.0`
 - Frontier status: `open`
 - Frontier revision: `morpho-midnight-coverage`
 - Current frontier: Euler v1/v2 now ship; Morpho Midnight fixed-maturity coverage and curation remain unimplemented.
 - Next Fiat job: Add fail-closed Morpho Midnight fixed-maturity coverage so a dossier can establish whether repayment was timely. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
 
-## History
-
-| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
-| --- | --- | --- | --- | --- | --- |
-| `probitas-v0.1.0` | baseline | `morpho-midnight-coverage` | `5f66077a0c39a9ee647bd34233504b3891493f864fe4a16a9eb0c0337b3ee688` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |
+- `probitas-v0.1.0` | baseline | `morpho-midnight-coverage` | `5f66077a0c39a9ee647bd34233504b3891493f864fe4a16a9eb0c0337b3ee688` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged.
+- `probitas-v0.2.0` | generation | `morpho-midnight-coverage` | `5f66077a0c39a9ee647bd34233504b3891493f864fe4a16a9eb0c0337b3ee688` | [Brevitas repository pass](../../README.md) | Prose and generated dossier structure changed; the frontier did not.

--- a/plugins/probitas/skills/probitas/SKILL.md
+++ b/plugins/probitas/skills/probitas/SKILL.md
@@ -9,7 +9,7 @@ description: >
   for questions about a single market's own numbers, and never to work out
   which individual controls an address.
 metadata:
-  version: "0.1.0"
+  version: "0.2.0"
 ---
 
 # Probitas
@@ -20,6 +20,7 @@ Probitas owns its own counterparty-diligence frontier, not Hexaemeron's delivery
 Solidity frontier. Its version, held target, next job, and maturity
 state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run
 another frontier pass after that ledger becomes mature.
+This prose generation moved from 0.1.0 to 0.2.0; the frontier did not move.
 
 <!-- marketplace-context:start -->
 ## Where this sits
@@ -61,7 +62,8 @@ arithmetic rather than by your reading it closely.
 
 ## The sequence
 
-Four commands, in this order. Do not skip the fourth.
+Run the first four commands in order; the final collect form is the Alexandria
+alternative. Do not skip verify.
 
 ```bash
 python3 scripts/probitas.py venues
@@ -69,24 +71,19 @@ python3 scripts/probitas.py venues
 python3 scripts/probitas.py collect \
   --entity "<name>" --address 0x... [--address 0x...] \
   [--inferred 0x...] --out evidence.json
-
 python3 scripts/probitas.py render evidence.json --out dossier.md
-
 python3 scripts/probitas.py verify dossier.md evidence.json
+python3 scripts/probitas.py collect \
+  --entity "<name>" --address 0x... \
+  --alexandria-index alexandria.sqlite --out evidence.json
 ```
 
 `collect` runs every venue adapter over the declared addresses and writes the
 evidence file. A record cannot enter that file without a transaction hash, a
 URL or a document reference, because the schema will not represent one.
 
-To use verified Alexandria releases instead of live or fixture adapters, pass
-an explicit disposable index:
-
-```bash
-python3 scripts/probitas.py collect \
-  --entity "<name>" --address 0x... \
-  --alexandria-index alexandria.sqlite --out evidence.json
-```
+The final form uses verified Alexandria releases through an explicit disposable
+index instead of live or fixture adapters.
 
 This path keeps Goldfinch and Clearpool as venue IDs and records Alexandria's
 release, component, capture, row and evidence identities. It combines

--- a/plugins/probitas/skills/probitas/references/gates.md
+++ b/plugins/probitas/skills/probitas/references/gates.md
@@ -36,13 +36,11 @@ would be worse than the gap it is already declaring.
 
 The five statuses mean different things and the difference matters:
 
-| Status | Meaning |
-| --- | --- |
-| `checked` | The adapter ran and returned what it found |
-| `empty` | The adapter ran and this counterparty has no history at this venue |
-| `error` | The adapter ran and failed. This is not a clean record |
-| `unimplemented` | No adapter exists yet |
-| `unconfigured` | An adapter exists but the operator supplied no credential |
+- `checked`: the adapter ran and returned what it found.
+- `empty`: the adapter ran and found no history for this counterparty.
+- `error`: the adapter ran and failed; this is not a clean record.
+- `unimplemented`: no adapter exists.
+- `unconfigured`: an adapter exists, but the operator supplied no credential.
 
 `empty` is a finding. The other three are gaps and become entries in the
 negative space section.

--- a/plugins/probitas/skills/probitas/references/venues.md
+++ b/plugins/probitas/skills/probitas/references/venues.md
@@ -29,19 +29,26 @@ would let a reader take one chain's silence for all of them.
 
 ## What does not, and why
 
-| Venue | Blocker |
-| --- | --- |
-| MetaMorpho vaults | Same keyless API as Morpho Blue, not collected. A counterparty may appear here as a curator rather than a borrower |
-| Morpho Vaults V2 | Same, a separate surface with its own allocation transactions |
-| Morpho Midnight | A different keyless REST API on Base, `api.morpho.org/v0/midnight`. Fixed maturities |
-| Centrifuge | Keyless GraphQL at `api.centrifuge.io`, introspects cleanly, 24 mainnet pools. Needs only an adapter |
-| Aave v3 | Keyless at `api.aave.com/graphql`, carrying `userBorrows` and `userPositions`. Introspection is off but errors name fields |
-| Aave v4 | Live on Ethereum mainnet since March 2026, same first-party API. A v3 borrower and a v4 borrower are one counterparty |
-| Maple Finance | Answers but disables introspection and publishes no schema, so the query shape cannot be established without guessing |
-| Compound v3 | No first-party API answered; The Graph gateway needs a paid key |
-| Goldfinch | Wound down June 2026 after defaults. Needs a gateway key. The record is a list of who did not repay, which is worth more than most live venues |
-| Clearpool | Live, behind a bot challenge returning 403. An agreement is the way in, not a workaround |
-| TrueFi | Restructured through a token migration completing May 2026; no public endpoint answered |
+- MetaMorpho vaults: same keyless API as Morpho Blue, not collected; a
+  counterparty can appear as a curator, not a borrower.
+- Morpho Vaults V2: same API, separate allocation surface.
+- Morpho Midnight: different keyless REST API on Base,
+  `api.morpho.org/v0/midnight`; fixed maturities.
+- Centrifuge: keyless GraphQL at `api.centrifuge.io`, clean introspection, 24
+  mainnet pools; needs only an adapter.
+- Aave v3: keyless `api.aave.com/graphql` with `userBorrows` and
+  `userPositions`; no introspection, but errors name fields.
+- Aave v4: live on Ethereum mainnet since March 2026 through the same
+  first-party API; v3 and v4 borrowers are one counterparty.
+- Maple Finance: answers without introspection or a published schema, so its
+  query shape cannot be established without guessing.
+- Compound v3: no first-party API answered; The Graph gateway needs a paid key.
+- Goldfinch: wound down in June 2026 after defaults; needs a gateway key; its
+  record names who did not repay.
+- Clearpool: live behind a 403 bot challenge; access needs an agreement, not a
+  workaround.
+- TrueFi: restructured through a token migration completing May 2026; no public
+  endpoint answered.
 
 Six of the eleven need only an adapter. The rest are blocked on somebody else's
 key, bot protection or documentation.
@@ -80,15 +87,15 @@ about a price.
 
 What the adapter emits, one record per event, each citing its own transaction:
 
-| Claim | What it says |
-| --- | --- |
-| `market_terms` | The reserve ratio, rate, grace period and penalty rate the borrower set |
-| `market_standing` | Drawn, repaid, penalty interest accrued, and whether the market is delinquent now |
-| `borrow`, `repayment` | Each draw and each repayment |
-| `delinquency_entered` | Liquidity fell below the reserve ratio, with what was held against what was required |
-| `delinquency_cured` | It came back, how long it took, and whether that ran past the grace period |
-| `withdrawal_batch_expired_unpaid` | A lender asked for money and did not get it |
-| `market_closed` | The borrower closed the market |
+- `market_terms`: reserve ratio, rate, grace period and penalty rate set by the
+  borrower.
+- `market_standing`: drawn, repaid, penalty interest accrued and current
+  delinquency state.
+- `borrow`, `repayment`: each draw and repayment.
+- `delinquency_entered`: liquidity held against the reserve requirement.
+- `delinquency_cured`: recovery time and whether it passed the grace period.
+- `withdrawal_batch_expired_unpaid`: a lender requested money and did not get it.
+- `market_closed`: the borrower closed the market.
 
 Two readings this adapter gets right and a naive one does not.
 
@@ -103,11 +110,9 @@ usually loses, and one of the synthetic fixtures exists to hold it still.
 
 ## Morpho Blue, in detail
 
-| Claim | What it says |
-| --- | --- |
-| `borrow`, `repayment` | Each draw and each repayment against a Blue market |
-| `liquidation` | The position was closed. The record states it was collateralised, so nobody reads it as a default |
-| `bad_debt` | The liquidation did not cover the debt. Lenders lost money |
+- `borrow`, `repayment`: each draw and repayment against a Blue market.
+- `liquidation`: the collateralised position closed; this is not labelled a default.
+- `bad_debt`: liquidation did not cover the debt; lenders lost money.
 
 Repaid and seized are different assets with different decimals, so they carry
 their own scales: `token_decimals` for the loan and `collateral_decimals` for


### PR DESCRIPTION
- Compresses all 12 Probitas Markdown files, renders list-form negative space, and regenerates the byte-equal dossier.
- Moves generation `0.1.0 → 0.2.0`; frontier revision, Next Fiat job, and digest `5f66077a0c39a9ee647bd34233504b3891493f864fe4a16a9eb0c0337b3ee688` are unchanged.
- Renderer: nine records, four of 15 venues, 11 gaps, gates 1 through 5 pass; status distinctions and six adapter-only gaps remain.
- Audit: `audit/AUDIT.md`, step 9 round 1, zero findings.
- Proof: root `22/22`; Probitas `276/276`; validators `2/2`; prose checks `12/12`; links `21/21`; protected proof `159/43/29/4`; `git diff --check`.
- No live venue call, chain-state claim, personal data, address attribution, or counterparty score was established.

<!-- wildcat-origin: shoggoth -->
