### PR TITLE
Commit the rule-classes frontier spec

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1080,3 +1080,14 @@ the in-place study corrections are named in the commit rather than silent.
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Rule-classes run, step 1, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0 over the
+two spec documents. Root 24/24, horos 55/55. Prose-only step; the committed
+copies match the receipted artefacts.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.

--- a/plugins/horos/docs/rules-v2/runbook.md
+++ b/plugins/horos/docs/rules-v2/runbook.md
@@ -1,0 +1,65 @@
+# The Horos rule-classes run, the runbook
+
+Four steps, dependency order, one pull request each. The study committed
+beside this runbook is the spec; both land in step 1.
+
+## Step 1: Commit the frontier spec
+
+**Goal.** The study and this runbook are in the tree the later steps build on.
+**Entry.** The run branch, cut from `main` at `d474d75`.
+**Exit.** Both suites green, three tree lints clean, imprimatur clean on
+both documents.
+**Files.** `plugins/horos/docs/rules-v2/study.md` and
+`plugins/horos/docs/rules-v2/runbook.md`.
+**Tests.** None new; the existing suites hold.
+
+## Step 2: The two rule classes
+
+**Goal.** The classifier evidences SVG text assets and migration SQL, and
+the shipped example proves both.
+**Entry.** Step 1's exit state.
+**Exit.** Plugin suite green; each rule has a positive and two near-miss
+cases; the example fixture's regenerated boundary is reproduced byte for
+byte.
+**Files.** `plugins/horos/skills/horos/scripts/horos.py`;
+`plugins/horos/tests/test_classify.py` extended;
+`plugins/horos/examples/fixture/icons/logo.svg` and
+`plugins/horos/examples/fixture/prisma/migrations/0001_init/migration.sql`
+added; `plugins/horos/examples/fixture/.horos/boundary.json` regenerated;
+`plugins/horos/examples/README.md` and
+`plugins/horos/tests/test_discipline.py` updated for the new categories.
+**Tests.** SVG with root element earns `asset`; `.svg` without the root and
+an `<svg` fragment under another name stay readable. `.sql` under a
+`migrations` segment earns `generated`; SQL outside the segment and non-SQL
+inside it stay readable. Expected count: about six new.
+
+## Step 3: The second capture
+
+**Goal.** The improvement is recorded against the same tree, machine-checked
+like the first capture, with zero false exclusions held.
+**Entry.** Step 2's exit state.
+**Exit.** `python3 -m unittest plugins.horos.tests.test_evidence -v` proves
+both captures; the second's classified share exceeds 80.3%; the entries
+added relative to the first capture are only `.svg` and
+migrations-segment `.sql` paths.
+**Files.** `plugins/horos/docs/evidence/wildcat-app-v2-rules.md` and
+`plugins/horos/docs/evidence/wildcat-app-v2-rules.boundary.json`;
+`plugins/horos/tests/test_evidence.py` extended.
+**Tests.** The consistency checks parametrised over both bundles, plus the
+delta check that new entries are only the two rule families. Expected
+count: about four new.
+
+## Step 4: Reledger and reconcile
+
+**Goal.** The ledger advances to `horos-v2.1.0` holding the
+maintainer-directed outline-extractor job, and every surface agrees.
+**Entry.** Step 3's exit state.
+**Exit.** Study success criteria 1 through 4 all pass as written.
+**Files.** `plugins/horos/skills/horos/EVOLUTION.md` (evolution row,
+script-computed digest); `plugins/horos/skills/horos/SKILL.md` (metadata
+`2.1.0`, frontier text, the refusal paragraph superseded in place, dated,
+naming the maintainer direction); `plugins/horos/README.md` (context block
+and job line); `.agents/skills/horos/SKILL.md`; root `README.md` (frontier
+cell).
+**Tests.** None new; the evolution and marketplace-prose contracts are the
+check.

