### PR TITLE
Audit round 1 fixes for the classifier

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -956,3 +956,18 @@ found nothing further.
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Step 2, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); the round ran the three bundled lints, all clean,
+then reviewed the classifier against the study's risk register.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S2-R1-01 | medium | plugins/horos/skills/horos/scripts/horos.py | classify_file swallowed OSError and returned None, so an unreadable file was reported as readable instead of counted in files_skipped_unreadable, understating what the scan skipped | fixed: the function raises and the walker counts, with a chmod-0 regression test |
+| S2-R1-02 | low | plugins/horos/skills/horos/scripts/horos.py | classify_file is public but did not itself refuse symlinks; only the walker guarded them, so a direct caller could make the scanner read outside root | fixed: the function refuses links as well |
+
+Leads not pursued: a stat-then-open race (a file swapped for a symlink between
+the check and the read) is accepted for the prototype; exploiting it requires
+an attacker writing to the tree during the scan, at which point the tree is
+already theirs.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -971,3 +971,15 @@ Leads not pursued: a stat-then-open race (a file swapped for a symlink between
 the check and the read) is accepted for the prototype; exploiting it requires
 an attacker writing to the tree during the scan, at which point the tree is
 already theirs.
+
+## Step 2, round 2 -- 2026-08-18
+
+Re-ran against the fixed tree. Lints: phylax 0, ephoros 0, hypomnema 0.
+Horos 26/26, root 24/24. The fix diff review found nothing further: the one
+public caller of classify_file already counts the raised OSError as skipped.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none beyond the accepted race recorded in
+round 1.

--- a/plugins/horos/skills/horos/scripts/horos.py
+++ b/plugins/horos/skills/horos/scripts/horos.py
@@ -140,13 +140,18 @@ def classify_content(name, size, prefix):
 
 
 def classify_file(root, relpath):
-    """Classify one file; None means it stays readable."""
+    """Classify one file; None means it stays readable.
+
+    Raises OSError when the file cannot be statted or read, so the caller
+    can count it as skipped rather than silently readable. Symlinks are
+    refused here as well as in the walk: this function is public, and a
+    caller handing it a link must not make the scanner read outside root.
+    """
     fullpath = os.path.join(root, relpath)
-    name = PurePosixPath(relpath).name
-    try:
-        size = os.stat(fullpath).st_size
-    except OSError:
+    if os.path.islink(fullpath):
         return None
+    name = PurePosixPath(relpath).name
+    size = os.stat(fullpath).st_size
 
     if name in LOCKFILE_NAMES:
         return {
@@ -156,10 +161,7 @@ def classify_file(root, relpath):
             "evidence": f"lockfile name {name}",
         }
 
-    try:
-        prefix = read_prefix(fullpath)
-    except OSError:
-        return None
+    prefix = read_prefix(fullpath)
     verdict = classify_content(name, size, prefix)
     if verdict is None:
         return None

--- a/plugins/horos/tests/test_classify.py
+++ b/plugins/horos/tests/test_classify.py
@@ -147,6 +147,14 @@ class ClassifyTests(unittest.TestCase):
         paths = [entry["path"] for entry in first["entries"]]
         self.assertEqual(paths, sorted(paths))
 
+    def test_an_unreadable_file_is_counted_as_skipped_not_readable(self):
+        path = write(self.root, "locked.txt", "cannot read me\n")
+        os.chmod(path, 0)
+        self.addCleanup(os.chmod, path, 0o644)
+        result = horos.scan_tree(self.root)
+        self.assertEqual(result["counts"]["files_skipped_unreadable"], 1)
+        self.assertEqual(result["entries"], [])
+
     def test_counts_report_bytes_per_category(self):
         write(self.root, "a.bin", b"\x00" * 10)
         write(self.root, "yarn.lock", "lock\n")


### PR DESCRIPTION
Review artefact for step 2's audit loop. Two findings fixed: unreadable files silently reported as readable instead of counted as skipped, and the public classify_file not refusing symlinks on its own. Log in audit/AUDIT.md.

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->