### PR TITLE
Implement the TypeScript outliner

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1166,3 +1166,23 @@ treats a slash literally, so a regex literal containing a brace or backtick
 inside `${...}` can mis-span the template. Bounded to that template, and
 deferred to the step 4 corpus run, which will show whether real code does
 this before any fix is designed.
+
+## Outline-extractor run, step 3, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0. Horos 89/89, root
+24/24. Two defects were found and fixed during the step's own build, before
+the implement receipt, and are recorded here for the trail: a statement
+position that never advanced on a stray closing brace hung the first live
+run (fixed with an explicit step-over plus a monotonic advance guard), and
+method heads truncated at their parameter list because the statement-end
+scanner was handed the closing parenthesis itself (fixed with
+position-ordered member dispatch). The round's review after those fixes
+walked the emitted fixture line by line against the source and found the
+slices verbatim and the confession exact.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings in the round itself. Leads not pursued: multiline arrow-
+function signatures quote only their first line; the differential in step 4
+measures whether that loses names in practice.

--- a/plugins/horos/examples/fixture-ts/market.ts
+++ b/plugins/horos/examples/fixture-ts/market.ts
@@ -1,0 +1,67 @@
+// A fixture market module for the Horos TypeScript outliner.
+import { WildcatSDK } from "@wildcatfi/wildcat-sdk";
+import type { Address } from "./types";
+
+export const DEFAULT_TIMEOUT = 30_000;
+
+export type MarketFilter = {
+  borrower?: Address;
+  minCapacity?: bigint;
+};
+
+export interface MarketSnapshot {
+  address: Address;
+  capacity: bigint;
+  apr: number;
+}
+
+export enum MarketState {
+  Open,
+  Delinquent,
+  Closed,
+}
+
+export const fetchSnapshot = async (
+  sdk: WildcatSDK,
+  address: Address
+): Promise<MarketSnapshot> => {
+  const market = await sdk.getMarket(address);
+  return { address, capacity: market.maxTotalSupply, apr: market.annualInterestBips / 100 };
+};
+
+function formatApr(bips: number): string {
+  return `${(bips / 100).toFixed(2)}%`;
+}
+
+@sealed
+export class MarketWatcher {
+  private readonly seen = new Map<Address, MarketSnapshot>();
+
+  constructor(private readonly sdk: WildcatSDK) {}
+
+  async refresh(filter: MarketFilter): Promise<MarketSnapshot[]> {
+    const markets = await this.sdk.getMarkets(filter);
+    return markets.map((m) => this.track(m));
+  }
+
+  private track(snapshot: MarketSnapshot): MarketSnapshot {
+    this.seen.set(snapshot.address, snapshot);
+    return snapshot;
+  }
+
+  get count(): number {
+    return this.seen.size;
+  }
+}
+
+export namespace MarketMath {
+  export function toRay(value: bigint): bigint {
+    return value * 10n ** 27n;
+  }
+}
+
+for (const warm of ["0x00"]) {
+  console.log(warm);
+}
+
+export default MarketWatcher;

