### PR TITLE
Run Brevitas over the README, and stop badging six skills as a category

### DIFF
--- a/.agents/skills/elenchus/SKILL.md
+++ b/.agents/skills/elenchus/SKILL.md
@@ -11,8 +11,8 @@ Elenchus works a failure you already have down to its cause and leaves a guard b
 
 On its own it is a triage order and a check. The check applies a commit's own test files to its parent and reports whether the guard is real, which needs nothing but git and your test command.
 
-Inside Hexaemeron it works whatever an audit round surfaces, and its guard check is what stops a fix landing on the promise of a test rather than the fact of one. It is one of six practice skills that share a shape and hand work
-to each other, so reaching for the neighbour a rule names usually beats
+Inside Hexaemeron it works whatever an audit round surfaces, and its guard check is what stops a fix landing on the promise of a test rather than the fact of one. It is one of six skills bundled with Hexaemeron that share a shape
+and hand work to each other, so reaching for the neighbour a rule names usually beats
 stretching this one.
 
 Read [the canonical Elenchus skill](../../../plugins/hexaemeron/skills/elenchus/SKILL.md)

--- a/.agents/skills/ephoros/SKILL.md
+++ b/.agents/skills/ephoros/SKILL.md
@@ -11,8 +11,8 @@ Ephoros decides what a step emits once nobody is watching it: events with stable
 
 On its own it is a set of on-call questions and a lint over three rules. Use it when shipping anything unattended, or when an incident could not be explained from what was recorded.
 
-Inside Hexaemeron it sits in the implement phase, and it inherits Phylax's rule about what must never appear in output rather than restating it. It is one of six practice skills that share a shape and hand work
-to each other, so reaching for the neighbour a rule names usually beats
+Inside Hexaemeron it sits in the implement phase, and it inherits Phylax's rule about what must never appear in output rather than restating it. It is one of six skills bundled with Hexaemeron that share a shape
+and hand work to each other, so reaching for the neighbour a rule names usually beats
 stretching this one.
 
 Read [the canonical Ephoros skill](../../../plugins/hexaemeron/skills/ephoros/SKILL.md)

--- a/.agents/skills/hexaemeron/SKILL.md
+++ b/.agents/skills/hexaemeron/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hexaemeron
-description: Route explicit Hexaemeron delivery runs, Kronos frontier loops, and named bundled fuzzing, audit, prose or practice work to their canonical skills. The practice skills are protasis, elenchus, phylax, ephoros, metron and hypomnema. Do not start Fiat or Kronos unless the user asks for it.
+description: Route explicit Hexaemeron delivery runs, Kronos frontier loops, and named bundled fuzzing, audit, prose, specification, debugging, hardening, telemetry, measurement or record-keeping work to their canonical skills. Do not start Fiat or Kronos unless the user asks for it.
 ---
 
 # Hexaemeron portable entrypoint
@@ -8,7 +8,7 @@ description: Route explicit Hexaemeron delivery runs, Kronos frontier loops, and
 <!-- marketplace-context:start -->
 ## Where this sits
 
-Hexaemeron runs an explicit, receipted delivery loop, and also exposes on their own the fuzzing, audit-readiness, security-review and prose skills it uses, plus six practice skills covering specification, debugging, hardening, telemetry, measurement and what gets recorded.
+Hexaemeron runs an explicit, receipted delivery loop, and every skill it uses answers on its own: fuzzing, audit-readiness and security review, prose lint and voice, and the specification, debugging, hardening, telemetry, measurement and record-keeping skills the loop holds each phase to.
 
 **Use another tool when.** Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks.
 

--- a/.agents/skills/hypomnema/SKILL.md
+++ b/.agents/skills/hypomnema/SKILL.md
@@ -11,8 +11,8 @@ Hypomnema decides which decisions earn a written reason and which file holds it,
 
 On its own it answers where a decision, a runbook or a gotcha belongs, and its lint reports records pointing at things that do not exist, which reads as though a reason was checked when it was not.
 