--- a/plugins/horos/docs/rules-v2/study.md
+++ b/plugins/horos/docs/rules-v2/study.md
@@ -1,0 +1,140 @@
+# The Horos rule-classes run, the study
+
+This run executes Horos's held frontier job: add evidence-bearing rule
+classes for text assets and machine-emitted migration SQL, holding zero
+false exclusions against the recorded wildcat-app-v2 bundle. At its close it
+records the maintainer-directed successor job: the TypeScript outline
+extractor, internal to Horos.
+
+## Assumptions
+
+Proceeding on these unless corrected:
+
+1. The two rule classes are exactly the capture's quantified misses. Text
+   assets means SVG, the only text-asset family the bundle evidences; fonts
+   and raster images are already caught by null byte.
+2. The capture target for the second recorded scan is the same shallow clone
+   at commit `9b8b6d5d6db06428c5b539f267623277b65315cd`, still on this
+   machine and unchanged.
+3. The maintainer directed this session that TypeScript skeletons return as
+   an outline extractor internal to Horos: verbatim source slices, confessed
+   unparsed regions, stdlib-only shipping, a dev-time differential corpus.
+   That supersedes the recorded refusal's premise (parsing TS or taking a
+   dependency) without contradicting it, and becomes the next held job.
+4. The completed job increments evolution: `horos-v1.1.0` becomes
+   `horos-v2.1.0`, generation and epoch retained.
+
+## 1. Problem statement
+
+The v1.1.0 capture left 503,249 bytes of evidenced sinks readable: 97 SVG
+text assets (204,371 bytes) and 17 machine-emitted prisma migration SQL
+files (298,878 bytes), about 15% of what remained after the scan. This run
+teaches the classifier both families, with the same fail-open discipline as
+every existing rule, and records a second capture proving the improvement on
+the same tree with zero false exclusions.
+
+The two rules, stated so a test can refuse them:
+
+- **Text asset (SVG).** A file whose name ends `.svg` and whose bounded
+  prefix carries an `<svg` root element is category `asset`. Evidence names
+  the root element and the prefix. A `.svg` without the root element, or an
+  `<svg` fragment under any other name, stays readable.
+- **Migration SQL.** A file whose name ends `.sql` and whose path contains a
+  directory segment named exactly `migrations` is category `generated`.
+  Evidence names the segment. Hand-kept SQL outside a migrations segment
+  stays readable, as does anything non-SQL inside one.
+
+A working prototype means: both rules earn their entries on the shipped
+example fixture and in unit tests with near-misses; the second capture is
+committed and machine-checked like the first; the ledger advances to
+`horos-v2.1.0` holding the outline-extractor job; and every surface agrees.
+
+## 2. Prior art
+
+The first two Horos runs: the classifier's rule-class shape, the evidence
+bundle with machine-readable capture lines, and the consistency test that
+pins prose to the committed boundary. GitHub Linguist treats SVG as
+`generated` in diffs for the same reading-cost reason. The outline-extractor
+design recorded as the next job follows this session's assessment: verbatim
+slices need a lexer, not a grammar, and confessed coverage converts silent
+wrongness into visible incompleteness.
+
+## 3. Constraints and non-goals
+
+- Stdlib only; two rules, no new verbs, no map changes.
+- The shipped example grows one specimen per new rule and its committed
+  boundary is regenerated; everything else in the example holds.
+- The first capture's bundle and boundary are immutable evidence behind the
+  v1.1.0 ledger row; the second capture lands beside them, never over them.
+- Non-goals: the outline extractor itself (next job, recorded not built),
+  any reclassification of the 12 remaining readable megabytes the bundle
+  does not evidence, and re-scanning in CI.
+
+## 4. Design options
+
+**A. Two narrow rules as stated, second capture beside the first.** Chosen.
+Trade: narrowness caps recall (a `.svgz`, an unmarked SQL dump outside
+`migrations/`, and any other text-asset family stay readable), which is the
+fail-open contract working as designed.
+
+**B. A general text-asset heuristic (extension allowlist without content
+check).** Rejected: name-only rules carry no evidence line worth quoting,
+and the house rule is that only evidence excludes.
+
+**C. Fold migration SQL into a general generated-directory name rule.**
+Rejected: `migrations` directories hold hand-written files in many stacks;
+the SQL suffix gate keeps the rule inside what the evidence supports.
+
+## 5. Risk register seed
+
+- False exclusion is the failure that matters: the acceptance re-checks that
+  no hand-written `src/` TypeScript is excluded and that only `.svg` and
+  `.sql` paths joined the entry list against the first capture.
+- The example fixture's regenerated boundary must be reproduced byte for
+  byte by the discipline test, as before.
+- The two bundles must not share machine-line names in one file; they live
+  in separate files with one consistency test parametrised over both.
+- The SKILL.md refusal paragraph must be superseded in place, dated, naming
+  the maintainer direction, so the record shows a decision revised rather
+  than erased.
+- The ledger digest is script-computed, as before.
+
+## 6. Glossary seeds
+
+- Text asset: a text-encoded file that is an asset rather than code; SVG is
+  the only family this run evidences.
+- Migrations segment: a path directory named exactly `migrations`.
+- Outline extractor: the recorded next job; a lexer-accurate TS outliner
+  quoting declaration slices verbatim with confessed unparsed regions,
+  internal to Horos.
+
+## 7. Boundaries
+
+- **Always.** Both suites and the three tree lints before a commit;
+  imprimatur on every shipped document; digests by script.
+- **Ask first.** Any rule beyond the two stated; touching the map verb;
+  changing either committed capture.
+- **Never.** Rewrite the v1.1.0 bundle or boundary; re-scan inside a test;
+  weaken a near-miss test to make a rule fit.
+
+## 8. Success criteria
+
+1. `python3 -m unittest discover -s tests` passes, holding the v2.1.0
+   ledger row and surface agreement.
+2. `python3 -m unittest discover -s plugins/horos/tests -t plugins/horos`
+   passes, including the new rule tests, the regenerated example boundary
+   and the two-bundle consistency test.
+3. `python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests`
+   and the ephoros equivalent exit clean.
+4. Demo path: `python3 -m unittest plugins.horos.tests.test_evidence -v`
+   proves both captures' quoted numbers against their committed boundaries,
+   and the second capture's classified share exceeds the first's 80.3%.
+
+## 9. Sources
+
+The v1.1.0 evidence bundle at `plugins/horos/docs/evidence/wildcat-app-v2.md`
+and its ledger row. The maintainer's directions this session: run the held
+job, and place the TypeScript slicer internal to Horos. The clone at commit
+`9b8b6d5d6db06428c5b539f267623277b65315cd`. GitHub Linguist's generated
+handling of SVG. The versioning contract at
+`plugins/hexaemeron/skills/VERSIONING.md`.


### PR DESCRIPTION
Step 1 of Horos's held job. The study and runbook land at
plugins/horos/docs/rules-v2/: teach the classifier the capture's two
quantified misses (SVG text assets and machine-emitted migration SQL),
record a second capture against the same tree holding zero false
exclusions, and advance the ledger to horos-v2.1.0 holding the
maintainer-directed TypeScript outline extractor as the next job.

Audit: one round, zero findings; log in audit/AUDIT.md.

Proof: both suites and the three tree lints, all green.

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
