### PR TITLE
Bump Hexaemeron to 1.1.0 so the six new skills reach installations

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
       "displayName": "Hexaemeron",
       "source": "./plugins/hexaemeron",
       "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing and prose tools.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"

--- a/plugins/hexaemeron/.claude-plugin/plugin.json
+++ b/plugins/hexaemeron/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hexaemeron",
   "displayName": "Hexaemeron",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing and prose tools.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/hexaemeron/.codex-plugin/plugin.json
+++ b/plugins/hexaemeron/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hexaemeron",
-  "version": "1.0.0+codex.20260816145806",
+  "version": "1.1.0",
   "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing and prose tools.",
   "author": {
     "name": "Wildcat Labs",


### PR DESCRIPTION
Six skills landed in #103 while the plugin kept declaring `1.0.0`. That is the
version the marketplace holds and the version every installation already has,
so nothing downstream had a reason to re-fetch and a reload reported no changes.

This bumps all three manifests to `1.1.0`:

- `.claude-plugin/marketplace.json`
- `plugins/hexaemeron/.claude-plugin/plugin.json`
- `plugins/hexaemeron/.codex-plugin/plugin.json`

The codex manifest also carried a one-off build stamp,
`1.0.0+codex.20260816145806`, which none of the other five plugins have. It
becomes a plain `1.1.0` to match them.

Worth noting separately: the installed copy on this machine is a snapshot from
2026-08-17 and lacks `kronos` as well, so it has been behind for longer than
today's change.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
