### PR TITLE
Commit the outline-extractor spec and the languages folder

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1135,3 +1135,16 @@ them, and that both prior ledger rows are byte-identical to before.
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Outline-extractor run, step 1, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0. Horos
+67/67, root 24/24. The review checked the move: the Python extractor's
+output is pinned by the untouched fixture test, the registry refuses
+unregistered suffixes naming its supported list, and the refusal-message
+test moved with the message as the runbook records.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.

--- a/plugins/horos/docs/ts-outline/runbook.md
+++ b/plugins/horos/docs/ts-outline/runbook.md
@@ -1,0 +1,82 @@
+# The TypeScript outline extractor, the runbook
+
+Five steps, dependency order, one pull request each. The study committed
+beside this runbook is the spec; both land in step 1.
+
+## Step 1: Commit the frontier spec and the languages folder
+
+**Goal.** The spec is in the tree, and the Python mapper lives at
+`languages/python/python.py` behind a suffix registry, output unchanged.
+**Entry.** The run branch, cut from `main` at `f68c247`.
+**Exit.** Both suites green with the Python map fixture untouched; three
+tree lints clean; imprimatur clean on both documents.
+**Files.** `plugins/horos/docs/ts-outline/study.md` and `runbook.md`;
+`plugins/horos/skills/horos/scripts/languages/__init__.py` (the registry);
+`plugins/horos/skills/horos/scripts/languages/python/python.py` (moved
+mapper, one folder per language);
+`horos.py` dispatching map through the registry.
+**Tests.** The pinned Python fixture holds unchanged; the refusal message
+moves to the registry and its test moves with it, asserting the supported
+list is named.
+
+## Step 2: The TypeScript lexer
+
+**Goal.** One pass classifies every character of a `.ts`/`.tsx` source:
+code, line comment, block comment, string, template with `${}` nesting,
+regex.
+**Entry.** Step 1's exit state.
+**Exit.** Plugin suite green; the lexer test block passes.
+**Files.**
+`plugins/horos/skills/horos/scripts/languages/typescript/typescript.py`
+(lexer half); `plugins/horos/tests/test_ts_lexer.py`.
+**Tests.** Strings with escapes; templates nested two deep; line and block
+comments; regex after `=`, `(`, `return` and `,`; division after `)`,
+identifiers and numbers; the newline guard reclassifying a false regex; an
+unterminated string confessing the remainder. Expected count: about
+twelve.
+
+## Step 3: The outliner
+
+**Goal.** Declarations sliced verbatim at module, export, namespace and
+class depth; everything unmatched skipped structurally and confessed by
+line range; map wired for `.ts`/`.tsx`.
+**Entry.** Step 2's exit state.
+**Exit.** Plugin suite green; the pinned TypeScript fixture outline matches
+byte for byte.
+**Files.** `languages/typescript/typescript.py` (outliner half);
+`plugins/horos/examples/fixture-ts/market.ts` (the pinned fixture);
+`plugins/horos/tests/test_ts_outline.py`.
+**Tests.** Imports and exports; function, class with methods and
+decorators, interface, type alias, enum, namespace, const arrow function;
+an unmatched statement confessed with its lines; the confession footer
+format; the fixture pin. Expected count: about ten.
+
+## Step 4: The differential corpus
+
+**Goal.** The outliner is held against the compiler API over all 867
+hand-written `.ts`/`.tsx` files in the wildcat-app-v2 clone, and the result
+is recorded as a machine-checked evidence bundle.
+**Entry.** Step 3's exit state.
+**Exit.** Zero crashes over the corpus; every name-level mismatch triaged
+as a fix or a confessed region; the bundle's machine lines checked by the
+suite; `python3 -m unittest plugins.horos.tests.test_evidence -v` green.
+**Files.** `plugins/horos/dev/ts_oracle.mjs` (the dev-time node tool, never
+imported by the suite); `plugins/horos/docs/evidence/wildcat-app-v2-outline.md`
+and its committed per-file results JSON;
+`plugins/horos/tests/test_evidence.py` extended; fixes to
+`languages/typescript/typescript.py` as the corpus demands.
+**Tests.** Bundle-consistency checks in the shape of the two scan
+captures. Expected count: about three.
+
+## Step 5: Reledger and reconcile
+
+**Goal.** The ledger advances to `horos-v3.2.0` holding the filetype-census
+job the maintainer named, and every surface agrees.
+**Entry.** Step 4's exit state.
+**Exit.** Study success criteria 1 through 4 all pass as written.
+**Files.** `EVOLUTION.md` (evolution row, script-computed digest);
+`SKILL.md` (metadata `3.2.0`, frontier text, the map section describing
+both languages and the confession contract); `plugins/horos/README.md`;
+`.agents/skills/horos/SKILL.md`; root `README.md`.
+**Tests.** None new; the evolution and marketplace-prose contracts are the
+check.

