### PR TITLE
Drop Brevitas's per-point fence rule and widen the fence cap

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -227,7 +227,7 @@
       "displayName": "Brevitas",
       "source": "./plugins/brevitas",
       "description": "Evidence-preserving budgets for engineering prose.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"

--- a/plugins/brevitas/.claude-plugin/plugin.json
+++ b/plugins/brevitas/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "brevitas",
   "displayName": "Brevitas",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Evidence-preserving budgets for engineering prose.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/brevitas/.codex-plugin/plugin.json
+++ b/plugins/brevitas/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brevitas",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Evidence-preserving budgets for engineering prose.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/brevitas/skills/brevitas/EVOLUTION.md
+++ b/plugins/brevitas/skills/brevitas/EVOLUTION.md
@@ -2,10 +2,11 @@ Brevitas evolution ledger
 
 Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
 
-- Current version: `brevitas-v0.1.0`
+- Current version: `brevitas-v0.2.0`
 - Frontier status: `open`
 - Frontier revision: `held-engineering-corpus`
 - Current frontier: The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked.
 - Next Fiat job: `Forward-test Brevitas across held x-ray, Solidity-auditor, gas, invariant and diff-review outputs, then add every confirmed structural bypass to the corpus without weakening evidence precedence. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.`
 
 - `brevitas-v0.1.0` | baseline | `held-engineering-corpus` | `dcff4f6b1397570468dedb18a1ebaa5f45377272bcd2f71cd69ad6818eeb0b62` | [README marketplace-context](../../README.md) | Versioning starts with the executable linter and three audit-derived corpus cases.
+- `brevitas-v0.2.0` | generation | `held-engineering-corpus` | `dcff4f6b1397570468dedb18a1ebaa5f45377272bcd2f71cd69ad6818eeb0b62` | Maintainer report: the per-point fence rule fired only on reference documents and the fence cap flagged command lists a reader is meant to copy whole | The one-fence-per-point rule is removed and the fence cap widens from 15 to 40 content lines. In one day of running the linter across this repository the per-point rule produced eight findings, none of which survived review, and obeying one duplicated ten headings. The cap keeps catching pasted dumps, including the 116-line tree it found. Frontier unchanged.

--- a/plugins/brevitas/skills/brevitas/SKILL.md
+++ b/plugins/brevitas/skills/brevitas/SKILL.md
@@ -2,7 +2,7 @@
 name: brevitas
 description: Enforce evidence-preserving structural output budgets on engineering prose. Apply automatically to chat answers and written drafts containing audit findings, security or diff review, gas analysis, `invariant` discussion, protocol analysis, or specification commentary, and on explicit $brevitas invocation. Govern volume, structure, and connective prose only. Do not apply to code comments, commit messages, or completeness-oriented specification documents.
 metadata:
-  version: "0.1.0"
+  version: "0.2.0"
 ---
 
 # Brevitas
@@ -45,7 +45,7 @@ irreducible over-budget finding with the evidence exception below.
 2. Apply these physical-line budgets:
    - Direct answer: at most 6 nonblank lines before the first list or code fence.
    - Finding: at most 5 prose lines: claim, location, mechanism, impact, fix.
