### PR TITLE
Implement the skeleton map

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1008,3 +1008,19 @@ review found nothing further.
 
 Zero findings. Leads not pursued: none beyond round 1's accepted parse-memory
 lead.
+
+## Step 4, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0. Horos
+45/45, root 24/24. The review checked the map verb against the never rules:
+it parses and never imports or executes the target, hostile nesting is capped
+by the tokenizer's indentation limit and lands in the caught SyntaxError
+path, and undecodable bytes are replaced before parsing.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: map reads the named file whole, unlike the
+bounded scanner; that is the verb's purpose (one tool read instead of the
+agent reading the file), and the file is user-named rather than
+tree-discovered.

--- a/plugins/horos/skills/horos/scripts/horos.py
+++ b/plugins/horos/skills/horos/scripts/horos.py
@@ -3,6 +3,7 @@
 scan <root>    classify the tree; --json prints the boundary document,
                --write commits it to .horos/boundary.json atomically
 check <root>   re-derive the boundary and name every drifted path
+map <file.py>  print the file's skeleton instead of the file
 
 Classification is fail-open: a file the rules cannot evidence stays readable
 and earns no entry. The scanner stats every file but reads at most
@@ -12,6 +13,7 @@ what it saves.
 
 from pathlib import PurePosixPath
 import argparse
+import ast
 import fnmatch
 import json
 import os
@@ -351,6 +353,65 @@ def check_tree(root, out=None):
     return 1
 
 
+def first_docstring_line(node):
+    docstring = ast.get_docstring(node)
+    if not docstring:
+        return None
+    return docstring.strip().splitlines()[0]
+
+
+def skeleton_lines(node, depth=0):
+    """Signatures and class structure, one line each, bodies left behind."""
+    lines = []
+    pad = "    " * depth
+    for child in node.body if hasattr(node, "body") else []:
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for decorator in child.decorator_list:
+                lines.append(f"{pad}@{ast.unparse(decorator)}")
+            keyword = "async def" if isinstance(child, ast.AsyncFunctionDef) else "def"
+            returns = f" -> {ast.unparse(child.returns)}" if child.returns else ""
+            line = f"{pad}{keyword} {child.name}({ast.unparse(child.args)}){returns}:"
+            summary = first_docstring_line(child)
+            if summary:
+                line += f"  # {summary}"
+            lines.append(line)
+        elif isinstance(child, ast.ClassDef):
+            for decorator in child.decorator_list:
+                lines.append(f"{pad}@{ast.unparse(decorator)}")
+            bases = ", ".join(ast.unparse(base) for base in child.bases)
+            line = f"{pad}class {child.name}" + (f"({bases}):" if bases else ":")
+            summary = first_docstring_line(child)
+            if summary:
+                line += f"  # {summary}"
+            lines.append(line)
+            lines.extend(skeleton_lines(child, depth + 1))
+    return lines
+
+
+def map_file(path, out=None):
+    """Print a Python file's skeleton; orientation without the read."""
+    out = out if out is not None else sys.stdout
+    if not path.endswith(".py"):
+        print(f"horos: map reads Python only, not {path}", file=out)
+        return 2
+    try:
+        with open(path, "rb") as handle:
+            source = handle.read().decode("utf-8", errors="replace")
+    except OSError as error:
+        print(f"horos: cannot read {path}: {error}", file=out)
+        return 2
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as error:
+        print(f"horos: syntax error in {path} at line {error.lineno}", file=out)
+        return 1
+    summary = first_docstring_line(tree)
+    print(f"module: {summary}" if summary else "module: (no docstring)", file=out)
+    for line in skeleton_lines(tree):
+        print(line, file=out)
+    return 0
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(prog="horos", description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -364,7 +425,12 @@ def main(argv=None):
     )
     checker = subparsers.add_parser("check", help="verify the committed boundary")
     checker.add_argument("root", help="directory to check")
