### PR TITLE
The loop names the phase skills as contract

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -892,3 +892,15 @@ No findings. The amended commit carries both provenance trailers, the lint
 battery is clean over the fixed tree, and both suites pass.
 
 Leads not pursued: none.
+
+## Step 2, round 1 -- 2026-08-18
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+No findings. The three lints exit clean over the changed tree; the diff
+touches two references and one phase note, none of which a test pins; the new
+lint commands resolve through `$PLUGIN_ROOT` exactly as the masks already do
+in the same file; and both suites pass. Root 24/24, hexaemeron 124/124.
+
+Leads not pursued: none.

--- a/plugins/hexaemeron/skills/fiat/SKILL.md
+++ b/plugins/hexaemeron/skills/fiat/SKILL.md
@@ -205,9 +205,12 @@ skills that ran to the receipt. Repo copies are committed later, in step 1 of
 the runbook, after the prose pass.
 
 **Implementation.** Pick the construction that takes the least effort to
-comprehend, then stop. Consult `phylax` for the boundaries the step introduces,
-`ephoros` for what it must emit once it runs unattended, and `metron` before
-any change made in the name of speed. The runbook step is the yardstick: reread it before
+comprehend, then stop. The step runs under the phase skills: `phylax` names
+the boundaries the step introduces and the control each needs, `ephoros` names
+what it must emit once it runs unattended, `metron` refuses any change made in
+the name of speed without a recorded before and after, and a failure worked
+mid-step follows `elenchus` rather than a guess. Their lints run in every
+audit round, so meeting them here is cheaper than meeting them there. The runbook step is the yardstick: reread it before
 declaring the step complete, and do not add anything it does not ask for.
 Branch as `step-<n>-<slug>` from the base named by `config git.step_base`
 (`chain` means branch from the previous step's branch; `base` means branch

--- a/plugins/hexaemeron/skills/fiat/references/audit-loop.md
+++ b/plugins/hexaemeron/skills/fiat/references/audit-loop.md
@@ -66,10 +66,25 @@ phase.
 ## Non-Solidity steps
 
 When a step touches no Solidity and no configured skill applies, the round
-is still real: review the diff for the risk register's concerns, log the
-result, record the round. The suite waiver in the `security_suite` receipt
-covers why the Pashov pair did not run; it does not excuse skipping the
-look.
+is still real, and it has a mechanical part. Run the three bundled lints
+against the changed tree and require exit 0 from each:
+
+```text
+python3 "$PLUGIN_ROOT/skills/phylax/scripts/phylax.py" <changed paths>
+python3 "$PLUGIN_ROOT/skills/ephoros/scripts/ephoros.py" <changed paths>
+python3 "$PLUGIN_ROOT/skills/hypomnema/scripts/hypomnema.py" <changed docs>
+```
+
+A non-zero exit is a finding like any other: log it, fix it on the stacked
+branch, and run the next round against the fixed tree. Then review the diff
+for the risk register's concerns the lints cannot see, log the result, and
+record the round with the lint outcomes in the log entry. The suite waiver in
+the `security_suite` receipt covers why the Pashov pair did not run; it does
+not excuse skipping the look, and it does not excuse skipping the lints.
+
+When a round surfaces a failure -- a test gone red, a lint that will not come
+clean, behaviour that stopped matching -- work it under `elenchus`: reproduce,
+reduce, fix the mechanism, and guard it before the next round.
 
 ## Honesty
 

--- a/plugins/hexaemeron/skills/fiat/references/prose-pass.md
+++ b/plugins/hexaemeron/skills/fiat/references/prose-pass.md
@@ -15,18 +15,24 @@ bundled in this plugin, so no external install is involved.
 
 ## Order
 
-1. **Lint.** Run the bundled script on each file:
+1. **Record.** Apply `hypomnema` (read `$PLUGIN_ROOT/skills/hypomnema/SKILL.md`)
+   before touching a word: decide which decisions this step made that earn a
+   written reason, put each in the file its rules name, and run its pointer
+   lint over the changed documents so nothing shipped links to something
+   absent. A record pointing nowhere fails the phase the same way a hard lint
+   hit does.
+2. **Lint.** Run the bundled script on each file:
    `python3 "$PLUGIN_ROOT/skills/imprimatur/scripts/imprimatur.py" <file>`.
    Hard hits are defects: rewrite the sentence, never substitute a
    neighbour from the same family. Keep every qualifier that carries
    scope, risk, or legal meaning.
-2. **Voice.** Apply the `vulgate` mask (read
+3. **Voice.** Apply the `vulgate` mask (read
    `$PLUGIN_ROOT/skills/vulgate/SKILL.md` and follow it -- `$PLUGIN_ROOT`
    as defined in the entry skill): neutral
    register unless the document's content demands serious. The mask changes
    surface only; every fact, number, commitment, and caveat survives
    verbatim, and the spelling convention stays consistent.
-3. **Re-lint.** The mask can reintroduce a marker; run the lint once more
+4. **Re-lint.** The mask can reintroduce a marker; run the lint once more
    and settle any new hits.
 
 ## PR text


### PR DESCRIPTION
Step 1 made Protasis the content authority for two phases. This step gives the
other four their standing.

The non-Solidity audit round gains a mechanical part: the phylax, ephoros and
hypomnema lints run against the changed tree, exit 0 required, a non-zero exit
logged and fixed like any other finding. A failure surfaced mid-round is worked
under elenchus rather than by guessing. The prose pass opens with hypomnema,
deciding what the step must record and running its pointer lint, before the
masks touch a word. Fiat's implement note binds metron's rule, no
performance-motivated change without a recorded before and after, and points a
mid-step failure at elenchus.

Hypomnema's decision for this step: it made none that earn a record. It states
where existing contracts apply; the reasons live in the ledgers already.

The audit record lives in `audit/AUDIT.md`, step 2, round 1, clean. Proof:
both suites, the three lints, imprimatur at 100 and the brevitas linter clean
on all three touched files.

<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