--- a/plugins/horos/docs/ts-outline/study.md
+++ b/plugins/horos/docs/ts-outline/study.md
@@ -1,0 +1,168 @@
+# The TypeScript outline extractor, the study
+
+This run executes Horos's held frontier job: build the TypeScript outline
+extractor inside the map verb. It lexes rather than parses, quotes
+declaration slices verbatim, confesses unparsed regions by count and
+location, ships stdlib-only, and is developed against a dev-time
+differential corpus. Two maintainer directions from this session shape it:
+extractors live under a `languages/` folder built for more languages later,
+and the next held job recorded at this run's close is the filetype census
+mode for scan.
+
+## Assumptions
+
+Proceeding on these unless corrected:
+
+1. Extractors live one folder per language at
+   `plugins/horos/skills/horos/scripts/languages/<language>/<language>.py`,
+   so fixtures and notes can sit beside each extractor. The existing Python
+   mapper moves into `languages/python/python.py` in the same run,
+   so map dispatches by suffix through one registry and the folder is the
+   pattern for every later language.
+2. The extractor covers `.ts` and `.tsx`. Plain JavaScript is out of the
+   prototype; its lexer is nearly the same and it can join the registry
+   later with its own evidence.
+3. The differential oracle is the real TypeScript compiler API, driven by a
+   node script kept in the repository as a dev-time tool. Node v26.6.0 is on
+   this machine; the `typescript` package installs into the scratchpad for
+   the corpus run and is never a plugin dependency. The corpus is the
+   wildcat-app-v2 clone at `9b8b6d5d6db06428c5b539f267623277b65315cd`: 867
+   hand-written `.ts`/`.tsx` files under `src/`.
+4. The completed job increments evolution: `horos-v2.2.0` becomes
+   `horos-v3.2.0`, generation and epoch retained.
+
+## 1. Problem statement
+
+`map` orients an agent in a Python file without the file being read whole.
+TypeScript repositories, where the scan already does its measured best work,
+get no such orientation. The refusal of 2026-08-18 stands against parsing
+TypeScript or taking a parser dependency; the superseding design this run
+builds needs neither.
+
+What the extractor does, stated so a test can refuse it:
+
+- **Lexing, not parsing.** One pass classifies every character into code,
+  comment, string, template (with `${}` nesting) or regex. The
+  regex-versus-division ambiguity is resolved by the previous significant
+  token, guarded by the fact that a regex literal cannot contain an
+  unescaped newline: a candidate regex that meets a newline before its
+  closing slash is reclassified as division and rescanned.
+- **Declarations, sliced verbatim.** At module depth and inside `export`,
+  `namespace` and class bodies, the outliner recognises imports, exports,
+  functions, classes, interfaces, type aliases, enums, namespaces, variable
+  declarations with arrow or function initialisers, decorators, and class
+  members. Each match is quoted as the exact source slice from the
+  declaration's first token to its body brace or terminating semicolon,
+  types untouched.
+- **Confession, not guessing.** Any statement position the recognisers do
+  not match is skipped structurally (to the balancing brace or semicolon)
+  and recorded as an unparsed region with its line range. The report ends
+  with declarations counted, regions confessed, and their locations. A
+  lexer-level failure (an unterminated string or template) confesses the
+  remainder of the file.
+
+A working prototype means: the pinned fixture outline matches byte for
+byte; the corpus run over all 867 files completes with zero crashes; the
+differential against the compiler API is recorded as an evidence bundle
+with every mismatch triaged (fixed, or confessed as a named unparsed
+region); and every suite and lint is green.
+
+## 2. Prior art
+
+The map verb's Python path (this plugin) fixes the output register:
+signatures, structure, first docstring lines, refusal and error paths.
+Pandects' stripper tests pin the string-literal traps a lexer must not
+repeat; Lemma's chunkers already walk Solidity with the same
+comment-and-string discipline. Outside: aider's repo-map and Repomix
+compress prove the outline's value; universal-ctags demonstrates the
+lexer-plus-recognisers approach and its failure mode (silent omission),
+which the confession contract exists to fix; the TypeScript compiler API is
+the reference oracle. The session assessment of 2026-08-18 (recorded in the
+v2.1.0 ledger row) is the design's source.
+
+## 3. Constraints and non-goals
+
+- Stdlib only in everything that ships. The node differential tool is
+  dev-time, lives under the plugin's `dev/` directory, and nothing in the
+  test suite imports or invokes it.
+- The scan and check verbs do not change. The boundary format does not
+  change.
+- Non-goals: JavaScript, JSON, Solidity and every other language (the
+  registry is the extension point, not this run); JSX structure inside
+  bodies (bodies are skipped whole); type-correctness of slices (they are
+  quotes, not claims); the filetype census (next held job); any cap on
+  slice length beyond the source line itself.
+
+## 4. Design options
+
+**A. Lexer plus recognisers, slices verbatim, confession mandatory.**
+Chosen, as directed. Trade: recall is bounded by the recogniser list, so
+the outline understates a file the way the boundary understates a tree; the
+confession line is what keeps that honest.
+
+**B. Regex-only sketch without a lexer.** Rejected: a string or template
+containing `class X {` derails it silently, which is the exact guess the
+refusal named.
+
+**C. Ship the compiler API as the extractor.** Rejected: a node subprocess
+in the runtime path crosses both grounds the refusal keeps.
+
+## 5. Risk register seed
+
+- The regex-versus-division rule is the classic lexer trap; it gets its own
+  test block, including division after `)`, after identifiers, and a regex
+  containing quotes and braces. The newline guard bounds the damage of a
+  wrong guess to one line.
+- Template literals nest (`` `a${ {b: `c${d}`} }e` ``); depth is a stack,
+  not a flag, and the tests include two levels.
+- `.tsx` generics versus JSX: the outliner never enters bodies, and
+  declaration headers cannot contain JSX, so the ambiguity is confined to
+  regions the extractor either slices as headers or skips whole. The corpus
+  run is the check that this holds on real code.
+- An unterminated string must confess the remainder, never hang or raise.
+- The differential's mismatches are the acceptance evidence: each one is a
+  fix or a confessed region, and the bundle names the count of each.
+- Moving the Python mapper must not change its pinned output; the fixture
+  test from the first delivery holds unchanged.
+
+## 6. Glossary seeds
+
+- Extractor: one language's outline module under `languages/`.
+- Registry: the suffix-to-extractor table map dispatches through.
+- Slice: the verbatim source text of one declaration head.
+- Confession: the recorded line ranges the outliner did not understand.
+- Differential corpus: the recorded comparison of outliner declarations
+  against the compiler API's, per file, dev-time only.
+
+## 7. Boundaries
+
+- **Always.** Both suites and the three tree lints before a commit;
+  imprimatur on every shipped document; the pinned fixtures are the format
+  contract.
+- **Ask first.** Any runtime dependency; adding a language beyond
+  TypeScript; changing the map output register; weakening the confession.
+- **Never.** Import or execute scanned code; let the node tool into the
+  runtime path or the test suite; report a corpus or differential run that
+  did not happen; delete a failing test.
+
+## 8. Success criteria
+
+1. `python3 -m unittest discover -s tests` passes.
+2. `python3 -m unittest discover -s plugins/horos/tests -t plugins/horos`
+   passes, including the TypeScript lexer, outliner and dispatch tests, and
+   the unchanged Python fixture.
+3. `python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests`
+   and the ephoros equivalent exit clean.
+4. Demo path: `python3 plugins/horos/skills/horos/scripts/horos.py map
+   plugins/horos/examples/fixture-ts/market.ts` prints the pinned outline,
+   and the committed differential evidence bundle at
+   `plugins/horos/docs/evidence/wildcat-app-v2-outline.md` is
+   machine-checked by the suite like the two scan captures.
+
+## 9. Sources
+
+The v2.1.0 ledger row holding this job and the session assessment behind
+it. The maintainer's directions this session: the `languages/` folder and
+the filetype census as the probable next goal. The wildcat-app-v2 clone at
+`9b8b6d5d6db06428c5b539f267623277b65315cd`. The TypeScript compiler API as
+oracle. The map verb's existing pinned fixtures.

