### PR TITLE
Stack the steps, merge once

### DIFF
--- a/plugins/hexaemeron/.codex-plugin/plugin.json
+++ b/plugins/hexaemeron/.codex-plugin/plugin.json
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Hexaemeron",
     "shortDescription": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose, specification, debugging, hardening, telemetry and measurement skills.",
-    "longDescription": "Takes a topic from nothing to a working prototype through a receipt-backed controller: a study and runbook held to Protasis's contract, then per step the simplest satisfying implementation, audit rounds over the vendored Pashov suite with the bundled phylax, ephoros and hypomnema lints covering what ships no Solidity, a prose pass through Hypomnema, Imprimatur and Vulgate, and a merged pull request with its task issue closed. Six further skills hold each phase to a standard, four of them with an executable check. Kronos can rank eligible held frontiers and repeat complete Fiat runs until no worthwhile frontier remains.",
+    "longDescription": "Takes a topic from nothing to a working prototype through a receipt-backed controller: a study and runbook held to Protasis's contract, then per step the simplest satisfying implementation, audit rounds over the vendored Pashov suite with the bundled phylax, ephoros and hypomnema lints covering what ships no Solidity, a prose pass through Hypomnema, Imprimatur and Vulgate, and one stacked pull request per step that comes down in order onto a single run branch, which merges into the base once with its task issue closed. Six further skills hold each phase to a standard, four of them with an executable check. Kronos can rank eligible held frontiers and repeat complete Fiat runs until no worthwhile frontier remains.",
     "developerName": "Wildcat Labs",
     "category": "Developer Tools",
     "capabilities": [],

--- a/plugins/hexaemeron/README.md
+++ b/plugins/hexaemeron/README.md
@@ -17,7 +17,8 @@ Let there be light.
 One command that takes a topic from nothing to a working prototype:
 study, runbook, then for each runbook step the simplest implementation that
 satisfies it, a security loop that runs until clean or
-reasoned out, a prose pass in the house voice, and a merged PR. Every phase
+reasoned out, a prose pass in the house voice, and a reviewable pull request.
+The steps stack; the stack lands on the base in one merge. Every phase
 leaves a receipt in a hash-chained ledger, so the run survives context
 resets, crashes, and week-long pauses -- resume is the same command.
 
@@ -34,7 +35,14 @@ Let there be light. A deterministic controller (`hexctl`) decides what comes nex
 3. Implement the least complicated construction that satisfies each runbook step.
 4. Run the vendored Pashov suite (`x-ray`, `solidity-auditor`, `fizz`) in rounds until a round comes back clean or the remaining leads are judged not worth another pass, fixes on a stacked branch.
 5. Rewrite every shipped document and the PR text through the bundled `imprimatur` lint and `vulgate` voice mask.
-6. Push the PR and move to the next step.
+6. Push the step branch, open its pull request against the step below it, and move to the next step.
+7. Once every step is pushed, merge the stack into the run branch in order, then merge the run branch into the base once.
+
+A run works on one integration branch cut from the base (`fiat/<run slug>` by
+default) with a chain of descriptively named step branches on top of it. Each
+step's pull request targets the step below it, step 1 targets the run branch,
+and nothing merges until the whole stack is ready. The base sees exactly one
+merge per run.
 
 ## What it ships
 
@@ -65,7 +73,8 @@ Let there be light. A deterministic controller (`hexctl`) decides what comes nex
 | 3-4 | `implement` | Build the step, least mental load that satisfies the runbook |
 | 5 | `audit` | The vendored Pashov suite in rounds until clean or reasoned out; non-Solidity rounds run the `phylax`, `ephoros` and `hypomnema` lints; fixes on a stacked branch |
 | 6 | `prose` | `hypomnema` decides what gets recorded, then the `imprimatur` lint and the `vulgate` mask, on every document and the PR text |
-| rest | `push` | Stage and commit the final diff, push, merge the PR, clean up the branch, and close the task issue |
+| rest | `push` | Stage and commit the final diff, push the step branch, and open its stacked pull request |
+| -- | `integrate` | Merge the stack into the run branch in step order, then the run branch into the base once, and close the task issue |
 
 Days 3 through the rest repeat per step. The sixth day makes the prose in
 a human image, which is roughly the joke the name is carrying.
@@ -121,9 +130,12 @@ The receipts are opinionated where the process is: the audit phase will not
 open without a resolved (or explicitly waived) security suite; it will not
 close with findings open unless a reasoned no-further-leads verdict is
 recorded; a prose receipt missing either configured skill is rejected; and a
-push receipt requires the final head, a merged PR, and closure of any recorded
-task issue. Fiat creates no GitHub issue unless the user or target repository
-requires one.
+push receipt requires the final head and a pull request aimed at the step below
+it in the stack, and refuses a merge commit outright. Merges are the integrate
+phase's business: the controller hands them out one step at a time, in order,
+and the run is not done until the run branch has landed on the base and any
+recorded task issue is closed. Fiat creates no GitHub issue unless the user or
+target repository requires one.
 
 ## Skill versions and the stopping rule
 
@@ -154,8 +166,8 @@ Per-run, via `hexctl config set <path> <value>`:
 | `audit.stacked_suffix` | `--audit` | Fix branch: `<step-branch>--audit` |
 | `audit.fold` | `false` | Merge the stacked branch into the step branch on close |
 | `audit.log_path` | `audit/AUDIT.md` | Where rounds append |
-| `git.base` | `main` | Starting ref |
-| `git.step_base` | `chain` | Steps branch from the prior step (`base` for independent) |
+| `git.base` | `main` | Starting ref, and the only branch a run merges into |
+| `git.run_branch_prefix` | `fiat/` | Run branch is this plus the topic slug, unless `init --run-branch` names one |
 
 The Pashov suite -- `x-ray`, `solidity-auditor`, and `fizz` -- is based on
 https://github.com/pashov/skills tag `v28062026` under the MIT licence. Each

--- a/plugins/hexaemeron/agents/mason.md
+++ b/plugins/hexaemeron/agents/mason.md
@@ -31,9 +31,11 @@ color: green
 You implement exactly one runbook step.
 
 You will be given: the runbook step (goal, entry, exit, files, tests), the
-branch name (`step-<n>-<slug>`), and the ref to
-branch from. Create or check out the branch, confirm the entry state
-builds and its tests pass, then work.
+branch name to create, and the ref to branch from -- both taken verbatim from
+the controller's `implement` directive, which chains this step onto the one
+below it. Use those exact names; do not shorten, renumber, or invent one.
+Create or check out the branch, confirm the entry state builds and its tests
+pass, then work.
 
 Rules of construction: choose the implementation that takes the least
 mental load to comprehend and still meets the runbook step -- fewest moving
@@ -42,7 +44,8 @@ does not ask for. Reread the step before every significant choice and again
 before declaring it complete; it is the yardstick. Write
 the tests the step schema names and keep the tree green.
 
-Commit in coherent units. Do not push, do not open a PR, and do not touch
-the controller -- the orchestrator owns all of that. Report back: branch,
+Commit in coherent units. Do not push, do not open a PR, do not merge
+anything, and do not touch the controller -- the orchestrator owns all of
+that. Report back: branch,
 head commit sha, test command and its pass count, and anything the step asked
 for that you deliberately deferred (with why).

--- a/plugins/hexaemeron/agents/scribe.md
+++ b/plugins/hexaemeron/agents/scribe.md
@@ -32,7 +32,8 @@ You run the prose pass for one step: every prose artefact the step ships,
 plus its PR title and body.
 
 You will be given: the file list (README, runbooks, glossaries, primers,
-docs, committed study/runbook copies where applicable), the PR draft path
+docs, committed study/runbook copies where applicable), the branch this step
+stacks on (the PR body says so), the PR draft path
 (`.hexaemeron/steps/<n>/pr.md`), and the plugin root. Both masks are files
 under that root -- run the lint with
 `python3 "<plugin-root>/skills/imprimatur/scripts/imprimatur.py" <file>`

