### PR TITLE
Record the second wildcat-app-v2 capture

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1107,3 +1107,17 @@ scan by decision, recorded as a comment at the check itself.
 Zero findings. Leads not pursued: .svgz and other compressed asset variants
 stay readable; they are binary when deflated on disk and out of the held
 job's evidence either way.
+
+## Rule-classes run, step 3, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0 over the
+new bundle. Horos 65/65, root 24/24. The review held the register's rows:
+the first capture's files are untouched (git shows additions only), the
+delta test proves the added entries are exactly the two families with
+nothing removed, both bundles name the same commit, and the consistency
+tests read only committed files.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.

--- a/plugins/horos/docs/evidence/wildcat-app-v2-rules.boundary.json
+++ b/plugins/horos/docs/evidence/wildcat-app-v2-rules.boundary.json
@@ -1,0 +1,796 @@
+{
+  "counts": {
+    "bytes_asset": 204371,
+    "bytes_binary": 2598609,
+    "bytes_blob": 1635281,
+    "bytes_generated": 7866067,
+    "bytes_lockfile": 1895425,
+    "files_skipped_unreadable": 0,
+    "files_walked": 1041
+  },
+  "entries": [
+    {
+      "bytes": 1895425,
+      "category": "lockfile",
+      "evidence": "lockfile name package-lock.json",
+      "path": "package-lock.json"
+    },
+    {
+      "bytes": 2934,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20241203190404_rm_message_hash_change_id_to_unique/migration.sql"
+    },
+    {
+      "bytes": 158,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20241206142305_add_admin/migration.sql"
+    },
+    {
+      "bytes": 1901,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20241210085852_add_mla/migration.sql"
+    },
+    {
+      "bytes": 256,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20241210155447_mla_signature_time_signed/migration.sql"
+    },
+    {
+      "bytes": 344,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20250104193246_add_assignment_refusal/migration.sql"
+    },
+    {
+      "bytes": 259,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20250104193456_add_kind/migration.sql"
+    },
+    {
+      "bytes": 313,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20250115234303_more_borrower_details/migration.sql"
+    },
+    {
+      "bytes": 258,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20250115234944_add_borrower_details_to_invitation/migration.sql"
+    },
+    {
+      "bytes": 85,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20250210184604_add_hide_template/migration.sql"
+    },
+    {
+      "bytes": 159,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20250211191101_add_telegram/migration.sql"
+    },
+    {
+      "bytes": 230,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20250213224525_add_alias_to_profile/migration.sql"
+    },
+    {
+      "bytes": 155,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20250217080144_add_avatar_to_profile/migration.sql"
+    },
+    {
+      "bytes": 173,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20250519152128_add_additional_urls/migration.sql"
+    },
+    {
+      "bytes": 286,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20250703011352_add_market_summary/migration.sql"
+    },
+    {
+      "bytes": 4675,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20260513005528_chain_scoped_admin_mla/migration.sql"
+    },
+    {
+      "bytes": 285635,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20260610045343_service_agreement_versioning/migration.sql"
+    },
+    {
+      "bytes": 1057,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "path": "prisma/migrations/20260623000000_non_mla_lender_acknowledgement/migration.sql"
+    },
+    {
+      "bytes": 126,
+      "category": "generated",
+      "evidence": "marker 'do not edit' in the first 4096 bytes",
+      "path": "prisma/migrations/migration_lock.toml"
+    },
+    {
+      "bytes": 1375,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "public/next.svg"
+    },
+    {
+      "bytes": 629,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "public/vercel.svg"
+    },
+    {
+      "bytes": 3688,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "public/wildcat-logo.svg"
+    },
+    {
+      "bytes": 166377,
+      "category": "blob",
+      "evidence": "mean line length above 400 in the first 4096 bytes",
+      "path": "src/app/api/mla/default-mla.json"
+    },
+    {
+      "bytes": 102801,
+      "category": "binary",
+      "evidence": "null byte in the first 4096 bytes",
+      "path": "src/app/favicon.ico"
+    },
+    {
+      "bytes": 2288,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/companies-icons/ethena_icon.svg"
+    },
+    {
+      "bytes": 2649,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/companies-icons/ethereal-white_icon.svg"
+    },
+    {
+      "bytes": 2652,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/companies-icons/ethereal_icon.svg"
+    },
+    {
+      "bytes": 644,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/companies-icons/test-points-white_icon.svg"
+    },
+    {
+      "bytes": 665,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/companies-icons/test-points_icon.svg"
+    },
+    {
+      "bytes": 3060,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/airdrop_logo_new.svg"
+    },
+    {
+      "bytes": 10130,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/allMarkets_icon.svg"
+    },
+    {
+      "bytes": 253,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/arrowLeft_icon.svg"
+    },
+    {
+      "bytes": 270,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/arrowRight_icon.svg"
+    },
+    {
+      "bytes": 1761,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/ask_icon.svg"
+    },
+    {
+      "bytes": 921,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/avatar_icon.svg"
+    },
+    {
+      "bytes": 3434,
+      "category": "binary",
+      "evidence": "null byte in the first 4096 bytes",
+      "path": "src/assets/icons/avatarmob_icon.png"
+    },
+    {
+      "bytes": 255,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/backArrow_icon.svg"
+    },
+    {
+      "bytes": 819,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/borrowAndRepay_icon.svg"
+    },
+    {
+      "bytes": 3851,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/bug_icon.svg"
+    },
+    {
+      "bytes": 243,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/burgerMenu_icon.svg"
+    },
+    {
+      "bytes": 517,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/calendar_icon.svg"
+    },
+    {
+      "bytes": 873,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/change_icon.svg"
+    },
+    {
+      "bytes": 214,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/check_icon.svg"
+    },
+    {
+      "bytes": 896,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/circledAlertRed_icon.svg"
+    },
+    {
+      "bytes": 837,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/circledAlert_icon.svg"
+    },
+    {
+      "bytes": 462,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/circledBackArrow_icon.svg"
+    },
+    {
+      "bytes": 444,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/circledCheckBlue_icon.svg"
+    },
+    {
+      "bytes": 557,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/circledCrossRed_icon.svg"
+    },
+    {
+      "bytes": 438,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/circledPlus_icon.svg"
+    },
+    {
+      "bytes": 2173,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/circledQuestion_icon.svg"
+    },
+    {
+      "bytes": 541,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/clock_icon.svg"
+    },
+    {
+      "bytes": 504,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/coinbase_icon.svg"
+    },
+    {
+      "bytes": 2822,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/coins_icon.svg"
+    },
+    {
+      "bytes": 2329,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/collateralContract_icon.svg"
+    },
+    {
+      "bytes": 2876,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/confetti_pattern.svg"
+    },
+    {
+      "bytes": 682,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/copy_icon.svg"
+    },
+    {
+      "bytes": 334,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/cross_icon.svg"
+    },
+    {
+      "bytes": 562,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/docs_icon.svg"
+    },
+    {
+      "bytes": 243,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/downArrow20_icon.svg"
+    },
+    {
+      "bytes": 282,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/downArrow_icon.svg"
+    },
+    {
+      "bytes": 1144,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/edit_icon.svg"
+    },
+    {
+      "bytes": 2853,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/feat_icon.svg"
+    },
+    {
+      "bytes": 306,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/filter_icon.svg"
+    },
+    {
+      "bytes": 2785,
+      "category": "binary",
+      "evidence": "null byte in the first 4096 bytes",
+      "path": "src/assets/icons/fire_icon.png"
+    },
+    {
+      "bytes": 233,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/fullArrow_icon.svg"
+    },
+    {
+      "bytes": 599,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/gallery_icon.svg"
+    },
+    {
+      "bytes": 1764,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/hotRateCard_icon.svg"
+    },
+    {
+      "bytes": 885,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/info_icon.svg"
+    },
+    {
+      "bytes": 69585,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/keplr_icon.svg"
+    },
+    {
+      "bytes": 397,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/ledger_icon.svg"
+    },
+    {
+      "bytes": 730,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/lenderBorrower_icon.svg"
+    },
+    {
+      "bytes": 562,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/link_icon.svg"
+    },
+    {
+      "bytes": 3688,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/logo_black.svg"
+    },
+    {
+      "bytes": 3688,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/logo_white.svg"
+    },
+    {
+      "bytes": 1125,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/marketEvents_icon.svg"
+    },
+    {
+      "bytes": 795,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/marketSummary_icon.svg"
+    },
+    {
+      "bytes": 2169,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/markets_icon.svg"
+    },
+    {
+      "bytes": 826,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/mediumWarning_icon.svg"
+    },
+    {
+      "bytes": 940,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/message_icon.svg"
+    },
+    {
+      "bytes": 4262,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/meta_icon.svg"
+    },
+    {
+      "bytes": 928,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/noNameLogo_icon.svg"
+    },
+    {
+      "bytes": 657,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/notifications_read.svg"
+    },
+    {
+      "bytes": 666,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/notifications_unread.svg"
+    },
+    {
+      "bytes": 2231,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/oneOfMany_icon.svg"
+    },
+    {
+      "bytes": 1618,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/partnership_icon.svg"
+    },
+    {
+      "bytes": 1134,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/phantom_icon.svg"
+    },
+    {
+      "bytes": 220,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/plus_icon.svg"
+    },
+    {
+      "bytes": 1413,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/policies_icon.svg"
+    },
+    {
+      "bytes": 1712,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/popularCard_icon.svg"
+    },
+    {
+      "bytes": 580,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/profile_icon.svg"
+    },
+    {
+      "bytes": 855,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/provenCard_icon.svg"
+    },
+    {
+      "bytes": 1952,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/question_icon.svg"
+    },
+    {
+      "bytes": 3202,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/rabby_icon.svg"
+    },
+    {
+      "bytes": 4280,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/rainbow_icon.svg"
+    },
+    {
+      "bytes": 760,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/return_icon.svg"
+    },
+    {
+      "bytes": 1826,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/safe.svg"
+    },
+    {
+      "bytes": 3735,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/sale_logo_black.svg"
+    },
+    {
+      "bytes": 497,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/search_icon.svg"
+    },
+    {
+      "bytes": 242,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/sharpArrow_icon.svg"
+    },
+    {
+      "bytes": 3699,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/stack_icon.svg"
+    },
+    {
+      "bytes": 955,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/statusAndDetails_icon.svg"
+    },
+    {
+      "bytes": 795,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/summary_icon.svg"
+    },
+    {
+      "bytes": 148,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/tableSort-ascSort_icon.svg"
+    },
+    {
+      "bytes": 144,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/tableSort-descSort_icon.svg"
+    },
+    {
+      "bytes": 187,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/tableSort-unsorted_icon.svg"
+    },
+    {
+      "bytes": 464,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/table_icon.svg"
+    },
+    {
+      "bytes": 3950,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/telegramFly_icon.svg"
+    },
+    {
+      "bytes": 851,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/telegram_icon.svg"
+    },
+    {
+      "bytes": 248,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/textChipArrow_icon.svg"
+    },
+    {
+      "bytes": 2798,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/tokenWrap_icon.svg"
+    },
+    {
+      "bytes": 875,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/topFundedCard_icon.svg"
+    },
+    {
+      "bytes": 633,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/trendingCard_icon.svg"
+    },
+    {
+      "bytes": 286,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/upArrow_icon.svg"
+    },
+    {
+      "bytes": 1191,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/walletConnect_icon.svg"
+    },
+    {
+      "bytes": 1346,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/wallet_icon.svg"
+    },
+    {
+      "bytes": 826,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/warning_icon.svg"
+    },
+    {
+      "bytes": 1803,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/withdrawal-coins_icon.svg"
+    },
+    {
+      "bytes": 732,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/icons/withdrawalAndRequests_icon.svg"
+    },
+    {
+      "bytes": 1299338,
+      "category": "binary",
+      "evidence": "null byte in the first 4096 bytes",
+      "path": "src/assets/pictures/background.webp"
+    },
+    {
+      "bytes": 10410,
+      "category": "binary",
+      "evidence": "null byte in the first 4096 bytes",
+      "path": "src/assets/pictures/bannerBG.webp"
+    },
+    {
+      "bytes": 167999,
+      "category": "binary",
+      "evidence": "null byte in the first 4096 bytes",
+      "path": "src/assets/pictures/banner_bg.png"
+    },
+    {
+      "bytes": 6478,
+      "category": "binary",
+      "evidence": "null byte in the first 4096 bytes",
+      "path": "src/assets/pictures/ethereum-icon.webp"
+    },
+    {
+      "bytes": 94370,
+      "category": "binary",
+      "evidence": "null byte in the first 4096 bytes",
+      "path": "src/assets/pictures/login_page.webp"
+    },
+    {
+      "bytes": 899778,
+      "category": "binary",
+      "evidence": "null byte in the first 4096 bytes",
+      "path": "src/assets/pictures/overviewBG.webp"
+    },
+    {
+      "bytes": 11216,
+      "category": "binary",
+      "evidence": "null byte in the first 4096 bytes",
+      "path": "src/assets/pictures/plasma-icon.png"
+    },
+    {
+      "bytes": 1334,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/pictures/telegramSmallBanner_bg.svg"
+    },
+    {
+      "bytes": 1308,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "path": "src/assets/pictures/telegram_banner_bg.svg"
+    },
+    {
+      "bytes": 1448802,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 1448802 bytes",
+      "path": "src/config/elfs-by-country.json"
+    },
+    {
+      "bytes": 20102,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 20102 bytes",
+      "path": "src/config/jurisdictions.json"
+    },
+    {
+      "bytes": 7567063,
+      "category": "generated",
+      "evidence": "directory name storybook-static",
+      "files": 72,
+      "path": "storybook-static/"
+    }
+  ],
+  "schema": 1,
+  "tool": "horos"
+}