--- a/plugins/horos/skills/horos/scripts/horos.py
+++ b/plugins/horos/skills/horos/scripts/horos.py
@@ -13,11 +13,12 @@ what it saves.
 
 from pathlib import PurePosixPath
 import argparse
-import ast
 import fnmatch
 import json
 import os
 import sys
+
+import languages
 
 # The classifier's own reading limit. Raising it is an ask-first change once
 # the tests pin it: every content rule below is defined against this prefix.
@@ -384,46 +385,17 @@ def check_tree(root, out=None):
     return 1
 
 
-def first_docstring_line(node):
-    docstring = ast.get_docstring(node)
-    if not docstring:
-        return None
-    return docstring.strip().splitlines()[0]
-
-
-def skeleton_lines(node, depth=0):
-    """Signatures and class structure, one line each, bodies left behind."""
-    lines = []
-    pad = "    " * depth
-    for child in node.body if hasattr(node, "body") else []:
-        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            for decorator in child.decorator_list:
-                lines.append(f"{pad}@{ast.unparse(decorator)}")
-            keyword = "async def" if isinstance(child, ast.AsyncFunctionDef) else "def"
-            returns = f" -> {ast.unparse(child.returns)}" if child.returns else ""
-            line = f"{pad}{keyword} {child.name}({ast.unparse(child.args)}){returns}:"
-            summary = first_docstring_line(child)
-            if summary:
-                line += f"  # {summary}"
-            lines.append(line)
-        elif isinstance(child, ast.ClassDef):
-            for decorator in child.decorator_list:
-                lines.append(f"{pad}@{ast.unparse(decorator)}")
-            bases = ", ".join(ast.unparse(base) for base in child.bases)
-            line = f"{pad}class {child.name}" + (f"({bases}):" if bases else ":")
-            summary = first_docstring_line(child)
-            if summary:
-                line += f"  # {summary}"
-            lines.append(line)
-            lines.extend(skeleton_lines(child, depth + 1))
-    return lines
-
-
 def map_file(path, out=None):