--- a/plugins/hexaemeron/agents/warden.md
+++ b/plugins/hexaemeron/agents/warden.md
@@ -30,7 +30,8 @@ color: red
 
 You run exactly one audit round on one step's branch.
 
-You will be given: the step branch, the stacked branch name, the resolved
+You will be given: the step branch (which already carries every step below
+it in the stack), the stacked branch name, the resolved
 security suite identifiers, the plugin root, the audit log path, the round
 number, and the risk register seed from the study. The suite is vendored:
 read `<plugin-root>/skills/x-ray/SKILL.md`, then

--- a/plugins/hexaemeron/skills/fiat/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/fiat/EVOLUTION.md
@@ -2,7 +2,7 @@
 
 Policy: [../VERSIONING.md](../VERSIONING.md)
 
-- Current version: `fiat-v3.3.1`
+- Current version: `fiat-v3.4.1`
 - Frontier status: `open`
 - Frontier revision: `receipted-lint-rounds`
 - Current frontier: The loop runs under the phase skills as contract, and the lint outcomes a non-Solidity audit round depends on live only as prose in the audit log.
@@ -18,3 +18,4 @@ Policy: [../VERSIONING.md](../VERSIONING.md)
 | `fiat-v2.3.0` | generation | `installed-path-and-maturity-proof` | `17c94c70b434ea1cbc9c3cd6ff5f3054972af08f8e027b7ea9850f5e06695f77` | Maintainer report: stacked runs on a named base silently retargeted to the default branch | The push phase now passes the base recorded at `init` to `gh pr create` instead of letting GitHub default it, so a run started from a named branch merges back into that branch. Frontier unchanged and still mature. |
 | `fiat-v2.3.1` | epoch | `phase-skill-integration` | `71a670a73c5566775210abd42395263bc129bf66db2139ec209ab144a7e435eb` | Maintainer reopening: six sibling phase skills landed in [skills#103](https://github.com/wildcat-finance/skills/pull/103) and Protasis's held job supersedes two Fiat references, so the closed frontier's premise that the loop's content rules live in Fiat no longer holds | Reopens the mature frontier by epoch at the maintainer's direction, for the run that folds the phase skills into the loop. |
 | `fiat-v3.3.1` | evolution | `receipted-lint-rounds` | `f6ab990ae6f7c8c720e923cc0c661ee6025d03015cfb05baa23dd47aa2f1b76f` | [skills#116](https://github.com/wildcat-finance/skills/pull/116), [skills#117](https://github.com/wildcat-finance/skills/pull/117), [skills#118](https://github.com/wildcat-finance/skills/pull/118) | Completes the reopened frontier: Protasis holds the study and runbook contract alone, the non-Solidity audit round runs the three bundled lints as its mechanical part, the prose pass opens with Hypomnema, and every surface describing the loop says so. |
+| `fiat-v3.4.1` | generation | `receipted-lint-rounds` | `f6ab990ae6f7c8c720e923cc0c661ee6025d03015cfb05baa23dd47aa2f1b76f` | Maintainer report: every step branch merged straight into `main` under names like `step1`, so a single run left a pile of merges on the default branch | A run now works on one descriptively named integration branch off the base, with step branches chained onto each other and their pull requests stacked on the step below. Nothing merges while the steps run: the new `integrate` phase brings the stack down into the run branch in step order, then merges the run branch into the base exactly once and closes any recorded task issue. Frontier unchanged. |

--- a/plugins/hexaemeron/skills/fiat/SKILL.md
+++ b/plugins/hexaemeron/skills/fiat/SKILL.md
@@ -7,7 +7,7 @@ description: >
   or report a Hexaemeron or Fiat delivery, including /hexaemeron:fiat forms.
   Do not infer activation from a similar task.
 metadata:
-  version: "3.3.1"
+  version: "3.4.1"
 ---
 
 # Fiat
@@ -102,8 +102,11 @@ the second.
    run the read-only preflight checks below, then `hexctl init --topic
    "<topic>" --base <ref>`, record the post-init receipts, and enter the loop.
    `--base` defaults to `main`; honour any branch, repo, or commit the user
-   named as the starting point, and carry that same ref through to the pull
-   request created in the push phase.
+   named as the starting point. `init` also names the run branch, printed and
+   held in state: one integration branch for the whole run, cut from the base.
+   Create it before the first step (`git checkout -b <run branch> <base>`) and
+   push it. Pass `--run-branch <name>` only when the user wants a different
+   name than the topic slug.
 
 ## Frontier maturity gate
 
@@ -160,6 +163,30 @@ without pretending that it changes Fiat or another skill.
    '"<url>"'`. Do not invent an issue otherwise.
 6. Nothing else.
 
+## Branches, stacks, and the one merge
+
+A run is one integration branch off the base and a stack of step branches on
+top of it. The controller names every branch and every pull request base; take
+them from the directive rather than inventing a name.
+
+```text
+main ─── fiat/<run slug>                                  the run branch
+          └── fiat/<run slug>-step-1-<slug>               PR -> run branch
+               └── fiat/<run slug>-step-2-<slug>          PR -> step 1
+                    └── fiat/<run slug>-step-3-<slug>     PR -> step 2
+```
+
+Each step branches from the step below it and its pull request targets that
+same branch, so a reviewer sees one step's diff and nothing else. Step branches
+are siblings of the run branch, never nested under it: git cannot hold
+`fiat/x` and `fiat/x/step-1` as refs at once.
+
+Nothing merges while the steps run. The stack stays open, each pull request
+reviewable on its own, until every step is pushed. Then the `integrate` phase
+merges the stack into the run branch in step order and merges the run branch
+into the base exactly once. One merge into `main` per run, at the end, carrying
+the whole delivery.
+
 ## The loop
 
 Repeat until `next` returns `done`, `halted`, or `audit-verdict`:
@@ -179,7 +206,9 @@ Act on the single directive it prints, then receipt it. The directory:
 | `close-audit` | Last round was clean; close the phase | [audit-loop.md](references/audit-loop.md) | `done audit [--fixes-ref <ref>]` |
 | `resolve-security-suite` | Suite receipt missing; resolve or waive | preflight step 4 | `record security_suite ...` |
 | `prose` | Rewrite every prose artefact and draft the PR text | [prose-pass.md](references/prose-pass.md) | `done prose --files <n> --skills <csv>` |
-| `push` | Stage and commit final changes, push, open and merge the PR, delete the task branch where allowed, and close any recorded task issue | [push-discipline.md](references/push-discipline.md) | `done push --pr-url <url> --head-commit <sha> --merge-commit <sha> [--closed-issue-url <url>]` |
+| `push` | Stage and commit final changes, push the step branch, open its stacked PR against `pr_base`, and leave it open | [push-discipline.md](references/push-discipline.md) | `done push --pr-url <url> --head-commit <sha> --pr-base <ref>` |
+| `merge-step` | Merge the named step's PR into the run branch, bottom of the stack first | [push-discipline.md](references/push-discipline.md) | `done merge-step --step <n> --merge-commit <sha>` |
+| `integrate` | Open and merge one PR from the run branch into the base, then clean up and close any recorded task issue | [push-discipline.md](references/push-discipline.md) | `done integrate --pr-url <url> --merge-commit <sha> [--closed-issue-url <url>]` |
 | `audit-verdict` | Max rounds hit with findings open | ask the user | `done audit --no-further-leads --reason ...` or `halt --reason ...` |
 | `halted` | Report the reason; wait for the user | -- | `resume --note ...` when cleared |
 | `done` | Final report | below | -- |
@@ -214,9 +243,10 @@ the name of speed without a recorded before and after, and a failure worked
 mid-step follows `elenchus` rather than a guess. Their lints run in every
 audit round, so meeting them here is cheaper than meeting them there. The runbook step is the yardstick: reread it before
 declaring the step complete, and do not add anything it does not ask for.
-Branch as `step-<n>-<slug>` from the base named by `config git.step_base`
-(`chain` means branch from the previous step's branch; `base` means branch
-from `config git.base`).
+The `implement` directive carries `branch` and `branch_from`: cut that exact
+branch from that exact ref. Step 1 branches from the run branch, every later
+step from the step below it, so each step builds on the reviewed tree of the
+one before without waiting for a merge.
 
 **Audit.** `elenchus` works any failure a round surfaces down to its cause.
 The longest phase by design. One round is the full suite: `x-ray`
@@ -237,13 +267,21 @@ constant. Both are bundled: run the lint script by path, read the mask's
 SKILL.md by path and apply it. The receipt refuses a skills list missing
 either configured id.
 
-**Push.** Stage and commit every intended final change, push the branch, and
-open a PR using the prepared prose. Do not add an issue reference unless one
-was independently supplied or required by higher-priority repository policy.
-Wait for gates, merge without bypassing them, remove the task branch where
-allowed, and close any recorded task issue. Receipt the final head SHA, PR URL,
-merge SHA, and closed issue URL. A routine publish or closure action is not a
-handoff to a human.
+**Push.** Stage and commit every intended final change, push the step branch,
+and open its pull request against the `pr_base` the directive names, using the
+prepared prose. Wait for its gates but leave it open: a step's work lands in the
+integrate phase, not here. Do not add an issue reference unless one was
+independently supplied or required by higher-priority repository policy. Receipt
+the head SHA, PR URL, and PR base.
+
+**Integrate.** Once every step is pushed, the stack comes down in order. Merge
+step 1's pull request into the run branch, delete its branch, and let the next
+step's pull request retarget onto the run branch; receipt each merge before
+starting the next. With the stack landed, open one pull request from the run
+branch into the recorded base, wait for its gates, merge it without bypassing
+them, delete the run branch where policy allows, and close any recorded task
+issue. That merge is the only one into the base for the whole run. A routine
+publish or closure action is not a handoff to a human.
 
 ## Delegation and context
 
@@ -268,6 +306,13 @@ Use `hexctl halt --reason ...` so the stop itself is on the ledger.
 - Never reconstruct progress from chat; `status` and `next` are the truth.
 - Never claim a lint, audit round, or test run happened when it did not.
 - Never force-push over someone else's work or bypass a merge gate.
+- Never target the base or the repository default branch with a step pull
+  request, and never merge one during the steps; the stack lands in
+  `integrate`.
+- Never merge into the base more than once in a run, and never open a step
+  branch straight off the base once a run branch exists.
+- Never invent a branch name the controller did not give, and never name a
+  branch after its number alone.
 - Never call a plan or implementation complete while its own final changes,
   PR, task branch, or recorded issue still need routine stage, push, merge,
   deletion, or closure work.
@@ -283,5 +328,7 @@ Use `hexctl halt --reason ...` so the stop itself is on the ledger.
 ## Final report
 
 When `next` returns `done`, run `hexctl status` and `hexctl verify`, then
-hand over: topic, step list with PR URLs, audit rounds per step with the
-closing state of each, and where the study and runbook live.
+hand over: topic, the run branch and the base it landed on, the step list with
+each stacked PR URL and the order the stack merged in, the integration PR and
+its merge SHA, audit rounds per step with the closing state of each, and where
+the study and runbook live.

--- a/plugins/hexaemeron/skills/fiat/references/audit-loop.md
+++ b/plugins/hexaemeron/skills/fiat/references/audit-loop.md
@@ -63,6 +63,13 @@ review artefact and the step's PR body links it. Set it true to merge the
 stacked branch into the step branch once the loop closes, before the prose
 phase.
 
+Steps chain, so an unfolded fix branch costs more than a stray review
+artefact: the next step branches from this step's branch, and fixes parked
+elsewhere are missing from every step above it and from the run branch that
+finally lands. Either set `config audit.fold true` for the run or commit the
+fixes onto the step branch itself before the prose phase. Leave fixes on an
+unmerged side branch only when nothing further will build on this step.
+
 ## Non-Solidity steps
 
 When a step touches no Solidity and no configured skill applies, the round

--- a/plugins/hexaemeron/skills/fiat/references/push-discipline.md
+++ b/plugins/hexaemeron/skills/fiat/references/push-discipline.md
@@ -1,13 +1,26 @@
 # Push discipline
 
-The pushed branch, merged pull request, and closed task issue are the delivery
-trail. Fiat does not create an issue unless the user or a higher-priority
-target-repository rule requires one. If one exists, record it as
-`task_issue` and close it before the terminal receipt.
+The stacked branches, their pull requests, the one merge into the base, and a
+closed task issue are the delivery trail. Fiat does not create an issue unless
+the user or a higher-priority target-repository rule requires one. If one
+exists, record it as `task_issue` and close it with the integration merge.
 
 ## Branches and commits
 
-- Branch as `step-<n>-<slug>` where repository conventions allow.
+A run owns one integration branch off the base, named at `init` and held in
+state. Cut it before step 1 and push it:
+
+```text
+git checkout -b <run branch> <base>
+git push -u origin <run branch>
+```
+
+- Take the step branch and the ref to cut it from out of the `implement`
+  directive (`branch`, `branch_from`); the controller refuses a receipt for
+  any other name. Step branches are siblings of the run branch, never nested
+  under it -- git cannot hold `fiat/x` and `fiat/x/step-1` at the same time.
+- A step branch is descriptive by construction: run slug, step number, step
+  title. A branch called `step1` says nothing to whoever finds it later.
 - Keep commits scoped to the current runbook step.
 - Preserve the target repository's required commit format and checks.
 - End every Fiat-created commit message, after a blank line, with both exact
@@ -18,16 +31,24 @@ target-repository rule requires one. If one exists, record it as
   Wildcat-Origin: shoggoth
   ```
 
-## Pull request and closure
+## The stacked pull request
 
-Push the branch, then open a pull request using the title and body prepared in
-the prose phase. Target the base recorded at `init`, passing it explicitly as
-`gh pr create --base <recorded base>`. Never let the pull request fall back to
-the repository default branch: when the run was started from a named branch,
-that branch is where the work belongs, and a silent retarget to the default
-branch merges work the user meant to hold back. The body states what changed, why, where the audit record
-lives, and how to run the proof. Do not invent an issue reference. Include one
-only when the user independently supplied a relevant issue.
+Push the step branch, then open its pull request using the title and body
+prepared in the prose phase, targeting the `pr_base` the directive names:
+
+```text
+gh pr create --base <pr_base> --head <branch> ...
+```
+
+For step 1 that base is the run branch; for every later step it is the step
+below it. Pass it explicitly, every time. Never let a pull request fall back to
+the repository default branch, and never point one at the recorded base: a step
+that targets `main` puts unreviewed, unintegrated work one click from the
+default branch, and a run of those is the pile of merges this workflow exists
+to avoid. The body states what changed, why, where the audit record lives, how
+to run the proof, and which step it stacks on. Do not invent an issue
+reference. Include one only when the user independently supplied a relevant
+issue.
 
 Before opening the pull request, make sure the target repository has the
 `origin:ai` label. Append `<!-- wildcat-origin: shoggoth -->` to the prepared
@@ -39,25 +60,60 @@ Extra labels are additive. Do not remove or rename either provenance marker.
 Do not amend a pre-existing human commit or relabel a pre-existing human pull
 request merely because Fiat later resumes work around it.
 
-Verify the pull request URL after creation. Wait for required checks, convert
-the PR from draft if necessary, then merge it using the repository's permitted
-merge method. Enable auto-merge when checks are still running and the host
-supports it. Never force-push over another person's work and never bypass a
-required review or failing gate.
-
-After merge, verify the merge commit and delete the remote task branch where
-repository policy permits. If a `task_issue` receipt exists, close that exact
-issue with a short comment linking the merged PR. A plan or implementation is
-not complete while its own branch, PR, or issue is awaiting routine agent
-action.
-
-If GitHub rejects the push or merge, a required independent approval cannot be
-self-supplied, or an external gate fails, record `hexctl halt --reason ...`
-with the exact blocker. Do not call the run complete.
-
-## Receipt
+Verify the pull request URL after creation. Wait for required checks and
+convert the PR from draft if necessary, then stop: a step's pull request stays
+open until the whole stack is ready. Receipt it and move to the next step.
 
 ```text
-hexctl done push --pr-url <url> --head-commit <sha> --merge-commit <sha> \
+hexctl done push --pr-url <url> --head-commit <sha> --pr-base <ref>
+```
+
+The receipt refuses a `--merge-commit` here. Merges belong to `integrate`.
+
+## Bringing the stack down
+
+`next` returns `merge-step` once per step, in step order, starting at the
+bottom. For each one:
+
+1. Merge that step's pull request into the run branch with the repository's
+   permitted merge method, without bypassing a gate.
+2. Verify the merge commit, then delete the merged step branch where policy
+   permits. GitHub retargets the next step's pull request onto the run branch
+   when its base branch goes; confirm that it did, and retarget it by hand
+   (`gh pr edit <pr> --base <run branch>`) if it did not.
+3. Receipt it before touching the next one:
+
+   ```text
+   hexctl done merge-step --step <n> --merge-commit <sha>
+   ```
+
+The controller refuses these out of order, so a resumed run always knows how
+far down the stack it got.
+
+## The integration pull request
+
+With every step merged, the run branch holds the whole delivery. Open one pull
+request from the run branch into the recorded base, using the prose phase's
+run-level title and body, and apply the same provenance markers:
+
+```text
+gh pr create --base <recorded base> --head <run branch> ...
+```
+
+Wait for required checks, merge without bypassing them, verify the merge
+commit, and delete the run branch where policy permits. If a `task_issue`
+receipt exists, close that exact issue now with a short comment linking the
+merged pull request. This is the only merge into the base in the whole run.
+
+```text
+hexctl done integrate --pr-url <url> --merge-commit <sha> \
   [--closed-issue-url <url>]
 ```
+
+Never force-push over another person's work and never bypass a required review
+or failing gate. A plan or implementation is not complete while its own branch,
+PR, or issue is awaiting routine agent action.
+
+If GitHub rejects a push or merge, a required independent approval cannot be
+self-supplied, or an external gate fails, record `hexctl halt --reason ...`
+with the exact blocker. Do not call the run complete.

--- a/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
+++ b/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
@@ -7,10 +7,12 @@ append-only, hash-chained ledger (`.hexaemeron/ledger.jsonl`). Every mutating
 command appends a ledger entry, so `verify` can prove the run history was not
 edited after the fact.
 
-Phase order is fixed. Globally: study -> runbook -> steps -> done.
-Within each step: implement -> audit -> prose -> push. The push receipt is
-terminal only after the final head is pushed, its pull request is merged, and
-any recorded task issue is closed.
+Phase order is fixed. Globally: study -> runbook -> steps -> integrate -> done.
+Within each step: implement -> audit -> prose -> push. Step branches chain off
+one another and their pull requests stack; nothing merges while the steps run.
+The integrate phase merges the stack into the run branch in step order, then
+merges the run branch into the recorded base exactly once and closes any
+recorded task issue.
 
 Exit codes: 0 success, 2 validation/usage error, 1 unexpected failure.
 Stdout from `next` and `status --json` is a single JSON object; everything
@@ -35,7 +37,7 @@ LEDGER_FILE = "ledger.jsonl"
 # ``issue`` remains accepted only so runs created by older controllers can
 # advance directly into implementation without losing their ledger history.
 STEP_PHASES = ["issue", "implement", "audit", "prose", "push"]
-GLOBAL_PHASES = ["study", "runbook", "steps", "done"]
+GLOBAL_PHASES = ["study", "runbook", "steps", "integrate", "done"]
 
 # Decorative only: the day each phase maps to in the plugin's naming conceit.
 DAY = {
@@ -69,7 +71,7 @@ DEFAULT_CONFIG = {
     },
     "git": {
         "base": "main",
-        "step_base": "chain",
+        "run_branch_prefix": "fiat/",
         "draft_pr": False,
     },
     "solidity": "auto",
@@ -86,6 +88,72 @@ def die(msg: str, code: int = 2) -> None:
 
 def canonical(obj) -> str:
     return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+# ------------------------------------------------------------------ branches
+
+SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+# Conservative subset of git's refname rules: no whitespace, no traversal, no
+# leading or trailing separator, nothing that needs quoting in a shell.
+BRANCH_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*[A-Za-z0-9]$")
+
+
+def slug(text: str, limit: int = 48) -> str:
+    return SLUG_RE.sub("-", text.lower()).strip("-")[:limit].strip("-")
+
+
+def check_branch_name(name: str) -> None:
+    if not BRANCH_RE.match(name) or ".." in name or "//" in name:
+        die(f"'{name}' is not a usable branch name")
+    if name.endswith(".lock"):
+        die(f"'{name}' is not a usable branch name")
+
+
+def run_branch_of(state: dict):
+    """The run's integration branch, or None for a run started before 3.4."""
+    return state.get("run_branch")
+
+
+def step_branch_name(state: dict, step: dict) -> str:
+    """Descriptive chained step branch: run slug, step number, step title.
+
+    A sibling of the run branch rather than a child of it, because git cannot
+    hold `fiat/x` and `fiat/x/step-1-y` as refs at the same time.
+    """
+    tail = slug(step["title"], 32) or "untitled"
+    return f"{run_branch_of(state)}-step-{step['n']}-{tail}"
+
+
+def step_pr_base(state: dict, step: dict) -> str:
+    """A step stacks on the step below it; step 1 stacks on the run branch."""
+    if step["n"] <= 1:
+        return run_branch_of(state)
+    return step_branch_name(state, state["steps"][step["n"] - 2])
+
+
+def branch_plan(state: dict, step: dict) -> dict:
+    """Branch to cut and pull request base for a step, when the run has a run
+    branch. A pre-3.4 run gets nothing here and keeps its old freedom."""
+    if not run_branch_of(state):
+        return {}
+    parent = step_pr_base(state, step)
+    return {
+        "run_branch": run_branch_of(state),
+        "branch": step_branch_name(state, step),
+        "branch_from": parent,
+        "pr_base": parent,
+        "merge_now": False,
+    }
+
+
+def expected_task_issue(state: dict):
+    task_issue = state["receipts"].get("task_issue")
+    if isinstance(task_issue, str):
+        return task_issue
+    if isinstance(task_issue, dict):
+        return task_issue.get("url")
+    return None
 
 
 # ---------------------------------------------------------------- state io
@@ -343,11 +411,17 @@ def cmd_init(args) -> None:
     # .gitignore was not touched. Nested .gitignore with `*` covers it.
     with open(os.path.join(root, ".gitignore"), "w", encoding="utf-8") as fh:
         fh.write("*\n")
+    prefix = DEFAULT_CONFIG["git"]["run_branch_prefix"]
+    run_branch = args.run_branch or f"{prefix}{slug(args.topic) or 'run'}"
+    check_branch_name(run_branch)
+    if run_branch == args.base:
+        die("--run-branch must differ from --base; the run needs its own branch")
     state = {
         "version": 1,
         "controller": "hexctl",
         "topic": args.topic,
         "base": args.base,
+        "run_branch": run_branch,
         "created_at": now(),
         "phase": "study",
         "current_step": None,
@@ -356,8 +430,16 @@ def cmd_init(args) -> None:
         "config": json.loads(json.dumps(DEFAULT_CONFIG)),
         "halted": None,
     }
-    commit(args.dir, state, "init", {"topic": args.topic, "base": args.base})
-    print(f"initialised {root} (topic: {args.topic})")
+    commit(
+        args.dir,
+        state,
+        "init",
+        {"topic": args.topic, "base": args.base, "run_branch": run_branch},
+    )
+    print(
+        f"initialised {root} (topic: {args.topic}); "
+        f"run branch {run_branch} off {args.base}"
+    )
 
 
 RESERVED_RECEIPTS = {"study", "runbook"}
@@ -473,6 +555,13 @@ def done_implement(args, state: dict) -> None:
     legacy_phase = step["phase"] == "issue"
     if not args.branch or not args.commit:
         die("--branch and --commit are required")
+    if run_branch_of(state):
+        expected = step_branch_name(state, step)
+        if args.branch != expected:
+            die(
+                f"--branch must be '{expected}', chained off "
+                f"'{step_pr_base(state, step)}'; got '{args.branch}'"
+            )
     step["receipts"]["implement"] = {
         "branch": args.branch,
         "commit": args.commit,
@@ -597,24 +686,44 @@ def done_push(args, state: dict) -> None:
         die("--pr-url is required")
     if not args.head_commit:
         die("--head-commit is required")
-    if not args.merge_commit:
-        die("--merge-commit is required; the pull request is not terminal until merged")
-    task_issue = state["receipts"].get("task_issue")
-    expected_issue = None
-    if isinstance(task_issue, str):
-        expected_issue = task_issue
-    elif isinstance(task_issue, dict):
-        expected_issue = task_issue.get("url")
-    if task_issue is not None and not args.closed_issue_url:
-        die("--closed-issue-url is required because a task_issue receipt exists")
-    if expected_issue and args.closed_issue_url != expected_issue:
-        die(
-            "--closed-issue-url does not match the recorded task_issue "
-            f"({expected_issue})"
-        )
+    stacked = run_branch_of(state) is not None
+    if stacked:
+        expected_base = step_pr_base(state, step)
+        if not args.pr_base:
+            die(
+                f"--pr-base is required; this step's pull request targets "
+                f"'{expected_base}', never the repository default branch"
+            )
+        if args.pr_base != expected_base:
+            die(f"--pr-base must be '{expected_base}'; got '{args.pr_base}'")
+        if args.merge_commit:
+            die(
+                "a step pull request does not merge during the run; the stack "
+                "merges in step order in the integrate phase"
+            )
+        if args.closed_issue_url:
+            die(
+                "a recorded task issue closes in the integrate phase, once the "
+                "run branch lands on the base"
+            )
+    else:
+        if not args.merge_commit:
+            die(
+                "--merge-commit is required; the pull request is not terminal "
+                "until merged"
+            )
+        expected_issue = expected_task_issue(state)
+        if state["receipts"].get("task_issue") is not None and not args.closed_issue_url:
+            die("--closed-issue-url is required because a task_issue receipt exists")
+        if expected_issue and args.closed_issue_url != expected_issue:
+            die(
+                "--closed-issue-url does not match the recorded task_issue "
+                f"({expected_issue})"
+            )
     step["receipts"]["push"] = {
         "pr_url": args.pr_url,
         "head_commit": args.head_commit,
+        "pr_base": args.pr_base,
         "merge_commit": args.merge_commit,
         "closed_issue_url": args.closed_issue_url,
     }
@@ -629,15 +738,143 @@ def done_push(args, state: dict) -> None:
         tail = f"step {nxt['n']} -> implement"
     else:
         state["current_step"] = None
-        state["phase"] = "done"
-        tail = "all steps done"
+        if stacked:
+            state["phase"] = "integrate"
+            state["integrate"] = {"merged": [], "merges": {}}
+            tail = f"stack complete; merge it into {run_branch_of(state)}"
+        else:
+            state["phase"] = "done"
+            tail = "all steps done"
     commit(
         args.dir,
         state,
         "done:push",
         {"step": step["n"], **step["receipts"]["push"]},
     )
-    print(f"step {step['n']} published, merged, and receipted; {tail}")
+    if stacked:
+        print(
+            f"step {step['n']} pushed and stacked on '{args.pr_base}'; {tail}"
+        )
+    else:
+        print(f"step {step['n']} published, merged, and receipted; {tail}")
+
+
+def _integrate_directive(state: dict) -> dict:
+    """Merge the stack bottom up, then the run branch into the base once."""
+    run_branch = run_branch_of(state)
+    merged = state.get("integrate", {}).get("merged", [])
+    for step in state["steps"]:
+        if step["n"] in merged:
+            continue
+        return {
+            "do": "merge-step",
+            "step": step["n"],
+            "title": step["title"],
+            "branch": step_branch_name(state, step),
+            "pr_url": step["receipts"].get("push", {}).get("pr_url"),
+            "into": run_branch,
+            "then": (
+                f"hexctl done merge-step --step {step['n']} "
+                "--merge-commit <sha>"
+            ),
+        }
+    then = "hexctl done integrate --pr-url <url> --merge-commit <sha>"
+    if expected_task_issue(state):
+        then += " --closed-issue-url <url>"
+    return {
+        "do": "integrate",
+        "run_branch": run_branch,
+        "base": state["base"],
+        "steps": len(state["steps"]),
+        "then": then,
+    }
+
+
+def done_merge_step(args, state: dict) -> None:
+    if state["phase"] != "integrate":
+        die(
+            "merge-step is an integrate-phase receipt; the run is in phase "
+            f"'{state['phase']}'"
+        )
+    if state.get("halted"):
+        die(f"run is halted ({state['halted']['reason']}); `hexctl resume` first")
+    if args.step is None:
+        die("--step is required")
+    if not args.merge_commit:
+        die("--merge-commit is required")
+    pending = _integrate_directive(state)
+    if pending["do"] != "merge-step":
+        die(f"every step already merged into '{run_branch_of(state)}'")
+    if args.step != pending["step"]:
+        die(
+            f"the stack merges in step order; step {pending['step']} "
+            f"('{pending['branch']}') is next, not step {args.step}"
+        )
+    integrate = state.setdefault("integrate", {"merged": [], "merges": {}})
+    integrate.setdefault("merged", []).append(args.step)
+    integrate.setdefault("merges", {})[str(args.step)] = {
+        "branch": pending["branch"],
+        "into": pending["into"],
+        "merge_commit": args.merge_commit,
+    }
+    commit(
+        args.dir,
+        state,
+        "done:merge-step",
+        {
+            "step": args.step,
+            "branch": pending["branch"],
+            "into": pending["into"],
+            "merge_commit": args.merge_commit,
+        },
+    )
+    remaining = len(state["steps"]) - len(integrate["merged"])
+    tail = f"{remaining} step(s) left in the stack" if remaining else "stack merged"
+    print(f"step {args.step} merged into {pending['into']}; {tail}")
+
+
+def done_integrate(args, state: dict) -> None:
+    if state["phase"] != "integrate":
+        die(
+            "integrate is the terminal phase; the run is in phase "
+            f"'{state['phase']}'"
+        )
+    if state.get("halted"):
+        die(f"run is halted ({state['halted']['reason']}); `hexctl resume` first")
+    pending = _integrate_directive(state)
+    if pending["do"] != "integrate":
+        die(
+            f"step {pending['step']} still has to merge into "
+            f"'{run_branch_of(state)}' first"
+        )
+    if not args.pr_url:
+        die("--pr-url is required")
+    if not args.merge_commit:
+        die(
+            "--merge-commit is required; the run is not complete until the run "
+            f"branch is merged into '{state['base']}'"
+        )
+    expected_issue = expected_task_issue(state)
+    if state["receipts"].get("task_issue") is not None and not args.closed_issue_url:
+        die("--closed-issue-url is required because a task_issue receipt exists")
+    if expected_issue and args.closed_issue_url != expected_issue:
+        die(
+            "--closed-issue-url does not match the recorded task_issue "
+            f"({expected_issue})"
+        )
+    state["receipts"]["integrate"] = {
+        "run_branch": run_branch_of(state),
+        "base": state["base"],
+        "pr_url": args.pr_url,
+        "merge_commit": args.merge_commit,
+        "closed_issue_url": args.closed_issue_url,
+    }
+    state["phase"] = "done"
+    commit(args.dir, state, "done:integrate", state["receipts"]["integrate"])
+    print(
+        f"{run_branch_of(state)} merged into {state['base']} "
+        f"({args.merge_commit}); run complete"
+    )
 
 
 DONE_HANDLERS = {
@@ -647,6 +884,8 @@ DONE_HANDLERS = {
     "audit": done_audit,
     "prose": done_prose,
     "push": done_push,
+    "merge-step": done_merge_step,
+    "integrate": done_integrate,
 }
 
 
@@ -679,6 +918,8 @@ def _next_directive(state: dict) -> dict:
             "do": "runbook",
             "then": "hexctl done runbook --artifact <path> --steps-file <path>",
         }
+    if phase == "integrate":
+        return _integrate_directive(state)
     if phase == "done":
         return {"do": "done", "steps": len(state["steps"])}
     step = current_step(state)
@@ -712,6 +953,8 @@ def _next_directive(state: dict) -> dict:
         }
     if step["phase"] == "issue":
         return {**base, "do": "implement", "legacy_issue_phase_skipped": True}
+    if step["phase"] in ("implement", "push"):
+        return {**base, "do": step["phase"], **branch_plan(state, step)}
     return {**base, "do": step["phase"]}
 
 
@@ -729,11 +972,19 @@ def cmd_status(args) -> None:
         return
     print(f"topic: {clean(state['topic'])}")
     print(f"base:  {state['base']}")
+    if state.get("run_branch"):
+        print(f"run:   {state['run_branch']} -> {state['base']}")
     if state.get("halted"):
         print(f"HALTED: {state['halted']['reason']}")
     phase = state["phase"]
     if phase in ("study", "runbook"):
         print(f"phase: {phase} (day {DAY[phase]})")
+    elif phase == "integrate":
+        merged = len(state.get("integrate", {}).get("merged", []))
+        print(
+            f"phase: integrate ({merged}/{len(state['steps'])} steps merged "
+            f"into {state['run_branch']})"
+        )
     elif phase == "done":
         print(f"phase: done ({len(state['steps'])} steps shipped)")
     else:
@@ -807,6 +1058,14 @@ def verify_run(base_dir: str) -> int:
             "state file does not match the last ledger entry; "
             "state.json was edited outside hexctl", 1
         )
+    if state["phase"] == "integrate":
+        merged = state.get("integrate", {}).get("merged", [])
+        expected = [s["n"] for s in state["steps"][: len(merged)]]
+        if merged != expected:
+            die(
+                "integrate state is inconsistent: the stack must merge in step "
+                f"order, got {merged}", 1
+            )
     if state["phase"] == "steps":
         step = current_step(state)
         if step["status"] != "open" or step["phase"] not in STEP_PHASES:
@@ -864,6 +1123,11 @@ def build_parser() -> argparse.ArgumentParser:
     sp = sub.add_parser("init", help="start a run")
     sp.add_argument("--topic", required=True)
     sp.add_argument("--base", default="main")
+    sp.add_argument(
+        "--run-branch",
+        dest="run_branch",
+        help="integration branch for the whole run (default: slug of --topic)",
+    )
     sp.set_defaults(fn=cmd_init)
 
     sp = sub.add_parser("status", help="show run state")
@@ -898,6 +1162,8 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--log")
     sp.add_argument("--files", type=int)
     sp.add_argument("--pr-url", dest="pr_url")
+    sp.add_argument("--pr-base", dest="pr_base")
+    sp.add_argument("--step", type=int)
     sp.add_argument("--head-commit", dest="head_commit")
     sp.add_argument("--merge-commit", dest="merge_commit")
     sp.add_argument("--closed-issue-url", dest="closed_issue_url")

--- a/plugins/hexaemeron/skills/kronos/SKILL.md
+++ b/plugins/hexaemeron/skills/kronos/SKILL.md
@@ -56,8 +56,11 @@ bare.
 6. Read the selected skill's canonical instructions, its ledger, and Fiat's
    `SKILL.md`. Invoke Fiat with the held Next Fiat job byte for byte.
 7. Let Fiat finish its complete terminal path: implement, validate, stage,
-   commit, push, merge, branch cleanup where permitted, and issue closure.
-   A PR merely opened is not a completed iteration.
+   commit, push each step's stacked pull request, then the integrate phase --
+   the stack merged into the run branch in order, the run branch merged into
+   the base, branch cleanup where permitted, and issue closure. A stack of
+   pull requests merely opened is not a completed iteration; the controller
+   reaching `done` is.
 8. Require the completed frontier run to update that skill's ledger under
    `VERSIONING.md`: evolution advances once and the held job is replaced, or
    the frontier becomes mature. Then rescan the entire scope from disk --

--- a/plugins/hexaemeron/tests/test_fiat_skill.py
+++ b/plugins/hexaemeron/tests/test_fiat_skill.py
@@ -91,11 +91,37 @@ class FiatSkillContractTests(unittest.TestCase):
         self.assertIn("pre-existing human pull\nrequest", self.push_discipline)
 
     def test_publish_phase_merges_and_closes_its_own_work(self):
-        self.assertIn("merge it using the repository's permitted", self.push_discipline)
-        self.assertIn("close that exact\nissue", self.push_discipline)
-        self.assertIn("--head-commit <sha> --merge-commit <sha>", self.push_discipline)
+        flat = " ".join(self.push_discipline.split())
+        self.assertIn("permitted merge method", flat)
+        self.assertIn("close that exact issue", flat)
+        self.assertIn(
+            "hexctl done integrate --pr-url <url> --merge-commit <sha>",
+            self.push_discipline,
+        )
         self.assertNotIn("Never merge it", self.push_discipline)
-        self.assertIn("routine publish or closure action is not a\nhandoff", self.fiat)
+        self.assertIn(
+            "routine publish or closure action is not a handoff",
+            " ".join(self.fiat.split()),
+        )
+
+    def test_steps_stack_and_only_the_run_branch_merges_into_the_base(self):
+        flat = " ".join(self.push_discipline.split())
+        fiat = " ".join(self.fiat.split())
+        # A step's pull request targets the step below it, never the base.
+        self.assertIn("gh pr create --base <pr_base> --head <branch>", self.push_discipline)
+        self.assertIn("hexctl done push --pr-url <url> --head-commit <sha> --pr-base <ref>",
+                      self.push_discipline)
+        self.assertIn("never point one at the recorded base", flat)
+        self.assertIn("only merge into the base in the whole run", flat)
+        # The stack comes down in order, in its own phase.
+        self.assertIn("hexctl done merge-step --step <n> --merge-commit <sha>",
+                      self.push_discipline)
+        self.assertIn("Merges belong to `integrate`", self.push_discipline)
+        # And the loop itself says so.
+        self.assertIn("Never target the base or the repository default branch with a step pull",
+                      self.fiat)
+        self.assertIn("Never merge into the base more than once in a run", self.fiat)
+        self.assertIn("nothing merges while the steps run", fiat.lower())
 
 
 class ContributorCheckTests(unittest.TestCase):

--- a/plugins/hexaemeron/tests/test_hexctl.py
+++ b/plugins/hexaemeron/tests/test_hexctl.py
@@ -3,6 +3,7 @@
 import json
 import hashlib
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -52,6 +53,46 @@ class HexctlCase(unittest.TestCase):
 
     def init(self, topic="test topic"):
         self.run_ctl("init", "--topic", topic)
+
+    def state(self):
+        return json.loads(self.run_ctl("status", "--json").stdout)
+
+    def run_branch(self):
+        return self.state()["run_branch"]
+
+    def step_branch(self, n, state=None):
+        state = state or self.state()
+        title = state["steps"][n - 1]["title"]
+        tail = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")[:32].strip("-")
+        return f"{state['run_branch']}-step-{n}-{tail or 'untitled'}"
+
+    def step_base(self, n, state=None):
+        state = state or self.state()
+        if n == 1:
+            return state["run_branch"]
+        return self.step_branch(n - 1, state)
+
+    def strip_run_branch(self):
+        """Make the state look like a run started before stacked branches."""
+        path = os.path.join(self.dir, ".hexaemeron", "state.json")
+        with open(path, encoding="utf-8") as fh:
+            state = json.load(fh)
+        state.pop("run_branch", None)
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(state, fh)
+
+    def merge_stack(self):
+        for step in self.state()["steps"]:
+            self.run_ctl("done", "merge-step", "--step", str(step["n"]),
+                         "--merge-commit", f"m{step['n']}")
+
+    def integrate_run(self, closed_issue_url=None):
+        self.merge_stack()
+        args = ["done", "integrate", "--pr-url", "https://x/pr/run",
+                "--merge-commit", "runmerge"]
+        if closed_issue_url:
+            args += ["--closed-issue-url", closed_issue_url]
+        self.run_ctl(*args)
 
     def spawn_lock_holder(self, ready, release, command="cmd_record"):
         program = """
@@ -126,12 +167,12 @@ with module.held_lock(sys.argv[2], sys.argv[3]):
 
     def to_audit(self):
         self.to_steps()
-        self.run_ctl("done", "implement", "--branch", "step-1-scaffold",
+        self.run_ctl("done", "implement", "--branch", self.step_branch(1),
                      "--commit", "abc123")
 
     def finish_step(self, step_no=1):
-        self.run_ctl("done", "implement", "--branch", f"step-{step_no}",
-                     "--commit", "abc123")
+        self.run_ctl("done", "implement", "--branch", self.step_branch(step_no),
+                     "--commit", f"abc{step_no}")
         self.run_ctl("audit-round", "--findings", "0", "--log", "audit/AUDIT.md")
         self.run_ctl("done", "audit")
         self.run_ctl("done", "prose", "--files", "3",
@@ -140,7 +181,7 @@ with module.held_lock(sys.argv[2], sys.argv[3]):
             "done", "push",
             "--pr-url", f"https://x/pr/{step_no}",
             "--head-commit", f"head{step_no}",
-            "--merge-commit", f"merge{step_no}",
+            "--pr-base", self.step_base(step_no),
         )
 
 
@@ -302,7 +343,8 @@ class TestStepGates(HexctlCase):
         self.assertEqual(directive["do"], "implement")
         self.assertTrue(directive["legacy_issue_phase_skipped"])
         self.run_ctl(
-            "done", "implement", "--branch", "step-1", "--commit", "abc123"
+            "done", "implement", "--branch", self.step_branch(1),
+            "--commit", "abc123",
         )
         self.assertEqual(self.next_json()["do"], "resolve-security-suite")
 
@@ -402,13 +444,94 @@ class TestProseAndPush(HexctlCase):
             "done", "push", "--pr-url", "https://x/pr/1",
             "--head-commit", "abc123", expect=2,
         )
+        self.assertIn("--pr-base", proc.stderr)
+        self.run_ctl(
+            "done", "push", "--pr-url", "https://x/pr/1",
+            "--head-commit", "abc123", "--pr-base", self.step_base(1),
+        )
+
+    def test_step_pull_request_may_not_target_the_repository_base(self):
+        self.to_prose()
+        self.run_ctl("done", "prose", "--files", "1",
+                     "--skills", "hexaemeron:imprimatur,hexaemeron:vulgate")
+        proc = self.run_ctl(
+            "done", "push", "--pr-url", "https://x/pr/1",
+            "--head-commit", "abc123", "--pr-base", "main", expect=2,
+        )
+        self.assertIn("--pr-base must be", proc.stderr)
+        self.assertIn(self.run_branch(), proc.stderr)
+
+    def test_step_pull_request_is_not_merged_during_the_run(self):
+        self.to_prose()
+        self.run_ctl("done", "prose", "--files", "1",
+                     "--skills", "hexaemeron:imprimatur,hexaemeron:vulgate")
+        proc = self.run_ctl(
+            "done", "push", "--pr-url", "https://x/pr/1",
+            "--head-commit", "abc123", "--pr-base", self.step_base(1),
+            "--merge-commit", "def456", expect=2,
+        )
+        self.assertIn("integrate", proc.stderr)
+
+    def test_second_step_stacks_on_the_first(self):
+        self.to_steps(("Scaffold", "Core"))
+        self.run_ctl("record", "security_suite", '"waived: prose-only repo"')
+        directive = self.next_json()
+        self.assertEqual(directive["branch"], self.step_branch(1))
+        self.assertEqual(directive["branch_from"], self.run_branch())
+        self.assertEqual(directive["pr_base"], self.run_branch())
+        self.assertFalse(directive["merge_now"])
+        self.finish_step(1)
+        directive = self.next_json()
+        self.assertEqual(directive["branch"], self.step_branch(2))
+        self.assertEqual(directive["branch_from"], self.step_branch(1))
+        self.assertEqual(directive["pr_base"], self.step_branch(1))
+
+    def test_run_branch_defaults_to_the_topic_slug_and_may_be_named(self):
+        self.init("Borrowing-base covenant hook for V2.5")
+        self.assertEqual(self.run_branch(), "fiat/borrowing-base-covenant-hook-for-v2-5")
+        self.assertNotEqual(self.run_branch(), self.state()["base"])
+        self.run_ctl("reset", expect=2)
+
+    def test_named_run_branch_is_honoured_and_checked(self):
+        proc = self.run_ctl("init", "--topic", "t", "--run-branch", "bad branch",
+                            expect=2)
+        self.assertIn("not a usable branch name", proc.stderr)
+        proc = self.run_ctl("init", "--topic", "t", "--run-branch", "main",
+                            "--base", "main", expect=2)
+        self.assertIn("must differ from --base", proc.stderr)
+        self.run_ctl("init", "--topic", "t", "--run-branch", "release/prep")
+        self.assertEqual(self.run_branch(), "release/prep")
+
+    def test_titleless_step_still_yields_a_usable_branch(self):
+        self.to_steps(("###",))
+        self.assertEqual(self.next_json()["branch"],
+                         f"{self.run_branch()}-step-1-untitled")
+
+    def test_step_branch_name_is_the_controller_s_to_give(self):
+        self.to_steps(("Scaffold",))
+        proc = self.run_ctl("done", "implement", "--branch", "step1",
+                            "--commit", "abc123", expect=2)
+        self.assertIn(self.step_branch(1), proc.stderr)
+
+    def test_pre_stack_run_keeps_the_old_per_step_merge_contract(self):
+        self.to_prose()
+        self.run_ctl("done", "prose", "--files", "1",
+                     "--skills", "hexaemeron:imprimatur,hexaemeron:vulgate")
+        self.strip_run_branch()
+        proc = self.run_ctl(
+            "done", "push", "--pr-url", "https://x/pr/1",
+            "--head-commit", "abc123", expect=2,
+        )
         self.assertIn("--merge-commit", proc.stderr)
         self.run_ctl(
             "done", "push", "--pr-url", "https://x/pr/1",
             "--head-commit", "abc123", "--merge-commit", "def456",
         )
+        out = self.next_json()
+        self.assertEqual((out["do"], out["step"]), ("implement", 2))
+        self.assertNotIn("pr_base", out)
 
-    def test_recorded_task_issue_must_be_closed_before_push_receipt(self):
+    def test_recorded_task_issue_must_be_closed_before_the_run_completes(self):
         self.to_prose()
         self.run_ctl("record", "task_issue", '"https://x/issues/74"')
         self.run_ctl(
@@ -417,30 +540,81 @@ class TestProseAndPush(HexctlCase):
         )
         proc = self.run_ctl(
             "done", "push", "--pr-url", "https://x/pr/1",
-            "--head-commit", "abc123", "--merge-commit", "def456",
-            expect=2,
+            "--head-commit", "abc123", "--pr-base", self.step_base(1),
+            "--closed-issue-url", "https://x/issues/74", expect=2,
+        )
+        self.assertIn("integrate phase", proc.stderr)
+        self.run_ctl(
+            "done", "push", "--pr-url", "https://x/pr/1",
+            "--head-commit", "abc123", "--pr-base", self.step_base(1),
+        )
+        self.finish_step(2)
+        self.merge_stack()
+        self.assertIn(
+            "--closed-issue-url", self.next_json()["then"]
+        )
+        proc = self.run_ctl(
+            "done", "integrate", "--pr-url", "https://x/pr/run",
+            "--merge-commit", "runmerge", expect=2,
         )
         self.assertIn("--closed-issue-url", proc.stderr)
         proc = self.run_ctl(
-            "done", "push", "--pr-url", "https://x/pr/1",
-            "--head-commit", "abc123", "--merge-commit", "def456",
+            "done", "integrate", "--pr-url", "https://x/pr/run",
+            "--merge-commit", "runmerge",
             "--closed-issue-url", "https://x/issues/75", expect=2,
         )
         self.assertIn("does not match", proc.stderr)
         self.run_ctl(
-            "done", "push", "--pr-url", "https://x/pr/1",
-            "--head-commit", "abc123", "--merge-commit", "def456",
+            "done", "integrate", "--pr-url", "https://x/pr/run",
+            "--merge-commit", "runmerge",
             "--closed-issue-url", "https://x/issues/74",
         )
+        self.assertEqual(self.next_json()["do"], "done")
 
-    def test_push_advances_steps_then_run_completes(self):
+    def test_push_advances_steps_then_the_stack_integrates(self):
         self.to_steps(("One", "Two"))
         self.run_ctl("record", "security_suite", '"suite"')
+        run_branch = self.run_branch()
+        first, second = self.step_branch(1), self.step_branch(2)
         self.finish_step(1)
         out = self.next_json()
         self.assertEqual((out["do"], out["step"]), ("implement", 2))
         self.finish_step(2)
+
+        out = self.next_json()
+        self.assertEqual((out["do"], out["step"]), ("merge-step", 1))
+        self.assertEqual((out["branch"], out["into"]), (first, run_branch))
+
+        proc = self.run_ctl("done", "merge-step", "--step", "2",
+                            "--merge-commit", "m2", expect=2)
+        self.assertIn("step order", proc.stderr)
+        proc = self.run_ctl("done", "integrate", "--pr-url", "https://x/pr/run",
+                            "--merge-commit", "runmerge", expect=2)
+        self.assertIn("still has to merge", proc.stderr)
+
+        self.run_ctl("done", "merge-step", "--step", "1", "--merge-commit", "m1")
+        out = self.next_json()
+        self.assertEqual((out["do"], out["step"]), ("merge-step", 2))
+        self.assertEqual((out["branch"], out["into"]), (second, run_branch))
+        self.run_ctl("done", "merge-step", "--step", "2", "--merge-commit", "m2")
+
+        out = self.next_json()
+        self.assertEqual(out["do"], "integrate")
+        self.assertEqual((out["run_branch"], out["base"]), (run_branch, "main"))
+        proc = self.run_ctl("done", "integrate", "--pr-url", "https://x/pr/run",
+                            expect=2)
+        self.assertIn("--merge-commit", proc.stderr)
+        self.run_ctl("done", "integrate", "--pr-url", "https://x/pr/run",
+                     "--merge-commit", "runmerge")
         self.assertEqual(self.next_json()["do"], "done")
+        self.run_ctl("verify")
+
+    def test_reset_refuses_a_run_whose_stack_has_not_landed(self):
+        self.to_steps(("One",))
+        self.run_ctl("record", "security_suite", '"suite"')
+        self.finish_step(1)
+        proc = self.run_ctl("reset", expect=2)
+        self.assertIn("integrate", proc.stderr)
 
 
 class TestControls(HexctlCase):
@@ -480,6 +654,7 @@ class TestControls(HexctlCase):
         self.to_steps(("One",))
         self.run_ctl("record", "security_suite", '"suite"')
         self.finish_step(1)
+        self.integrate_run()
         self.assertEqual(self.next_json()["do"], "done")
 
         self.run_ctl("reset")


### PR DESCRIPTION
Every step branch merged straight into `main` under a name like `step1`, so a single Fiat run left a pile of merges on the default branch and no way to read the delivery as one thing. The `git.step_base: chain` config said steps chained, but nothing consumed it, and push discipline told the model to open each step against the recorded base — so they all landed on `main` anyway.

## What changes

A run cuts one descriptively named integration branch from the recorded base and chains its step branches onto each other:

```
main ─── fiat/<run slug>                               run branch, off the recorded base
          └── fiat/<run slug>-step-1-<title>           PR -> run branch
               └── fiat/<run slug>-step-2-<title>      PR -> step 1
                    └── fiat/<run slug>-step-3-<title> PR -> step 2
```

Commits chain and the pull requests stack the same way, so a reviewer sees one step diff. Nothing merges while the steps run. The new `integrate` phase brings the stack down into the run branch in step order, then merges the run branch into the base exactly once and closes any recorded task issue.

Step branches are siblings of the run branch rather than children: git cannot hold `fiat/x` and `fiat/x/step-1` as refs at the same time.

## Enforced by the controller, not just described

- `init` derives and holds the run branch (`git.run_branch_prefix` plus the topic slug; `--run-branch` overrides, and the name is checked).
- `next` hands out `branch`, `branch_from`, `pr_base` and `merge_now: false`.
- `done implement` refuses any branch name but the one the controller gave.
- `done push` requires `--pr-base` and refuses `--merge-commit` outright.
- `done merge-step` refuses an out-of-order merge; `done integrate` refuses until the stack has landed, and is where a recorded task issue closes.
- Runs started before this carry no run branch and keep their old per-step merge contract, so anything mid-flight still resumes.

`git.step_base` is gone; `git.run_branch_prefix` replaces it.

## Record

Fiat advances by generation to `fiat-v3.4.1` under `skills/VERSIONING.md`, held frontier unchanged byte for byte, with a ledger row citing the maintainer report.

## Proof

- `python3 plugins/hexaemeron/tests/run_tests.py` — 134/134, 17 new tests covering the stack contract, order enforcement, branch naming, and pre-stack compatibility.
- `python3 -m unittest discover -s tests` — 24/24 repository contracts.
- A three-step run walked end to end against the real controller: descriptive run branch, chained step branches, stacked bases, one merge into the base, `verify` clean at 23 ledger entries.
- Branch coexistence checked in a scratch repository; the nested form fails as expected.
- `imprimatur` reports 0 defects on every document touched.

<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