-Inside Hexaemeron it runs before the prose phase and decides whether there is anything to write, leaving the mask order and the receipt to Fiat. It is one of six practice skills that share a shape and hand work
-to each other, so reaching for the neighbour a rule names usually beats
+Inside Hexaemeron it runs before the prose phase and decides whether there is anything to write, leaving the mask order and the receipt to Fiat. It is one of six skills bundled with Hexaemeron that share a shape
+and hand work to each other, so reaching for the neighbour a rule names usually beats
 stretching this one.
 
 Read [the canonical Hypomnema skill](../../../plugins/hexaemeron/skills/hypomnema/SKILL.md)

--- a/.agents/skills/metron/SKILL.md
+++ b/.agents/skills/metron/SKILL.md
@@ -11,8 +11,8 @@ Metron holds every measurement except gas: the page, the route, the query, the h
 
 On its own it is four refusals and a decision table. No baseline means no change, no re-measurement means no keep, neutral is a revert, and a red suite means no win however good the number looks.
 
-Inside Hexaemeron it applies to any change made in the name of speed, and it is the discipline Hermes already imposes on gas, extended to everything gas is not. It is one of six practice skills that share a shape and hand work
-to each other, so reaching for the neighbour a rule names usually beats
+Inside Hexaemeron it applies to any change made in the name of speed, and it is the discipline Hermes already imposes on gas, extended to everything gas is not. It is one of six skills bundled with Hexaemeron that share a shape
+and hand work to each other, so reaching for the neighbour a rule names usually beats
 stretching this one.
 
 Read [the canonical Metron skill](../../../plugins/hexaemeron/skills/metron/SKILL.md)

--- a/.agents/skills/phylax/SKILL.md
+++ b/.agents/skills/phylax/SKILL.md
@@ -11,8 +11,8 @@ Phylax guards the off-chain surface in three shapes: the Python that harvests an
 
 On its own it is a boundary review plus a lint that settles four rules mechanically. Point it at a diff or a tree and it reports shell invocations, string commands, unpinned dependencies and credentials in the open.
 
-Inside Hexaemeron the boundaries it names feed the study's risk register, which is where the audit loop reads what to look hardest at. It is one of six practice skills that share a shape and hand work
-to each other, so reaching for the neighbour a rule names usually beats
+Inside Hexaemeron the boundaries it names feed the study's risk register, which is where the audit loop reads what to look hardest at. It is one of six skills bundled with Hexaemeron that share a shape
+and hand work to each other, so reaching for the neighbour a rule names usually beats
 stretching this one.
 
 Read [the canonical Phylax skill](../../../plugins/hexaemeron/skills/phylax/SKILL.md)

--- a/.agents/skills/protasis/SKILL.md
+++ b/.agents/skills/protasis/SKILL.md
@@ -11,8 +11,8 @@ Protasis holds the content contract for a specification and the steps derived fr
 
 On its own it answers one question: does this say enough to build from? Hand it a spec, a ticket or a paragraph of intent and it reports what is missing, without any controller involved.
 
-Inside Hexaemeron it is the standard the study and runbook phases are held to, and Fiat will not pass a step whose exit no command can prove. It is one of six practice skills that share a shape and hand work
-to each other, so reaching for the neighbour a rule names usually beats
+Inside Hexaemeron it is the standard the study and runbook phases are held to, and Fiat will not pass a step whose exit no command can prove. It is one of six skills bundled with Hexaemeron that share a shape
+and hand work to each other, so reaching for the neighbour a rule names usually beats
 stretching this one.
 
 Read [the canonical Protasis skill](../../../plugins/hexaemeron/skills/protasis/SKILL.md)

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
       "name": "hexaemeron",
       "displayName": "Hexaemeron",
       "source": "./plugins/hexaemeron",
