### PR TITLE
Audit round 1 fixes for the Horos scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ another person can rebuild after the endpoint that served them is gone.
 
 Scored out of 10 for doing the job, not for reading the output. A marketer can quote a verified gas number without having any use for Hermes itself.
 
-| Role | Alexandria | Ariadne | Brevitas | Hermes | Hexaemeron | Lemma | Lazarus | Pandects | Probitas | Sapheneia | Tabularium |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Developers | 8 | 8 | 8 | 9 | 9 | 6 | 8 | 8 | 4 | 8 | 7 |
-| Security and audit | 8 | 9 | 10 | 7 | 8 | 4 | 8 | 9 | 5 | 7 | 7 |
-| Marketing | 1 | 1 | 1 | 3 | 6 | 1 | 1 | 1 | 1 | 3 | 1 |
-| Business development | 6 | 2 | 2 | 2 | 5 | 1 | 2 | 2 | 9 | 4 | 3 |
-| Finance | 8 | 1 | 2 | 3 | 4 | 1 | 2 | 2 | 7 | 4 | 7 |
-| Legal | 3 | 3 | 2 | 1 | 4 | 1 | 2 | 2 | 4 | 4 | 2 |
+| Role | Alexandria | Ariadne | Brevitas | Hermes | Hexaemeron | Horos | Lemma | Lazarus | Pandects | Probitas | Sapheneia | Tabularium |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Developers | 8 | 8 | 8 | 9 | 9 | 8 | 6 | 8 | 8 | 4 | 8 | 7 |
+| Security and audit | 8 | 9 | 10 | 7 | 8 | 2 | 4 | 8 | 9 | 5 | 7 | 7 |
+| Marketing | 1 | 1 | 1 | 3 | 6 | 1 | 1 | 1 | 1 | 1 | 3 | 1 |
+| Business development | 6 | 2 | 2 | 2 | 5 | 1 | 1 | 2 | 2 | 9 | 4 | 3 |
+| Finance | 8 | 1 | 2 | 3 | 4 | 1 | 1 | 2 | 2 | 7 | 4 | 7 |
+| Legal | 3 | 3 | 2 | 1 | 4 | 1 | 1 | 2 | 2 | 4 | 4 | 2 |
 
 Five is the barrier. At or above it, the plugin's entry carries a worked example of what that role would use it for. Below it there is no example, because there is no honest one to give. These are engineering tools, and a 2 means we could not find a reason for that desk to open the plugin rather than read what it produced.
 

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -930,3 +930,18 @@ cold read's one defect, a hand-off line predating the phase skills, was fixed
 in the step commit. Root 24/24, hexaemeron 124/124.
 
 Leads not pursued: none.
+
+## Step 1, round 1 -- 2026-08-18
+
+Run: Horos, the reading-boundary skill. Step 1 scaffolds and registers the
+plugin. Suite waived (no Solidity); the round ran the three bundled lints and
+a diff review against the study's risk register.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R1-01 | low | plugins/horos/README.md | "What it ships" claimed the scanner, boundary and maps in the present tense while this step ships only the scaffold | fixed: section reframed as what the runbook lands, in order |
+| S1-R1-02 | low | plugins/horos/docs/runbook.md | the committed runbook copy pointed at the gitignored .hexaemeron path as the spec | fixed: points at the committed study beside it |
+| S1-R1-03 | low | README.md | the role matrix omits a Horos column, and a Developers score at or above five demands a worked example the landing README lacked | fixed: column added (Developers 8, Security 2, all other desks 1) and a Day-to-day example added |
+
+Lints: phylax 0, ephoros 0, hypomnema 0 over plugins tests and the changed
+documents. Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -945,3 +945,14 @@ a diff review against the study's risk register.
 
 Lints: phylax 0, ephoros 0, hypomnema 0 over plugins tests and the changed
 documents. Leads not pursued: none.
+
+## Step 1, round 2 -- 2026-08-18
+
+The round re-ran against the tree with round 1's fixes applied. Lints: phylax
+0, ephoros 0, hypomnema 0. Root 24/24, horos 4/4. The review of the fix diff
+found nothing further.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.

--- a/plugins/horos/README.md
+++ b/plugins/horos/README.md
@@ -24,7 +24,10 @@ rewriting at up to 12 points of task completion. Not reading the sinks at all
 is the mechanism that wins, and Horos makes it checkable. The full argument
 is committed at [docs/study.md](./docs/study.md).
 
-## What it ships
+## What the delivery builds
+
+The runbook at [docs/runbook.md](./docs/runbook.md) lands these in order,
+one reviewed step each:
 
 - a standard-library scanner that classifies token sinks and quotes the
   evidence line that earned each entry;
@@ -33,6 +36,14 @@ is committed at [docs/study.md](./docs/study.md).
 - Python skeleton maps, so a large file can be oriented in without being
   read; and
 - one binding rule: no boundary applies during security review.
+
+## Day to day
+
+**Developers.** An agent is pointed at a frontend repository where two thirds
+of the readable bytes are a checked-in Storybook build, a lockfile and a data
+file on one line. The committed boundary sends the reading budget to `src/`
+instead, `check` catches the day the boundary goes stale, and a skeleton map
+orients the agent in a thousand-line module without opening it whole.
 
 ## Where it is honest about limits
 

--- a/plugins/horos/docs/runbook.md
+++ b/plugins/horos/docs/runbook.md
@@ -1,9 +1,9 @@
 # Horos, the runbook
 
 Five steps, dependency order, one pull request each. Every step assumes the
-exit state of the one before it and nothing else. The study at
-`.hexaemeron/study.md` is the spec; repo copies of both documents land in
-step 1.
+exit state of the one before it and nothing else. The study committed beside
+this runbook at [study.md](./study.md) is the spec; both documents landed
+here in step 1.
 
 Module trace: scaffold, classify, boundary, skeleton, discipline. One
 capability, so no decomposition table; the modules are the steps.


### PR DESCRIPTION
Review artefact for step 1's audit loop. Three low findings, all fixed here: present-tense shipping claims in the landing README, a gitignored spec pointer in the committed runbook copy, and the missing Horos column in the root role matrix. The audit log entry is in audit/AUDIT.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)