### PR TITLE
Implement the TypeScript lexer

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1148,3 +1148,21 @@ test moved with the message as the runbook records.
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Outline-extractor run, step 2, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0. Horos 79/79, root
+24/24. The review walked the risk register's lexer rows: escapes consume
+line continuations, character classes protect a slash inside a regex, the
+newline guard bounds a wrong regex guess to one line, operator folding
+keeps arrow and equality tokens whole, and every unterminated construct
+confesses the remainder.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: inside a template expression the scanner
+treats a slash literally, so a regex literal containing a brace or backtick
+inside `${...}` can mis-span the template. Bounded to that template, and
+deferred to the step 4 corpus run, which will show whether real code does
+this before any fix is designed.

--- a/plugins/horos/skills/horos/scripts/languages/typescript/typescript.py
+++ b/plugins/horos/skills/horos/scripts/languages/typescript/typescript.py
@@ -1,0 +1,278 @@
+"""TypeScript outline extraction for Horos's map verb.
+
+This module lexes rather than parses. The lexer classifies every character
+of the source into code, comments, strings, template literals and regex
+literals; the outliner (a later step) works only over the code spans. It
+never imports or executes what it reads.
+"""
+
+# Tokens after which a slash starts a regex literal rather than division.
+# After an identifier, a number, or a closing ) ] } the slash divides.
+REGEX_ALLOWED_AFTER = frozenset(
+    {
+        "",
+        "(",
+        "[",
+        "{",
+        "}",
+        ",",
+        ";",
+        ":",
+        "=",
+        "=>",
+        "==",
+        "===",
+        "!",
+        "!=",
+        "!==",
+        "&",
+        "&&",
+        "|",
+        "||",
+        "?",
+        "??",
+        "+",
+        "-",
+        "*",
+        "/",
+        "%",
+        "<",
+        ">",
+        "<=",
+        ">=",
+        "~",
+        "^",
+        "return",
+        "case",
+        "typeof",
+        "instanceof",
+        "in",
+        "of",
+        "new",
+        "delete",
+        "void",
+        "do",
+        "else",
+        "yield",
+        "await",
+        "throw",
+    }
+)
+
+WORD_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_$"
+)
+
+
+def lex(source):
+    """Classify the whole source into spans; fail-open on what it cannot end.
+
+    Returns (spans, errors). Each span is (kind, start, end) with kind one
+    of code, line_comment, block_comment, string, template, regex; spans
+    cover the source in order. Each error is (offset, reason) for a
+    construct that never terminated; the span still covers the remainder so
+    the caller can confess it.
+    """
+    spans = []
+    errors = []
+    n = len(source)
+    i = 0
+    code_start = 0
+    prev = ""  # last significant code token, for the regex decision
+
+    def flush_code(end):
+        if end > code_start:
+            spans.append(("code", code_start, end))
+
+    while i < n:
+        c = source[i]
+
+        if c == "/" and i + 1 < n and source[i + 1] == "/":
+            flush_code(i)
+            end = source.find("\n", i)
+            end = n if end == -1 else end
+            spans.append(("line_comment", i, end))
+            i = end
+            code_start = i
+            continue
+
+        if c == "/" and i + 1 < n and source[i + 1] == "*":
+            flush_code(i)
+            end = source.find("*/", i + 2)
+            if end == -1:
+                errors.append((i, "unterminated block comment"))
+                spans.append(("block_comment", i, n))
+                return spans, errors
+            spans.append(("block_comment", i, end + 2))
+            i = end + 2
+            code_start = i
+            continue
+
+        if c in "'\"":
+            flush_code(i)
+            end = _scan_string(source, i)
+            if end is None:
+                errors.append((i, "unterminated string"))
+                spans.append(("string", i, n))
+                return spans, errors
+            spans.append(("string", i, end))
+            i = end
+            code_start = i
+            prev = "string"
+            continue
+
+        if c == "`":
+            flush_code(i)
+            end = _scan_template(source, i)
+            if end is None:
+                errors.append((i, "unterminated template literal"))
+                spans.append(("template", i, n))
+                return spans, errors
+            spans.append(("template", i, end))
+            i = end
+            code_start = i
+            prev = "template"
+            continue
+
+        if c == "/" and prev in REGEX_ALLOWED_AFTER:
+            end = _scan_regex(source, i)
+            if end is not None:
+                flush_code(i)
+                spans.append(("regex", i, end))
+                i = end
+                code_start = i
+                prev = "regex"
+                continue
+            # A regex cannot hold an unescaped newline; the scan failing
+            # means this slash divides after all, so fall through as code.
+
+        if c in WORD_CHARS:
+            j = i
+            while j < n and source[j] in WORD_CHARS:
+                j += 1
+            prev = source[i:j]
+            i = j
+            continue
+
+        if not c.isspace():
+            # Fold repeated operator characters so `=>` and `===` count as
+            # one significant token for the regex decision.
+            if prev and prev[-1] == c and (prev + c) in REGEX_ALLOWED_AFTER:
+                prev += c
+            elif c == ">" and prev == "=":
+                prev = "=>"
+            else:
+                prev = c
+        i += 1
+
+    flush_code(n)
+    return spans, errors
+
+
+def _scan_string(source, start):
+    """From the opening quote past the closing one; None if it never closes.
+
+    An escape consumes the next character, which legally includes a newline
+    (line continuation); a raw newline ends the literal unterminated.
+    """
+    quote = source[start]
+    n = len(source)
+    i = start + 1
+    while i < n:
+        c = source[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == quote:
+            return i + 1
+        if c == "\n":
+            return None
+        i += 1
+    return None
+
+
+def _scan_template(source, start):
+    """From the opening backtick past its match, through nested ${...}
+    expressions that may themselves hold strings, templates and comments.
+    None if it never closes."""
+    n = len(source)
+    i = start + 1
+    while i < n:
+        c = source[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == "`":
+            return i + 1
+        if c == "$" and i + 1 < n and source[i + 1] == "{":
+            i = _scan_template_expression(source, i + 2)
+            if i is None:
+                return None
+            continue
+        i += 1
+    return None
+
+
+def _scan_template_expression(source, start):
+    """From just after `${` past the balancing `}`; None if unbalanced."""
+    n = len(source)
+    depth = 1
+    i = start
+    while i < n:
+        c = source[i]
+        if c in "'\"":
+            i = _scan_string(source, i)
+            if i is None:
+                return None
+            continue
+        if c == "`":
+            i = _scan_template(source, i)
+            if i is None:
+                return None
+            continue
+        if c == "/" and i + 1 < n and source[i + 1] == "/":
+            end = source.find("\n", i)
+            if end == -1:
+                return None
+            i = end
+            continue
+        if c == "/" and i + 1 < n and source[i + 1] == "*":
+            end = source.find("*/", i + 2)
+            if end == -1:
+                return None
+            i = end + 2
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return None
+
+
+def _scan_regex(source, start):
+    """From the opening slash past the closing one and its flags; None when
+    a newline arrives first, which proves this slash was division."""
+    n = len(source)
+    i = start + 1
+    in_class = False
+    while i < n:
+        c = source[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == "\n":
+            return None
+        if c == "[":
+            in_class = True
+        elif c == "]":
+            in_class = False
+        elif c == "/" and not in_class:
+            i += 1
+            while i < n and source[i] in "dgimsuvy":
+                i += 1
+            return i
+        i += 1
+    return None

--- a/plugins/horos/tests/test_ts_lexer.py
+++ b/plugins/horos/tests/test_ts_lexer.py
@@ -1,0 +1,93 @@
+"""The TypeScript lexer classifies every character and never guesses long."""
+
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "horos" / "scripts"))  # noqa: E402  (locates horos.py)
+
+from languages.typescript import typescript as ts  # noqa: E402
+
+
+def kinds(source):
+    spans, _ = ts.lex(source)
+    return [(kind, source[start:end]) for kind, start, end in spans]
+
+
+def only(source, kind):
+    return [text for k, text in kinds(source) if k == kind]
+
+
+class LexerTests(unittest.TestCase):
+    def test_spans_cover_the_source_in_order(self):
+        source = 'const a = "x"; // done\nconst b = 2;\n'
+        spans, errors = ts.lex(source)
+        self.assertEqual(errors, [])
+        joined = "".join(source[start:end] for _, start, end in spans)
+        self.assertEqual(joined, source)
+
+    def test_a_string_with_escapes_is_one_span(self):
+        self.assertEqual(only(r'const s = "a\"b\\";', "string"), [r'"a\"b\\"'])
+
+    def test_a_class_keyword_inside_a_string_is_not_code(self):
+        source = 'const s = "class X {";\n'
+        code = "".join(only(source, "code"))
+        self.assertNotIn("class X", code)
+
+    def test_templates_nest_two_deep(self):
+        source = "const t = `a${ {b: `c${d}e`} }f`;\n"
+        templates = only(source, "template")
+        self.assertEqual(templates, ["`a${ {b: `c${d}e`} }f`"])
+
+    def test_line_and_block_comments_are_classified(self):
+        source = "// line\n/* block\nstill */ const x = 1;\n"
+        self.assertEqual(only(source, "line_comment"), ["// line"])
+        self.assertEqual(only(source, "block_comment"), ["/* block\nstill */"])
+
+    def test_regex_after_assignment_paren_return_and_comma(self):
+        for source in (
+            "const r = /ab+c/g;\n",
+            "match(/ab+c/)\n",
+            "return /ab+c/;\n",
+            "f(x, /ab+c/)\n",
+        ):
+            with self.subTest(source=source):
+                self.assertEqual(only(source, "regex"), ["/ab+c/g"] if "g;" in source else ["/ab+c/"])
+
+    def test_division_after_parens_identifiers_and_numbers(self):
+        for source in ("const x = (a + b) / c;\n", "const y = total / 2;\n", "const z = 10 / 5;\n"):
+            with self.subTest(source=source):
+                self.assertEqual(only(source, "regex"), [])
+
+    def test_a_regex_containing_quotes_braces_and_a_class_slash(self):
+        source = "const r = /[\"'{}/]+/;\n"
+        self.assertEqual(only(source, "regex"), ["/[\"'{}/]+/"])
+
+    def test_the_newline_guard_reclassifies_a_false_regex(self):
+        source = "const a = x /\n  y;\nconst s = 'safe';\n"
+        spans, errors = ts.lex(source)
+        self.assertEqual(errors, [])
+        self.assertEqual(only(source, "regex"), [])
+        self.assertEqual(only(source, "string"), ["'safe'"])
+
+    def test_an_unterminated_string_confesses_the_remainder(self):
+        source = "const s = 'no end\nconst x = 1;\n"
+        spans, errors = ts.lex(source)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("unterminated string", errors[0][1])
+        self.assertEqual(spans[-1][0], "string")
+        self.assertEqual(spans[-1][2], len(source))
+
+    def test_an_unterminated_template_confesses_the_remainder(self):
+        source = "const t = `open ${a};\n"
+        _, errors = ts.lex(source)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("unterminated template", errors[0][1])
+
+    def test_a_comment_inside_a_template_expression_is_contained(self):
+        source = "const t = `a${ b /* } */ + c }d`;\n"
+        self.assertEqual(only(source, "template"), ["`a${ b /* } */ + c }d`"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
One pass classifies every character of a .ts or .tsx source into code, line
comment, block comment, string, template or regex. Templates nest through a
recursive scan whose expressions may hold strings, templates and comments
of their own. The regex-versus-division ambiguity is decided by the
previous significant token and guarded by the rule that a regex literal
cannot contain an unescaped newline: a candidate that meets one is
reclassified as division. Unterminated constructs confess the remainder
instead of raising. Twelve tests pin the traps, including the false-regex
reclassification and two-deep template nesting.

Stacks on step 1 (the spec and the languages folder). Audit: one round,
zero findings, one recorded lead deferred to the step 4 corpus run; log in
audit/AUDIT.md.

Proof: `python3 -m unittest plugins.horos.tests.test_ts_lexer -v` and both
suites.

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
