### PR TITLE
Implement boundary emit and check

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -996,3 +996,15 @@ risk register's partial-write and determinism rows.
 Leads not pursued: a giant hand-crafted boundary.json can make check spend
 memory parsing it; accepted for the prototype, the file is repository-local
 and the parse failure path already exits 2.
+
+## Step 3, round 2 -- 2026-08-18
+
+Re-ran against the fixed tree. Lints: phylax 0, ephoros 0, hypomnema 0.
+Horos 39/39, root 24/24. The fix diff is one line plus its comment; the
+review found nothing further.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none beyond round 1's accepted parse-memory
+lead.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -983,3 +983,16 @@ public caller of classify_file already counts the raised OSError as skipped.
 
 Zero findings. Leads not pursued: none beyond the accepted race recorded in
 round 1.
+
+## Step 3, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0. Review focused on the
+risk register's partial-write and determinism rows.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R1-01 | low | plugins/horos/skills/horos/scripts/horos.py | the temporary boundary file used one fixed name, so two concurrent scans of the same tree could unlink each other's half-written temporary and fail one run's atomic replace | fixed: the temporary name carries the writing process id; the existing cleanup tests pin that no temporary survives either path |
+
+Leads not pursued: a giant hand-crafted boundary.json can make check spend
+memory parsing it; accepted for the prototype, the file is repository-local
+and the parse failure path already exits 2.

