### PR TITLE
Split the checks section, and name the lints it was missing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,9 @@ rather than broadening the selected skill.
 
 ## Checks for changes to this repository
 
-Run the checks that cover every changed area:
+Run the checks that cover every changed area.
+
+### Suites
 
 ```bash
 python3 -m unittest discover -s tests
@@ -92,11 +94,27 @@ python3 -m unittest discover -s plugins/sapheneia/tests -t plugins/sapheneia
 python3 -m unittest discover -s plugins/tabularium/tests -t plugins/tabularium
 ```
 
+### Solidity
+
 Pandects also carries Solidity. From `plugins/pandects/`:
 
 ```bash
 forge build
 forge test
+```
+
+### Lints
+
+Prose that ships goes through the lexicon lint and then the structural one.
+The three skill lints read a tree rather than a diff, so they run from the root
+and must exit clean:
+
+```bash
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py <changed prose>
+python3 plugins/brevitas/skills/brevitas/scripts/brevitas.py <changed prose>
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs
 ```
 
 Validate every changed skill directory against the Agent Skills frontmatter


### PR DESCRIPTION
The last Brevitas finding in a top-level document. `README.md` came clean in
#109; `AGENTS.md` had one B008 at its checks section, where the suite list and
the Pandects `forge` pair sat under a single heading.

They cannot be merged into one fence, because `forge` runs from
`plugins/pandects/` rather than the root, so each gets a heading: **Suites**,
**Solidity**, **Lints**.

The third is new. Three lints shipped in the last few changes and this section
named none of them, so a contributor reading the contract would not know they
exist or that they must exit clean. Both prose passes are named alongside them.

Every command in the new subsection was run against this tree before being
written down; all three exit clean.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