-   - Code: at most one fence per point and 15 content lines per fence.
+   - Code: at most 40 content lines per fence.
 3. Give each finding this checkable shape:
 
    ```text

--- a/plugins/brevitas/skills/brevitas/scripts/brevitas.py
+++ b/plugins/brevitas/skills/brevitas/scripts/brevitas.py
@@ -122,9 +122,9 @@ def _code_fences(lines: Sequence[str]) -> tuple[list[tuple[int, int, int]], set[
             if re.match(rf"^\s*{re.escape(marker[0])}{{{len(marker)},}}\s*$", line):
                 content_length = index - opener[0] - 1
                 fences.append((opener[0], index, content_length))
-                if content_length > 15:
+                if content_length > 40:
                     issues.append(
-                        Issue(opener[0], "B006", f"code fence has {content_length} lines; maximum is 15")
+                        Issue(opener[0], "B006", f"code fence has {content_length} lines; maximum is 40")
                     )
                 opener = None
     if opener is not None:
@@ -308,21 +308,6 @@ def _point_for_line(
     return max(candidates, default=(0, "document"), key=lambda item: item[0])[1]
 
 
-def _fence_count_issues(
-    lines: Sequence[str], fences: Sequence[tuple[int, int, int]], findings: Sequence[Finding]
-) -> list[Issue]:
-    headings = [index for index, line in enumerate(lines, start=1) if HEADING_RE.match(line)]
-    list_points = [index for index, line in enumerate(lines, start=1) if TOP_LIST_RE.match(line)]
-    owners: dict[str, list[int]] = defaultdict(list)
-    for start, _, _ in fences:
-        owners[_point_for_line(start, findings, headings, list_points)].append(start)
-    return [
-        Issue(starts[1], "B008", "point contains more than one code fence")
-        for starts in owners.values()
-        if len(starts) > 1
-    ]
-
-
 def _structural_move_issues(lines: Sequence[str], code_lines: set[int]) -> list[Issue]:
     issues: list[Issue] = []
     nonblank = [index for index, line in enumerate(lines, start=1) if line.strip()]
@@ -413,7 +398,6 @@ def lint_text(
     issues.extend(section_issues)
     issues.extend(_finding_issues(lines, findings, code_lines))
     issues.extend(_table_issues(lines, code_lines))
-    issues.extend(_fence_count_issues(lines, fences, findings))
     issues.extend(_structural_move_issues(lines, code_lines))
     issues.extend(_direct_answer_issues(lines, code_lines, mode, findings, sections))
     if source_text is not None:

--- a/plugins/brevitas/tests/test_brevitas.py
+++ b/plugins/brevitas/tests/test_brevitas.py
@@ -57,8 +57,16 @@ class BrevitasTests(unittest.TestCase):
         self.assertIn("B005", self.codes(text))
 
     def test_code_fence_limit(self) -> None:
-        text = "```solidity\n" + "\n".join("x" for _ in range(16)) + "\n```\n"
+        text = "```solidity\n" + "\n".join("x" for _ in range(41)) + "\n```\n"
         self.assertIn("B006", self.codes(text))
+
+    def test_a_forty_line_fence_passes(self) -> None:
+        text = "```text\n" + "\n".join("x" for _ in range(40)) + "\n```\n"
+        self.assertNotIn("B006", self.codes(text))
+
+    def test_two_fences_under_one_point_pass(self) -> None:
+        text = "## Install\n\n```bash\na\n```\n\nthen\n\n```bash\nb\n```\n"
+        self.assertEqual([c for c in self.codes(text) if c.startswith("B00")], [])
 
     def test_small_table(self) -> None:
         text = "| a | b | c |\n|---|---|---|\n| 1 | 2 | 3 |\n"


### PR DESCRIPTION
Brevitas is a day old here and two of its rules spent that day generating
declined findings.

## The record

| Rule | Fired | Survived review |
| --- | --- | --- |
| B008 one fence per point | 8 | 0 |
| B006 fence over 15 lines | 3 | 1 |

B008's hits were all reference sections: install commands, invocation lists,
Fiat's path-variables-then-command pair. Obeying one produced the duplicate
headings that #111 had to revert. **Removed.**

B006's one real catch was the 116-line stale layout tree. Its false hits were
command lists a reader copies whole. **Cap widened 15 to 40**, which keeps the
tree catch and releases the lists.

## Mechanics

- Skill generation `brevitas-v0.1.0` to `v0.2.0`, same frontier revision and
  digest, reasoning in the ledger row.
- Plugin manifests to 0.2.0 in all three places, so installations re-fetch.
- Tests updated with the semantics: 41-line fence still fails, 40 passes, two
  fences under one heading pass. All 15 pass, the three evals pass, and the
  root suite is green.
- Re-ran the linter over every document that fought it today: all clean now,
  including `fiat/SKILL.md`, whose B008 predated this session.

Probitas's README carries two pre-existing B011 table findings. Different
rule, untouched here.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
