### PR TITLE
Move each plugin's detail into its own README, then cut the root

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,81 +34,13 @@ build.
 [Alexandria](./plugins/alexandria) keeps heterogeneous lending data unchanged,
 then derives only the credit rows a reviewed mapping can defend.
 
-Raw GraphQL responses and archive logs do not need one payload schema. Each
-release stores the original bytes under their SHA-256, names the source, chain,
-scope, finality class and counted coverage, and verifies offline. Goldfinch and
-Clearpool releases can then produce a narrow Tabularium view without turning
-the archive itself into an interpretation layer.
-
-The Compound v3 Phase 0 release pins 28 production Comet deployments at one
-upstream commit and preserves a bounded old-and-recent Ethereum USDC RPC
-corpus. Its offline checker binds archive access, nested calls,
-transaction-start state, proxy implementation code, ordered storage writes and
-a provider-reported finalized boundary. It is a one-provider method proof, not
-an interval history or independent chain proof.
-
-The SQLite address index is disposable. Every query rechecks its schema,
-logical digest and exact release-backed contents before returning rows. The
-explicit Probitas route keeps both venue and archive provenance and leaves all
-unharvested registry venues visible as gaps.
-
-Alexandria includes:
-
-- the standard-library [`alexandria.py`](./plugins/alexandria/scripts/alexandria.py)
-  ingest, verify, derive, index and query command;
-- raw-release, coverage, credit-row, query and demonstration schemas;
-- registered Goldfinch and Clearpool mappings with exact source and context
-  selectors;
-- the offline [`credit-history-v0`](./plugins/alexandria/examples/credit-history-v0/README.md)
-  path through Probitas's five gates; and
-- a checked-in [Compound v3 Phase 0 raw release](./plugins/alexandria/examples/compound-v3-phase0-v0/README.md),
-  separate explicit network capture command and pinned
-  [production harvest specification](./plugins/alexandria/docs/compound-v3-harvest.md).
-
-#### Day to day
-
-**Developers.** Preserve a protocol response now, with its gaps and usage
-restrictions, then rebuild the same release after the endpoint is gone.
-
-**Security and audit.** Check that every derived row resolves to the raw object
-and mapping rule that assigned its meaning. An unknown implementation or
-selector stays unsupported.
-
-**Finance.** Query a counterparty address across the archived venues without
-letting an unharvested venue read as clean history.
+The full account, what it ships and who it is for live in [Alexandria's README](./plugins/alexandria/README.md).
 
 ### Ariadne
 
 [Ariadne](./plugins/ariadne) binds a release to the evidence behind it, in a statement another person can check.
 
-A release publishes a claim. The compiler that produced the bytecode, the test run, the fuzz campaign, the audit and its scope, the deployment: all of it sits somewhere else, joined to the claim by a URL and a promise. Those links do not establish that the audit covered the released commit, that the build produced the deployed bytecode, or that the fuzz run used the settings the report describes. Ariadne writes the join down as a statement whose subject is a digest, so the binding survives the assembly.
-
-The statement is [in-toto's](https://github.com/in-toto/attestation) and the envelope is [DSSE's](https://github.com/secure-systems-lab/dsse). Neither is forked. What Ariadne adds is the discipline a bare statement does not carry, as seven gates:
-
-1. Every claim names the exact digest it covers. A result tied to a repository or a branch is refused, because those move.
-2. The environment is recoverable. A compiler version without the optimiser settings, the EVM target, the dependency lock and the command is not a build description.
-3. Absence stays visible. Skipped, failed, timed-out and redacted work stays in the statement record, and anything other than a pass carries a reason.
-4. Results are not upgraded into conclusions. A passing property records the property and the run, never that the artefact is safe.
-5. Deltas name both sides. A comparison fails when either baseline cannot be identified by digest, rather than degrading into a report of no changes.
-6. Replay distinguishes deterministic work. Bytecode can require an exact match; a fuzz campaign's coverage cannot.
-7. Signature verification is external. Ariadne holds no key, checks no signature, and says so every time it is asked.
-
-Five of those belong to an artefact-neutral core and run for any predicate, including a type the build has never seen. The other two come from the predicate, and a type without them is reported as unchecked rather than clean.
-
-Ariadne includes:
-
-- the executable [`ariadne.py`](./plugins/ariadne/scripts/ariadne.py) capture, verifier and replay, standard library only;
-- the [Solidity release predicate](./plugins/ariadne/docs/solidity-release.md) and [its published schema](./plugins/ariadne/schemas/solidity-release-v1.json), tied together by a test so the two cannot drift;
-- capture from a Foundry build that reads the compiler's own output, refuses to decide whether your tests passed, and scrubs a build command before recording it;
-- conformance fixtures with a passing statement and one breach per core gate, for anyone writing another producer or verifier;
-- two example attestations, one of them carrying a fuzz campaign that timed out and an audit covering an earlier revision; and
-- 310 tests, including a set that fails when a shipped document drifts from the code it describes, and an audit log ([`audit/AUDIT.md`](./plugins/ariadne/audit/AUDIT.md)) recording every round.
-
-#### Day to day
-
-**Developers.** A release goes out, and six months later somebody asks which commit the deployed bytecode came from and whether the audit covered it. `capture` reads that out of the build you already ran, and the statement answers from its own contents rather than from a changelog nobody updated.
-
-**Security and audit.** An attestation arrives with a release. `verify` says which gates hold, which went unchecked and why, and states plainly that it checked no signature. `replay` re-runs the deterministic half and compares the artefacts, so the recorded digests are something you can test rather than something you accept.
+The full account, what it ships and who it is for live in [Ariadne's README](./plugins/ariadne/README.md).
 
 ### Brevitas
 
@@ -118,92 +50,19 @@ commentary. It controls line count, finding shape, headings, tables, code fences
 and connective prose. Imprimatur still owns vocabulary, Vulgate owns register,
 and Sapheneia owns AuDHD interaction shape.
 
-Evidence outranks every budget. Addresses, transaction hashes, `file:line`
-references, numbers, counterexamples, reproduction steps and statements of what
-could not be established survive compression. The linter accepts a draft from a
-file or stdin, rejects mechanical breaches with line-numbered diagnostics, and
-can compare a compressed draft with its source. A marked evidence exception keeps
-an irreducible finding intact when the evidence itself needs more than five lines.
-
-Brevitas includes:
-
-- the standard-library [`brevitas.py`](./plugins/brevitas/skills/brevitas/scripts/brevitas.py) linter;
-- Make targets for written reports and source-preservation checks;
-- three audit-derived before/after cases with pinned fixture digests; and
-- tests for finding, heading, table, fence and banned-structure failures.
-
-#### Day to day
-
-**Developers.** A diff review has two defects buried under setup and a repeated
-summary. Brevitas keeps each defect to claim, location, mechanism, impact and fix,
-then rejects the draft if its structure drifts.
-
-**Security and audit.** A finding carries addresses, exact locations, numeric
-traces and reproduction steps. Brevitas cuts connective prose first, checks the
-machine-readable evidence against the source, and permits a marked exception when
-the protected evidence needs more than five lines.
+The full account, what it ships and who it is for live in [Brevitas's README](./plugins/brevitas/README.md).
 
 ### Hermes
 
 [Hermes](./plugins/hermes) treats Solidity gas work as a verification problem.
 
-Gas changes are easy to praise and surprisingly easy to get wrong. Hermes takes one optimisation class at a time through a fail-closed Foundry run:
-
-1. Seal a clean baseline with `forge snapshot` and a green `forge test`.
-2. Apply exactly one declared optimisation class.
-3. Prove the saving with `forge snapshot --diff`, reject every positive delta, and capture `forge test --gas-report`.
-4. Run the full test suite again with the pinned fuzz seed, then once more unpinned.
-5. Diff storage layouts and method identifiers for every recorded contract. Any layout change to a hook, role provider, proxied contract or other protected contract aborts the run.
-6. For unchecked arithmetic that can affect persistent state, asset accounting, external calls, permissions, or rounding, run the existing targeted differential or property test before accepting the candidate.
-
-A candidate only clears Hermes when every gate clears. The run leaves behind `result.json`, command logs, gas comparisons, the Solidity diff, storage layouts and method maps, so the number and the safety case can be reviewed together.
-
-Hermes includes:
-
-- the executable [`hermes.py`](./plugins/hermes/skills/hermes/scripts/hermes.py) harness;
-- a catalogue of [12 optimisation classes](./plugins/hermes/skills/hermes/references/optimisation-catalogue.md);
-- Codex metadata for explicit or automatic invocation; and
-- a test suite covering accepted runs and representative failures across Gates 2 to 6.
-
-#### Day to day
-
-**Developers.** A gas change shaves a few hundred units off a hot path and nobody can say whether behaviour moved with it. Run Hermes on that one optimisation class and the review arrives with the snapshot diff, both fuzz passes, the storage layout comparison and a `result.json`, rather than a number and an assurance.
-
-**Security and audit.** A gas change arrives from outside the team. Instead of reading it for intent, put it through Gate 5 to see whether any protected contract's storage layout or method identifiers moved, and Gate 6 for unchecked arithmetic that reaches persistent state.
-
+The full account, what it ships and who it is for live in [Hermes's README](./plugins/hermes/README.md).
 
 ### Hexaemeron
 
 [Hexaemeron](./plugins/hexaemeron) takes a topic from nothing to a working prototype through one receipted loop.
 
-Let there be light. A deterministic controller (`hexctl`) decides what comes next and refuses to advance without a receipt; state and a hash-chained ledger survive context resets, so resume is the same command.
-
-1. Study the topic and write a linted study file.
-2. Derive a runbook of discrete, self-contained steps.
-3. Implement the least complicated construction that satisfies each runbook step.
-4. Run the vendored Pashov suite (`x-ray`, `solidity-auditor`, `fizz`) in rounds until a round comes back clean or the remaining leads are judged not worth another pass, fixes on a stacked branch.
-5. Rewrite every shipped document and the PR text through the bundled `imprimatur` lint and `vulgate` voice mask.
-6. Push the PR and move to the next step.
-
-Hexaemeron includes:
-
-- the executable [`hexctl.py`](./plugins/hexaemeron/skills/fiat/scripts/hexctl.py) controller with a tamper-evident ledger (`verify` proves both chain and state);
-- the [`imprimatur`](./plugins/hexaemeron/skills/imprimatur) three-tier prose lint and the [`vulgate`](./plugins/hexaemeron/skills/vulgate) voice mask, invokable on their own;
-- [`kronos`](./plugins/hexaemeron/skills/kronos), which ranks eligible held frontier jobs and loops complete Fiat runs until none remain;
-- six more skills holding each phase to a standard, four of them with an executable check: [`protasis`](./plugins/hexaemeron/skills/protasis) on what a study and runbook must answer, [`elenchus`](./plugins/hexaemeron/skills/elenchus) on the root cause of a failure that already happened, [`phylax`](./plugins/hexaemeron/skills/phylax) on the off-chain surface, [`ephoros`](./plugins/hexaemeron/skills/ephoros) on what a step emits once it runs unattended, [`metron`](./plugins/hexaemeron/skills/metron) on every measurement except gas, and [`hypomnema`](./plugins/hexaemeron/skills/hypomnema) on what gets recorded and where;
-- the Pashov Audit Group suite vendored verbatim (MIT; `LICENSE` and `NOTICE.md` in each skill directory);
-- Codex metadata for explicit or automatic invocation; and
-- 124 controller, contract and practice-check tests, 55 lint tests, and a fuzz-audit log ([`audit/AUDIT.md`](./plugins/hexaemeron/audit/AUDIT.md)) covering the controller's own surfaces.
-
-#### Day to day
-
-**Developers.** A half-formed idea and a week to find out whether it holds. Hexaemeron turns it into a study, a runbook of discrete steps, and one pull request per step, with the audit suite run against each before it is pushed.
-
-**Security and audit.** You want the Pashov suite over a contract and nothing else. `x-ray`, `solidity-auditor` and `fizz` are vendored whole and run on their own, without taking on the loop around them.
-
-**Marketing.** A launch post reads like a machine wrote it. `imprimatur` says what is wrong with it across three tiers and `vulgate` rewrites it in house voice. Neither needs the controller, and neither needs installing separately.
-
-**Business development.** An integration document has to be accurate about what the protocol does and readable by someone who is not an engineer. The study phase produces the first and the prose masks produce the second.
+The full account, what it ships and who it is for live in [Hexaemeron's README](./plugins/hexaemeron/README.md).
 
 ### Lemma
 
@@ -211,25 +70,7 @@ Hexaemeron includes:
 into JSONL chunks. The two chunkers share one schema and keep source text used
 for quotation separate from text prepared for a model or embedder.
 
-Lemma includes:
-
-- a Solidity chunker driven by the compiler AST;
-- a Markdown chunker that splits on rendered heading structure;
-- schema validation and an invented baseline corpus; and
-- a pinned `solc` container wrapper for reproducible compiler output.
-
-It stops after chunking. It does not embed, index, retrieve, or answer from the
-output.
-
-Its one skill is `chunk`, giving the qualified name `lemma:chunk`. The plain
-name matches the operation and avoids implying the unrelated NLP operation of
-lemmatisation.
-
-#### Day to day
-
-**Developers.** A documentation or verified-contract corpus needs source-linked
-JSONL before it can enter a retrieval system. Lemma creates that file and
-rejects chunks that fail its schema checks.
+The full account, what it ships and who it is for live in [Lemma's README](./plugins/lemma/README.md).
 
 ### Lazarus
 
@@ -237,37 +78,7 @@ rejects chunks that fail its schema checks.
 state and RPC evidence that one application test needs, then replays only the
 requests in that fixture.
 
-Capture fixes a block, records exact JSON-RPC requests and responses, and binds
-the fixture to a deterministic manifest. Account and storage claims must pass
-EIP-1186 trie-proof checks against the captured header; contract code must match
-the proved code hash. Receipts, log queries, calls and traces remain labelled as
-recorded RPC evidence. They are not promoted into state proofs.
-
-Replay verifies the fixture before opening a loopback server. An uncaptured
-request returns a stable `-32070` error describing the missing plan entry, and
-there is no provider fallback. The checked-in Goldfinch example exercises
-proof-backed code and storage, a receipt, a log query, a deliberate miss, proof
-mutation rejection and byte-for-byte manifest rebuilding without a network.
-
-Lazarus includes:
-
-- finite, bounded capture from one fixed historical block;
-- canonical JSON and JSONL formats with versioned, digest-pinned schemas;
-- offline header, account, storage, code and manifest verification;
-- exact-request JSON-RPC replay over loopback, including batches and
-  notifications; and
-- 144 tests plus a proof-checked Goldfinch demonstration.
-
-#### Day to day
-
-**Developers.** An old integration test depends on an archive endpoint that is
-slow, costly or gone. Capture the exact historical state and responses the test
-uses, commit the fixture, and run the same requests locally with a visible miss
-for anything the plan omitted.
-
-**Security and audit.** A historical fixture claims an account balance, code
-hash or storage value. Run `verify` to check the trie path against the named
-header and keep ordinary RPC evidence outside that proof boundary.
+The full account, what it ships and who it is for live in [Lazarus's README](./plugins/lazarus/README.md).
 
 ### Pandects
 
@@ -277,66 +88,15 @@ contract it is proven to catch, a reduced counterexample, and a statement of
 the accounting model and observables it requires.
 
 The catalogue holds ten laws across conservation, accrual and withdrawal
-claims. Nine are exact. The path-independence law carries a bound derived from
-the rounding performed by linear accrual, and its tests assert the figures on
-both the sound reference and the compounding specimen.
+claims. Nine are exact.
 
-Pandects includes:
-
-- one-state and transition laws written against economic observables rather
-  than protocol-specific function names;
-- broken specimens and replayable counterexamples for every law;
-- observer, driver and differential adapters for Foundry, Echidna and Medusa;
-- a reduced Wildcat market model recording where three laws need narrower
-  applicability; and
-- a checker, catalogue renderer, search record and tests that keep each law's
-  six required parts together.
-
-#### Day to day
-
-**Security and audit.** A credit protocol arrives and its economic invariants
-have to be settled before a fuzz campaign can mean anything. Pandects supplies
-the laws, the assumptions behind them, and evidence that each catches the fault
-it names.
-
-**Developers.** A change touches accrual or a withdrawal queue. Run the
-applicable laws against the build and inspect the quantities behind any verdict
-that moved.
+The full account, what it ships and who it is for live in [Pandects's README](./plugins/pandects/README.md).
 
 ### Probitas
 
 [Probitas](./plugins/probitas) builds a sourced dossier on what a counterparty has done across on-chain lending venues.
 
-Undercollateralised lending is the reason to want one: nothing stands between a lender and a total loss except a judgement about the borrower, and that judgement usually gets assembled by hand from whatever the person asking happens to remember. The tool is not limited to that case. Most on-chain borrowing is collateralised and it still tells you plenty, because a liquidation says a price moved, a bad debt says somebody was not made whole, and a missed maturity says what it says anywhere.
-
-Two halves, doing different jobs. A deterministic collector queries venue adapters and writes an evidence file in which a record cannot exist without a transaction hash, a URL or a document reference. The model writes the narrative from that file, and a gate checker reads the document and the evidence together before either ships.
-
-Five gates decide whether a dossier is honest enough to hand to a lender:
-
-1. Declared, provably linked and inferred addresses stay in separate sections.
-2. Every venue in the registry gets a coverage row, and a venue that was queried says over what block range. Silence about a venue would read as a clean record.
-3. Every assertion carries a citation, and every figure in the document traces back to a record.
-4. What could not be established gets its own section, ahead of anything that reads like a conclusion.
-5. No score without a rubric printed beside it. This version emits none.
-
-Gate 3 is the one that does the work. It rebuilds, from the evidence alone, every number and hash a truthful dossier could carry, then fails the document on any figure that is not in that set. An invented transaction hash, an amount rounded in the retelling, a market that was never there: each fails the run rather than shipping in it.
-
-Probitas includes:
-
-- the executable [`probitas.py`](./plugins/probitas/scripts/probitas.py) collector, renderer and gate checker, standard library only;
-- adapters for [Wildcat](https://wildcat.finance) and Morpho Blue, and eleven further venues carried as named gaps rather than silence;
-- nine synthetic borrower fixtures, including the cured delinquency that a hand-assembled writeup usually reads as a default;
-- a [committed example dossier](./plugins/probitas/docs/example-dossier.md) that the tests regenerate and compare, so it cannot drift;
-- [a guide to closing a coverage gap](./plugins/probitas/docs/adding-a-venue.md) that assumes no knowledge of Wildcat; and
-- 234 tests and an audit log ([`audit/AUDIT.md`](./plugins/probitas/audit/AUDIT.md)) recording every round, including the fixes that were wrong the first time.
-
-#### Day to day
-
-**Business development.** A counterparty asks for a market and someone has to decide whether their word is worth anything. Give this the addresses they declared and it comes back with what they borrowed elsewhere, whether they gave it back, and a list of the venues nobody could check, so the thin parts of the record are visible rather than absent.
-
-**Finance.** Exposure to a name that also borrows in three other places. The dossier states each position's venue, the amounts as exact on-chain integers, and whether anything was left unpaid after a liquidation, which is the number that ends up mattering.
-
-**Security and audit.** A document arrives asserting things about a counterparty and you have to decide whether to believe it. Run `verify` against the evidence file it came with: every figure in the document has to trace back to a record with a transaction hash, and one that does not fails the check by arithmetic rather than by your reading it closely.
+The full account, what it ships and who it is for live in [Probitas's README](./plugins/probitas/README.md).
 
 ### Sapheneia
 
@@ -344,100 +104,14 @@ Probitas includes:
 engineers. It keeps the next action, task boundary, done condition, current
 state, evidence and unknowns visible from turn to turn.
 
-The contract sits upstream of whatever the agent is producing. It applies to
-commentary, progress updates, questions, errors and final replies for the rest
-of the session once selected. It does not diagnose the reader, and it yields
-as soon as the reader states a different preference.
-
-The ten rules are ranked. The first line carries the action or finished result;
-asks are literal and labelled; multi-step work has one active step; facts,
-assumptions and unknowns stay separate; and unfinished work ends with one next
-action. Imprimatur remains the prose lint, and a voice mask remains responsible
-for register.
-
-Sapheneia includes:
-
-- one canonical [`SKILL.md`](./plugins/sapheneia/skills/sapheneia/SKILL.md) shared by Codex, Claude Code and portable agents;
-- an agent-facing runtime contract that makes the agent itself the subject;
-- contract tests that hold the ranked rule count, persistence language, host descriptions and portable links together.
-
-#### Day to day
-
-**Developers.** A coding task spans several turns and the current step keeps
-falling out of view. Sapheneia keeps one step active, says what changed and
-what was verified, and ends with one next action.
-
-**Security and audit.** A finding mixes observed behaviour, inference and an
-untested assumption. Sapheneia labels each one and keeps the risk-bearing
-qualification attached to the decision it changes.
+The full account, what it ships and who it is for live in [Sapheneia's README](./plugins/sapheneia/README.md).
 
 ### Tabularium
 
 [Tabularium](./plugins/tabularium) preserves on-chain credit events in a form
 another person can rebuild after the endpoint that served them is gone.
 
-The first release captures Goldfinch's borrower-side record: 34 borrow and 477
-repay entities mapped into 511 canonical rows. Two Euler releases now add a
-real Euler v1 canonical-proxy borrow log and a fixed Euler V2 owner/second
-activity response from the Euler V3 API. Each row keeps the complete
-venue-native record and names the source selector, adapter version and mapping
-rule that produced it. Euler V2 protocol generation and Euler V3 source API
-remain separate fields.
-
-A separate Compound v3 Phase 0 path consumes Alexandria's verified raw release
-and rebuilds non-canonical ordered calls, relevant proxy-storage writes and one
-signed-principal transition. It establishes the recorded interpretation method
-for one transaction; the canonical Compound event adapter and interval
-specimen remain Phase 1 work.
-
-The release is four files doing separate jobs. `source.json` is the preserved
-response. `capture.json` records where and when it was taken. `events.jsonl` is
-the interpretation. `coverage.json` binds all three by digest, counts what was
-mapped and what was not, and states the evidence gaps.
-
-Verification does not stop at those digests. It checks the capture against the
-source, confines every path to the release directory, requires one ordered
-source selector per event and rebuilds the canonical bytes from the preserved
-input. The worked release is unsigned and its block boundary is what the hosted
-indexer reported, so a clean run establishes internal consistency rather than
-publisher authenticity or an independent chain proof.
-
-Tabularium includes:
-
-- the standard-library [`tabularium.py`](./plugins/tabularium/scripts/tabularium.py)
-  builder and offline verifier;
-- versioned event schemas [v1](./plugins/tabularium/schemas/canonical-event-v1.json)
-  and [v2](./plugins/tabularium/schemas/canonical-event-v2.json), plus coverage
-  schemas [v1](./plugins/tabularium/schemas/coverage-manifest-v1.json) and
-  [v2](./plugins/tabularium/schemas/coverage-manifest-v2.json);
-- the complete [`goldfinch-v0`](./plugins/tabularium/examples/goldfinch-v0/README.md)
-  release, its data dictionary and a fresh-directory rebuild demonstration;
-- source-bound [`euler-v1-v0`](./plugins/tabularium/examples/euler-v1-v0/README.md)
-  and [`euler-v2-v0`](./plugins/tabularium/examples/euler-v2-v0/README.md)
-  releases with their own dictionaries and rebuild demonstrations;
-- a non-canonical [Compound v3 Phase 0 witness](./plugins/tabularium/examples/compound-v3-phase0-v0/README.md)
-  rebuilt from Alexandria's verified release;
-- an [adapter guide](./plugins/tabularium/docs/adding-an-adapter.md) and an
-  immutable [release policy](./plugins/tabularium/docs/release-policy.md); and
-- 134 tests and an audit log
-  ([`audit/AUDIT.md`](./plugins/tabularium/audit/AUDIT.md)) recording every
-  review round and fix.
-
-#### Day to day
-
-**Developers.** A hosted indexer is still answering for a venue whose front end
-has gone. Preserve the response and its capture boundary, then publish a
-release whose mapping and bytes somebody else can reproduce without that
-endpoint.
-
-**Security and audit.** A dataset arrives with a digest and a claim that it was
-built from a named source. Run `verify`: it rebuilds the event bytes and checks
-the one-to-one source trace rather than trusting the release's own row count.
-
-**Finance.** A repayment record needs to be compared with another venue's
-record without erasing the difference between them. The common family makes
-the rows searchable; the venue-qualified action and native record keep the
-economic meaning attached.
+The full account, what it ships and who it is for live in [Tabularium's README](./plugins/tabularium/README.md).
 
 ## Who these are for
 

--- a/plugins/alexandria/README.md
+++ b/plugins/alexandria/README.md
@@ -19,6 +19,51 @@ each capture to explicit scope and coverage, derives a narrow Tabularium credit
 view and supplies that view to Probitas through a disposable index. Alexandria
 is an archive and data source, not a lending venue or underwriting system.
 
+## How it works
+
+Raw GraphQL responses and archive logs do not need one payload schema. Each
+release stores the original bytes under their SHA-256, names the source, chain,
+scope, finality class and counted coverage, and verifies offline. Goldfinch and
+Clearpool releases can then produce a narrow Tabularium view without turning
+the archive itself into an interpretation layer.
+
+The Compound v3 Phase 0 release pins 28 production Comet deployments at one
+upstream commit and preserves a bounded old-and-recent Ethereum USDC RPC
+corpus. Its offline checker binds archive access, nested calls,
+transaction-start state, proxy implementation code, ordered storage writes and
+a provider-reported finalized boundary. It is a one-provider method proof, not
+an interval history or independent chain proof.
+
+The SQLite address index is disposable. Every query rechecks its schema,
+logical digest and exact release-backed contents before returning rows. The
+explicit Probitas route keeps both venue and archive provenance and leaves all
+unharvested registry venues visible as gaps.
+
+## What it ships
+
+- the standard-library [`alexandria.py`](./scripts/alexandria.py)
+  ingest, verify, derive, index and query command;
+- raw-release, coverage, credit-row, query and demonstration schemas;
+- registered Goldfinch and Clearpool mappings with exact source and context
+  selectors;
+- the offline [`credit-history-v0`](./examples/credit-history-v0/README.md)
+  path through Probitas's five gates; and
+- a checked-in [Compound v3 Phase 0 raw release](./examples/compound-v3-phase0-v0/README.md),
+  separate explicit network capture command and pinned
+  [production harvest specification](./docs/compound-v3-harvest.md).
+
+## Day to day
+
+**Developers.** Preserve a protocol response now, with its gaps and usage
+restrictions, then rebuild the same release after the endpoint is gone.
+
+**Security and audit.** Check that every derived row resolves to the raw object
+and mapping rule that assigned its meaning. An unknown implementation or
+selector stays unsupported.
+
+**Finance.** Query a counterparty address across the archived venues without
+letting an unharvested venue read as clean history.
+
 ## Complete prototype
 
 Alexandria can ingest raw releases, derive verified credit views, rebuild an

--- a/plugins/ariadne/README.md
+++ b/plugins/ariadne/README.md
@@ -33,6 +33,37 @@ rather than the only one, and a dataset, a chain-state fixture and a
 grounded-agent release each get a predicate beside it rather than a tool of
 their own.
 
+## How it works
+
+A release publishes a claim. The compiler that produced the bytecode, the test run, the fuzz campaign, the audit and its scope, the deployment: all of it sits somewhere else, joined to the claim by a URL and a promise. Those links do not establish that the audit covered the released commit, that the build produced the deployed bytecode, or that the fuzz run used the settings the report describes. Ariadne writes the join down as a statement whose subject is a digest, so the binding survives the assembly.
+
+The statement is [in-toto's](https://github.com/in-toto/attestation) and the envelope is [DSSE's](https://github.com/secure-systems-lab/dsse). Neither is forked. What Ariadne adds is the discipline a bare statement does not carry, as seven gates:
+
+1. Every claim names the exact digest it covers. A result tied to a repository or a branch is refused, because those move.
+2. The environment is recoverable. A compiler version without the optimiser settings, the EVM target, the dependency lock and the command is not a build description.
+3. Absence stays visible. Skipped, failed, timed-out and redacted work stays in the statement record, and anything other than a pass carries a reason.
+4. Results are not upgraded into conclusions. A passing property records the property and the run, never that the artefact is safe.
+5. Deltas name both sides. A comparison fails when either baseline cannot be identified by digest, rather than degrading into a report of no changes.
+6. Replay distinguishes deterministic work. Bytecode can require an exact match; a fuzz campaign's coverage cannot.
+7. Signature verification is external. Ariadne holds no key, checks no signature, and says so every time it is asked.
+
+Five of those belong to an artefact-neutral core and run for any predicate, including a type the build has never seen. The other two come from the predicate, and a type without them is reported as unchecked rather than clean.
+
+## What it ships
+
+- the executable [`ariadne.py`](./scripts/ariadne.py) capture, verifier and replay, standard library only;
+- the [Solidity release predicate](./docs/solidity-release.md) and [its published schema](./schemas/solidity-release-v1.json), tied together by a test so the two cannot drift;
+- capture from a Foundry build that reads the compiler's own output, refuses to decide whether your tests passed, and scrubs a build command before recording it;
+- conformance fixtures with a passing statement and one breach per core gate, for anyone writing another producer or verifier;
+- two example attestations, one of them carrying a fuzz campaign that timed out and an audit covering an earlier revision; and
+- 310 tests, including a set that fails when a shipped document drifts from the code it describes, and an audit log ([`audit/AUDIT.md`](./audit/AUDIT.md)) recording every round.
+
+## Day to day
+
+**Developers.** A release goes out, and six months later somebody asks which commit the deployed bytecode came from and whether the audit covered it. `capture` reads that out of the build you already ran, and the statement answers from its own contents rather than from a changelog nobody updated.
+
+**Security and audit.** An attestation arrives with a release. `verify` says which gates hold, which went unchecked and why, and states plainly that it checked no signature. `replay` re-runs the deterministic half and compares the artefacts, so the recorded digests are something you can test rather than something you accept.
+
 ## What is in it
 
 **The core.** Digest sets and their matching rules, in-toto Statement v1, the

--- a/plugins/brevitas/README.md
+++ b/plugins/brevitas/README.md
@@ -12,6 +12,33 @@ Brevitas puts mechanical volume and structure limits on engineering review prose
 **Next Fiat job.** Use /hexaemeron:fiat to Forward-test Brevitas across held x-ray, Solidity-auditor, gas, `invariant` and diff-review outputs, then add every confirmed structural bypass to the corpus without weakening evidence precedence. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
 <!-- marketplace-context:end -->
 
+## How it works
+
+Evidence outranks every budget. Addresses, transaction hashes, `file:line`
+references, numbers, counterexamples, reproduction steps and statements of what
+could not be established survive compression. The linter accepts a draft from a
+file or stdin, rejects mechanical breaches with line-numbered diagnostics, and
+can compare a compressed draft with its source. A marked evidence exception keeps
+an irreducible finding intact when the evidence itself needs more than five lines.
+
+## What it ships
+
+- the standard-library [`brevitas.py`](./skills/brevitas/scripts/brevitas.py) linter;
+- Make targets for written reports and source-preservation checks;
+- three audit-derived before/after cases with pinned fixture digests; and
+- tests for finding, heading, table, fence and banned-structure failures.
+
+## Day to day
+
+**Developers.** A diff review has two defects buried under setup and a repeated
+summary. Brevitas keeps each defect to claim, location, mechanism, impact and fix,
+then rejects the draft if its structure drifts.
+
+**Security and audit.** A finding carries addresses, exact locations, numeric
+traces and reproduction steps. Brevitas cuts connective prose first, checks the
+machine-readable evidence against the source, and permits a marked exception when
+the protected evidence needs more than five lines.
+
 ## Contract
 
 Brevitas is the last structural pass for audit findings, security reviews, gas

--- a/plugins/hermes/README.md
+++ b/plugins/hermes/README.md
@@ -14,3 +14,29 @@ Hermes measures one Solidity gas optimisation class at a time and rejects the ca
 
 The canonical workflow and complete gate contract live in
 [`skills/hermes/SKILL.md`](skills/hermes/SKILL.md).
+## How it works
+
+Gas changes are easy to praise and surprisingly easy to get wrong. Hermes takes one optimisation class at a time through a fail-closed Foundry run:
+
+1. Seal a clean baseline with `forge snapshot` and a green `forge test`.
+2. Apply exactly one declared optimisation class.
+3. Prove the saving with `forge snapshot --diff`, reject every positive delta, and capture `forge test --gas-report`.
+4. Run the full test suite again with the pinned fuzz seed, then once more unpinned.
+5. Diff storage layouts and method identifiers for every recorded contract. Any layout change to a hook, role provider, proxied contract or other protected contract aborts the run.
+6. For unchecked arithmetic that can affect persistent state, asset accounting, external calls, permissions, or rounding, run the existing targeted differential or property test before accepting the candidate.
+
+A candidate only clears Hermes when every gate clears. The run leaves behind `result.json`, command logs, gas comparisons, the Solidity diff, storage layouts and method maps, so the number and the safety case can be reviewed together.
+
+## What it ships
+
+- the executable [`hermes.py`](./skills/hermes/scripts/hermes.py) harness;
+- a catalogue of [12 optimisation classes](./skills/hermes/references/optimisation-catalogue.md);
+- Codex metadata for explicit or automatic invocation; and
+- a test suite covering accepted runs and representative failures across Gates 2 to 6.
+
+## Day to day
+
+**Developers.** A gas change shaves a few hundred units off a hot path and nobody can say whether behaviour moved with it. Run Hermes on that one optimisation class and the review arrives with the snapshot diff, both fuzz passes, the storage layout comparison and a `result.json`, rather than a number and an assurance.
+
+**Security and audit.** A gas change arrives from outside the team. Instead of reading it for intent, put it through Gate 5 to see whether any protected contract's storage layout or method identifiers moved, and Gate 6 for unchecked arithmetic that reaches persistent state.
+

--- a/plugins/hexaemeron/README.md
+++ b/plugins/hexaemeron/README.md
@@ -25,6 +25,37 @@ Named for the six days of ordered creation from a void to finished work,
 then rest. The entry skill is `fiat`, so the invocation is
 `/hexaemeron:fiat` and a fresh run's first words are the line above.
 
+## How it works
+
+Let there be light. A deterministic controller (`hexctl`) decides what comes next and refuses to advance without a receipt; state and a hash-chained ledger survive context resets, so resume is the same command.
+
+1. Study the topic and write a linted study file.
+2. Derive a runbook of discrete, self-contained steps.
+3. Implement the least complicated construction that satisfies each runbook step.
+4. Run the vendored Pashov suite (`x-ray`, `solidity-auditor`, `fizz`) in rounds until a round comes back clean or the remaining leads are judged not worth another pass, fixes on a stacked branch.
+5. Rewrite every shipped document and the PR text through the bundled `imprimatur` lint and `vulgate` voice mask.
+6. Push the PR and move to the next step.
+
+## What it ships
+
+- the executable [`hexctl.py`](./skills/fiat/scripts/hexctl.py) controller with a tamper-evident ledger (`verify` proves both chain and state);
+- the [`imprimatur`](./skills/imprimatur) three-tier prose lint and the [`vulgate`](./skills/vulgate) voice mask, invokable on their own;
+- [`kronos`](./skills/kronos), which ranks eligible held frontier jobs and loops complete Fiat runs until none remain;
+- six more skills holding each phase to a standard, four of them with an executable check: [`protasis`](./skills/protasis) on what a study and runbook must answer, [`elenchus`](./skills/elenchus) on the root cause of a failure that already happened, [`phylax`](./skills/phylax) on the off-chain surface, [`ephoros`](./skills/ephoros) on what a step emits once it runs unattended, [`metron`](./skills/metron) on every measurement except gas, and [`hypomnema`](./skills/hypomnema) on what gets recorded and where;
+- the Pashov Audit Group suite vendored verbatim (MIT; `LICENSE` and `NOTICE.md` in each skill directory);
+- Codex metadata for explicit or automatic invocation; and
+- 124 controller, contract and practice-check tests, 55 lint tests, and a fuzz-audit log ([`audit/AUDIT.md`](./audit/AUDIT.md)) covering the controller's own surfaces.
+
+## Day to day
+
+**Developers.** A half-formed idea and a week to find out whether it holds. Hexaemeron turns it into a study, a runbook of discrete steps, and one pull request per step, with the audit suite run against each before it is pushed.
+
+**Security and audit.** You want the Pashov suite over a contract and nothing else. `x-ray`, `solidity-auditor` and `fizz` are vendored whole and run on their own, without taking on the loop around them.
+
+**Marketing.** A launch post reads like a machine wrote it. `imprimatur` says what is wrong with it across three tiers and `vulgate` rewrites it in house voice. Neither needs the controller, and neither needs installing separately.
+
+**Business development.** An integration document has to be accurate about what the protocol does and readable by someone who is not an engineer. The study phase produces the first and the prose masks produce the second.
+
 ## The shape of a run
 
 | Day | Phase | What happens |

--- a/plugins/lazarus/README.md
+++ b/plugins/lazarus/README.md
@@ -24,6 +24,40 @@ writes canonical JSON and JSONL, confines fixture paths, derives exact request
 keys, verifies component digests, recomputes the header hash, traverses
 EIP-1186 proofs, checks captured code and serves exact requests over loopback.
 
+## How it works
+
+Capture fixes a block, records exact JSON-RPC requests and responses, and binds
+the fixture to a deterministic manifest. Account and storage claims must pass
+EIP-1186 trie-proof checks against the captured header; contract code must match
+the proved code hash. Receipts, log queries, calls and traces remain labelled as
+recorded RPC evidence. They are not promoted into state proofs.
+
+Replay verifies the fixture before opening a loopback server. An uncaptured
+request returns a stable `-32070` error describing the missing plan entry, and
+there is no provider fallback. The checked-in Goldfinch example exercises
+proof-backed code and storage, a receipt, a log query, a deliberate miss, proof
+mutation rejection and byte-for-byte manifest rebuilding without a network.
+
+## What it ships
+
+- finite, bounded capture from one fixed historical block;
+- canonical JSON and JSONL formats with versioned, digest-pinned schemas;
+- offline header, account, storage, code and manifest verification;
+- exact-request JSON-RPC replay over loopback, including batches and
+  notifications; and
+- 144 tests plus a proof-checked Goldfinch demonstration.
+
+## Day to day
+
+**Developers.** An old integration test depends on an archive endpoint that is
+slow, costly or gone. Capture the exact historical state and responses the test
+uses, commit the fixture, and run the same requests locally with a visible miss
+for anything the plan omitted.
+
+**Security and audit.** A historical fixture claims an account balance, code
+hash or storage value. Run `verify` to check the trie path against the named
+header and keep ordinary RPC evidence outside that proof boundary.
+
 ## Evidence boundary
 
 - **Proof-backed state** is checked through an EIP-1186 proof against the

--- a/plugins/lemma/README.md
+++ b/plugins/lemma/README.md
@@ -26,6 +26,26 @@ instead of repeating the plugin name in the call.
 `lemmatise` was avoided because it already means reducing words to dictionary
 forms in natural-language processing, which this plugin does not do.
 
+## What it ships
+
+- a Solidity chunker driven by the compiler AST;
+- a Markdown chunker that splits on rendered heading structure;
+- schema validation and an invented baseline corpus; and
+- a pinned `solc` container wrapper for reproducible compiler output.
+
+It stops after chunking. It does not embed, index, retrieve, or answer from the
+output.
+
+Its one skill is `chunk`, giving the qualified name `lemma:chunk`. The plain
+name matches the operation and avoids implying the unrelated NLP operation of
+lemmatisation.
+
+## Day to day
+
+**Developers.** A documentation or verified-contract corpus needs source-linked
+JSONL before it can enter a retrieval system. Lemma creates that file and
+rejects chunks that fail its schema checks.
+
 ## Solidity
 
 Pass one or more solc standard JSON input files:

--- a/plugins/pandects/README.md
+++ b/plugins/pandects/README.md
@@ -23,6 +23,35 @@ subset in a local harness, and the harness dies with the engagement.
 
 This is the corpus that survives it.
 
+## How it works
+
+The catalogue holds ten laws across conservation, accrual and withdrawal
+claims. Nine are exact. The path-independence law carries a bound derived from
+the rounding performed by linear accrual, and its tests assert the figures on
+both the sound reference and the compounding specimen.
+
+## What it ships
+
+- one-state and transition laws written against economic observables rather
+  than protocol-specific function names;
+- broken specimens and replayable counterexamples for every law;
+- observer, driver and differential adapters for Foundry, Echidna and Medusa;
+- a reduced Wildcat market model recording where three laws need narrower
+  applicability; and
+- a checker, catalogue renderer, search record and tests that keep each law's
+  six required parts together.
+
+## Day to day
+
+**Security and audit.** A credit protocol arrives and its economic invariants
+have to be settled before a fuzz campaign can mean anything. Pandects supplies
+the laws, the assumptions behind them, and evidence that each catches the fault
+it names.
+
+**Developers.** A change touches accrual or a withdrawal queue. Run the
+applicable laws against the build and inspect the quantities behind any verdict
+that moved.
+
 ## What a law is
 
 Six parts, and the checker refuses anything with fewer:

--- a/plugins/probitas/README.md
+++ b/plugins/probitas/README.md
@@ -33,6 +33,39 @@ not to be. So this runs on the lender's own machine, against a borrower they're
 considering, and they reach their own conclusion. We hand over the instrument
 and not the verdict.
 
+## How it works
+
+Undercollateralised lending is the reason to want one: nothing stands between a lender and a total loss except a judgement about the borrower, and that judgement usually gets assembled by hand from whatever the person asking happens to remember. The tool is not limited to that case. Most on-chain borrowing is collateralised and it still tells you plenty, because a liquidation says a price moved, a bad debt says somebody was not made whole, and a missed maturity says what it says anywhere.
+
+Two halves, doing different jobs. A deterministic collector queries venue adapters and writes an evidence file in which a record cannot exist without a transaction hash, a URL or a document reference. The model writes the narrative from that file, and a gate checker reads the document and the evidence together before either ships.
+
+Five gates decide whether a dossier is honest enough to hand to a lender:
+
+1. Declared, provably linked and inferred addresses stay in separate sections.
+2. Every venue in the registry gets a coverage row, and a venue that was queried says over what block range. Silence about a venue would read as a clean record.
+3. Every assertion carries a citation, and every figure in the document traces back to a record.
+4. What could not be established gets its own section, ahead of anything that reads like a conclusion.
+5. No score without a rubric printed beside it. This version emits none.
+
+Gate 3 is the one that does the work. It rebuilds, from the evidence alone, every number and hash a truthful dossier could carry, then fails the document on any figure that is not in that set. An invented transaction hash, an amount rounded in the retelling, a market that was never there: each fails the run rather than shipping in it.
+
+## What it ships
+
+- the executable [`probitas.py`](./scripts/probitas.py) collector, renderer and gate checker, standard library only;
+- adapters for [Wildcat](https://wildcat.finance) and Morpho Blue, and eleven further venues carried as named gaps rather than silence;
+- nine synthetic borrower fixtures, including the cured delinquency that a hand-assembled writeup usually reads as a default;
+- a [committed example dossier](./docs/example-dossier.md) that the tests regenerate and compare, so it cannot drift;
+- [a guide to closing a coverage gap](./docs/adding-a-venue.md) that assumes no knowledge of Wildcat; and
+- 234 tests and an audit log ([`audit/AUDIT.md`](./audit/AUDIT.md)) recording every round, including the fixes that were wrong the first time.
+
+## Day to day
+
+**Business development.** A counterparty asks for a market and someone has to decide whether their word is worth anything. Give this the addresses they declared and it comes back with what they borrowed elsewhere, whether they gave it back, and a list of the venues nobody could check, so the thin parts of the record are visible rather than absent.
+
+**Finance.** Exposure to a name that also borrows in three other places. The dossier states each position's venue, the amounts as exact on-chain integers, and whether anything was left unpaid after a liquidation, which is the number that ends up mattering.
+
+**Security and audit.** A document arrives asserting things about a counterparty and you have to decide whether to believe it. Run `verify` against the evidence file it came with: every figure in the document has to trace back to a record with a transaction hash, and one that does not fails the check by arithmetic rather than by your reading it closely.
+
 ## Run it
 
 From this directory, `plugins/probitas`:

--- a/plugins/sapheneia/README.md
+++ b/plugins/sapheneia/README.md
@@ -32,3 +32,22 @@ what was verified, and ends with one next action.
 **Security and audit.** A finding mixes observed behaviour, inference and an
 untested assumption. Sapheneia labels each one and keeps the risk-bearing
 qualification attached to the decision it changes.
+## How it works
+
+The contract sits upstream of whatever the agent is producing. It applies to
+commentary, progress updates, questions, errors and final replies for the rest
+of the session once selected. It does not diagnose the reader, and it yields
+as soon as the reader states a different preference.
+
+The ten rules are ranked. The first line carries the action or finished result;
+asks are literal and labelled; multi-step work has one active step; facts,
+assumptions and unknowns stay separate; and unfinished work ends with one next
+action. Imprimatur remains the prose lint, and a voice mask remains responsible
+for register.
+
+## What it ships
+
+- one canonical [`SKILL.md`](./skills/sapheneia/SKILL.md) shared by Codex, Claude Code and portable agents;
+- an agent-facing runtime contract that makes the agent itself the subject;
+- contract tests that hold the ranked rule count, persistence language, host descriptions and portable links together.
+

--- a/plugins/tabularium/README.md
+++ b/plugins/tabularium/README.md
@@ -43,6 +43,71 @@ Three rules hold the release together:
    maps the preserved source again and requires the bytes, order and source
    selectors to agree.
 
+## How it works
+
+The first release captures Goldfinch's borrower-side record: 34 borrow and 477
+repay entities mapped into 511 canonical rows. Two Euler releases now add a
+real Euler v1 canonical-proxy borrow log and a fixed Euler V2 owner/second
+activity response from the Euler V3 API. Each row keeps the complete
+venue-native record and names the source selector, adapter version and mapping
+rule that produced it. Euler V2 protocol generation and Euler V3 source API
+remain separate fields.
+
+A separate Compound v3 Phase 0 path consumes Alexandria's verified raw release
+and rebuilds non-canonical ordered calls, relevant proxy-storage writes and one
+signed-principal transition. It establishes the recorded interpretation method
+for one transaction; the canonical Compound event adapter and interval
+specimen remain Phase 1 work.
+
+The release is four files doing separate jobs. `source.json` is the preserved
+response. `capture.json` records where and when it was taken. `events.jsonl` is
+the interpretation. `coverage.json` binds all three by digest, counts what was
+mapped and what was not, and states the evidence gaps.
+
+Verification does not stop at those digests. It checks the capture against the
+source, confines every path to the release directory, requires one ordered
+source selector per event and rebuilds the canonical bytes from the preserved
+input. The worked release is unsigned and its block boundary is what the hosted
+indexer reported, so a clean run establishes internal consistency rather than
+publisher authenticity or an independent chain proof.
+
+## What it ships
+
+- the standard-library [`tabularium.py`](./scripts/tabularium.py)
+  builder and offline verifier;
+- versioned event schemas [v1](./schemas/canonical-event-v1.json)
+  and [v2](./schemas/canonical-event-v2.json), plus coverage
+  schemas [v1](./schemas/coverage-manifest-v1.json) and
+  [v2](./schemas/coverage-manifest-v2.json);
+- the complete [`goldfinch-v0`](./examples/goldfinch-v0/README.md)
+  release, its data dictionary and a fresh-directory rebuild demonstration;
+- source-bound [`euler-v1-v0`](./examples/euler-v1-v0/README.md)
+  and [`euler-v2-v0`](./examples/euler-v2-v0/README.md)
+  releases with their own dictionaries and rebuild demonstrations;
+- a non-canonical [Compound v3 Phase 0 witness](./examples/compound-v3-phase0-v0/README.md)
+  rebuilt from Alexandria's verified release;
+- an [adapter guide](./docs/adding-an-adapter.md) and an
+  immutable [release policy](./docs/release-policy.md); and
+- 134 tests and an audit log
+  ([`audit/AUDIT.md`](./audit/AUDIT.md)) recording every
+  review round and fix.
+
+## Day to day
+
+**Developers.** A hosted indexer is still answering for a venue whose front end
+has gone. Preserve the response and its capture boundary, then publish a
+release whose mapping and bytes somebody else can reproduce without that
+endpoint.
+
+**Security and audit.** A dataset arrives with a digest and a claim that it was
+built from a named source. Run `verify`: it rebuilds the event bytes and checks
+the one-to-one source trace rather than trusting the release's own row count.
+
+**Finance.** A repayment record needs to be compared with another venue's
+record without erasing the difference between them. The common family makes
+the rows searchable; the venue-qualified action and native record keep the
+economic meaning attached.
+
 ## Run it
 
 From this directory, `plugins/tabularium`:


### PR DESCRIPTION
735 lines to 409.

## Why move rather than delete

I first read `## Plugins` as a third telling of maintained content and proposed
cutting it. That was wrong, and I checked before acting on it:

| | Day to day | Component list |
| --- | --- | --- |
| In the root README | 11 of 11 | 11 of 11 |
| Also in the plugin's own README | 1 | 4 |

Only Sapheneia's vignettes existed in both places. Cutting would have destroyed
around 300 lines that existed nowhere else.

## What happened instead

Each plugin README gains `## How it works`, `## What it ships` and `## Day to
day`, inserted after its `## In one line` section so the marketplace-context
block is untouched. Every root-relative link was rewritten for its new depth,
and `hypomnema` confirms all of them resolve.

The root block keeps its opening paragraph and gains a pointer. Selection still
happens in the table; invocation still happens in `## Use`.

## Verification

- Both suites green, 24 and 124.
- `hypomnema` clean across README, AGENTS, plugins, .agents and docs, which is
  what proves the link rewriting.
- Imprimatur 100 on the root README and on all eleven plugin READMEs.
- Brevitas findings per plugin README are unchanged before and after the move:
  alexandria 2, ariadne 1, lemma 1, pandects 2, probitas 3, tabularium 1. The
  move introduced none of them.

## Two notes

The `## Use` B008 remains declined, for the reason given in #111.

Restoring the Pandects law counts was not optional: a test anchors those two
sentences in both READMEs because a prose count derives from neither. I first
replaced the third sentence with a paraphrase of my own, then dropped it, since
the sourced version moved down intact.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