--- a/plugins/horos/docs/evidence/wildcat-app-v2-rules.md
+++ b/plugins/horos/docs/evidence/wildcat-app-v2-rules.md
@@ -1,0 +1,57 @@
+# Evidence bundle: wildcat-app-v2, second capture
+
+The same tree as [the first capture](./wildcat-app-v2.md), rescanned after
+the text-asset and migration-SQL rules landed. The first capture is
+immutable evidence behind the `horos-v1.1.0` ledger row; this one records
+what the two new rules changed, and nothing else changed.
+
+## The capture
+
+- Repository: `wildcat-finance/wildcat-app-v2`
+- Commit: `9b8b6d5d6db06428c5b539f267623277b65315cd`, identical to the first
+  capture; the clone was not touched between the two
+- Captured: 2026-08-18
+- Tool: `horos` with the two rule classes of this run, released as
+  `horos-v2.1.0`
+- Boundary document: [wildcat-app-v2-rules.boundary.json](./wildcat-app-v2-rules.boundary.json)
+
+## The totals
+
+Classified bytes rose from 13,696,504 to 14,199,753 of 17,053,779: **83.3%
+of readable bytes**, up from 80.3%. Entries rose from 16 to 130. The delta
+is exactly the two rule families and nothing else: 97 SVG text assets
+(204,371 bytes, every SVG outside the Storybook build) and 17 migration SQL
+files (298,878 bytes). No entry from the first capture moved or vanished,
+and no hand-written TypeScript or TSX joined the boundary.
+
+| Category | Bytes | Change from the first capture |
+| --- | --- | --- |
+| generated | 7,866,067 | up 298,878: the migration SQL |
+| binary | 2,598,609 | unchanged |
+| lockfile | 1,895,425 | unchanged |
+| blob | 1,635,281 | unchanged |
+| asset | 204,371 | new category: the 97 SVGs |
+
+## What still stays readable
+
+About 2.85 MB, all of it unevidenced by the current rules: hand-written
+source, configuration, prose, and the machine-regular-but-hand-committed
+files (the MUI theme, GraphQL query strings) the fail-open contract leaves
+alone.
+
+## Machine-readable capture lines
+
+The consistency test parses these against the committed boundary document,
+as it does for the first capture.
+
+<!-- evidence2:commit 9b8b6d5d6db06428c5b539f267623277b65315cd -->
+<!-- evidence2:total_bytes 17053779 -->
+<!-- evidence2:classified_bytes 14199753 -->
+<!-- evidence2:entries 130 -->
+<!-- evidence2:files_walked 1041 -->
+<!-- evidence2:files_skipped_unreadable 0 -->
+<!-- evidence2:bytes_generated 7866067 -->
+<!-- evidence2:bytes_binary 2598609 -->
+<!-- evidence2:bytes_lockfile 1895425 -->
+<!-- evidence2:bytes_blob 1635281 -->
+<!-- evidence2:bytes_asset 204371 -->