--- a/plugins/horos/skills/horos/scripts/languages/__init__.py
+++ b/plugins/horos/skills/horos/scripts/languages/__init__.py
@@ -6,9 +6,12 @@ absent here is refused by map, never guessed at.
 """
 
 from .python import python
+from .typescript import typescript
 
 EXTRACTORS = {
     ".py": python.outline,
+    ".ts": typescript.outline,
+    ".tsx": typescript.outline,
 }
 
 

--- a/plugins/horos/skills/horos/scripts/languages/typescript/typescript.py
+++ b/plugins/horos/skills/horos/scripts/languages/typescript/typescript.py
@@ -252,6 +252,293 @@ def _scan_template_expression(source, start):
     return None
 
 
+OPENERS = "([{"
+CLOSERS = ")]}"
+
+MODIFIERS = frozenset(
+    {
+        "export",
+        "default",
+        "declare",
+        "abstract",
+        "async",
+        "public",
+        "private",
+        "protected",
+        "static",
+        "readonly",
+        "override",
+        "accessor",
+        "get",
+        "set",
+    }
+)
+
+# Keywords whose declaration head runs to the body brace.
+HEADED = frozenset({"function", "class", "interface", "enum", "namespace", "module"})
+
+# Keywords whose declaration is quoted as its first line.
+SIMPLE = frozenset({"import", "type", "const", "let", "var"})
+
+# Statement-final characters that suppress the newline statement end: a line
+# ending in one of these still owes the next line something.
+CONTINUERS = frozenset(",=&|+-*/<>?:.([{")
+
+
+def _line_of(source, offset):
+    return source.count("\n", 0, offset) + 1
+
+
+def _masked(source, spans):
+    """The source with every non-code span blanked, newlines kept, so
+    structure tracking cannot be derailed by braces inside literals."""
+    parts = []
+    for kind, start, end in spans:
+        segment = source[start:end]
+        if kind == "code":
+            parts.append(segment)
+        else:
+            parts.append("".join(ch if ch == "\n" else " " for ch in segment))
+    return "".join(parts)
+
+
+def _statement_end(mask, i, end):
+    """Index just past the statement starting at i: a balanced `;`, a
+    newline that plausibly ends it, or the region's closing brace."""
+    depth = 0
+    last = ""
+    while i < end:
+        c = mask[i]
+        if c in OPENERS:
+            depth += 1
+        elif c in CLOSERS:
+            depth -= 1
+            if depth < 0:
+                return i
+            last = c
+        elif depth == 0 and c == ";":
+            return i + 1
+        elif depth == 0 and c == "\n":
+            if last and last not in CONTINUERS:
+                return i + 1
+        elif not c.isspace():
+            last = c
+        i += 1
+    return end
+
+
+def _find_at_depth(mask, start, stop, target):
+    """The first target character at bracket depth zero, or -1."""
+    depth = 0
+    i = start
+    while i < stop:
+        c = mask[i]
+        if c in OPENERS:
+            if c == target and depth == 0:
+                return i
+            depth += 1
+        elif c in CLOSERS:
+            depth -= 1
+        elif c == target and depth == 0:
+            return i
+        i += 1
+    return -1
+
+
+def _matching_brace(mask, open_index, end):
+    depth = 0
+    i = open_index
+    while i < end:
+        c = mask[i]
+        if c in OPENERS:
+            depth += 1
+        elif c in CLOSERS:
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return end
+
+
+def _leading_words(mask, i, end):
+    """The statement's leading identifier-like words, for recognition."""
+    words = []
+    while i < end and len(words) < 8:
+        while i < end and mask[i] in " \t":
+            i += 1
+        j = i
+        while j < end and mask[j] in WORD_CHARS:
+            j += 1
+        if j == i:
+            break
+        words.append(mask[i:j])
+        i = j
+    return words
+
+
+def _first_line(source, start, stop):
+    newline = source.find("\n", start, stop)
+    cut = stop if newline == -1 else newline
+    return source[start:cut].rstrip().rstrip(";").rstrip()
+
+
+class _Outline:
+    def __init__(self, source, mask):
+        self.source = source
+        self.mask = mask
+        self.lines = []
+        self.regions = []
+        self.declarations = 0
+
+    def emit(self, text, depth):
+        pad = "    " * depth
+        for line in text.splitlines():
+            self.lines.append(pad + line.strip() if depth else line.rstrip())
+
+    def confess(self, start, stop):
+        first = _line_of(self.source, start)
+        last = _line_of(self.source, max(start, stop - 1))
+        if self.regions and self.regions[-1][1] >= first - 1:
+            self.regions[-1] = (self.regions[-1][0], max(self.regions[-1][1], last))
+        else:
+            self.regions.append((first, last))
+
+    def region(self, start, end, depth, in_class):
+        mask = self.mask
+        i = start
+        while i < end:
+            while i < end and (mask[i].isspace() or mask[i] == ";"):
+                i += 1
+            if i >= end:
+                break
+            if mask[i] in CLOSERS:
+                # A stray closer at statement position cannot start anything;
+                # stepping over it is what keeps this loop finite.
+                i += 1
+                continue
+            if mask[i] == "@":
+                stop = self._decorator_end(i, end)
+                self.emit(self.source[i:stop].rstrip(), depth)
+                i = max(stop, i + 1)
+                continue
+            if in_class:
+                i = max(self._member(i, end, depth), i + 1)
+                continue
+            i = max(self._statement(i, end, depth), i + 1)
+
+    def _decorator_end(self, i, end):
+        j = i + 1
+        while j < end and self.mask[j] in WORD_CHARS.union("."):
+            j += 1
+        if j < end and self.mask[j] == "(":
+            return _matching_brace(self.mask, j, end) + 1
+        return j
+
+    def _statement(self, i, end, depth):
+        words = _leading_words(self.mask, i, end)
+        keyword = next((w for w in words if w not in MODIFIERS), None)
+
+        if keyword in HEADED:
+            return self._headed(i, end, depth, keyword)
+        if keyword in SIMPLE or (words[:2] == ["export", "default"]) or (
+            words and words[0] == "export" and keyword is None
+        ):
+            stop = _statement_end(self.mask, i, end)
+            self.emit(_first_line(self.source, i, stop), depth)
+            self.declarations += 1
+            return stop
+        stop = _statement_end(self.mask, i, end)
+        self.confess(i, stop)
+        return stop
+
+    def _headed(self, i, end, depth, keyword):
+        brace = self.mask.find("{", i, _statement_end(self.mask, i, end))
+        if brace == -1:
+            stop = _statement_end(self.mask, i, end)
+            self.emit(_first_line(self.source, i, stop), depth)
+            self.declarations += 1
+            return stop
+        self.emit(self.source[i:brace].rstrip(), depth)
+        self.declarations += 1
+        close = _matching_brace(self.mask, brace, end)
+        if keyword == "class":
+            self.region(brace + 1, close, depth + 1, in_class=True)
+        elif keyword in ("namespace", "module"):
+            self.region(brace + 1, close, depth + 1, in_class=False)
+        return close + 1
+
+    def _member(self, i, end, depth):
+        stmt_stop = _statement_end(self.mask, i, end)
+        paren = _find_at_depth(self.mask, i, stmt_stop, "(")
+        equals = _find_at_depth(self.mask, i, stmt_stop, "=")
+        brace = _find_at_depth(self.mask, i, stmt_stop, "{")
+        first = min(x for x in (paren, equals, brace, stmt_stop) if x != -1)
+
+        if first == paren:
+            # A method: head runs from the modifiers through the parameter
+            # list and any return type, up to the body brace.
+            after = _matching_brace(self.mask, paren, end) + 1
+            rest_stop = _statement_end(self.mask, after, end)
+            body = _find_at_depth(self.mask, after, rest_stop, "{")
+            head_stop = body if body != -1 else rest_stop
+            self.emit(self.source[i:head_stop].rstrip().rstrip(";").rstrip(), depth)
+            self.declarations += 1
+            if body != -1:
+                return _matching_brace(self.mask, body, end) + 1
+            return rest_stop
+        if first == brace:
+            # A static initialiser block or similar: name it, skip its body.
+            self.emit(self.source[i:brace].rstrip(), depth)
+            self.declarations += 1
+            return _matching_brace(self.mask, brace, end) + 1
+        # A property, with or without an initialiser: quote the head only.
+        head_stop = equals if first == equals else stmt_stop
+        self.emit(_first_line(self.source, i, head_stop), depth)
+        self.declarations += 1
+        return stmt_stop
+
+
+def _module_header(source, spans):
+    for kind, start, end in spans:
+        if kind == "code" and source[start:end].strip():
+            return None
+        if kind in ("line_comment", "block_comment"):
+            for raw in source[start:end].splitlines():
+                text = raw.strip().lstrip("/*").rstrip("*/").strip("* ").strip()
+                if text:
+                    return text
+            return None
+    return None
+
+
+def outline(path, source, out):
+    """Print the file's declaration outline; 0 clean, 1 when the lexer
+    confessed an unterminated construct."""
+    spans, errors = lex(source)
+    mask = _masked(source, spans)
+    header = _module_header(source, spans)
+    print(f"module: {header}" if header else "module: (no header comment)", file=out)
+
+    walker = _Outline(source, mask)
+    lexed_end = spans[-1][2] if errors and spans else len(source)
+    walker.region(0, lexed_end if not errors else spans[-1][1], 0, in_class=False)
+    for offset, reason in errors:
+        print(f"lexer: {reason} at line {_line_of(source, offset)}", file=out)
+        walker.confess(offset, len(source))
+
+    for line in walker.lines:
+        print(line, file=out)
+    print(f"declarations: {walker.declarations}", file=out)
+    if walker.regions:
+        listed = ", ".join(
+            f"lines {a}-{b}" if a != b else f"line {a}" for a, b in walker.regions
+        )
+        print(f"unparsed: {len(walker.regions)} region(s): {listed}", file=out)
+    else:
+        print("unparsed: none", file=out)
+    return 1 if errors else 0
+
+
 def _scan_regex(source, start):
     """From the opening slash past the closing one and its flags; None when
     a newline arrives first, which proves this slash was division."""

