### PR TITLE
Commit the live-evidence frontier spec

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1041,3 +1041,14 @@ inert data that no suite imports or executes.
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Live-evidence run, step 1, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0 over the
+two committed spec documents. Root 24/24, horos 51/51. The step adds prose
+only; the review checked the committed copies match the receipted artefacts.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.

--- a/plugins/horos/docs/live-evidence/runbook.md
+++ b/plugins/horos/docs/live-evidence/runbook.md
@@ -1,0 +1,48 @@
+# The Horos live-evidence run, the runbook
+
+Three steps, dependency order, one pull request each. The study committed
+beside this runbook is the spec; both land in step 1.
+
+## Step 1: Commit the frontier spec
+
+**Goal.** The study and this runbook are in the tree the later steps build on.
+**Entry.** The run branch, cut from `main` at `e17f8ce`.
+**Exit.** Both suites green, three tree lints clean, imprimatur clean on both
+documents.
+**Files.** `plugins/horos/docs/live-evidence/study.md` and
+`plugins/horos/docs/live-evidence/runbook.md`.
+**Tests.** None new; the existing suites hold.
+
+## Step 2: Record the evidence bundle
+
+**Goal.** The wildcat-app-v2 capture is committed with its numbers
+machine-checked.
+**Entry.** Step 1's exit state.
+**Exit.** Plugin suite green including the new consistency test; the demo
+command from the study runs:
+`python3 -m unittest plugins.horos.tests.test_evidence -v`.
+**Files.** `plugins/horos/docs/evidence/wildcat-app-v2.md` (the bundle:
+commit, date, tool version, totals, every entry, the misses, the criterion
+check) and `plugins/horos/docs/evidence/wildcat-app-v2.boundary.json` (the
+scan's boundary document, committed verbatim);
+`plugins/horos/tests/test_evidence.py`.
+**Tests.** The committed boundary parses with schema 1; its classified-byte
+total, entry count and per-category totals equal the numbers the bundle
+markdown quotes in its machine-readable lines; the bundle names the commit.
+Expected count: about four.
+
+## Step 3: Decide, reledger, reconcile
+
+**Goal.** The TypeScript refusal is recorded, the ledger advances to
+`horos-v1.1.0` with the new held job, and every marketplace surface agrees.
+**Entry.** Step 2's exit state.
+**Exit.** Study success criteria 1 through 4 all pass as written; the root
+suite validates the new ledger row's digest and the surfaces' agreement.
+**Files.** `plugins/horos/skills/horos/EVOLUTION.md` (evolution row, new
+frontier and held job, script-computed digest);
+`plugins/horos/skills/horos/SKILL.md` (metadata `1.1.0`, frontier text, the
+recorded refusal with its reason); `plugins/horos/README.md` (context block:
+frontier and Next Fiat job line); `.agents/skills/horos/SKILL.md` (frontier);
+root `README.md` (the Horos frontier cell).
+**Tests.** None new; the evolution and marketplace-prose contracts in the
+root suite are the check.

--- a/plugins/horos/docs/live-evidence/study.md
+++ b/plugins/horos/docs/live-evidence/study.md
@@ -1,0 +1,134 @@
+# The Horos live-evidence run, the study
+
+This run executes Horos's held frontier job: record a live-repository scan of
+wildcat-app-v2 as an evidence bundle, and decide the TypeScript skeleton
+parser question. It ships evidence, one decision and a ledger update; it
+changes no classifier behaviour.
+
+## Assumptions
+
+Proceeding on these unless corrected:
+
+1. The capture target is the shallow clone of wildcat-finance/wildcat-app-v2
+   already on this machine, at commit `9b8b6d5d6db06428c5b539f267623277b65315cd`.
+   The bundle records that commit and the capture date; it is evidence of one
+   run against one tree, not a gate others can re-run offline.
+2. The TypeScript decision was put to the maintainer this session and
+   answered: refuse. No TS skeletons without a real parser, and no parser
+   dependency or subprocess boundary is justified by a secondary verb.
+3. The frontier stays open. The scan's own misses are the evidence: text
+   assets and machine-emitted migration SQL stay readable, and adding their
+   rule classes is a concrete, evidenced improvement with a checkable
+   acceptance. Closing mature would discard what the bundle itself names.
+4. Per the versioning contract, the completed job increments evolution:
+   `horos-v0.1.0` becomes `horos-v1.1.0`, generation and epoch retained, and
+   the SKILL.md metadata follows.
+
+## 1. Problem statement
+
+Horos shipped with a frontier that promised two things it had not done:
+scan a live external repository and record the result, and settle whether
+TypeScript skeleton maps get built. This run does both. A working prototype
+means the bundle is committed with its numbers machine-checked, the decision
+is recorded where the ledger contract can hold it, every marketplace surface
+agrees on the new frontier, and both suites plus the tree lints are green.
+
+The scan already ran as study input. Against 17,053,779 bytes outside
+`.git`, Horos classified 13,696,504 bytes as sinks: **80.3% of readable
+bytes**, through 16 evidence-bearing entries, with zero hand-written
+TypeScript or TSX excluded. The largest entries are the checked-in Storybook
+build (7,567,063 bytes by directory name), `package-lock.json` (1,895,425 by
+lockfile name), the single-line legal-entity dataset (1,448,802 by blob
+geometry) and nine binary assets by null byte. The study criterion from the
+first run asked for at least 60%; the live tree gives 80.3%.
+
+What stayed readable and should not have, by a human's judgement: 98 SVG
+text assets (205,663 bytes) and the prisma migration SQL (298,878 bytes,
+machine-emitted, no marker). Both are fail-open misses by design, and both
+become the next held job.
+
+## 2. Prior art
+
+The first Horos run built everything this run uses: the scanner, the
+boundary document, the shipped example. The evidence-bundle shape follows
+Hermes's held ambition (a complete, reproducible evidence bundle against a
+real target) scaled to what a scan honestly is: one recorded run against one
+named commit. The ledger mechanics follow the versioning contract at
+`plugins/hexaemeron/skills/VERSIONING.md` and the worked rows in Fiat's own
+`EVOLUTION.md`.
+
+## 3. Constraints and non-goals
+
+- No classifier changes in this run. The bundle records what v0.1.0 does;
+  improving recall is the next job, not this one.
+- Stdlib only, as before. The bundle's consistency test uses `json` and
+  `unittest`.
+- Non-goals: TS skeletons (refused, recorded), new rule classes (next job),
+  re-running the scan in CI (the clone is environmental), and any change to
+  the shipped example.
+
+## 4. Design options
+
+**A. Bundle as prose plus committed boundary, machine-checked.** The bundle
+markdown carries the story and the numbers; the scan's boundary document is
+committed beside it; a test parses both and asserts the quoted totals equal
+the document's, so the prose cannot drift from the evidence. Chosen. Trade:
+one committed JSON of 2,991 bytes that no runtime reads.
+
+**B. Bundle as prose only.** Rejected: numbers nobody can check are
+Metron's definition of an opinion.
+
+**C. Re-scan in CI as a gate.** Rejected: the target is a moving external
+repository; the bundle records a capture, and a gate that breaks when
+someone else pushes to wildcat-app-v2 is not a gate.
+
+## 5. Risk register seed
+
+- The bundle must name the commit and the tool version; a number without its
+  tree is unverifiable by construction.
+- The consistency test must read the committed boundary, never re-scan; a
+  network- or clone-dependent test would rot.
+- The ledger row's digest is over the exact canonical line; compute it, never
+  hand-type it.
+- Every surface carrying the frontier text must change in the same step, or
+  the marketplace prose tests fail on the split.
+- The refusal must be recorded so it cannot be mistaken for an omission: the
+  SKILL.md frontier section and the ledger row both say refused, with the
+  reason.
+
+## 6. Glossary seeds
+
+- Evidence bundle: a committed record of one scan against one named commit,
+  with its boundary document and machine-checked totals.
+- Capture: the single recorded run; not reproducible once the remote moves.
+- Refusal: a decision recorded with its reason, distinct from an omission.
+
+## 7. Boundaries
+
+- **Always.** Both suites and the three tree lints before a commit;
+  imprimatur on every shipped document; the digest computed by script.
+- **Ask first.** Any classifier change (out of scope here); any dependency;
+  reopening the TS decision.
+- **Never.** Re-scan inside a test; delete a failing test; claim the scan
+  ran on a tree other than the recorded commit.
+
+## 8. Success criteria
+
+1. `python3 -m unittest discover -s tests -t .` passes, holding the new
+   ledger row's digest and every surface's frontier agreement.
+2. `python3 -m unittest discover -s plugins/horos/tests -t plugins/horos`
+   passes, including the bundle-consistency test.
+3. `python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests`
+   and the ephoros equivalent exit clean.
+4. Demo path: the bundle-consistency test run alone,
+   `python3 -m unittest plugins.horos.tests.test_evidence -v`, proves the
+   quoted numbers equal the committed boundary document's.
+
+## 9. Sources
+
+The live scan of this session (commit
+`9b8b6d5d6db06428c5b539f267623277b65315cd`, 2026-08-18). The maintainer's
+recorded answer refusing TS skeletons, this session. The Horos study at
+`plugins/horos/docs/study.md`. The versioning contract at
+`plugins/hexaemeron/skills/VERSIONING.md`. The evolution ledgers of Fiat and
+Kronos as worked examples of evolution rows and maturity.


### PR DESCRIPTION
Step 1 of Horos's held frontier job. The study and runbook land at
plugins/horos/docs/live-evidence/: record the wildcat-app-v2 scan as a
machine-checked evidence bundle, record the maintainer's refusal of
TypeScript skeletons with its reason, and advance the ledger to
horos-v1.1.0 with the next evidenced job.

Audit: one round, zero findings; log in audit/AUDIT.md.

Proof: `python3 -m unittest discover -s tests` and the horos suite, plus the
three tree lints, all green.

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