-    """Print a Python file's skeleton; orientation without the read."""
+    """Print a file's skeleton via its language extractor; orientation
+    without the read."""
     out = out if out is not None else sys.stdout
-    if not path.endswith(".py"):
-        print(f"horos: map reads Python only, not {path}", file=out)
+    extractor = None
+    for suffix in sorted(languages.EXTRACTORS, key=len, reverse=True):
+        if path.endswith(suffix):
+            extractor = languages.EXTRACTORS[suffix]
+            break
+    if extractor is None:
+        print(f"horos: map supports {languages.supported()}, not {path}", file=out)
         return 2
     try:
         with open(path, "rb") as handle:
@@ -431,16 +403,7 @@ def map_file(path, out=None):
     except OSError as error:
         print(f"horos: cannot read {path}: {error}", file=out)
         return 2
-    try:
-        tree = ast.parse(source)
-    except SyntaxError as error:
-        print(f"horos: syntax error in {path} at line {error.lineno}", file=out)
-        return 1
-    summary = first_docstring_line(tree)
-    print(f"module: {summary}" if summary else "module: (no docstring)", file=out)
-    for line in skeleton_lines(tree):
-        print(line, file=out)
-    return 0
+    return extractor(path, source, out)
 
 
 def main(argv=None):

--- a/plugins/horos/skills/horos/scripts/languages/__init__.py
+++ b/plugins/horos/skills/horos/scripts/languages/__init__.py
@@ -1,0 +1,16 @@
+"""The language registry Horos's map verb dispatches through.
+
+One folder per language. An extractor exposes outline(path, source, out)
+and returns an exit code; the registry maps file suffixes onto it. A suffix
+absent here is refused by map, never guessed at.
+"""
+
+from .python import python
+
+EXTRACTORS = {
+    ".py": python.outline,
+}
+
+
+def supported():
+    return ", ".join(sorted(EXTRACTORS))

