### PR TITLE
Teach the classifier text assets and migration SQL

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1091,3 +1091,19 @@ copies match the receipted artefacts.
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Rule-classes run, step 2, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0 over plugins tests,
+hypomnema 0 over the changed README. Horos 61/61, root 24/24. The review
+checked the register's false-exclusion row: both rules are gated on name
+plus content or name plus path, each carries two near-miss tests, and the
+example's readable file stays readable. The SVG rule runs before the marker
+scan by decision, recorded as a comment at the check itself.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: .svgz and other compressed asset variants
+stay readable; they are binary when deflated on disk and out of the held
+job's evidence either way.

--- a/plugins/horos/examples/README.md
+++ b/plugins/horos/examples/README.md
@@ -3,7 +3,8 @@
 `fixture/` is a miniature repository holding one file per classifier rule
 class: a binary asset, a lockfile, a marker-generated file, a generated
 directory, a vendored directory, a sourcemap, a single-line blob, a minified
-bundle, and a directory vendored through `.gitattributes`. One hand-written
+bundle, a directory vendored through `.gitattributes`, an SVG text asset,
+and a migration SQL file under a `migrations` segment. One hand-written
 file, `src/app.py`, stays readable. Its committed boundary lives at
 `fixture/.horos/boundary.json`.
 

