### PR TITLE
Every surface agrees

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
       "displayName": "Hexaemeron",
       "source": "./plugins/hexaemeron",
       "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose, specification, debugging, hardening, telemetry and measurement skills.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -904,3 +904,17 @@ lint commands resolve through `$PLUGIN_ROOT` exactly as the masks already do
 in the same file; and both suites pass. Root 24/24, hexaemeron 124/124.
 
 Leads not pursued: none.
+
+## Step 3, round 1 -- 2026-08-18
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+No findings. The lint battery is clean over the changed tree; the diff touches
+two READMEs' prose, one manifest description and three version fields; the
+short description four surfaces must agree on is untouched, and the marketplace
+prose tests hold. Root 24/24, hexaemeron 124/124.
+
+Leads not pursued: the root README's one-line Hexaemeron entry says nothing
+about the phase skills. It also says nothing false, and the status table's
+"Use it for" cell already names them, so no change.

--- a/plugins/hexaemeron/.claude-plugin/plugin.json
+++ b/plugins/hexaemeron/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hexaemeron",
   "displayName": "Hexaemeron",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose, specification, debugging, hardening, telemetry and measurement skills.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/hexaemeron/.codex-plugin/plugin.json
+++ b/plugins/hexaemeron/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hexaemeron",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose, specification, debugging, hardening, telemetry and measurement skills.",
   "author": {
     "name": "Wildcat Labs",
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Hexaemeron",
     "shortDescription": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose, specification, debugging, hardening, telemetry and measurement skills.",
-    "longDescription": "Takes a topic from nothing to a working prototype through a receipt-backed controller: a linted study, a runbook of discrete steps, then per step the simplest satisfying implementation, a security loop over the vendored Pashov suite, a prose pass through Imprimatur and Vulgate, and a merged pull request with its task issue closed. Six further skills hold each phase to a standard, four of them with an executable check. Kronos can rank eligible held frontiers and repeat complete Fiat runs until no worthwhile frontier remains.",
+    "longDescription": "Takes a topic from nothing to a working prototype through a receipt-backed controller: a study and runbook held to Protasis's contract, then per step the simplest satisfying implementation, audit rounds over the vendored Pashov suite with the bundled phylax, ephoros and hypomnema lints covering what ships no Solidity, a prose pass through Hypomnema, Imprimatur and Vulgate, and a merged pull request with its task issue closed. Six further skills hold each phase to a standard, four of them with an executable check. Kronos can rank eligible held frontiers and repeat complete Fiat runs until no worthwhile frontier remains.",
     "developerName": "Wildcat Labs",
     "category": "Developer Tools",
     "capabilities": [],

--- a/plugins/hexaemeron/README.md
+++ b/plugins/hexaemeron/README.md
@@ -60,11 +60,11 @@ Let there be light. A deterministic controller (`hexctl`) decides what comes nex
 
 | Day | Phase | What happens |
 | --- | --- | --- |
-| 1 | `study` | Study the topic; write `.hexaemeron/study.md`, linted |
-| 2 | `runbook` | Divide the work into discrete, self-contained steps |
+| 1 | `study` | Study the topic; write `.hexaemeron/study.md` to `protasis`'s contract, linted |
+| 2 | `runbook` | Divide the work into steps that meet `protasis`'s schema: discrete, self-contained, provable exits |
 | 3-4 | `implement` | Build the step, least mental load that satisfies the runbook |
-| 5 | `audit` | The vendored Pashov suite in rounds until clean or reasoned out; fixes on a stacked branch |
-| 6 | `prose` | The `imprimatur` lint, then the `vulgate` voice mask, on every document and the PR text |
+| 5 | `audit` | The vendored Pashov suite in rounds until clean or reasoned out; non-Solidity rounds run the `phylax`, `ephoros` and `hypomnema` lints; fixes on a stacked branch |
+| 6 | `prose` | `hypomnema` decides what gets recorded, then the `imprimatur` lint and the `vulgate` mask, on every document and the PR text |
 | rest | `push` | Stage and commit the final diff, push, merge the PR, clean up the branch, and close the task issue |
 
 Days 3 through the rest repeat per step. The sixth day makes the prose in


### PR DESCRIPTION
Steps 1 and 2 changed what the loop is; this step makes every description of
it say so. The plugin README's loop table now names the contract each phase
runs under: the study and runbook held to protasis, non-Solidity audit rounds
running the phylax, ephoros and hypomnema lints, and the prose pass opening
with hypomnema before the masks. The codex long description tells a Codex user
the same thing. The plugin version moves to 1.2.0 in all three manifests, so
installations have a reason to re-fetch, which one version bump already taught
this repository today.

Hypomnema's decision for this step: no new record. The reasons live in the two
merged steps and the ledgers.

The audit record lives in `audit/AUDIT.md`, step 3, round 1, clean. Proof:
both suites, the three lints, imprimatur and the brevitas linter over the
touched README.

<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
