### PR TITLE
Audit round 1 fix for boundary emit

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -996,3 +996,15 @@ risk register's partial-write and determinism rows.
 Leads not pursued: a giant hand-crafted boundary.json can make check spend
 memory parsing it; accepted for the prototype, the file is repository-local
 and the parse failure path already exits 2.
+
+## Step 3, round 2 -- 2026-08-18
+
+Re-ran against the fixed tree. Lints: phylax 0, ephoros 0, hypomnema 0.
+Horos 39/39, root 24/24. The fix diff is one line plus its comment; the
+review found nothing further.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none beyond round 1's accepted parse-memory
+lead.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -983,3 +983,16 @@ public caller of classify_file already counts the raised OSError as skipped.
 
 Zero findings. Leads not pursued: none beyond the accepted race recorded in
 round 1.
+
+## Step 3, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0. Review focused on the
+risk register's partial-write and determinism rows.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R1-01 | low | plugins/horos/skills/horos/scripts/horos.py | the temporary boundary file used one fixed name, so two concurrent scans of the same tree could unlink each other's half-written temporary and fail one run's atomic replace | fixed: the temporary name carries the writing process id; the existing cleanup tests pin that no temporary survives either path |
+
+Leads not pursued: a giant hand-crafted boundary.json can make check spend
+memory parsing it; accepted for the prototype, the file is repository-local
+and the parse failure path already exits 2.

--- a/plugins/horos/skills/horos/scripts/horos.py
+++ b/plugins/horos/skills/horos/scripts/horos.py
@@ -296,7 +296,9 @@ def write_boundary(root, document):
     directory = os.path.join(root, os.path.dirname(BOUNDARY_RELPATH))
     os.makedirs(directory, exist_ok=True)
     final = os.path.join(root, BOUNDARY_RELPATH)
-    temporary = final + ".tmp"
+    # Per-process name: two concurrent scans must not unlink each other's
+    # half-written temporary in the finally block below.
+    temporary = f"{final}.{os.getpid()}.tmp"
     try:
         with open(temporary, "w", encoding="utf-8") as handle:
             handle.write(render(document))


### PR DESCRIPTION
Review artefact for step 3's audit loop. One finding fixed: the fixed temporary-file name let concurrent scans unlink each other's half-written temporary. Log in audit/AUDIT.md.

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->