### PR TITLE
Scaffold and register the Horos plugin

### DIFF
--- a/.agents/skills/horos/SKILL.md
+++ b/.agents/skills/horos/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: horos
+description: Route requests to cut a repository's reading cost without rewriting code to Horos, which classifies token sinks with evidence, emits a verifiable reading boundary and prints Python skeleton maps.
+---
+
+Horos portable entrypoint
+
+<!-- marketplace-context:start -->
+Horos classifies a repository's token sinks with evidence and emits the reading boundary agents respect.
+
+**Use another tool when.** Use Lemma to chunk source for retrieval, Brevitas for prose budgets, and Hexaemeron's Metron for runtime cost. Horos decides what goes unread; it never rewrites what is read.
+
+**Current frontier.** TypeScript and JavaScript skeleton maps remain unimplemented, and no scan of a live external repository is recorded as evidence.
+<!-- marketplace-context:end -->
+
+Read [the canonical Horos skill](../../../plugins/horos/skills/horos/SKILL.md)
+and [the plugin landing page](../../../plugins/horos/README.md) in full. They
+are authoritative if this entrypoint disagrees. Never apply a reading boundary
+during security review.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -50,6 +50,28 @@
       ]
     },
     {
+      "name": "horos",
+      "displayName": "Horos",
+      "source": "./plugins/horos",
+      "description": "Classify a repository's token sinks with evidence and emit the reading boundary agents respect.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Wildcat Labs",
+        "url": "https://wildcat.finance"
+      },
+      "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/horos",
+      "repository": "https://github.com/wildcat-finance/skills",
+      "category": "Developer Tools",
+      "tags": [
+        "reading-boundary",
+        "token-budget",
+        "generated-code",
+        "vendored-code",
+        "skeleton-map",
+        "agent-context"
+      ]
+    },
+    {
       "name": "sapheneia",
       "displayName": "Sapheneia",
       "source": "./plugins/sapheneia",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ python3 -m unittest discover -s plugins/brevitas/tests -t plugins/brevitas
 python3 plugins/hermes/skills/hermes/scripts/test_hermes.py
 python3 plugins/hexaemeron/tests/run_tests.py
 python3 plugins/hexaemeron/skills/imprimatur/tests/run_tests.py
+python3 -m unittest discover -s plugins/horos/tests -t plugins/horos
 python3 plugins/lemma/tests/test_markdown.py
 python3 plugins/lemma/tests/test_solidity.py
 python3 -m unittest discover -s plugins/lazarus/tests -t plugins/lazarus

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ and Sapheneia owns AuDHD interaction shape.
 [Hexaemeron](./plugins/hexaemeron) takes a topic from nothing to a working prototype through one receipted loop.
 
 
+### Horos
+
+[Horos](./plugins/horos) decides what an agent does not read. It classifies a
+repository's token sinks with evidence and emits the boundary agents consult
+before reading, so the budget goes to the code that matters.
+
+
 ### Lemma
 
 [Lemma](./plugins/lemma) turns Solidity compiler inputs and Markdown documents
@@ -108,6 +115,7 @@ The short map of what each plugin does and what is honestly left to build.
 | [Brevitas](./plugins/brevitas) | Enforcing mechanical volume and structure budgets on engineering review prose while preserving evidence. | The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked. |
 | [Hermes](./plugins/hermes) | Measuring one Solidity gas-optimisation class through fail-closed Foundry checks. | No complete, reproducible live Wildcat evidence bundle is published. |
 | [Hexaemeron](./plugins/hexaemeron) | Running an explicit, receipted delivery loop, ranking frontier work with Kronos, or using its fuzzing, audit and prose skills separately. | The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery. |
+| [Horos](./plugins/horos) | Classifying a repository's token sinks with evidence and emitting the reading boundary agents respect. | TypeScript and JavaScript skeleton maps remain unimplemented, and no scan of a live external repository is recorded as evidence. |
 | [Lemma](./plugins/lemma) | Producing source-linked chunks from Solidity compiler inputs or Markdown. | Callable-surface ABI validation does not independently check return types or state mutability. |
 | [Lazarus](./plugins/lazarus) | Capturing a finite fixed-block Ethereum fixture, checking proof-backed state and replaying exact requests without fallback. | Preservation-pipeline integration and an Ariadne state-fixture predicate remain unimplemented. |
 | [Pandects](./plugins/pandects) | Supplying executable credit laws, broken specimens and reduced counterexamples. | The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records. |

--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ another person can rebuild after the endpoint that served them is gone.
 
 Scored out of 10 for doing the job, not for reading the output. A marketer can quote a verified gas number without having any use for Hermes itself.
 
-| Role | Alexandria | Ariadne | Brevitas | Hermes | Hexaemeron | Lemma | Lazarus | Pandects | Probitas | Sapheneia | Tabularium |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Developers | 8 | 8 | 8 | 9 | 9 | 6 | 8 | 8 | 4 | 8 | 7 |
-| Security and audit | 8 | 9 | 10 | 7 | 8 | 4 | 8 | 9 | 5 | 7 | 7 |
-| Marketing | 1 | 1 | 1 | 3 | 6 | 1 | 1 | 1 | 1 | 3 | 1 |
-| Business development | 6 | 2 | 2 | 2 | 5 | 1 | 2 | 2 | 9 | 4 | 3 |
-| Finance | 8 | 1 | 2 | 3 | 4 | 1 | 2 | 2 | 7 | 4 | 7 |
-| Legal | 3 | 3 | 2 | 1 | 4 | 1 | 2 | 2 | 4 | 4 | 2 |
+| Role | Alexandria | Ariadne | Brevitas | Hermes | Hexaemeron | Horos | Lemma | Lazarus | Pandects | Probitas | Sapheneia | Tabularium |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Developers | 8 | 8 | 8 | 9 | 9 | 8 | 6 | 8 | 8 | 4 | 8 | 7 |
+| Security and audit | 8 | 9 | 10 | 7 | 8 | 2 | 4 | 8 | 9 | 5 | 7 | 7 |
+| Marketing | 1 | 1 | 1 | 3 | 6 | 1 | 1 | 1 | 1 | 1 | 3 | 1 |
+| Business development | 6 | 2 | 2 | 2 | 5 | 1 | 1 | 2 | 2 | 9 | 4 | 3 |
+| Finance | 8 | 1 | 2 | 3 | 4 | 1 | 1 | 2 | 2 | 7 | 4 | 7 |
+| Legal | 3 | 3 | 2 | 1 | 4 | 1 | 1 | 2 | 2 | 4 | 4 | 2 |
 
 Five is the barrier. At or above it, the plugin's entry carries a worked example of what that role would use it for. Below it there is no example, because there is no honest one to give. These are engineering tools, and a 2 means we could not find a reason for that desk to open the plugin rather than read what it produced.
 

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -930,3 +930,18 @@ cold read's one defect, a hand-off line predating the phase skills, was fixed
 in the step commit. Root 24/24, hexaemeron 124/124.
 
 Leads not pursued: none.
+
+## Step 1, round 1 -- 2026-08-18
+
+Run: Horos, the reading-boundary skill. Step 1 scaffolds and registers the
+plugin. Suite waived (no Solidity); the round ran the three bundled lints and
+a diff review against the study's risk register.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R1-01 | low | plugins/horos/README.md | "What it ships" claimed the scanner, boundary and maps in the present tense while this step ships only the scaffold | fixed: section reframed as what the runbook lands, in order |
+| S1-R1-02 | low | plugins/horos/docs/runbook.md | the committed runbook copy pointed at the gitignored .hexaemeron path as the spec | fixed: points at the committed study beside it |
+| S1-R1-03 | low | README.md | the role matrix omits a Horos column, and a Developers score at or above five demands a worked example the landing README lacked | fixed: column added (Developers 8, Security 2, all other desks 1) and a Day-to-day example added |
+
+Lints: phylax 0, ephoros 0, hypomnema 0 over plugins tests and the changed
+documents. Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -945,3 +945,14 @@ a diff review against the study's risk register.
 
 Lints: phylax 0, ephoros 0, hypomnema 0 over plugins tests and the changed
 documents. Leads not pursued: none.
+
+## Step 1, round 2 -- 2026-08-18
+
+The round re-ran against the tree with round 1's fixes applied. Lints: phylax
+0, ephoros 0, hypomnema 0. Root 24/24, horos 4/4. The review of the fix diff
+found nothing further.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.

--- a/plugins/horos/.claude-plugin/plugin.json
+++ b/plugins/horos/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "horos",
+  "displayName": "Horos",
+  "version": "0.1.0",
+  "description": "Classify a repository's token sinks with evidence and emit the reading boundary agents respect.",
+  "author": {
+    "name": "Wildcat Labs",
+    "url": "https://wildcat.finance"
+  },
+  "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/horos",
+  "repository": "https://github.com/wildcat-finance/skills",
+  "keywords": [
+    "reading-boundary",
+    "token-budget",
+    "generated-code",
+    "vendored-code",
+    "skeleton-map",
+    "agent-context"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/horos/.codex-plugin/plugin.json
+++ b/plugins/horos/.codex-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "horos",
+  "version": "0.1.0",
+  "description": "Classify a repository's token sinks with evidence and emit the reading boundary agents respect.",
+  "author": {
+    "name": "Wildcat Labs",
+    "url": "https://wildcat.finance"
+  },
+  "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/horos",
+  "repository": "https://github.com/wildcat-finance/skills",
+  "keywords": [
+    "reading-boundary",
+    "token-budget",
+    "generated-code",
+    "vendored-code",
+    "skeleton-map",
+    "agent-context"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Horos",
+    "shortDescription": "Classify a repository's token sinks with evidence and emit the reading boundary agents respect.",
+    "longDescription": "Walks a repository, classifies generated files, vendored trees, lockfiles, minified bundles and single-line blobs with the evidence that earned each entry, writes a deterministic committed boundary, verifies it against the tree, and prints Python skeleton maps for oriented reading.",
+    "developerName": "Wildcat Labs",
+    "category": "Developer Tools",
+    "capabilities": [],
+    "defaultPrompt": "Use horos to scan this repository and emit the reading boundary."
+  }
+}

--- a/plugins/horos/README.md
+++ b/plugins/horos/README.md
@@ -24,7 +24,10 @@ rewriting at up to 12 points of task completion. Not reading the sinks at all
 is the mechanism that wins, and Horos makes it checkable. The full argument
 is committed at [docs/study.md](./docs/study.md).
 
-## What it ships
+## What the delivery builds
+
+The runbook at [docs/runbook.md](./docs/runbook.md) lands these in order,
+one reviewed step each:
 
 - a standard-library scanner that classifies token sinks and quotes the
   evidence line that earned each entry;
@@ -33,6 +36,14 @@ is committed at [docs/study.md](./docs/study.md).
 - Python skeleton maps, so a large file can be oriented in without being
   read; and
 - one binding rule: no boundary applies during security review.
+
+## Day to day
+
+**Developers.** An agent is pointed at a frontend repository where two thirds
+of the readable bytes are a checked-in Storybook build, a lockfile and a data
+file on one line. The committed boundary sends the reading budget to `src/`
+instead, `check` catches the day the boundary goes stale, and a skeleton map
+orients the agent in a thousand-line module without opening it whole.
 
 ## Where it is honest about limits
 

--- a/plugins/horos/README.md
+++ b/plugins/horos/README.md
@@ -1,0 +1,42 @@
+# Horos
+
+<!-- marketplace-context:start -->
+## In one line
+
+Horos classifies a repository's token sinks with evidence and emits the reading boundary agents respect.
+
+**Try something else when.** Use Lemma to chunk source for retrieval, Brevitas for prose budgets, and Hexaemeron's Metron for runtime cost. Horos decides what goes unread; it never rewrites what is read.
+
+**Current frontier.** TypeScript and JavaScript skeleton maps remain unimplemented, and no scan of a live external repository is recorded as evidence.
+
+**Next Fiat job.** Use /hexaemeron:fiat to Record a live-repository scan of wildcat-app-v2 as an evidence bundle and decide the TypeScript skeleton parser question. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
+<!-- marketplace-context:end -->
+
+## Why it exists
+
+An agent working in a repository spends most of its reading budget on files
+that return nothing: build output committed to the tree, vendored
+dependencies, lockfiles, minified bundles, data blobs on a single line.
+Measured against two Wildcat repositories, those files were 66% and 87% of
+readable bytes. Rewriting code to save tokens was studied first and rejected;
+the licensed saving was about 3% and published evidence prices aggressive
+rewriting at up to 12 points of task completion. Not reading the sinks at all
+is the mechanism that wins, and Horos makes it checkable. The full argument
+is committed at [docs/study.md](./docs/study.md).
+
+## What it ships
+
+- a standard-library scanner that classifies token sinks and quotes the
+  evidence line that earned each entry;
+- a deterministic committed boundary at `.horos/boundary.json`, verified
+  against the tree by `check`, which names every drifted path;
+- Python skeleton maps, so a large file can be oriented in without being
+  read; and
+- one binding rule: no boundary applies during security review.
+
+## Where it is honest about limits
+
+Classification is fail-open. A file Horos cannot evidence stays readable, so
+Horos misses sinks a person would catch, and its report says what it skipped.
+The scanner reads at most a fixed prefix of any file, so a scan never costs a
+fraction of what it saves.

--- a/plugins/horos/README.md
+++ b/plugins/horos/README.md
@@ -49,5 +49,5 @@ orients the agent in a thousand-line module without opening it whole.
 
 Classification is fail-open. A file Horos cannot evidence stays readable, so
 Horos misses sinks a person would catch, and its report says what it skipped.
-The scanner reads at most a fixed prefix of any file, so a scan never costs a
-fraction of what it saves.
+The scanner reads at most a fixed prefix of any file, so a scan never costs
+more than a fraction of what it saves.

--- a/plugins/horos/docs/runbook.md
+++ b/plugins/horos/docs/runbook.md
@@ -1,9 +1,9 @@
 # Horos, the runbook
 
 Five steps, dependency order, one pull request each. Every step assumes the
-exit state of the one before it and nothing else. The study at
-`.hexaemeron/study.md` is the spec; repo copies of both documents land in
-step 1.
+exit state of the one before it and nothing else. The study committed beside
+this runbook at [study.md](./study.md) is the spec; both documents landed
+here in step 1.
 
 Module trace: scaffold, classify, boundary, skeleton, discipline. One
 capability, so no decomposition table; the modules are the steps.

--- a/plugins/horos/docs/runbook.md
+++ b/plugins/horos/docs/runbook.md
@@ -1,0 +1,96 @@
+# Horos, the runbook
+
+Five steps, dependency order, one pull request each. Every step assumes the
+exit state of the one before it and nothing else. The study at
+`.hexaemeron/study.md` is the spec; repo copies of both documents land in
+step 1.
+
+Module trace: scaffold, classify, boundary, skeleton, discipline. One
+capability, so no decomposition table; the modules are the steps.
+
+## Step 1: Scaffold and register the plugin
+
+**Goal.** `plugins/horos/` exists in the house shape and every marketplace
+surface knows about it.
+**Entry.** The run branch, cut from `main` at `6168e54`.
+**Exit.** `python3 -m unittest discover -s tests -t .` green with the plugin
+set now twelve; `python3 -m unittest discover -s plugins/horos/tests -t
+plugins/horos` green; phylax and ephoros clean over `plugins tests`;
+imprimatur clean on every new document.
+**Files.** `plugins/horos/.claude-plugin/plugin.json` and
+`.codex-plugin/plugin.json` (repository, homepage, agreed description,
+`interface.shortDescription`); `plugins/horos/skills/horos/SKILL.md` with
+frontmatter, `version: "0.1.0"` metadata and a link to its ledger;
+`plugins/horos/skills/horos/EVOLUTION.md` with a baseline row whose digest
+satisfies the evolution contract; `plugins/horos/README.md` carrying
+`## In one line` and the rolling Next Fiat job line with the exact prefix and
+suffix the prose contract demands; `.agents/skills/horos/SKILL.md` portable
+entrypoint; a row in the root `README.md` selection table; the new plugin
+entry in `.claude-plugin/marketplace.json`; copies of the study and this
+runbook at `plugins/horos/docs/`; `plugins/horos/tests/__init__.py` and
+`test_scaffold.py`.
+**Tests.** Extend `tests/test_marketplace_prose.py` (the `PLUGINS` tuple,
+`CANONICAL_SKILLS`, the landing-README count) and the fixed name list in
+`tests/test_portable_skills.py` to include horos; add `test_scaffold.py`
+asserting the two host manifests agree with the marketplace entry.
+
+## Step 2: The classifier
+
+**Goal.** One stdlib script that classifies a tree's token sinks with
+evidence, reading at most a fixed prefix of any file.
+**Entry.** Step 1's exit state.
+**Exit.** Plugin suite green; every rule class has at least one positive and
+one negative case.
+**Files.** `plugins/horos/skills/horos/scripts/horos.py`;
+`plugins/horos/tests/test_classify.py`.
+**Tests.** Per rule class (binary, lockfile, generated marker, generated
+directory, vendored, single-line blob, minified geometry): a file that earns
+the entry and a near-miss that stays readable. A symlink pointing outside the
+root is never followed. Undecodable bytes never raise. The walk order is
+deterministic and `.git` and `.horos` are never scanned. Expected count:
+about eighteen.
+
+## Step 3: Boundary emit and check
+
+**Goal.** `scan` writes the committed boundary artefact; `check` re-derives
+it and names every drifted path.
+**Entry.** Step 2's exit state.
+**Exit.** Plugin suite green; `scan` twice over the same tree produces
+byte-identical output; `check` exits 0 on a fresh boundary and non-zero on
+any mutation, naming the path.
+**Files.** `horos.py` extended; `plugins/horos/tests/test_boundary.py`.
+**Tests.** Determinism (two scans, byte-identical, sorted paths, no
+timestamps, no absolute paths); atomic write (temporary file plus rename);
+drift is reported per path; a boundary entry the tree no longer evidences
+fails `check` (the poisoned-boundary case); scan output reports files walked,
+bytes per category and files skipped. Expected count: about ten.
+
+## Step 4: The skeleton map
+
+**Goal.** `map` prints the signatures, class structure and first docstring
+lines of a Python file so the file can be oriented in without being read.
+**Entry.** Step 3's exit state.
+**Exit.** Plugin suite green; `map` over a fixture module matches its pinned
+output; a file with a syntax error produces a report, not a traceback.
+**Files.** `horos.py` extended; `plugins/horos/tests/test_map.py`.
+**Tests.** Pinned skeleton for a fixture module covering nested classes,
+async functions and decorated definitions; the syntax-error path; a
+non-Python path is refused with a clear message. Expected count: about six.
+
+## Step 5: The discipline, the example, the demonstration
+
+**Goal.** The SKILL.md teaches the reading discipline, the shipped example
+proves the pipeline, and the demo path from the study runs.
+**Entry.** Step 4's exit state.
+**Exit.** Study success criteria 1 through 4 all pass as written, from the
+repo root; imprimatur clean on every shipped document.
+**Files.** `plugins/horos/skills/horos/SKILL.md` full text, including the
+verbatim rule that no boundary applies during security review;
+`plugins/horos/examples/fixture/` with one file per rule class and the
+committed expected boundary; `plugins/horos/examples/README.md` documenting
+the mutation that makes `check` fail; `plugins/horos/README.md` finished;
+`plugins/horos/tests/test_discipline.py`.
+**Tests.** The security-review rule is present verbatim in the SKILL.md
+(asserted by test so an edit cannot drop it silently); the example fixture's
+committed boundary matches a fresh scan byte for byte; the documented
+mutation makes `check` exit non-zero. Expected count: about five.

--- a/plugins/horos/docs/study.md
+++ b/plugins/horos/docs/study.md
@@ -1,0 +1,210 @@
+# Horos, the study
+
+Horos, ὅρος, the boundary stone. A skill that decides what an agent does not
+read, and proves the decision instead of asserting it.
+
+This study is the successor to the Epitome assessment of 2026-08-18, which
+measured the code-compression premise against this marketplace and two Wildcat
+repositories and rejected it: the licensed saving was about 3% of tokens,
+published evidence prices representation-degrading transforms at up to 12
+points of task completion, and not reading generated or vendored files at all
+removed 66% to 87% of readable bytes at no semantic risk. Horos builds the
+mechanism that wins that comparison.
+
+## Assumptions
+
+Proceeding on these unless corrected:
+
+1. Python 3.11 and stdlib `unittest`, matching every other plugin here. No
+   third-party dependency without asking first.
+2. Horos ships as a new marketplace plugin at `plugins/horos/` in the house
+   shape: `skills/horos/SKILL.md` with version metadata, `EVOLUTION.md`
+   conforming to the marketplace evolution contract, scripts under
+   `skills/horos/scripts/`, tests under `tests/`, registration in
+   `.claude-plugin/marketplace.json`.
+3. A target repository is a directory tree on disk. Horos walks the working
+   tree; it does not need git, the network, or a subprocess.
+4. TypeScript and JavaScript skeleton maps are out of the prototype. Stdlib
+   Python cannot parse them honestly, and a regex sketch of a language is the
+   kind of guess this marketplace refuses. Python skeletons via `ast` are in.
+
+## 1. Problem statement
+
+An agent asked to work in a repository spends most of its reading budget on
+files that carry nothing for the task: build output committed to the tree,
+vendored dependencies, lockfiles, minified bundles, single-line data blobs.
+Measured this week: 87% of readable bytes in `v2-protocol` (9.7 MB of solc
+output under `deployments/`), 66% in `wildcat-app-v2` (a checked-in Storybook
+build, `package-lock.json`, and a 1.4 MB JSON file on one physical line worth
+roughly 360,000 tokens on its own).
+
+Horos gives the agent three verbs and a discipline:
+
+- `scan` walks a tree, classifies each file it can evidence as a token sink,
+  and writes `.horos/boundary.json`: a deterministic, sorted record where
+  every entry carries its category, size and the evidence line that earned it.
+- `check` re-derives the classification and compares it with the committed
+  boundary, exiting non-zero on drift.
+- `map` prints a skeleton of a Python file, meaning its signatures, class
+  structure and the first line of each docstring, so a large file can be
+  oriented in before it is read whole, or instead of being read whole.
+
+The SKILL.md teaches the agent the discipline: consult the boundary before
+reading, treat everything inside it as unread-by-default, use `map` before
+opening any large Python file, and ignore the boundary entirely during
+security review, where hiding a file is exactly what an adversary would want.
+
+A working prototype means the demo path runs: `scan` over the committed
+example fixture reproduces the committed expected boundary byte for byte,
+`check` passes on the intact fixture and fails on a documented mutation of
+it, and both test suites and the tree lints are green.
+
+## 2. Prior art
+
+Outside: GitHub Linguist's `linguist-generated` and `linguist-vendored`
+attributes are the closest ancestor: a per-path classification that changes
+what a reader (the diff view) shows, driven by heuristics plus maintainer
+annotation. aider's repo-map and Repomix `--compress` build tree-sitter
+skeletons under a token budget. LongCodeZip (arXiv 2510.00446) supplies the
+evidence that selection-based reduction preserves task performance where
+rewriting does not. None of these emits a checked-in, evidence-bearing,
+verifiable boundary; that is the gap Horos occupies.
+
+Inside this repository: the Epitome study (the measurement this design rests
+on); Lemma's chunkers, which already separate quotation text from model text
+per chunk; Hypomnema's `VENDORED` set, a hand-kept ancestor of the vendored
+category; and Pandects' comment-stripper tests, which pin the
+string-literal traps any content-sniffing pass must not repeat.
+
+## 3. Constraints and non-goals
+
+- Stdlib only. `os`, `ast`, `json`, `unittest`; no tree-sitter, no tokenizer.
+- The marketplace contract tests govern the plugin shape: a conforming
+  `EVOLUTION.md`, SKILL.md version metadata matching it, portable-skill and
+  marketplace-prose rules. The phylax and ephoros lints must exit clean over
+  `plugins tests`.
+- Classification is fail-open. A file Horos cannot evidence stays readable.
+  The asymmetry is deliberate: a wrongly excluded source file blinds the
+  agent; a wrongly included sink merely wastes what it always wasted.
+- Bounded reads. The classifier stats every file but reads at most a fixed
+  prefix (4 KiB) of any of them. A scan must never cost a fraction of what it
+  saves.
+- Non-goals for the prototype: code transformation of any kind (Epitome's
+  ground, already rejected), TS/JS skeletons, git-history signals, network
+  fetches, automatic boundary regeneration, and any per-token accounting.
+  Bytes are the unit; the Epitome study already established the conversion.
+
+## 4. Design options
+
+**A. One stdlib classifier, a checked-in boundary, Python skeletons.** Rule
+classes: binary content (null byte in prefix); lockfiles by exact name;
+generated files by marker in the read prefix ("DO NOT EDIT", "@generated",
+"Code generated by", solc output shapes, `.map` sourcemaps) or by directory
+convention (`dist/`, `build/`, `storybook-static/`, `deployments/` when
+marker-confirmed); vendored directories by name and by `linguist-vendored`
+attributes where a `.gitattributes` exists; blobs by physical-line geometry
+(single line over a byte threshold, or mean line length over a minified-code
+threshold). Trade: heuristics misclassify, so every entry must carry evidence
+and the uncertain case defaults to readable, which caps recall: Horos will
+miss sinks a human would catch, and says so in its report.
+
+**B. Wrap repomix or aider's repo-map.** Trade: a Node dependency chain, no
+evidence contract, no verifiable committed artefact. Rejected: it buys the
+skeleton half and abandons the boundary half, in a toolchain this marketplace
+does not carry.
+
+**C. Prose-only SKILL.md heuristics, no script.** Trade: nothing to test,
+nothing to verify, and every claim drifts. Rejected by Metron's rule: an
+optimisation with no measurement attached is an opinion.
+
+**D. Drive everything from `.gitattributes` annotations.** Trade: covers only
+what maintainers already annotated, and the measured sinks in both Wildcat
+repos carried no annotations at all. Folded into A as one input signal.
+
+**Chosen: A.** It is the cheapest construction to comprehend that meets the
+problem statement. Its one trade, bounded recall in exchange for zero false
+exclusions of hand-written source, points the right way for a tool whose
+worst error is hiding code from the reader.
+
+## 5. Risk register seed
+
+What the audit loop should look hardest at, phylax first:
+
+- Symlinks. The walker must never follow a link out of the scan root; a
+  hostile tree can otherwise walk the scanner into `$HOME`.
+- Partial writes. `boundary.json` is written to a temporary file and renamed,
+  so a killed run leaves either the old boundary or the new one, never half.
+- Undecodable bytes. Marker search decodes the prefix with
+  `errors="replace"`; classification must not raise on any byte sequence.
+- Determinism. Same tree, same boundary, byte for byte: sorted paths, sorted
+  keys, no timestamps, no absolute paths inside the artefact.
+- The poisoned boundary. A committed `boundary.json` in a hostile repository
+  could list source files as sinks to keep a reviewing agent from reading
+  them. Two controls: `check` re-derives everything it asserts before an
+  agent leans on it, and the SKILL.md forbids applying any boundary during
+  security review. The skill text carries this rule verbatim, and the test
+  suite asserts its presence so an edit cannot drop it silently.
+- Evidence strings. The marker or geometry line that earned each entry is
+  quoted exactly, never paraphrased, so a human can dispute a classification
+  from the artefact alone.
+- Ephoros: a scan that runs unattended must report counts (files walked,
+  bytes classified per category, files skipped as unreadable), and `check`
+  must name every drifted path, not just fail.
+
+## 6. Glossary seeds
+
+- Token sink: a file whose bytes cost reading budget and return nothing for
+  the task at hand.
+- Reading boundary: the committed set of paths an agent leaves unread by
+  default, each with the evidence that put it there.
+- Fail-open classification: uncertainty keeps a file readable; only evidence
+  excludes.
+- Skeleton map: the signatures-and-structure view of a file, printed instead
+  of the file.
+- Bounded read: the classifier's own reading limit, which is to stat
+  everything and read at most a fixed prefix.
+- Drift: any difference between the committed boundary and one derived fresh
+  from the tree.
+
+## 7. Boundaries
+
+- **Always.** Both test suites before a commit (`python3 -m unittest discover
+  -s plugins/horos/tests -t plugins/horos` and the root contract suite). The
+  phylax and ephoros lints over `plugins tests`. The imprimatur lint on every
+  shipped document. Atomic writes for every artefact Horos emits.
+- **Ask first.** Any dependency. Any change to the boundary schema once one
+  release has shipped. TS/JS skeleton support. Touching CI. Raising the read
+  prefix or the blob thresholds once tests pin them.
+- **Never.** Follow a symlink out of the scan root. Execute or import
+  anything from a scanned repository. Apply a reading boundary during
+  security review or an audit round. Fetch anything over the network. Delete
+  a failing test to make a suite pass.
+
+## 8. Success criteria
+
+1. `python3 -m unittest discover -s plugins/horos/tests -t plugins/horos`
+   passes.
+2. `python3 -m unittest discover -s tests -t .` passes, which holds the
+   evolution ledger, portability and marketplace-prose contracts.
+3. `python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests`
+   and the ephoros equivalent exit clean.
+4. Demo path: `python3 plugins/horos/skills/horos/scripts/horos.py scan
+   plugins/horos/examples/fixture --json` reproduces the committed expected
+   boundary byte for byte; `check` exits 0 on the intact fixture and non-zero
+   after the documented mutation in the example's README.
+5. Recorded once as environmental evidence, not a repeatable gate: a scan of
+   the wildcat-app-v2 clone classifies at least 60% of its readable bytes as
+   sinks while excluding zero hand-written files under `src/`, checked
+   against the file list from the Epitome study.
+
+## 9. Sources
+
+The Epitome protasis study (2026-08-18, this session; measurements of this
+marketplace, v2-protocol and wildcat-app-v2). GitHub Linguist documentation
+on `linguist-generated` and `linguist-vendored`. aider repo-map
+(aider.chat/2023/10/22/repomap.html). Repomix compress
+(repomix.com/guide/code-compress). LongCodeZip (arXiv 2510.00446). Minification
+task-cost evidence (arXiv 2606.01326). In-repo: `plugins/lemma/chunkers/`,
+`plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py` (the `VENDORED`
+set), `plugins/pandects/tests/test_search_record.py` (stripper traps),
+`tests/test_evolution_contract.py` (the ledger contract Horos must meet).

--- a/plugins/horos/docs/study.md
+++ b/plugins/horos/docs/study.md
@@ -87,8 +87,8 @@ string-literal traps any content-sniffing pass must not repeat.
   The asymmetry is deliberate: a wrongly excluded source file blinds the
   agent; a wrongly included sink merely wastes what it always wasted.
 - Bounded reads. The classifier stats every file but reads at most a fixed
-  prefix (4 KiB) of any of them. A scan must never cost a fraction of what it
-  saves.
+  prefix (4 KiB) of any of them. A scan must never cost more than a fraction of
+  what it saves.
 - Non-goals for the prototype: code transformation of any kind (Epitome's
   ground, already rejected), TS/JS skeletons, git-history signals, network
   fetches, automatic boundary regeneration, and any per-token accounting.

--- a/plugins/horos/skills/horos/EVOLUTION.md
+++ b/plugins/horos/skills/horos/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Horos evolution ledger
+
+Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
+
+- Current version: `horos-v0.1.0`
+- Frontier status: `open`
+- Frontier revision: `live-evidence-and-ts-maps`
+- Current frontier: TypeScript and JavaScript skeleton maps remain unimplemented, and no scan of a live external repository is recorded as evidence.
+- Next Fiat job: Record a live-repository scan of wildcat-app-v2 as an evidence bundle and decide the TypeScript skeleton parser question. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `horos-v0.1.0` | baseline | `live-evidence-and-ts-maps` | `35be1190b60ef3acab18434ca647628943a0073ecbbc14dc0a0f041365352fe8` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |

--- a/plugins/horos/skills/horos/SKILL.md
+++ b/plugins/horos/skills/horos/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: horos
+description: Emit and verify an evidence-backed reading boundary over a repository. Classify token sinks (generated files, vendored trees, lockfiles, minified bundles, single-line blobs), write the deterministic boundary agents consult before reading, and print Python skeleton maps for oriented reading. Use when a user names Horos or asks to cut the reading cost of a repository without rewriting its code. Never apply a boundary during security review.
+metadata:
+  version: "0.1.0"
+---
+
+# Horos
+
+From *horos*, the boundary stone. Horos decides what an agent does not read,
+and proves the decision instead of asserting it.
+
+## Where this sits
+
+Horos owns the reading boundary: which files in a repository an agent leaves
+unread by default, each exclusion carrying the evidence that earned it. Its
+version, held frontier, next job, and maturity state live in
+[EVOLUTION.md](EVOLUTION.md).
+
+**Use another tool when.** Use Lemma to chunk source for retrieval rather than
+to skip it; use Brevitas for prose volume; use Metron for runtime cost. Horos
+never rewrites code: the compression premise was measured and rejected in the
+study this plugin ships at `docs/study.md`.
+
+**Current frontier.** TypeScript and JavaScript skeleton maps remain unimplemented, and no scan of a live external repository is recorded as evidence.
+
+## Status of this scaffold
+
+This step ships the plugin's registration surface: manifests, ledger, tests
+and the committed study and runbook at [docs/](../../docs/). The `scan`,
+`check` and `map` verbs land in the later steps of the same delivery, in the
+order the runbook fixes. Until they land, the study is the contract and this
+file names it.
+
+## The one rule that is already binding
+
+No reading boundary applies during security review. A committed boundary in a
+hostile repository could list source files as sinks precisely so a reviewing
+agent never opens them. During any audit, review or incident work, read as if
+no boundary exists.

--- a/plugins/horos/tests/test_scaffold.py
+++ b/plugins/horos/tests/test_scaffold.py
@@ -1,0 +1,49 @@
+"""Scaffold contracts for the Horos plugin."""
+
+from pathlib import Path
+import json
+import unittest
+
+PLUGIN = Path(__file__).resolve().parents[1]
+ROOT = PLUGIN.parents[1]
+
+
+def marketplace_entry():
+    payload = json.loads(
+        (ROOT / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8")
+    )
+    entries = [entry for entry in payload["plugins"] if entry["name"] == "horos"]
+    if len(entries) != 1:
+        raise AssertionError(f"expected one horos marketplace entry, found {len(entries)}")
+    return entries[0]
+
+
+class ScaffoldTests(unittest.TestCase):
+    def test_host_manifests_agree_with_the_marketplace_entry(self):
+        entry = marketplace_entry()
+        for host in (".claude-plugin", ".codex-plugin"):
+            manifest = json.loads(
+                (PLUGIN / host / "plugin.json").read_text(encoding="utf-8")
+            )
+            with self.subTest(host=host):
+                self.assertEqual(manifest["description"], entry["description"])
+                self.assertEqual(manifest["version"], entry["version"])
+                self.assertEqual(manifest["homepage"], entry["homepage"])
+
+    def test_the_skill_links_its_ledger(self):
+        text = (PLUGIN / "skills" / "horos" / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn("[EVOLUTION.md](EVOLUTION.md)", text)
+
+    def test_the_docs_carry_the_study_and_runbook(self):
+        for name in ("study.md", "runbook.md"):
+            with self.subTest(document=name):
+                self.assertTrue((PLUGIN / "docs" / name).is_file())
+
+    def test_the_security_review_rule_is_present(self):
+        rule = "No reading boundary applies during security review."
+        text = (PLUGIN / "skills" / "horos" / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn(rule, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_marketplace_prose.py
+++ b/tests/test_marketplace_prose.py
@@ -14,6 +14,7 @@ PLUGINS = (
     "brevitas",
     "hermes",
     "hexaemeron",
+    "horos",
     "lemma",
     "lazarus",
     "pandects",
@@ -27,6 +28,7 @@ CANONICAL_SKILLS = {
     "brevitas": ROOT / "plugins" / "brevitas" / "skills" / "brevitas" / "SKILL.md",
     "hermes": ROOT / "plugins" / "hermes" / "skills" / "hermes" / "SKILL.md",
     "hexaemeron": ROOT / "plugins" / "hexaemeron" / "skills" / "fiat" / "SKILL.md",
+    "horos": ROOT / "plugins" / "horos" / "skills" / "horos" / "SKILL.md",
     "lemma": ROOT / "plugins" / "lemma" / "skills" / "chunk" / "SKILL.md",
     "lazarus": ROOT / "plugins" / "lazarus" / "skills" / "lazarus" / "SKILL.md",
     "pandects": ROOT / "plugins" / "pandects" / "skills" / "pandects" / "SKILL.md",
@@ -127,7 +129,7 @@ class MarketplaceProseTests(unittest.TestCase):
     def test_plugin_landing_readmes_publish_unique_rolling_fiat_jobs(self):
         landings = plugin_landing_readmes()
         self.assertEqual(set(landings), set(PLUGINS))
-        self.assertEqual(len(landings), 11)
+        self.assertEqual(len(landings), 12)
 
         topics = {}
         for name, path in landings.items():

--- a/tests/test_portable_skills.py
+++ b/tests/test_portable_skills.py
@@ -35,6 +35,7 @@ class PortableSkillTests(unittest.TestCase):
             "brevitas",
             "hermes",
             "hexaemeron",
+            "horos",
             "lazarus",
             "lemma",
             "pandects",


### PR DESCRIPTION
Horos is the reading-boundary skill: classify a repository's token sinks with
evidence and emit the boundary agents respect. It came out of a study that
measured the code-compression idea it replaces and rejected it; not reading
generated and vendored files beat rewriting code by an order of magnitude at
no semantic risk. The study and runbook are committed at plugins/horos/docs/.

This first step ships the registration surface and nothing else: both host
manifests, the evolution ledger with its baseline row, the landing README,
the portable entrypoint, the marketplace entry, a row and a column in the
root README, and the contract-test extensions that hold the shipped plugin
set at twelve. The scan, check and map verbs land in the next steps of the
same run.

Audit: two rounds, three low findings in round 1, all fixed; the log is in
audit/AUDIT.md and the stacked review PR is #121.

Proof: `python3 -m unittest discover -s tests` and `python3 -m unittest
discover -s plugins/horos/tests -t plugins/horos`, plus the phylax and
ephoros lints over `plugins tests`.

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