--- a/plugins/horos/skills/horos/scripts/horos.py
+++ b/plugins/horos/skills/horos/scripts/horos.py
@@ -1,6 +1,8 @@
 """Horos: classify a repository's token sinks and emit the reading boundary.
 
-scan <root>   walk a tree, classify every file it can evidence, print JSON
+scan <root>    classify the tree; --json prints the boundary document,
+               --write commits it to .horos/boundary.json atomically
+check <root>   re-derive the boundary and name every drifted path
 
 Classification is fail-open: a file the rules cannot evidence stays readable
 and earns no entry. The scanner stats every file but reads at most
@@ -270,19 +272,114 @@ def scan_tree(root):
     return {"entries": entries, "counts": counts}
 
 
+BOUNDARY_RELPATH = ".horos/boundary.json"
+BOUNDARY_SCHEMA = 1
+
+
+def boundary_document(result):
+    """The committed artefact: schema-tagged, no timestamps, no absolute paths."""
+    return {
+        "schema": BOUNDARY_SCHEMA,
+        "tool": "horos",
+        "entries": result["entries"],
+        "counts": result["counts"],
+    }
+
+
+def render(document):
+    """One canonical byte form, so equal documents are equal files."""
+    return json.dumps(document, indent=2, sort_keys=True) + "\n"
+
+
+def write_boundary(root, document):
+    """Write atomically: a killed run leaves the old boundary or the new one."""
+    directory = os.path.join(root, os.path.dirname(BOUNDARY_RELPATH))
+    os.makedirs(directory, exist_ok=True)
+    final = os.path.join(root, BOUNDARY_RELPATH)
+    temporary = final + ".tmp"
+    try:
+        with open(temporary, "w", encoding="utf-8") as handle:
+            handle.write(render(document))
+        os.replace(temporary, final)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def load_boundary(root):
+    with open(os.path.join(root, BOUNDARY_RELPATH), encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def diff_documents(committed, fresh):
+    """Name every drifted path; a symmetric compare, so a committed entry the
+    tree no longer evidences drifts exactly like a new sink the boundary lacks.
+    """
+    old = {entry["path"]: entry for entry in committed.get("entries", [])}
+    new = {entry["path"]: entry for entry in fresh.get("entries", [])}
+    drifted = []
+    for path in sorted(set(old) | set(new)):
+        if path not in new:
+            drifted.append((path, "in the boundary but no longer evidenced by the tree"))
+        elif path not in old:
+            drifted.append((path, "evidenced by the tree but missing from the boundary"))
+        elif old[path] != new[path]:
+            drifted.append((path, "entry changed: %s -> %s" % (old[path], new[path])))
+    return drifted
+
+
+def check_tree(root, out=None):
+    out = out if out is not None else sys.stdout
+    try:
+        committed = load_boundary(root)
+    except FileNotFoundError:
+        print(f"horos: no boundary at {BOUNDARY_RELPATH}; run scan --write", file=out)
+        return 2
+    except (OSError, json.JSONDecodeError) as error:
+        print(f"horos: unreadable boundary: {error}", file=out)
+        return 2
+    fresh = boundary_document(scan_tree(root))
+    drifted = diff_documents(committed, fresh)
+    if not drifted:
+        print("boundary matches the tree", file=out)
+        return 0
+    for path, reason in drifted:
+        print(f"drift: {path}: {reason}", file=out)
+    print(f"{len(drifted)} path(s) drifted", file=out)
+    return 1
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(prog="horos", description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
-    scan = subparsers.add_parser("scan", help="classify a tree and print JSON")
+    scan = subparsers.add_parser("scan", help="classify a tree")
     scan.add_argument("root", help="directory to scan")
+    scan.add_argument(
+        "--json", action="store_true", help="print the boundary document"
+    )
+    scan.add_argument(
+        "--write", action="store_true", help=f"write {BOUNDARY_RELPATH} atomically"
+    )
+    checker = subparsers.add_parser("check", help="verify the committed boundary")
+    checker.add_argument("root", help="directory to check")
     args = parser.parse_args(argv)
 
     if not os.path.isdir(args.root):
         print(f"horos: not a directory: {args.root}", file=sys.stderr)
         return 2
-    result = scan_tree(args.root)
-    json.dump(result, sys.stdout, indent=2, sort_keys=True)
-    print()
+
+    if args.command == "check":
+        return check_tree(args.root)
+
+    document = boundary_document(scan_tree(args.root))
+    if args.write:
+        write_boundary(args.root, document)
+    if args.json:
+        sys.stdout.write(render(document))
+    else:
+        for key, value in sorted(document["counts"].items()):
+            print(f"{key}: {value}")
+        print(f"entries: {len(document['entries'])}")
     return 0
 
 

--- a/plugins/horos/skills/horos/scripts/horos.py
+++ b/plugins/horos/skills/horos/scripts/horos.py
@@ -296,7 +296,9 @@ def write_boundary(root, document):
     directory = os.path.join(root, os.path.dirname(BOUNDARY_RELPATH))
     os.makedirs(directory, exist_ok=True)
     final = os.path.join(root, BOUNDARY_RELPATH)
-    temporary = final + ".tmp"
+    # Per-process name: two concurrent scans must not unlink each other's
+    # half-written temporary in the finally block below.
+    temporary = f"{final}.{os.getpid()}.tmp"
     try:
         with open(temporary, "w", encoding="utf-8") as handle:
             handle.write(render(document))

--- a/plugins/horos/tests/test_boundary.py
+++ b/plugins/horos/tests/test_boundary.py
@@ -1,0 +1,135 @@
+"""The boundary artefact is deterministic, atomic, and drift names every path."""
+
+from pathlib import Path
+from unittest import mock
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "horos" / "scripts"))  # noqa: E402  (locates horos.py)
+
+import horos  # noqa: E402
+
+
+def write(root, relpath, content):
+    path = Path(root) / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, str):
+        content = content.encode("utf-8")
+    path.write_bytes(content)
+    return path
+
+
+class BoundaryTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.addCleanup(self._tmp.cleanup)
+        write(self.root, "yarn.lock", "lock\n")
+        write(self.root, "src/app.py", "x = 1\n")
+
+    def document(self):
+        return horos.boundary_document(horos.scan_tree(self.root))
+
+    def check(self):
+        out = io.StringIO()
+        code = horos.check_tree(self.root, out=out)
+        return code, out.getvalue()
+
+    def test_two_scans_render_byte_identical_documents(self):
+        self.assertEqual(horos.render(self.document()), horos.render(self.document()))
+
+    def test_the_document_carries_no_absolute_paths(self):
+        self.assertNotIn(self.root, horos.render(self.document()))
+
+    def test_write_creates_the_boundary_and_leaves_no_temporary(self):
+        horos.write_boundary(self.root, self.document())
+        boundary = Path(self.root) / horos.BOUNDARY_RELPATH
+        self.assertEqual(boundary.read_text(encoding="utf-8"), horos.render(self.document()))
+        self.assertEqual(list(boundary.parent.glob("*.tmp")), [])
+
+    def test_a_failed_replace_leaves_the_old_boundary_intact(self):
+        horos.write_boundary(self.root, self.document())
+        before = (Path(self.root) / horos.BOUNDARY_RELPATH).read_text(encoding="utf-8")
+        with mock.patch.object(horos.os, "replace", side_effect=OSError("disk full")):
+            with self.assertRaises(OSError):
+                horos.write_boundary(self.root, {"schema": 1, "entries": [], "counts": {}})
+        after = (Path(self.root) / horos.BOUNDARY_RELPATH).read_text(encoding="utf-8")
+        self.assertEqual(before, after)
+        boundary = Path(self.root) / horos.BOUNDARY_RELPATH
+        self.assertEqual(list(boundary.parent.glob("*.tmp")), [])
+
+    def test_check_passes_on_a_fresh_boundary(self):
+        horos.write_boundary(self.root, self.document())
+        code, output = self.check()
+        self.assertEqual(code, 0)
+        self.assertIn("matches", output)
+
+    def test_a_new_sink_drifts_and_is_named(self):
+        horos.write_boundary(self.root, self.document())
+        write(self.root, "data.bin", b"\x00")
+        code, output = self.check()
+        self.assertEqual(code, 1)
+        self.assertIn("drift: data.bin: evidenced by the tree", output)
+
+    def test_a_removed_sink_drifts_and_is_named(self):
+        horos.write_boundary(self.root, self.document())
+        os.unlink(os.path.join(self.root, "yarn.lock"))
+        code, output = self.check()
+        self.assertEqual(code, 1)
+        self.assertIn("drift: yarn.lock: in the boundary", output)
+
+    def test_a_poisoned_entry_fails_the_check_by_name(self):
+        document = self.document()
+        document["entries"].append(
+            {
+                "path": "src/app.py",
+                "category": "generated",
+                "bytes": 6,
+                "evidence": "forged",
+            }
+        )
+        horos.write_boundary(self.root, document)
+        code, output = self.check()
+        self.assertEqual(code, 1)
+        self.assertIn("drift: src/app.py: in the boundary but no longer evidenced", output)
+
+    def test_a_changed_entry_drifts_and_is_named(self):
+        horos.write_boundary(self.root, self.document())
+        write(self.root, "yarn.lock", "lock grew longer\n")
+        code, output = self.check()
+        self.assertEqual(code, 1)
+        self.assertIn("drift: yarn.lock: entry changed", output)
+
+    def test_a_missing_boundary_is_a_distinct_failure(self):
+        code, output = self.check()
+        self.assertEqual(code, 2)
+        self.assertIn("no boundary", output)
+
+    def test_an_unparseable_boundary_is_a_distinct_failure(self):
+        write(self.root, horos.BOUNDARY_RELPATH, "{not json")
+        code, output = self.check()
+        self.assertEqual(code, 2)
+        self.assertIn("unreadable boundary", output)
+
+    def test_the_boundary_file_never_classifies_itself(self):
+        horos.write_boundary(self.root, self.document())
+        code, _ = self.check()
+        self.assertEqual(code, 0)
+        paths = [entry["path"] for entry in self.document()["entries"]]
+        self.assertNotIn(horos.BOUNDARY_RELPATH, paths)
+
+    def test_the_cli_json_output_is_the_rendered_document(self):
+        with mock.patch.object(sys, "stdout", new=io.StringIO()) as stdout:
+            code = horos.main(["scan", self.root, "--json"])
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout.getvalue(), horos.render(self.document()))
+        parsed = json.loads(stdout.getvalue())
+        self.assertEqual(parsed["schema"], horos.BOUNDARY_SCHEMA)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The scan verb now commits its result: scan --write puts the boundary at
.horos/boundary.json through a per-process temporary file and an atomic
replace, so a killed or racing run leaves the old boundary or the new one and
never half. scan --json prints the same canonical bytes, which is what the
example fixture will pin in step 5. check re-derives the classification and
names every drifted path symmetrically: a poisoned entry the tree no longer
evidences fails exactly like a new sink the boundary lacks, which is the
control the study demands against a hostile committed boundary. The document
carries a schema tag, sorted keys, no timestamps and no absolute paths.

Stacks on step 2 (the classifier). Audit: two rounds, one finding in round 1
(a fixed temporary-file name let concurrent scans unlink each other's
half-written temporary), fixed; log in audit/AUDIT.md, stacked review PR #125.

Proof: `python3 -m unittest discover -s plugins/horos/tests -t plugins/horos`
(39 tests) and the phylax and ephoros lints over `plugins tests`.

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