--- a/plugins/horos/tests/test_evidence.py
+++ b/plugins/horos/tests/test_evidence.py
@@ -9,11 +9,13 @@ PLUGIN = Path(__file__).resolve().parents[1]
 EVIDENCE = PLUGIN / "docs" / "evidence"
 BUNDLE = EVIDENCE / "wildcat-app-v2.md"
 BOUNDARY = EVIDENCE / "wildcat-app-v2.boundary.json"
+BUNDLE_2 = EVIDENCE / "wildcat-app-v2-rules.md"
+BOUNDARY_2 = EVIDENCE / "wildcat-app-v2-rules.boundary.json"
 
 
-def capture_lines():
-    text = BUNDLE.read_text(encoding="utf-8")
-    return dict(re.findall(r"<!-- evidence:(\S+) (\S+) -->", text))
+def capture_lines(bundle=BUNDLE, tag="evidence"):
+    text = bundle.read_text(encoding="utf-8")
+    return dict(re.findall(rf"<!-- {tag}:(\S+) (\S+) -->", text))
 
 
 class EvidenceBundleTests(unittest.TestCase):
@@ -48,6 +50,49 @@ class EvidenceBundleTests(unittest.TestCase):
         share = 100 * int(lines["classified_bytes"]) / int(lines["total_bytes"])
         self.assertGreaterEqual(share, 60.0)
         self.assertAlmostEqual(share, 80.3, places=1)
