### PR TITLE
Cold read, then close the ledger

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -918,3 +918,15 @@ prose tests hold. Root 24/24, hexaemeron 124/124.
 Leads not pursued: the root README's one-line Hexaemeron entry says nothing
 about the phase skills. It also says nothing false, and the status table's
 "Use it for" cell already names them, so no change.
+
+## Step 4, round 1 -- 2026-08-18
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+No findings. The lint battery is clean, the ledger axes hold under both
+suites, the evolution row's digest matches the recomputed header, and the
+cold read's one defect, a hand-off line predating the phase skills, was fixed
+in the step commit. Root 24/24, hexaemeron 124/124.
+
+Leads not pursued: none.

--- a/plugins/hexaemeron/skills/fiat/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/fiat/EVOLUTION.md
@@ -2,11 +2,11 @@
 
 Policy: [../VERSIONING.md](../VERSIONING.md)
 
-- Current version: `fiat-v2.3.1`
+- Current version: `fiat-v3.3.1`
 - Frontier status: `open`
-- Frontier revision: `phase-skill-integration`
-- Current frontier: Fiat's phases name the six sibling skills only as notes, and its own references still carry the study and runbook content rules that Protasis supersedes.
-- Next Fiat job: Fold the phase skills into the loop as contract: Protasis replaces the study and runbook references, the non-Solidity audit round runs the phylax, ephoros and hypomnema lints, the prose phase consults Hypomnema before the masks, and every surface describing the loop is reconciled and re-linted. Accepted when Fiat names no study or runbook content rule of its own, the lint runs are receipted per round, both suites pass, and the marketplace prose agrees across surfaces.
+- Frontier revision: `receipted-lint-rounds`
+- Current frontier: The loop runs under the phase skills as contract, and the lint outcomes a non-Solidity audit round depends on live only as prose in the audit log.
+- Next Fiat job: Teach hexctl to take the three lint results as structured fields on audit-round and to refuse a non-Solidity round without them. Accepted when a round missing a lint result is rejected in the controller's own tests, a complete round records all three, and both suites pass.
 
 ## History
 
@@ -17,3 +17,4 @@ Policy: [../VERSIONING.md](../VERSIONING.md)
 | `fiat-v2.2.0` | evolution | `installed-path-and-maturity-proof` | `17c94c70b434ea1cbc9c3cd6ff5f3054972af08f8e027b7ea9850f5e06695f77` | [installed delivery proof](../../docs/fiat-installed-path-and-maturity-proof/proof.md) | Closes the held frontier after recording the installed controller path and passing the installed and checkout test suites; later delivery receipts remain governed by the live controller. |
 | `fiat-v2.3.0` | generation | `installed-path-and-maturity-proof` | `17c94c70b434ea1cbc9c3cd6ff5f3054972af08f8e027b7ea9850f5e06695f77` | Maintainer report: stacked runs on a named base silently retargeted to the default branch | The push phase now passes the base recorded at `init` to `gh pr create` instead of letting GitHub default it, so a run started from a named branch merges back into that branch. Frontier unchanged and still mature. |
 | `fiat-v2.3.1` | epoch | `phase-skill-integration` | `71a670a73c5566775210abd42395263bc129bf66db2139ec209ab144a7e435eb` | Maintainer reopening: six sibling phase skills landed in [skills#103](https://github.com/wildcat-finance/skills/pull/103) and Protasis's held job supersedes two Fiat references, so the closed frontier's premise that the loop's content rules live in Fiat no longer holds | Reopens the mature frontier by epoch at the maintainer's direction, for the run that folds the phase skills into the loop. |
+| `fiat-v3.3.1` | evolution | `receipted-lint-rounds` | `f6ab990ae6f7c8c720e923cc0c661ee6025d03015cfb05baa23dd47aa2f1b76f` | [skills#116](https://github.com/wildcat-finance/skills/pull/116), [skills#117](https://github.com/wildcat-finance/skills/pull/117), [skills#118](https://github.com/wildcat-finance/skills/pull/118) | Completes the reopened frontier: Protasis holds the study and runbook contract alone, the non-Solidity audit round runs the three bundled lints as its mechanical part, the prose pass opens with Hypomnema, and every surface describing the loop says so. |

--- a/plugins/hexaemeron/skills/fiat/SKILL.md
+++ b/plugins/hexaemeron/skills/fiat/SKILL.md
@@ -7,7 +7,7 @@ description: >
   or report a Hexaemeron or Fiat delivery, including /hexaemeron:fiat forms.
   Do not infer activation from a similar task.
 metadata:
-  version: "2.3.1"
+  version: "3.3.1"
 ---
 
 # Fiat
@@ -20,7 +20,9 @@ skills. Its version, held frontier, next job, and maturity state live in
 resuming work intended to advance Fiat itself.
 
 **Use another tool when.** Run `imprimatur` or `vulgate` directly for prose,
-and the bundled Pashov skills directly for standalone Solidity review.
+the bundled Pashov skills directly for standalone Solidity review, and any
+phase skill on its own when the question is its and the controller is not
+wanted.
 
 **Current frontier.** The ledger above is authoritative. Never substitute
 Hexaemeron's plugin-wide Solidity frontier for Fiat's own held target.


### PR DESCRIPTION
The cold read found one thing a stranger would trip on: Fiat's hand-off line
still described a plugin with two prose masks and a Solidity suite, as though
the six phase skills did not exist. It now names them. Every other touched
document scored 100 on imprimatur and exits clean from the brevitas linter
without changes.

Fiat's ledger records the completed evolution. The frontier reopened by epoch
in skills#115 closes at `fiat-v3.3.1`: Protasis holds the study and runbook
contract alone, the non-Solidity audit round runs the phylax, ephoros and
hypomnema lints as its mechanical part, the prose pass opens with Hypomnema,
and every surface describing the loop agrees. The held next job is structured
lint receipts: hexctl's audit-round command taking the three results as fields
and refusing a non-Solidity round without them.

The audit record lives in `audit/AUDIT.md`, step 4, round 1, clean. Proof:
both suites, the three lints, and the full imprimatur and brevitas battery
over the run's touched set.

<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
