### PR TITLE
Reopen Fiat's frontier by epoch for the phase-skill integration run

### DIFF
--- a/plugins/hexaemeron/skills/fiat/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/fiat/EVOLUTION.md
@@ -2,11 +2,11 @@
 
 Policy: [../VERSIONING.md](../VERSIONING.md)
 
-- Current version: `fiat-v2.3.0`
-- Frontier status: `mature`
-- Frontier revision: `installed-path-and-maturity-proof`
-- Current frontier: Fiat's receipt-backed controller is unit-tested, and this delivery exercises its installed-path resolution and terminal maturity rule together from a packaged plugin.
-- Next Fiat job: `None -- mature`
+- Current version: `fiat-v2.3.1`
+- Frontier status: `open`
+- Frontier revision: `phase-skill-integration`
+- Current frontier: Fiat's phases name the six sibling skills only as notes, and its own references still carry the study and runbook content rules that Protasis supersedes.
+- Next Fiat job: Fold the phase skills into the loop as contract: Protasis replaces the study and runbook references, the non-Solidity audit round runs the phylax, ephoros and hypomnema lints, the prose phase consults Hypomnema before the masks, and every surface describing the loop is reconciled and re-linted. Accepted when Fiat names no study or runbook content rule of its own, the lint runs are receipted per round, both suites pass, and the marketplace prose agrees across surfaces.
 
 ## History
 
@@ -16,3 +16,4 @@ Policy: [../VERSIONING.md](../VERSIONING.md)
 | `fiat-v1.2.0` | generation | `installed-path-and-maturity-proof` | `a30bea33332e20c6780a77f5d82bc899d7004b8d09321628777d36289bd128d0` | [skills#74](https://github.com/wildcat-finance/skills/issues/74) | Made publish terminal only after final staging, push, merge, branch cleanup where permitted, and closure of any recorded task issue. |
 | `fiat-v2.2.0` | evolution | `installed-path-and-maturity-proof` | `17c94c70b434ea1cbc9c3cd6ff5f3054972af08f8e027b7ea9850f5e06695f77` | [installed delivery proof](../../docs/fiat-installed-path-and-maturity-proof/proof.md) | Closes the held frontier after recording the installed controller path and passing the installed and checkout test suites; later delivery receipts remain governed by the live controller. |
 | `fiat-v2.3.0` | generation | `installed-path-and-maturity-proof` | `17c94c70b434ea1cbc9c3cd6ff5f3054972af08f8e027b7ea9850f5e06695f77` | Maintainer report: stacked runs on a named base silently retargeted to the default branch | The push phase now passes the base recorded at `init` to `gh pr create` instead of letting GitHub default it, so a run started from a named branch merges back into that branch. Frontier unchanged and still mature. |
+| `fiat-v2.3.1` | epoch | `phase-skill-integration` | `71a670a73c5566775210abd42395263bc129bf66db2139ec209ab144a7e435eb` | Maintainer reopening: six sibling phase skills landed in [skills#103](https://github.com/wildcat-finance/skills/pull/103) and Protasis's held job supersedes two Fiat references, so the closed frontier's premise that the loop's content rules live in Fiat no longer holds | Reopens the mature frontier by epoch at the maintainer's direction, for the run that folds the phase skills into the loop. |

--- a/plugins/hexaemeron/skills/fiat/SKILL.md
+++ b/plugins/hexaemeron/skills/fiat/SKILL.md
@@ -7,7 +7,7 @@ description: >
   or report a Hexaemeron or Fiat delivery, including /hexaemeron:fiat forms.
   Do not infer activation from a similar task.
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
 ---
 
 # Fiat


### PR DESCRIPTION
Bookkeeping the gate demands before the run can start.

Fiat's ledger was `mature`, and its own maturity gate refuses a frontier run
until a maintainer-backed epoch reopening is recorded. The evidence: #103
changed the plugin's structure around Fiat — six sibling skills its phases
should consult, and Protasis's held job explicitly supersedes
`references/study.md` and `references/runbook-format.md`.

- `fiat-v2.3.0` → `fiat-v2.3.1`, axis epoch, counters otherwise retained.
- Status `open`, revision `phase-skill-integration`, held job with acceptance
  condition on the header, digest recomputed.
- Frontmatter version matches the ledger.

Both suites green. The evolution increment (to `fiat-v3.3.1`) happens once the
run completes, per the contract.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