--- a/plugins/horos/skills/horos/scripts/languages/python/python.py
+++ b/plugins/horos/skills/horos/scripts/languages/python/python.py
@@ -1,0 +1,52 @@
+"""Python outline extraction for Horos's map verb."""
+
+import ast
+
+
+def first_docstring_line(node):
+    docstring = ast.get_docstring(node)
+    if not docstring:
+        return None
+    return docstring.strip().splitlines()[0]
+
+
+def skeleton_lines(node, depth=0):
+    """Signatures and class structure, one line each, bodies left behind."""
+    lines = []
+    pad = "    " * depth
+    for child in node.body if hasattr(node, "body") else []:
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for decorator in child.decorator_list:
+                lines.append(f"{pad}@{ast.unparse(decorator)}")
+            keyword = "async def" if isinstance(child, ast.AsyncFunctionDef) else "def"
+            returns = f" -> {ast.unparse(child.returns)}" if child.returns else ""
+            line = f"{pad}{keyword} {child.name}({ast.unparse(child.args)}){returns}:"
+            summary = first_docstring_line(child)
+            if summary:
+                line += f"  # {summary}"
+            lines.append(line)
+        elif isinstance(child, ast.ClassDef):
+            for decorator in child.decorator_list:
+                lines.append(f"{pad}@{ast.unparse(decorator)}")
+            bases = ", ".join(ast.unparse(base) for base in child.bases)
+            line = f"{pad}class {child.name}" + (f"({bases}):" if bases else ":")
+            summary = first_docstring_line(child)
+            if summary:
+                line += f"  # {summary}"
+            lines.append(line)
+            lines.extend(skeleton_lines(child, depth + 1))
+    return lines
+
+
+def outline(path, source, out):
+    """Print the module's skeleton; 0 on success, 1 on a syntax error."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as error:
+        print(f"horos: syntax error in {path} at line {error.lineno}", file=out)
+        return 1
+    summary = first_docstring_line(tree)
+    print(f"module: {summary}" if summary else "module: (no docstring)", file=out)
+    for line in skeleton_lines(tree):
+        print(line, file=out)
+    return 0

--- a/plugins/horos/tests/test_map.py
+++ b/plugins/horos/tests/test_map.py
@@ -91,11 +91,12 @@ class MapTests(unittest.TestCase):
         self.assertIn("syntax error", output)
         self.assertIn("line 1", output)
 
-    def test_a_non_python_path_is_refused(self):
+    def test_an_unregistered_suffix_is_refused_naming_the_supported_list(self):
         path = write(self.root, "notes.txt", "words\n")
         code, output = self.map(path)
         self.assertEqual(code, 2)
-        self.assertIn("Python only", output)
+        self.assertIn("map supports", output)
+        self.assertIn(".py", output)
 
     def test_a_missing_file_is_a_plain_message(self):
         code, output = self.map(str(Path(self.root) / "absent.py"))


### PR DESCRIPTION
Step 1 of Horos's held frontier job. The study and runbook land at
plugins/horos/docs/ts-outline/. The map verb now dispatches through a
suffix registry at scripts/languages/, one folder per language as the
maintainer directed, and the Python mapper moves to
languages/python/python.py with its pinned fixture output unchanged. An
unregistered suffix is refused naming the supported list, so the registry
never guesses.

Audit: one round, zero findings; log in audit/AUDIT.md.

Proof: both suites (horos 67, root 24) and the three tree lints, all green.

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
