### PR TITLE
Print an adoption stanza after every boundary write

### DIFF
--- a/plugins/horos/README.md
+++ b/plugins/horos/README.md
@@ -47,6 +47,17 @@ file on one line. The committed boundary sends the reading budget to `src/`
 instead, `check` catches the day the boundary goes stale, and a skeleton map
 orients the agent in a thousand-line module without opening it whole.
 
+## Adopting a boundary in any repository
+
+The boundary binds agents that carry this skill; everyone else's agents
+learn it from the adopting repository's own instructions file. `scan
+--write` prints a short stanza for that repository's AGENTS.md or CLAUDE.md:
+consult `.horos/boundary.json` before reading broadly, leave listed paths
+unread unless the task demands one, and never apply the boundary during
+security review. Harnesses load those files at session start, so one paste
+makes the boundary effective for any instruction-following agent, with no
+install.
+
 ## Where it is honest about limits
 
 Classification is fail-open. A file Horos cannot evidence stays readable, so

--- a/plugins/horos/skills/horos/EVOLUTION.md
+++ b/plugins/horos/skills/horos/EVOLUTION.md
@@ -2,7 +2,7 @@
 
 Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
 
-- Current version: `horos-v2.1.0`
+- Current version: `horos-v2.2.0`
 - Frontier status: `open`
 - Frontier revision: `ts-outline-extractor`
 - Current frontier: Horos's map verb reads Python only; the maintainer-directed TypeScript outline extractor, internal to Horos with verbatim source slices and confessed unparsed regions, remains unbuilt.
@@ -15,3 +15,4 @@ Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VE
 | `horos-v0.1.0` | baseline | `live-evidence-and-ts-maps` | `35be1190b60ef3acab18434ca647628943a0073ecbbc14dc0a0f041365352fe8` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |
 | `horos-v1.1.0` | evolution | `text-asset-and-sql-rules` | `00037861d1e760fac2143bb83dd5d2d8c0978c391c3d669fc06cf70d01f7e187` | [wildcat-app-v2 evidence bundle](../../docs/evidence/wildcat-app-v2.md) | The held live-evidence job completed. The wildcat-app-v2 capture records 80.3% of readable bytes classified with zero false exclusions, and the maintainer refused TypeScript skeleton maps rather than take a parser dependency or a subprocess boundary. The new held job takes the capture's two quantified misses. |
 | `horos-v2.1.0` | evolution | `ts-outline-extractor` | `232d7abdc4940d51512b8bae935029cd0545cbabaa54a02182997e5df10af9b5` | [second wildcat-app-v2 capture](../../docs/evidence/wildcat-app-v2-rules.md) | The held rule-classes job completed: SVG text assets and migrations-segment SQL are classified with near-miss tests, and the second capture against the same commit rises from 80.3% to 83.3% with a delta proven to be exactly the two families. The maintainer directed this session that TypeScript skeletons return as an outline extractor internal to Horos, superseding the v1.1.0 refusal's premise without contradicting it; that is the new held job. |
+| `horos-v2.2.0` | generation | `ts-outline-extractor` | `232d7abdc4940d51512b8bae935029cd0545cbabaa54a02182997e5df10af9b5` | [README adoption section](../../README.md) | Maintainer question: a committed boundary bound only agents carrying this skill. scan --write now prints an adoption stanza for the target repository's AGENTS.md or CLAUDE.md, so the discipline travels with the repository and binds any instruction-following agent. Frontier unchanged. |

--- a/plugins/horos/skills/horos/SKILL.md
+++ b/plugins/horos/skills/horos/SKILL.md
@@ -2,7 +2,7 @@
 name: horos
 description: Emit and verify an evidence-backed reading boundary over a repository. Classify token sinks (generated files, vendored trees, lockfiles, minified bundles, single-line blobs), write the deterministic boundary agents consult before reading, and print Python skeleton maps for oriented reading. Use when a user names Horos or asks to cut the reading cost of a repository without rewriting its code. Never apply a boundary during security review.
 metadata:
-  version: "2.1.0"
+  version: "2.2.0"
 ---
 
 # Horos
@@ -82,6 +82,11 @@ recorded capture at
    enough.
 4. Classification is fail-open, so the boundary understates the sinks. What
    it lists is evidenced; what it omits is merely unproven.
+5. When writing a boundary into a repository other agents will work in, add
+   the adoption stanza that `scan --write` prints to that repository's
+   AGENTS.md or CLAUDE.md. Agent harnesses load those files at session
+   start, so the discipline travels with the repository; without the
+   stanza, the boundary binds only agents carrying this skill.
 
 ## The one rule that outranks the rest
 

--- a/plugins/horos/skills/horos/scripts/horos.py
+++ b/plugins/horos/skills/horos/scripts/horos.py
@@ -290,6 +290,24 @@ def scan_tree(root):
 BOUNDARY_RELPATH = ".horos/boundary.json"
 BOUNDARY_SCHEMA = 1
 
+# Printed after a boundary write, for the adopting repository's AGENTS.md or
+# CLAUDE.md. This is the whole bridge to agents that have never heard of
+# Horos: harnesses load those files at session start, so the discipline
+# travels with the repository instead of with this skill.
+ADOPTION_STANZA = """\
+Paste this into the repository's AGENTS.md or CLAUDE.md so agents without
+Horos inherit the boundary:
+
+## Reading boundary
+
+Before reading this repository broadly, consult `.horos/boundary.json`.
+Every path listed there is a classified token sink carrying the evidence
+that earned its entry; leave those paths unread unless the task demands
+one. The boundary is fail-open: what it omits is merely unproven. It never
+applies during security review; during any audit, review or incident work,
+read as if no boundary exists.
+"""
+
 
 def boundary_document(result):
     """The committed artefact: schema-tagged, no timestamps, no absolute paths."""
@@ -461,6 +479,9 @@ def main(argv=None):
         for key, value in sorted(document["counts"].items()):
             print(f"{key}: {value}")
         print(f"entries: {len(document['entries'])}")
+        if args.write:
+            print()
+            print(ADOPTION_STANZA, end="")
     return 0
 
 

--- a/plugins/horos/tests/test_boundary.py
+++ b/plugins/horos/tests/test_boundary.py
@@ -122,6 +122,21 @@ class BoundaryTests(unittest.TestCase):
         paths = [entry["path"] for entry in self.document()["entries"]]
         self.assertNotIn(horos.BOUNDARY_RELPATH, paths)
 
+    def test_a_write_prints_the_adoption_stanza(self):
+        with mock.patch.object(sys, "stdout", new=io.StringIO()) as stdout:
+            code = horos.main(["scan", self.root, "--write"])
+        self.assertEqual(code, 0)
+        output = stdout.getvalue()
+        self.assertIn("## Reading boundary", output)
+        self.assertIn("never\napplies during security review", output)
+        self.assertIn("AGENTS.md or CLAUDE.md", output)
+
+    def test_json_output_stays_pure_even_with_write(self):
+        with mock.patch.object(sys, "stdout", new=io.StringIO()) as stdout:
+            code = horos.main(["scan", self.root, "--json", "--write"])
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout.getvalue(), horos.render(self.document()))
+
     def test_the_cli_json_output_is_the_rendered_document(self):
         with mock.patch.object(sys, "stdout", new=io.StringIO()) as stdout:
             code = horos.main(["scan", self.root, "--json"])


### PR DESCRIPTION
A committed boundary bound only agents carrying the Horos skill; arbitrary agents had nothing routing them to it. scan --write now prints a stanza for the adopting repository's AGENTS.md or CLAUDE.md, so the discipline travels with the repository and binds any instruction-following agent, no install needed. The stanza carries the security-review exemption. Generation bump to horos-v2.2.0 with the frontier revision and digest retained byte for byte; two new tests pin the stanza and the JSON purity.

Proof: `python3 -m unittest discover -s plugins/horos/tests -t plugins/horos` (67 tests) and `python3 -m unittest discover -s tests` (24, holding the generation row).

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