--- a/plugins/horos/examples/fixture/.horos/boundary.json
+++ b/plugins/horos/examples/fixture/.horos/boundary.json
@@ -1,12 +1,13 @@
 {
   "counts": {
+    "bytes_asset": 138,
     "bytes_binary": 11,
     "bytes_blob": 50275,
-    "bytes_generated": 147,
+    "bytes_generated": 218,
     "bytes_lockfile": 54,
     "bytes_vendored": 53,
     "files_skipped_unreadable": 0,
-    "files_walked": 8
+    "files_walked": 10
   },
   "entries": [
     {
@@ -47,6 +48,12 @@
       "path": "gen/api.py"
     },
     {
+      "bytes": 138,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "icons/logo.svg"
+    },
+    {
       "bytes": 10,
       "category": "vendored",
       "evidence": "linguist-vendored for 'lib/**' in .gitattributes",
@@ -59,6 +66,12 @@
       "evidence": "directory name node_modules",
       "files": 1,
       "path": "node_modules/"
+    },
+    {
+      "bytes": 71,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/0001_init/migration.sql"
     },
     {
       "bytes": 54,

--- a/plugins/horos/examples/fixture/icons/logo.svg
+++ b/plugins/horos/examples/fixture/icons/logo.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="7"/></svg>

--- a/plugins/horos/examples/fixture/prisma/migrations/0001_init/migration.sql
+++ b/plugins/horos/examples/fixture/prisma/migrations/0001_init/migration.sql
@@ -1,0 +1,2 @@
+-- CreateTable
+CREATE TABLE "Market" ("id" TEXT NOT NULL PRIMARY KEY);

--- a/plugins/horos/skills/horos/scripts/horos.py
+++ b/plugins/horos/skills/horos/scripts/horos.py
@@ -123,6 +123,11 @@ def classify_content(name, size, prefix):
 
     text = prefix.decode("utf-8", errors="replace")
     lowered = text.lower()
+    # SVG before the marker scan: a tool-stamped SVG is still an asset, and
+    # asset is the more specific truth about it.
+    if name.endswith(".svg") and "<svg" in lowered:
+        return "asset", f"svg root element in the first {PREFIX_BYTES} bytes"
+
     for marker in GENERATED_MARKERS:
         if marker in lowered:
             return "generated", f"marker {marker!r} in the first {PREFIX_BYTES} bytes"
@@ -163,6 +168,14 @@ def classify_file(root, relpath):
             "category": "lockfile",
             "bytes": size,
             "evidence": f"lockfile name {name}",
+        }
+
+    if name.endswith(".sql") and "migrations" in PurePosixPath(relpath).parts[:-1]:
+        return {
+            "path": relpath,
+            "category": "generated",
+            "bytes": size,
+            "evidence": "sql file under a migrations directory segment",
         }
 
     prefix = read_prefix(fullpath)

--- a/plugins/horos/tests/test_classify.py
+++ b/plugins/horos/tests/test_classify.py
@@ -112,6 +112,34 @@ class ClassifyTests(unittest.TestCase):
         self.assertEqual(entry["category"], "vendored")
         self.assertIn(".gitattributes", entry["evidence"])
 
+    def test_an_svg_with_a_root_element_is_an_asset(self):
+        write(self.root, "icons/logo.svg", '<?xml version="1.0"?>\n<svg xmlns="x"></svg>\n')
+        entry = self.entries()["icons/logo.svg"]
+        self.assertEqual(entry["category"], "asset")
+        self.assertIn("svg root element", entry["evidence"])
+
+    def test_an_svg_file_without_the_root_element_stays_readable(self):
+        write(self.root, "notes.svg", "not actually vector art\n")
+        self.assertNotIn("notes.svg", self.entries())
+
+    def test_an_svg_fragment_under_another_name_stays_readable(self):
+        write(self.root, "snippet.html", "<div><svg></svg></div>\n")
+        self.assertNotIn("snippet.html", self.entries())
+
+    def test_sql_under_a_migrations_segment_is_generated(self):
+        write(self.root, "prisma/migrations/0001_init/migration.sql", "CREATE TABLE a (id int);\n")
+        entry = self.entries()["prisma/migrations/0001_init/migration.sql"]
+        self.assertEqual(entry["category"], "generated")
+        self.assertIn("migrations directory segment", entry["evidence"])
+
+    def test_sql_outside_a_migrations_segment_stays_readable(self):
+        write(self.root, "queries/report.sql", "SELECT 1;\n")
+        self.assertNotIn("queries/report.sql", self.entries())
+
+    def test_non_sql_inside_a_migrations_segment_stays_readable(self):
+        write(self.root, "prisma/migrations/README.md", "how we migrate\n")
+        self.assertNotIn("prisma/migrations/README.md", self.entries())
+
     def test_a_symlink_out_of_the_root_is_never_followed(self):
         outside = tempfile.TemporaryDirectory()
         self.addCleanup(outside.cleanup)

--- a/plugins/horos/tests/test_discipline.py
+++ b/plugins/horos/tests/test_discipline.py
@@ -51,9 +51,20 @@ class DisciplineTests(unittest.TestCase):
     def test_the_fixture_covers_every_shipped_rule_class(self):
         entries = horos.scan_tree(str(FIXTURE))["entries"]
         categories = {entry["category"] for entry in entries}
-        self.assertEqual(categories, {"binary", "lockfile", "generated", "vendored", "blob"})
+        self.assertEqual(
+            categories, {"binary", "lockfile", "generated", "vendored", "blob", "asset"}
+        )
         evidence = " | ".join(entry["evidence"] for entry in entries)
-        for family in ("marker", "directory name", "sourcemap", ".gitattributes", "no newline", "mean line length"):
+        for family in (
+            "marker",
+            "directory name",
+            "sourcemap",
+            ".gitattributes",
+            "no newline",
+            "mean line length",
+            "svg root element",
+            "migrations directory segment",
+        ):
             self.assertIn(family, evidence)
 
     def test_the_readable_file_stays_readable(self):


### PR DESCRIPTION
The two rule classes from the v1.1.0 capture's quantified misses. An .svg
whose bounded prefix carries an svg root element is an asset; the check runs
before the marker scan because a tool-stamped SVG is still an asset. A .sql
file under a directory segment named migrations is generated. Both are gated
on name plus content or name plus path, each carries two near-miss tests,
and the shipped example gains one specimen per rule with its committed
boundary regenerated and reproduced byte for byte.

Stacks on step 1 (the frontier spec). Audit: one round, zero findings; log
in audit/AUDIT.md.

Proof: `python3 -m unittest discover -s plugins/horos/tests -t plugins/horos`
(61 tests) and the tree lints.

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