-      "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose and practice skills.",
+      "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose, specification, debugging, hardening, telemetry and measurement skills.",
       "version": "1.1.0",
       "author": {
         "name": "Wildcat Labs",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ finite historical Ethereum state and exact RPC traffic a test needs, while
 Ariadne binds a released artefact digest to its evidence. Pandects supplies
 reviewed credit laws, Hermes measures a single gas-optimisation class,
 Hexaemeron controls a receipted delivery loop and holds each of its phases to a
-practice skill, while Lemma stops after producing
+named skill, while Lemma stops after producing
 source-linked chunks. Sapheneia shapes the agent's own replies for AuDHD
 readers without changing another skill's facts or gates. Brevitas controls the
 volume and structure of engineering prose after vocabulary and register passes.
@@ -53,7 +53,7 @@ rather than broadening the selected skill.
   directories on their named hosts. They do not change the meaning of a skill.
 - `.agents/skills/` contains host-neutral entrypoints for agents that implement
   the Agent Skills discovery convention. Each plugin has one. Hexaemeron's six
-  practice skills also have one each, because they are useful on their own and a
+  phase skills also have one each, because they are useful on their own and a
   host that only reads this folder would otherwise never learn they exist. Every
   such entry says what the skill does alone and what it does as part of the
   suite, and hands off to the canonical `SKILL.md`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ build.
 | [Ariadne](./plugins/ariadne) | Binding an artefact digest to build, test, review and deployment evidence. | An external Sigstore or cosign verifier for signatures. | The dataset predicate is the first unimplemented predicate; state-fixture and grounded-agent predicates also remain unimplemented. |
 | [Brevitas](./plugins/brevitas) | Enforcing mechanical volume and structure budgets on engineering review prose while preserving evidence. | Imprimatur for vocabulary; Vulgate for register; Sapheneia for AuDHD interaction shape. | The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked. |
 | [Hermes](./plugins/hermes) | Measuring one Solidity gas-optimisation class through fail-closed Foundry checks. | Pandects or the audit skills for broader behavioural and security work. | No complete, reproducible live Wildcat evidence bundle is published. |
-| [Hexaemeron](./plugins/hexaemeron) | Running an explicit, receipted delivery loop, ranking frontier work with Kronos, or using its fuzzing, audit, prose and practice skills separately. | A named bundled skill when the controller is unnecessary. | The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery. |
+| [Hexaemeron](./plugins/hexaemeron) | Running an explicit, receipted delivery loop, ranking frontier work with Kronos, or using its fuzzing, audit and prose skills separately. | A named bundled skill when the controller is unnecessary. | The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery. |
 | [Lemma](./plugins/lemma) | Producing source-linked chunks from Solidity compiler inputs or Markdown. | An embedding, index, retrieval or answering system for every later stage. | Callable-surface ABI validation does not independently check return types or state mutability. |
 | [Lazarus](./plugins/lazarus) | Capturing a finite fixed-block Ethereum fixture, checking proof-backed state and replaying exact requests without fallback. | Alexandria for a lending archive; Tabularium for event interpretation. | Preservation-pipeline integration and an Ariadne state-fixture predicate remain unimplemented. |
 | [Pandects](./plugins/pandects) | Supplying executable credit laws, broken specimens and reduced counterexamples. | Fizz for a protocol-specific fuzz harness. | The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records. |
@@ -190,7 +190,7 @@ Hexaemeron includes:
 - the executable [`hexctl.py`](./plugins/hexaemeron/skills/fiat/scripts/hexctl.py) controller with a tamper-evident ledger (`verify` proves both chain and state);
 - the [`imprimatur`](./plugins/hexaemeron/skills/imprimatur) three-tier prose lint and the [`vulgate`](./plugins/hexaemeron/skills/vulgate) voice mask, invokable on their own;
 - [`kronos`](./plugins/hexaemeron/skills/kronos), which ranks eligible held frontier jobs and loops complete Fiat runs until none remain;
-- six practice skills holding each phase to a standard, four of them with an executable check: [`protasis`](./plugins/hexaemeron/skills/protasis) on what a study and runbook must answer, [`elenchus`](./plugins/hexaemeron/skills/elenchus) on the root cause of a failure that already happened, [`phylax`](./plugins/hexaemeron/skills/phylax) on the off-chain surface, [`ephoros`](./plugins/hexaemeron/skills/ephoros) on what a step emits once it runs unattended, [`metron`](./plugins/hexaemeron/skills/metron) on every measurement except gas, and [`hypomnema`](./plugins/hexaemeron/skills/hypomnema) on what gets recorded and where;
+- six more skills holding each phase to a standard, four of them with an executable check: [`protasis`](./plugins/hexaemeron/skills/protasis) on what a study and runbook must answer, [`elenchus`](./plugins/hexaemeron/skills/elenchus) on the root cause of a failure that already happened, [`phylax`](./plugins/hexaemeron/skills/phylax) on the off-chain surface, [`ephoros`](./plugins/hexaemeron/skills/ephoros) on what a step emits once it runs unattended, [`metron`](./plugins/hexaemeron/skills/metron) on every measurement except gas, and [`hypomnema`](./plugins/hexaemeron/skills/hypomnema) on what gets recorded and where;
 - the Pashov Audit Group suite vendored verbatim (MIT; `LICENSE` and `NOTICE.md` in each skill directory);
 - Codex metadata for explicit or automatic invocation; and
 - 124 controller, contract and practice-check tests, 55 lint tests, and a fuzz-audit log ([`audit/AUDIT.md`](./plugins/hexaemeron/audit/AUDIT.md)) covering the controller's own surfaces.
@@ -458,20 +458,17 @@ Five is the barrier. At or above it, the plugin's entry carries a worked example
 
 ### Codex
 
-Add the Wildcat Labs marketplace from the Codex CLI:
+Add the Wildcat Labs marketplace from the Codex CLI, then list configured
+sources or fetch later updates:
 
 ```bash
 codex plugin marketplace add wildcat-finance/skills
-```
-
-Restart the ChatGPT desktop app, open the Plugins Directory, select **Wildcat Labs**, and install the plugin you need.
-
-To inspect configured sources or fetch later updates:
-
-```bash
 codex plugin marketplace list
 codex plugin marketplace upgrade wildcat-labs
 ```
+
+After adding it, restart the ChatGPT desktop app, open the Plugins Directory,
+select **Wildcat Labs**, and install the plugin you need.
 
 See OpenAI's [plugin packaging documentation](https://developers.openai.com/plugins/build/plugins) for the marketplace workflow.
 
@@ -494,37 +491,29 @@ Add the same marketplace and install a plugin from inside Claude Code:
 /plugin install tabularium@wildcat-labs
 ```
 
-If the install summary asks for it, run `/reload-plugins`. Claude namespaces plugin skills, so Alexandria is available as:
+If the install summary asks for it, run `/reload-plugins`.
+
+#### Invoke
+
+Claude namespaces plugin skills, so each entry skill answers as:
 
 ```text
 /alexandria:alexandria
-```
-
-Ariadne is:
-
-```text
 /ariadne:ariadne
-```
-
-Brevitas is:
-
-```text
 /brevitas:brevitas
-```
-
-Hermes is:
-
-```text
 /hermes:hermes
-```
-
-Hexaemeron's entry skill is:
-
-```text
 /hexaemeron:fiat "<topic>"
+/lemma:chunk
+/lazarus:lazarus
+/pandects:pandects
+/probitas:probitas
+/sapheneia:sapheneia
+/tabularium:tabularium
 ```
 
-Its practice skills answer on their own, without the controller:
+#### Hexaemeron's phase skills
+
+These answer on their own, without the controller:
 
 ```text
 /hexaemeron:protasis
@@ -533,42 +522,6 @@ Its practice skills answer on their own, without the controller:
 /hexaemeron:ephoros
 /hexaemeron:metron
 /hexaemeron:hypomnema
-```
-
-Lemma is available as:
-
-```text
-/lemma:chunk
-```
-
-Lazarus is available as:
-
-```text
-/lazarus:lazarus
-```
-
-Pandects is available as:
-
-```text
-/pandects:pandects
-```
-
-Probitas is available as:
-
-```text
-/probitas:probitas
-```
-
-Sapheneia is available as:
-
-```text
-/sapheneia:sapheneia
-```
-
-Tabularium is available as:
-
-```text
-/tabularium:tabularium
 ```
 
 See Anthropic's [skills](https://code.claude.com/docs/en/skills) and [plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces) documentation for the underlying format.
@@ -596,7 +549,7 @@ Use Brevitas to enforce evidence-preserving structural budgets on this engineeri
 Use Hermes to optimise gas in this Foundry repository.
 Use Hexaemeron Fiat to take "<topic>" through the delivery loop.
 Use Hexaemeron Fizz to generate a stateful fuzz suite.
-Use Hexaemeron Phylax to harden the off-chain surface of this change, or name Protasis, Elenchus, Ephoros, Metron or Hypomnema for the other practice skills.
+Use Hexaemeron Phylax to harden the off-chain surface of this change, or name Protasis, Elenchus, Ephoros, Metron or Hypomnema.
 Use Lemma to chunk this Solidity standard input into JSONL.
 Use Lazarus to capture, verify or replay this finite historical Ethereum fixture.
 Use Pandects to check this credit protocol against the executable laws in the corpus.
@@ -610,6 +563,8 @@ the controller unless the user names Hexaemeron or Fiat and asks to run it.
 
 ## Use
 
+### Alexandria
+
 Alexandria needs Python 3 and nothing else. Its checked-in demonstration and
 all verification paths run offline. Ask:
 
@@ -620,6 +575,8 @@ Use $alexandria to preserve this lending-data capture, derive its reviewed credi
 The release contracts, mapping boundary and refusal rules live in
 [Alexandria's `SKILL.md`](./plugins/alexandria/skills/alexandria/SKILL.md).
 
+### Ariadne
+
 Ariadne needs Python 3 and nothing else. Capturing from a Foundry project needs
 that project's build output, which `forge build` already wrote. Ask:
 
@@ -628,6 +585,8 @@ Use $ariadne to capture this release in an evidence statement, run its gates, an
 ```
 
 The gates, the predicate and the refusals live in [Ariadne's `SKILL.md`](./plugins/ariadne/skills/ariadne/SKILL.md).
+
+### Brevitas
 
 Brevitas needs Python 3 and no third-party package. Ask:
 
@@ -638,6 +597,8 @@ Use $brevitas to compress this engineering review without dropping addresses, tr
 The budgets, evidence precedence and exception rule live in
 [Brevitas's `SKILL.md`](./plugins/brevitas/skills/brevitas/SKILL.md).
 
+### Hermes
+
 Hermes needs Python 3, Git and [Foundry](https://getfoundry.sh/) available in the target repository. Start Codex from a clean Foundry worktree, then ask:
 
 ```text
@@ -645,6 +606,8 @@ Use $hermes to optimise gas in this repository. Work one optimisation class at a
 ```
 
 The full command contract, layout rules and property standard live in [Hermes's `SKILL.md`](./plugins/hermes/skills/hermes/SKILL.md).
+
+### Hexaemeron
 
 Hexaemeron needs Python 3, Git and `gh` in the target repository (plus [Foundry](https://getfoundry.sh/) when the run ships Solidity). Ask:
 
@@ -654,6 +617,8 @@ Use $hexaemeron to take "<topic>" from study to a merged delivery, one receipted
 
 The loop, the receipt contract and the controller reference live in [Hexaemeron's `SKILL.md`](./plugins/hexaemeron/skills/fiat/SKILL.md).
 
+### Lemma
+
 Lemma needs Python 3.10 or later. Solidity input also needs `solc`, Docker, or
 Podman. Ask:
 
@@ -662,6 +627,8 @@ Use $chunk to turn this Solidity standard input into validated JSONL chunks.
 ```
 
 The command selection and output rules live in [Lemma's `chunk` skill](./plugins/lemma/skills/chunk/SKILL.md).
+
+### Lazarus
 
 Lazarus needs Python 3.11 or later and the packages pinned in its lock file.
 Capture is the only command that needs an archive RPC; verification, replay and
@@ -673,6 +640,8 @@ Use $lazarus to capture this finite historical fixture, verify its proof-backed 
 
 The evidence boundary, refusal rules and commands live in [Lazarus's `SKILL.md`](./plugins/lazarus/skills/lazarus/SKILL.md).
 
+### Probitas
+
 Probitas needs Python 3 and nothing else. Neither shipped venue asks for a key, and `--fixtures` runs it with no network at all. Ask:
 
 ```text
@@ -680,6 +649,8 @@ Use $probitas to build a sourced dossier on "<entity>" from the addresses they d
 ```
 
 The sequence, the five gates and the refusals live in [Probitas's `SKILL.md`](./plugins/probitas/skills/probitas/SKILL.md).
+
+### Sapheneia
 
 Sapheneia needs no runtime dependency. Ask:
 
@@ -689,6 +660,8 @@ Use $sapheneia to shape your replies for an AuDHD reader throughout this task.
 
 The activation contract and ten ranked rules live in
 [Sapheneia's `SKILL.md`](./plugins/sapheneia/skills/sapheneia/SKILL.md).
+
+### Tabularium
 
 Tabularium needs Python 3.9 or later and nothing else. Its shipped releases and
 tests use no network. Ask:
@@ -703,121 +676,33 @@ The mapping, release rules and evidence boundary live in
 ## Repository layout
 
 ```text
-.claude-plugin/marketplace.json
-.agents/plugins/marketplace.json
-plugins/
-├── alexandria/
-│   ├── .claude-plugin/plugin.json
-│   ├── .codex-plugin/plugin.json
-│   ├── AGENTS.md
-│   ├── docs/
-│   ├── examples/
-│   ├── schemas/
-│   ├── scripts/
-│   ├── tests/
-│   └── skills/
-│       └── alexandria/
-├── ariadne/
-│   ├── .claude-plugin/plugin.json
-│   ├── .codex-plugin/plugin.json
-│   ├── AGENTS.md
-│   ├── audit/
-│   ├── docs/
-│   ├── examples/
-│   ├── schemas/
-│   ├── scripts/
-│   ├── tests/
-│   └── skills/
-│       └── ariadne/
-├── brevitas/
-│   ├── .claude-plugin/plugin.json
-│   ├── .codex-plugin/plugin.json
-│   ├── AGENTS.md
-│   ├── tests/
-│   └── skills/
-│       └── brevitas/
-├── hermes/
-│   ├── .claude-plugin/plugin.json
-│   ├── .codex-plugin/plugin.json
-│   └── skills/
-│       └── hermes/
-│           ├── SKILL.md
-│           ├── agents/
-│           ├── references/
-│           └── scripts/
-├── hexaemeron/
-│   ├── .claude-plugin/plugin.json
-│   ├── .codex-plugin/plugin.json
-│   ├── agents/
-│   ├── audit/
-│   ├── tests/
-│   └── skills/
-│       ├── fiat/
-│       ├── imprimatur/
-│       ├── vulgate/
-│       ├── x-ray/
-│       ├── solidity-auditor/
-│       └── fizz/
-├── lemma/
-│   ├── .claude-plugin/plugin.json
-│   ├── .codex-plugin/plugin.json
-│   ├── chunkers/
-│   ├── tests/
-│   └── skills/
-│       └── chunk/
-├── lazarus/
-│   ├── .claude-plugin/plugin.json
-│   ├── .codex-plugin/plugin.json
-│   ├── AGENTS.md
-│   ├── docs/
-│   ├── examples/
-│   ├── schemas/
-│   ├── scripts/
-│   ├── tests/
-│   └── skills/
-│       └── lazarus/
-├── pandects/
-│   ├── .claude-plugin/plugin.json
-│   ├── .codex-plugin/plugin.json
-│   ├── adapters/
-│   ├── catalogue/
-│   ├── docs/
-│   ├── specimens/
-│   ├── src/
-│   ├── test/
-│   ├── tests/
-│   └── skills/
-│       └── pandects/
-├── probitas/
-│   ├── .claude-plugin/plugin.json
-│   ├── .codex-plugin/plugin.json
-│   ├── AGENTS.md
-│   ├── audit/
-│   ├── docs/
-│   ├── scripts/
-│   ├── tests/
-│   └── skills/
-│       └── probitas/
-├── sapheneia/
-│   ├── .claude-plugin/plugin.json
-│   ├── .codex-plugin/plugin.json
-│   ├── AGENTS.md
-│   ├── tests/
-│   └── skills/
-│       └── sapheneia/
-└── tabularium/
-    ├── .claude-plugin/plugin.json
-    ├── .codex-plugin/plugin.json
-    ├── AGENTS.md
-    ├── audit/
-    ├── docs/
-    ├── examples/
-    ├── schemas/
-    ├── scripts/
-    ├── tests/
-    └── skills/
-        └── tabularium/
+.claude-plugin/marketplace.json   one entry per plugin
+.agents/plugins/marketplace.json  the same set, host-neutral
+.agents/skills/<name>/SKILL.md    a portable entrypoint per plugin, and per phase skill
+plugins/<name>/
+├── .claude-plugin/plugin.json    host manifests; discovery and installation only
+├── .codex-plugin/plugin.json
+├── AGENTS.md                     runtime contract and selection table
+├── README.md                     landing page
+├── tests/
+└── skills/<skill>/SKILL.md       canonical instructions, one directory per skill
 ```
+
+Every plugin has that shape. What each adds beyond it:
+
+| Plugin | Skills | Also carries |
+| --- | --- | --- |
+| Alexandria | `alexandria` | docs, examples, schemas, scripts |
+| Ariadne | `ariadne` | audit, docs, examples, schemas, scripts |
+| Brevitas | `brevitas` | evals |
+| Hermes | `hermes` | references and scripts inside the skill |
+| Hexaemeron | `fiat`, `kronos`, `imprimatur`, `vulgate`, the vendored `x-ray`, `solidity-auditor` and `fizz`, and `protasis`, `elenchus`, `phylax`, `ephoros`, `metron`, `hypomnema` | agents, audit, docs |
+| Lazarus | `lazarus` | docs, examples, schemas, scripts, pinned requirements |
+| Lemma | `chunk` | chunkers, baseline, schema, solc container, tools |
+| Pandects | `pandects` | Solidity under `src` and `test`, adapters, catalogue, specimens, integrations, audit |
+| Probitas | `probitas` | assets, audit, docs, scripts |
+| Sapheneia | `sapheneia` | nothing further |
+| Tabularium | `tabularium` | audit, docs, examples, schemas, scripts |
 
 Codex and Claude Code load the same skill directory. The host manifests only handle discovery and installation; each plugin's instructions, harness and acceptance conditions stay shared. Target-repository instructions still apply. More will turn up here as they become useful enough to keep.
 
@@ -847,10 +732,10 @@ now keeps the heterogeneous raw record and serves a reviewed address view to
 
 What remains, listed alphabetically:
 
-| Name | The public good |
-| --- | --- |
-| `berean` | A release manifest and evaluation corpus for agents that must support answers with exact documents and chain state |
-| `janus` | A conformance suite for what contract hooks may observe and change before and after a host action |
+- `berean`, a release manifest and evaluation corpus for agents that must
+  support answers with exact documents and chain state.
+- `janus`, a conformance suite for what contract hooks may observe and change
+  before and after a host action.
 
 These are tools we wanted and then needed. Their formats, datasets, properties,
 fixtures and tests become more useful when other teams can inspect, run and

--- a/plugins/hexaemeron/.claude-plugin/plugin.json
+++ b/plugins/hexaemeron/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "hexaemeron",
   "displayName": "Hexaemeron",
   "version": "1.1.0",
-  "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose and practice skills.",
+  "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose, specification, debugging, hardening, telemetry and measurement skills.",
   "author": {
     "name": "Wildcat Labs",
     "url": "https://wildcat.finance"

--- a/plugins/hexaemeron/.codex-plugin/plugin.json
+++ b/plugins/hexaemeron/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hexaemeron",
   "version": "1.1.0",
-  "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose and practice skills.",
+  "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose, specification, debugging, hardening, telemetry and measurement skills.",
   "author": {
     "name": "Wildcat Labs",
     "url": "https://wildcat.finance"
@@ -20,8 +20,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Hexaemeron",
-    "shortDescription": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose and practice skills.",
-    "longDescription": "Takes a topic from nothing to a working prototype through a receipt-backed controller: a linted study, a runbook of discrete steps, then per step the simplest satisfying implementation, a security loop over the vendored Pashov suite, a prose pass through Imprimatur and Vulgate, and a merged pull request with its task issue closed. Six practice skills hold each phase to a standard, four of them with an executable check. Kronos can rank eligible held frontiers and repeat complete Fiat runs until no worthwhile frontier remains.",
+    "shortDescription": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose, specification, debugging, hardening, telemetry and measurement skills.",
+    "longDescription": "Takes a topic from nothing to a working prototype through a receipt-backed controller: a linted study, a runbook of discrete steps, then per step the simplest satisfying implementation, a security loop over the vendored Pashov suite, a prose pass through Imprimatur and Vulgate, and a merged pull request with its task issue closed. Six further skills hold each phase to a standard, four of them with an executable check. Kronos can rank eligible held frontiers and repeat complete Fiat runs until no worthwhile frontier remains.",
     "developerName": "Wildcat Labs",
     "category": "Developer Tools",
     "capabilities": [],

--- a/plugins/hexaemeron/AGENTS.md
+++ b/plugins/hexaemeron/AGENTS.md
@@ -1,7 +1,7 @@
 # Hexaemeron runtime contract
 
 <!-- marketplace-context:start -->
-> **Marketplace context: Hexaemeron.** Hexaemeron runs an explicit, receipted delivery loop, and also exposes on their own the fuzzing, audit-readiness, security-review and prose skills it uses, plus six practice skills covering specification, debugging, hardening, telemetry, measurement and what gets recorded. Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks. **Current frontier:** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
+> **Marketplace context: Hexaemeron.** Hexaemeron runs an explicit, receipted delivery loop, and every skill it uses answers on its own: fuzzing, audit-readiness and security review, prose lint and voice, and the specification, debugging, hardening, telemetry, measurement and record-keeping skills the loop holds each phase to. Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks. **Current frontier:** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
 <!-- marketplace-context:end -->
 
 Hexaemeron contains several Agent Skills. Select from this table, then read the

--- a/plugins/hexaemeron/README.md
+++ b/plugins/hexaemeron/README.md
@@ -3,7 +3,7 @@
 <!-- marketplace-context:start -->
 ## In one line
 
-Hexaemeron runs an explicit, receipted delivery loop, and also exposes on their own the fuzzing, audit-readiness, security-review and prose skills it uses, plus six practice skills covering specification, debugging, hardening, telemetry, measurement and what gets recorded.
+Hexaemeron runs an explicit, receipted delivery loop, and every skill it uses answers on its own: fuzzing, audit-readiness and security review, prose lint and voice, and the specification, debugging, hardening, telemetry, measurement and record-keeping skills the loop holds each phase to.
 
 **Try something else when.** Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks.
 
@@ -136,7 +136,7 @@ https://www.pashov.com/. Preflight records the bundled ids in the
 so a stale config cannot fake a suite. Prose-free or Solidity-free runs record
 a waiver instead.
 
-## The practice skills
+## The skills each phase is held to
 
 Six skills carry the standards each phase is held to, and each runs on its own
 outside the loop. `protasis` says what a study and a runbook must answer.


### PR DESCRIPTION
Two things, both in prose.

## Brevitas over the README

Five findings, four real. 860 lines to 745, and the tree is no longer wrong.

| Finding | What it was | Now |
| --- | --- | --- |
| B006 | A 116-line layout tree repeating four identical files under each of eleven plugins, listing Hexaemeron's skills as they stood before Kronos | The shared shape once, then a table of what each plugin adds. 28 lines, and accurate |
| B008 | Twenty-six fences under `### Claude Code`, most wrapping one slash command behind "X is available as" | One fence for entry skills, one for phase skills, each under its own heading |
| B008 | Twenty fences under `## Use` | A heading per plugin |
| B008 | Two fences in the Codex section where one does | Merged, matching the Claude Code shape |
| B011 | A two-by-two table of forthcoming tools | A list |

Brevitas is not installed in this session — it merged yesterday and never
reached the plugin set — so this was applied by reading its `SKILL.md` and
running its linter, not by invoking it.

## The label

Six skills had been introduced as "practice skills", which implies a tier this
marketplace does not have. Removed from every surface: both marketplace
manifests, all three plugin manifests including the Codex long description, the
marketplace-context paragraph on three surfaces, the root contract, the topmost
README and the seven portable entrypoints. Where a collective noun carried
weight the prose now names what they cover; where it was decoration it is gone.

## Found while in there

`Pandects` has no entry in the `## Use` section. Every other plugin has one
giving its requirements and an activation sentence. Not filled in here, because
I would be inventing its requirements rather than reading them.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