--- a/plugins/horos/tests/test_ts_outline.py
+++ b/plugins/horos/tests/test_ts_outline.py
@@ -1,0 +1,112 @@
+"""The TypeScript outliner slices declarations verbatim and confesses the rest."""
+
+from pathlib import Path
+import io
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "horos" / "scripts"))  # noqa: E402  (locates horos.py)
+
+from languages.typescript import typescript as ts  # noqa: E402
+
+PLUGIN = Path(__file__).resolve().parents[1]
+FIXTURE = PLUGIN / "examples" / "fixture-ts" / "market.ts"
+
+EXPECTED = """module: A fixture market module for the Horos TypeScript outliner.
+import { WildcatSDK } from "@wildcatfi/wildcat-sdk"
+import type { Address } from "./types"
+export const DEFAULT_TIMEOUT = 30_000
+export type MarketFilter = {
+export interface MarketSnapshot
+export enum MarketState
+export const fetchSnapshot = async (
+function formatApr(bips: number): string
+@sealed
+export class MarketWatcher
+    private readonly seen
+    constructor(private readonly sdk: WildcatSDK)
+    async refresh(filter: MarketFilter): Promise<MarketSnapshot[]>
+    private track(snapshot: MarketSnapshot): MarketSnapshot
+    get count(): number
+export namespace MarketMath
+    export function toRay(value: bigint): bigint
+export default MarketWatcher
+declarations: 17
+unparsed: 1 region(s): lines 63-65
+"""
+
+
+def run(source):
+    out = io.StringIO()
+    code = ts.outline("test.ts", source, out)
+    return code, out.getvalue()
+
+
+class OutlineTests(unittest.TestCase):
+    def test_the_fixture_outline_is_pinned(self):
+        source = FIXTURE.read_text(encoding="utf-8")
+        out = io.StringIO()
+        code = ts.outline(str(FIXTURE), source, out)
+        self.assertEqual(code, 0)
+        self.assertEqual(out.getvalue(), EXPECTED)
+
+    def test_bodies_never_leak_into_the_outline(self):
+        source = FIXTURE.read_text(encoding="utf-8")
+        _, output = run(source)
+        self.assertNotIn("this.seen.set", output)
+        self.assertNotIn("10n ** 27n", output)
+
+    def test_a_function_head_spanning_lines_is_sliced_whole(self):
+        code, output = run(
+            "export function join(\n  a: string,\n  b: string\n): string {\n  return a + b;\n}\n"
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("export function join(\n  a: string,\n  b: string\n): string", output)
+
+    def test_an_interface_head_keeps_its_extends_clause(self):
+        _, output = run("interface A extends B<C> {\n  x: number;\n}\n")
+        self.assertIn("interface A extends B<C>", output)
+
+    def test_a_class_keyword_inside_a_template_is_not_a_declaration(self):
+        # The const's verbatim line may quote the template text; the hazard
+        # is structural: no class declaration, no body, exactly one entry.
+        _, output = run("const t = `class Fake {`;\nexport const after = 2;\n")
+        lines = output.splitlines()
+        self.assertFalse(any(line.startswith("class") for line in lines))
+        self.assertIn("const t = `class Fake {`", lines)
+        self.assertIn("export const after = 2", lines)
+        self.assertIn("declarations: 2", output)
+        self.assertIn("unparsed: none", output)
+
+    def test_module_level_statements_are_confessed_by_line(self):
+        code, output = run("const a = 1;\nif (a) {\n  console.log(a);\n}\n")
+        self.assertEqual(code, 0)
+        self.assertIn("unparsed: 1 region(s): lines 2-4", output)
+
+    def test_a_clean_file_reports_no_regions(self):
+        _, output = run("export const a = 1;\n")
+        self.assertIn("unparsed: none", output)
+        self.assertIn("declarations: 1", output)
+
+    def test_a_lexer_error_confesses_the_remainder_and_exits_one(self):
+        code, output = run("export const a = 1;\nconst s = 'open\nmore();\n")
+        self.assertEqual(code, 1)
+        self.assertIn("lexer: unterminated string at line 2", output)
+        self.assertIn("unparsed:", output)
+        self.assertNotIn("unparsed: none", output)
+
+    def test_a_file_without_a_header_comment_says_so(self):
+        _, output = run("export const a = 1;\n")
+        self.assertIn("module: (no header comment)", output)
+
+    def test_the_tsx_suffix_dispatches_too(self):
+        import horos  # noqa: E402  (registry dispatch under test)
+
+        out = io.StringIO()
+        path = str(PLUGIN / "examples" / "fixture-ts" / "market.ts")
+        self.assertEqual(horos.map_file(path, out=out), 0)
+        self.assertIn(".tsx", __import__("languages").supported())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Declarations sliced verbatim over the lexer's masked structure: imports and
exports, headed declarations to their body brace across multiple lines,
first-line quotes for type aliases and variables, decorators, and class
members dispatched by the first structural character at depth zero, so a
method keeps its parameter list and return type while a property stops at
its initialiser. Everything unmatched is skipped structurally and confessed
by line range; a lexer error confesses the remainder and exits one. The
fixture outline at examples/fixture-ts/market.ts is pinned byte for byte.

Two defects surfaced and were fixed during the build, recorded in the audit
log: a statement position that never advanced on a stray closer hung the
first live run, and method heads truncated at their parameter list.

Stacks on step 2 (the lexer). Audit: one round, zero further findings; one
lead (first-line quoting of multiline arrow signatures) deferred to the
step 4 differential.

Proof: `python3 -m unittest plugins.horos.tests.test_ts_outline -v` and both
suites (horos 89, root 24).

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