+    mapper = subparsers.add_parser("map", help="print a Python file's skeleton")
+    mapper.add_argument("file", help="Python file to map")
     args = parser.parse_args(argv)
+
+    if args.command == "map":
+        return map_file(args.file)
 
     if not os.path.isdir(args.root):
         print(f"horos: not a directory: {args.root}", file=sys.stderr)

--- a/plugins/horos/tests/test_map.py
+++ b/plugins/horos/tests/test_map.py
@@ -1,0 +1,107 @@
+"""The skeleton map prints structure instead of the file, and fails plainly."""
+
+from pathlib import Path
+import io
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "horos" / "scripts"))  # noqa: E402  (locates horos.py)
+
+import horos  # noqa: E402
+
+FIXTURE = '''"""A fixture module.
+
+Longer prose the map must not print.
+"""
+
+
+def top(a, b=1) -> int:
+    """Add things up."""
+    return a + b
+
+
+@staticmethod
+def decorated(*args, **kwargs):
+    return args
+
+
+class Outer(dict):
+    """Holds an inner class."""
+
+    def method(self, x):
+        return x
+
+    class Inner:
+        async def fetch(self, url):
+            """Get one thing."""
+            return url
+'''
+
+EXPECTED = """module: A fixture module.
+def top(a, b=1) -> int:  # Add things up.
+@staticmethod
+def decorated(*args, **kwargs):
+class Outer(dict):  # Holds an inner class.
+    def method(self, x):
+    class Inner:
+        async def fetch(self, url):  # Get one thing.
+"""
+
+
+def write(root, name, content):
+    path = Path(root) / name
+    path.write_text(content, encoding="utf-8")
+    return str(path)
+
+
+class MapTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.addCleanup(self._tmp.cleanup)
+
+    def map(self, path):
+        out = io.StringIO()
+        code = horos.map_file(path, out=out)
+        return code, out.getvalue()
+
+    def test_the_fixture_skeleton_is_pinned(self):
+        path = write(self.root, "fixture.py", FIXTURE)
+        code, output = self.map(path)
+        self.assertEqual(code, 0)
+        self.assertEqual(output, EXPECTED)
+
+    def test_the_map_never_prints_bodies_or_long_docstrings(self):
+        path = write(self.root, "fixture.py", FIXTURE)
+        _, output = self.map(path)
+        self.assertNotIn("return a + b", output)
+        self.assertNotIn("Longer prose", output)
+
+    def test_a_module_without_a_docstring_says_so(self):
+        path = write(self.root, "bare.py", "x = 1\n")
+        code, output = self.map(path)
+        self.assertEqual(code, 0)
+        self.assertEqual(output, "module: (no docstring)\n")
+
+    def test_a_syntax_error_is_a_report_not_a_traceback(self):
+        path = write(self.root, "broken.py", "def broken(:\n")
+        code, output = self.map(path)
+        self.assertEqual(code, 1)
+        self.assertIn("syntax error", output)
+        self.assertIn("line 1", output)
+
+    def test_a_non_python_path_is_refused(self):
+        path = write(self.root, "notes.txt", "words\n")
+        code, output = self.map(path)
+        self.assertEqual(code, 2)
+        self.assertIn("Python only", output)
+
+    def test_a_missing_file_is_a_plain_message(self):
+        code, output = self.map(str(Path(self.root) / "absent.py"))
+        self.assertEqual(code, 2)
+        self.assertIn("cannot read", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The map verb prints a Python file's structure instead of the file:
decorators, signatures with defaults and return annotations, nested classes,
and the first docstring line of the module and each definition. It parses
and never imports or executes what it reads. A syntax error is a one-line
report naming the line, a non-Python path is refused plainly, and a pinned
fixture test holds the exact output shape so the format cannot drift
silently.

Stacks on step 3 (boundary emit and check). Audit: one round, zero findings;
log in audit/AUDIT.md.

Proof: `python3 -m unittest discover -s plugins/horos/tests -t plugins/horos`
(45 tests) and the phylax and ephoros lints over `plugins tests`.

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