+
+
+class SecondCaptureTests(unittest.TestCase):
+    def test_the_quoted_totals_equal_the_boundary_documents(self):
+        lines = capture_lines(BUNDLE_2, "evidence2")
+        document = json.loads(BOUNDARY_2.read_text(encoding="utf-8"))
+        counts = document["counts"]
+        self.assertEqual(int(lines["entries"]), len(document["entries"]))
+        self.assertEqual(int(lines["files_walked"]), counts["files_walked"])
+        for category in ("generated", "binary", "lockfile", "blob", "asset"):
+            self.assertEqual(
+                int(lines["bytes_" + category]), counts["bytes_" + category]
+            )
+        classified = sum(entry["bytes"] for entry in document["entries"])
+        self.assertEqual(int(lines["classified_bytes"]), classified)
+
+    def test_both_captures_name_the_same_commit(self):
+        self.assertEqual(
+            capture_lines()["commit"], capture_lines(BUNDLE_2, "evidence2")["commit"]
+        )
+
+    def test_the_delta_is_exactly_the_two_rule_families(self):
+        old = json.loads(BOUNDARY.read_text(encoding="utf-8"))
+        new = json.loads(BOUNDARY_2.read_text(encoding="utf-8"))
+        old_paths = {entry["path"] for entry in old["entries"]}
+        new_paths = {entry["path"] for entry in new["entries"]}
+        self.assertEqual(old_paths - new_paths, set())
+        for path in new_paths - old_paths:
+            self.assertTrue(
+                path.endswith(".svg")
+                or (path.endswith(".sql") and "migrations" in path.split("/")),
+                path,
+            )
+
+    def test_the_second_share_exceeds_the_first(self):
+        first = capture_lines()
+        second = capture_lines(BUNDLE_2, "evidence2")
+        self.assertEqual(first["total_bytes"], second["total_bytes"])
+        self.assertGreater(
+            int(second["classified_bytes"]), int(first["classified_bytes"])
+        )
+        share = 100 * int(second["classified_bytes"]) / int(second["total_bytes"])
+        self.assertAlmostEqual(share, 83.3, places=1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The same tree and commit as the first capture, rescanned with the two new
rules. Classified bytes rise from 13,696,504 to 14,199,753 (80.3% to
83.3%), entries from 16 to 130, and a delta test proves the additions are
exactly 97 SVGs and 17 migration SQL files, nothing removed, no
hand-written TypeScript joining the boundary. The first capture stays
immutable behind the v1.1.0 ledger row; the second lands beside it with its
own machine-checked lines and the same never-touch-the-network rule.

Stacks on step 2 (the rule classes). Audit: one round, zero findings; log
in audit/AUDIT.md.

Proof: `python3 -m unittest plugins.horos.tests.test_evidence -v` (eight
tests across both captures).

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
