### PR TITLE
Put the practice skills on the README's invocation surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Ariadne includes:
 ### Brevitas
 
 [Brevitas](./plugins/brevitas) is the final structural pass for audit findings,
-security reviews, gas analysis, invariant discussion, diff review and protocol
+security reviews, gas analysis, `invariant` discussion, diff review and protocol
 commentary. It controls line count, finding shape, headings, tables, code fences
 and connective prose. Imprimatur still owns vocabulary, Vulgate owns register,
 and Sapheneia owns AuDHD interaction shape.
@@ -524,6 +524,17 @@ Hexaemeron's entry skill is:
 /hexaemeron:fiat "<topic>"
 ```
 
+Its practice skills answer on their own, without the controller:
+
+```text
+/hexaemeron:protasis
+/hexaemeron:elenchus
+/hexaemeron:phylax
+/hexaemeron:ephoros
+/hexaemeron:metron
+/hexaemeron:hypomnema
+```
+
 Lemma is available as:
 
 ```text
@@ -585,6 +596,7 @@ Use Brevitas to enforce evidence-preserving structural budgets on this engineeri
 Use Hermes to optimise gas in this Foundry repository.
 Use Hexaemeron Fiat to take "<topic>" through the delivery loop.
 Use Hexaemeron Fizz to generate a stateful fuzz suite.
+Use Hexaemeron Phylax to harden the off-chain surface of this change, or name Protasis, Elenchus, Ephoros, Metron or Hypomnema for the other practice skills.
 Use Lemma to chunk this Solidity standard input into JSONL.
 Use Lazarus to capture, verify or replay this finite historical Ethereum fixture.
 Use Pandects to check this credit protocol against the executable laws in the corpus.


### PR DESCRIPTION
Two invocation surfaces still showed only Fiat and Fizz.

**Slash-command section** now lists all six beneath the entry skill, under a
line saying they answer on their own without the controller.

**Plain-text activation block** gets one line naming the set rather than six
lines, so Hexaemeron does not take half the block.

**Also**: `README.md:116` had failed imprimatur's gated pass on `invariant` with
no concrete referent since before today. The README wrote the term bare where
Brevitas's own skill writes it in backticks; matching that clears it, and the
file now scores 100.

**Not changed**: the role-score matrix. Six practice skills arguably move
Hexaemeron's developer score, but those numbers are a judgement and not mine to
revise unasked.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
