### PR TITLE
Record the differential corpus against the compiler

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1186,3 +1186,23 @@ slices verbatim and the confession exact.
 Zero findings in the round itself. Leads not pursued: multiline arrow-
 function signatures quote only their first line; the differential in step 4
 measures whether that loses names in practice.
+
+## Outline-extractor run, step 4, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0. Horos
+92/92, root 24/24. The review held the register's rows: the oracle tool is
+committed but nothing in the runtime or test path imports or invokes it
+(the consistency tests read only the committed results JSON); the bundle
+names its commit, oracle version and altitudes; the acceptance numbers
+(missed 0, extra 0, crashes 0) are asserted by test rather than quoted; and
+the three corpus-found fixes each landed with the corpus rerun after them.
+The step 2 lead (a regex with braces inside a template expression) did not
+occur in 866 real files: no file crashed or misparsed on it, so it stays a
+recorded limitation.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: the corpus is one repository's style
+(prettier, semicolon-free); a semicolon-heavy or decorator-heavy corpus
+would exercise different paths and can join the evidence when one matters.

--- a/plugins/horos/dev/ts_oracle.mjs
+++ b/plugins/horos/dev/ts_oracle.mjs
@@ -1,0 +1,65 @@
+// Dev-time oracle for the Horos TypeScript outliner. Never imported or
+// executed by the shipped plugin or its test suite: the differential corpus
+// run drives it by hand, with the `typescript` package installed outside
+// the repository, and only the recorded results are committed.
+//
+// Usage: node ts_oracle.mjs <file.ts> [...] > oracle.json
+//
+// Emits, per file, the declarations the compiler sees at the altitudes the
+// outliner claims: module level, module/namespace blocks, and class
+// members. Function-body locals are deliberately absent on both sides.
+
+import ts from "typescript";
+import { readFileSync } from "node:fs";
+
+const out = {};
+
+for (const file of process.argv.slice(2)) {
+  const text = readFileSync(file, "utf8");
+  const kind = file.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+  const sf = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, kind);
+  const decls = [];
+  const lineOf = (node) =>
+    sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
+  const push = (name, node, kind) => {
+    if (name) decls.push({ name, line: lineOf(node), kind });
+  };
+
+  const visitMembers = (cls) => {
+    for (const m of cls.members) {
+      if (ts.isConstructorDeclaration(m)) push("constructor", m, "member");
+      else if (m.name && ts.isIdentifier(m.name)) push(m.name.text, m, "member");
+    }
+  };
+
+  const visitStatements = (statements) => {
+    for (const st of statements) {
+      if (ts.isFunctionDeclaration(st)) push(st.name?.text, st, "function");
+      else if (ts.isClassDeclaration(st)) {
+        push(st.name?.text, st, "class");
+        visitMembers(st);
+      } else if (ts.isInterfaceDeclaration(st)) push(st.name.text, st, "interface");
+      else if (ts.isTypeAliasDeclaration(st)) push(st.name.text, st, "type");
+      else if (ts.isEnumDeclaration(st)) push(st.name.text, st, "enum");
+      else if (ts.isModuleDeclaration(st)) {
+        push(
+          ts.isIdentifier(st.name) || ts.isStringLiteral(st.name)
+            ? st.name.text
+            : st.name.getText(sf),
+          st,
+          "namespace"
+        );
+        if (st.body && ts.isModuleBlock(st.body)) visitStatements(st.body.statements);
+      } else if (ts.isVariableStatement(st)) {
+        for (const d of st.declarationList.declarations) {
+          if (ts.isIdentifier(d.name)) push(d.name.text, d, "variable");
+        }
+      }
+    }
+  };
+
+  visitStatements(sf.statements);
+  out[file] = decls;
+}
+
+process.stdout.write(JSON.stringify(out));

--- a/plugins/horos/docs/evidence/wildcat-app-v2-outline.md
+++ b/plugins/horos/docs/evidence/wildcat-app-v2-outline.md
@@ -1,0 +1,54 @@
+# Evidence bundle: the TypeScript outliner against the compiler
+
+The differential corpus run the outline extractor's acceptance demanded:
+every hand-written TypeScript file in the wildcat-app-v2 clone, outlined by
+Horos and independently parsed by the TypeScript compiler API, with the two
+declaration lists compared per file.
+
+## The run
+
+- Corpus: `wildcat-finance/wildcat-app-v2` at commit
+  `9b8b6d5d6db06428c5b539f267623277b65315cd`, all 866 `.ts` and `.tsx`
+  files under `src/`
+- Captured: 2026-08-18
+- Outliner: `languages/typescript/typescript.py` as shipped in this
+  delivery, run through the same code path as `map`
+- Oracle: the TypeScript compiler API (`typescript@5.9.3` under node
+  v26.6.0), driven by the committed dev-time tool
+  [../../dev/ts_oracle.mjs](../../dev/ts_oracle.mjs), installed outside the
+  repository and absent from every runtime and test path
+- Altitudes compared on both sides: module level, namespace and module
+  blocks, class members; function-body locals excluded by design
+- Per-file results: [wildcat-app-v2-outline.results.json](./wildcat-app-v2-outline.results.json)
+
+## The result
+
+The compiler sees 2,239 declarations at the compared altitudes. The
+outliner names 2,237 of them, misses 0 outside its own confessions, and
+names nothing the compiler does not see. Zero files crashed. The two
+unmatched declarations sit inside confessed regions of one file
+(`src/components/CookieBanner/index.tsx`), which is the confession contract
+doing its job: the outliner said it did not understand those lines rather
+than guessing. 169 files carry at least one confessed region, almost all
+module-level side-effect statements and JSX render expressions the
+recogniser list deliberately excludes.
+
+Three defects were found by the corpus and fixed during the run, each now
+pinned by a unit test: blanked string literals left a stale continuation
+character that swallowed semicolon-free declarations; a bare `>` at line
+end (a generic or JSX close) was wrongly treated as a continuation; and a
+statement position could fail to advance on a stray closing brace.
+
+## Machine-readable capture lines
+
+The consistency test parses these against the committed results document.
+
+<!-- outline:commit 9b8b6d5d6db06428c5b539f267623277b65315cd -->
+<!-- outline:files 866 -->
+<!-- outline:crashes 0 -->
+<!-- outline:oracle 2239 -->
+<!-- outline:matched 2237 -->
+<!-- outline:missed 0 -->
+<!-- outline:missed_confessed 2 -->
+<!-- outline:extra 0 -->
+<!-- outline:files_with_regions 169 -->

--- a/plugins/horos/docs/evidence/wildcat-app-v2-outline.results.json
+++ b/plugins/horos/docs/evidence/wildcat-app-v2-outline.results.json
@@ -1,0 +1,7809 @@
+{
+ "files": {
+  "src/app/[locale]/admin/components/AdminSectionSwitcher/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/admin/components/BorrowerInvitesTable/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/app/[locale]/admin/components/BorrowerInvitesTable/interface.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/admin/components/BorrowersTable/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/admin/components/BorrowersTable/interface.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/admin/components/CancelInviteModal/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/admin/components/EditBorrowerModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/admin/components/InviteBorrowerModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/admin/hooks/useAllBorrowerInvitations.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/admin/hooks/useAllBorrowerProfiles.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/admin/hooks/useCancelInvite.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/admin/hooks/useInviteBorrower.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/admin/hooks/useRegisterTestnetBorrower.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/admin/page.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/app/[locale]/agreement/components/AgreementPage/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/agreement/components/AgreementText/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/agreement/components/ReacceptButton/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/agreement/components/SignButton/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/agreement/hooks/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/agreement/hooks/useSignAgreement.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/agreement/hooks/useSubmitSignature.ts": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "src/app/[locale]/agreement/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/agreement/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/AuthorizedLendersTable/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/AuthorizedLendersTable/interface.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/LendersSection/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/MarketsSection/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/MarketsSection/\u0441omponents/MarketSectionSwitcher/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/MarketsSection/\u0441omponents/MarketsTables/BorrowerActiveMarketsTables/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/MarketsSection/\u0441omponents/MarketsTables/BorrowerTerminatedMarketsTables/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/MarketsSection/\u0441omponents/MarketsTables/OtherMarketsTables/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/MarketsSection/\u0441omponents/MarketsTables/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/MarketsSection/\u0441omponents/MarketsTables/style.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/MarketsTables/BorrowerMarketsTable/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/MarketsTables/BorrowerMarketsTable/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/MarketsTables/OthersMarketsTable/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/MarketsTables/OthersMarketsTable/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/MarketsTables/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/components/MarketsTables/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/MarketsTables/style.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/MlaModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/components/MlaModal/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/components/PoliciesSection/index.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/ConfirmationFormItem/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/FormFooter/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/FormFooter/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/FormFooter/style.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/BasicSetupForn/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/BasicSetupForn/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/ConfirmationForm/index.test.tsx": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 7
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/ConfirmationForm/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/ConfirmationForm/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/ConfirmationForm/style.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/FinancialForm/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/FinancialForm/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/FinancialForm/style.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/LenderRestrictionsForm/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/LenderRestrictionsForm/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/MLAForm/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/MLAForm/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/MLAForm/style.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/MarketPolicyForm/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/MarketPolicyForm/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/PeriodsForm/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/PeriodsForm/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/WrapperForm/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/Forms/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/GlossarySidebar/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/GlossarySidebar/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/GlossarySidebar/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/StepCounterTitle/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/StepCounterTitle/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/UnderlyingAssetSelect/hooks/useGetTokensList.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/UnderlyingAssetSelect/hooks/useTokensList.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/UnderlyingAssetSelect/index.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/components/UnderlyingAssetSelect/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/deploy-style.ts": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/hooks/useDeployV2Market.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/hooks/useNewMarketForm.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/hooks/useNewMarketHooksData.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/hooks/useTokenMetadata.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/create-market/page.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/create-market/style.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/validation/deployFingerprint.test.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/create-market/validation/deployFingerprint.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/create-market/validation/validationSchema.ts": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 3
+  },
+  "src/app/[locale]/borrower/create-policy/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/ConfirmLendersForm/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/ConfirmLendersForm/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/ConfirmLendersForm/style.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/EditLendersForm/EditLendersByMarketTable/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/EditLendersForm/EditLendersTable/TableSelect/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/EditLendersForm/EditLendersTable/TableSelect/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/EditLendersForm/EditLendersTable/TableSelect/style.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/EditLendersForm/EditLendersTable/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/EditLendersForm/EditLendersTable/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/EditLendersForm/EditLendersTable/style.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/EditLendersForm/Modals/AddModal/AddSelect/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/EditLendersForm/Modals/AddModal/AddSelect/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/EditLendersForm/Modals/AddModal/AddSelect/style.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/EditLendersForm/Modals/AddModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/EditLendersForm/Modals/AddModal/useAddLenderForm.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/EditLendersForm/Modals/DeleteModal/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/EditLendersForm/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/MarketSelect/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/components/MarketSelect/style.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/hooks/useTrackLendersChanges.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/interface.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-lenders-list/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/edit-policy/components/ConfirmLendersForm/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/components/ConfirmLendersForm/interface.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/components/ConfirmLendersForm/style.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/components/EditLendersForm/EditLendersTable/TableSelect/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/components/EditLendersForm/EditLendersTable/TableSelect/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/components/EditLendersForm/EditLendersTable/TableSelect/style.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/components/EditLendersForm/EditLendersTable/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/components/EditLendersForm/EditLendersTable/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/components/EditLendersForm/EditLendersTable/style.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/components/EditLendersForm/Modals/AddModal/AddSelect/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/components/EditLendersForm/Modals/AddModal/AddSelect/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/components/EditLendersForm/Modals/AddModal/AddSelect/style.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/components/EditLendersForm/Modals/AddModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/components/EditLendersForm/Modals/AddModal/useAddLenderForm.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/components/EditLendersForm/Modals/DeleteModal/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/components/EditLendersForm/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/hooks/useSubmitUpdates.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/hooks/useTrackLendersChanges.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/interface.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/edit-policy/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/hooks/getMaketsHooks/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/hooks/getMaketsHooks/updateMarkets.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/hooks/getMaketsHooks/useGetBorrowerMarkets.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/hooks/getMaketsHooks/useGetOthersMarkets.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/hooks/mla/useCalculateMarketAddress.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/hooks/mla/useGetMlaTemplate.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/hooks/mla/useGetMlaTemplates.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/hooks/mla/usePreviewMla.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/hooks/mla/useSignBorrowerMla.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/hooks/useBorrowerInvitation.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/hooks/useBorrowerInvitationRedirect.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/hooks/useBorrowerNames.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/hooks/useGetAllLenders.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/hooks/useGetBorrowerHooksData.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 2
+  },
+  "src/app/[locale]/borrower/hooks/useGetPolicy.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/hooks/useGetServiceAgreementStatus.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/invitation/components/AcceptInvitationForm/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/invitation/hooks/useSubmitAcceptInvitation.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/invitation/page.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/invitation/style.ts": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/BorrowerMarketSummary/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketAuthorisedLenders/components/LenderName/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketAuthorisedLenders/components/LenderName/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketAuthorisedLenders/components/LenderName/style.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketAuthorisedLenders/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketAuthorisedLenders/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketAuthorisedLenders/style.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketMLA/index.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketStatusChart/CollateralObligations/CollateralObligationsData/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketStatusChart/CollateralObligations/CollateralObligationsData/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketStatusChart/CollateralObligations/DelinquentCollateralObligations/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketStatusChart/CollateralObligations/DelinquentCollateralObligations/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketStatusChart/constants.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketStatusChart/hooks/useGenerateBarData.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketStatusChart/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketStatusChart/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketTransactions/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketTransactions/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketTransactions/style.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketWithdrawalRequests/ClaimableTable/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketWithdrawalRequests/OngoingTable/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketWithdrawalRequests/OutstandingTable/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketWithdrawalRequests/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketWithdrawalRequests/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/MarketWithdrawalRequests/style.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/AprModal/components/DifferenceChip.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/AprModal/components/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/AprModal/components/style.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/AprModal/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/AprModal/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/AprModal/style.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/BorrowModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/BorrowModal/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/CapacityModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/FinalModals/ErrorModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/FinalModals/LoadingModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/FinalModals/SuccessModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/FinalModals/style.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/ForceBuyBackModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/ForceBuyBackModal/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/ForceBuyBackModal/style.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/MaturityModal/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/MinimumDepositModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/RepayModal/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/RepayModal/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/RepayModal/style.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/StatementModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/StatementModal/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/StatementModal/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/TerminateMarket/RepayAndTerminateFlow/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/TerminateMarket/RepayAndTerminateFlow/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/TerminateMarket/RepayAndTerminateFlow/style.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/TerminateMarket/RepayAndTerminateFlow/useTerminateModal.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/TerminateMarket/TerminateFlow/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/TerminateMarket/TerminateFlow/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/TerminateMarket/TerminateFlow/style.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/TerminateMarket/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/TerminateMarket/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/components/ModalDataItem/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/components/ModalDataItem/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/components/ModalDataItem/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/hooks/useApprovalModal.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/Modals/style.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/components/WrapDebtToken/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useAdjustApr.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useBorrow.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useCapacity.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useForceBuyBack.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useGetApproval.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useGetLenders.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useGetMarketLenders.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useGetWithdrawals.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useProcessUnpaidWithdrawalBatch.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useRepay.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useResetTempReserveRatio.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useScrollHandler.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useScrollSlidesHandler.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useSetFixedTermEndTime.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useSetMinimumDeposit.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useSidebarHighlight.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useTerminateMarket.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/hooks/useUpdateMarketSummary.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/market/[address]/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 2
+  },
+  "src/app/[locale]/borrower/market/[address]/style.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/notifications/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/notifications/style.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/page-style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/policy/compoents/AddModal/useAddLenderForm.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/compoents/EditLendersTable/style.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/components/DetailsTab/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/components/LendersTab/components/EditLendersTable/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/components/LendersTab/components/EditLendersTable/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/components/LendersTab/components/EditLendersTable/style.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/components/LendersTab/components/Modals/AddModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/components/LendersTab/components/Modals/AddModal/useAddLenderForm.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/components/LendersTab/components/Modals/ConfirmModal/index.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/components/LendersTab/components/Modals/DeleteModal/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/components/LendersTab/components/Modals/FinalModal/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/components/LendersTab/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/components/LendersTab/interface.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/components/MarketsTab/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/components/PolicySelect/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/hooks/useSubmitUpdates.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/hooks/useTrackLendersChanges.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/policy/page.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/profile/[address]/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 2
+  },
+  "src/app/[locale]/borrower/profile/edit/components/AvatarProfileItem/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/profile/edit/components/AvatarProfileItem/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/profile/edit/components/AvatarProfileItem/style.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/profile/edit/components/CountrySelector/index.tsx": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/profile/edit/components/EditProfileForm/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 2
+  },
+  "src/app/[locale]/borrower/profile/edit/components/EditProfileForm/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/profile/edit/components/EditProfileItem/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/profile/edit/components/EditProfileItem/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/profile/edit/components/EntityKindSelector/index.tsx": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/profile/edit/components/JurisdictionSelector/index.tsx": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/profile/edit/components/SelectProfileItem/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/profile/edit/components/SelectProfileItem/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/profile/edit/components/style.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/profile/edit/hooks/useEditPrivateForm.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/profile/edit/hooks/useEditPublicForm.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/profile/edit/hooks/useUpdateBorrowerProfile.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/profile/edit/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/profile/edit/style.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/profile/hooks/useGetBorrowerProfile.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/borrower/profile/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/borrower/profile/style.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/app/[locale]/layout-style.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/app/[locale]/layout.tsx": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/agreement/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/all-markets/components/AllMarketsSection/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/all-markets/components/MarketsTables/OtherMarketsTable/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/all-markets/components/MarketsTables/OtherMarketsTable/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/all-markets/components/MarketsTables/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/all-markets/components/MobileHeader/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/all-markets/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/components/ExploreSection/ExploreMarketsTable/index.tsx": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/components/ExploreSection/TrendingMarketsCarousel/TrendingMarketsCard/BorrowerBlock/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/components/ExploreSection/TrendingMarketsCarousel/TrendingMarketsCard/index.tsx": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 3
+  },
+  "src/app/[locale]/lender/components/ExploreSection/TrendingMarketsCarousel/TrendingMarketsCard/style.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/components/ExploreSection/TrendingMarketsCarousel/index.tsx": {
+   "extra": 0,
+   "matched": 21,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 21,
+   "ours": 21,
+   "regions": 2
+  },
+  "src/app/[locale]/lender/components/ExploreSection/TrendingMarketsCarousel/useTrendingUsdPrices.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/components/ExploreSection/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/components/LenderDataProvider/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/components/LenderMobileFooterMenu/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/context.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/hooks/useLendersMarkets.ts": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 4
+  },
+  "src/app/[locale]/lender/hooks/useMarketsWithRecentInflow.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/hooks/useNonMlaAcknowledgement.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/hooks/useRecentDeposits.ts": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/hooks/useSignLenderMla.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/hooks/useSignMla.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/layout.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/market/[address]/components/BarCharts/CapacityBarChart/constants.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/BarCharts/CapacityBarChart/hooks/useGenerateCapacityBarData.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/market/[address]/components/BarCharts/CapacityBarChart/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/BarCharts/DebtBarChart/constants.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/BarCharts/DebtBarChart/hooks/useGenerateDebtsBarData.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/market/[address]/components/BarCharts/DebtBarChart/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/BarCharts/WithdrawalsBarChart/constants.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/BarCharts/WithdrawalsBarChart/hooks/useGenerateWithdrawalsBarData.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/market/[address]/components/BarCharts/WithdrawalsBarChart/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/BarCharts/components/LenderLegendItem/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/BarCharts/components/LenderLegendItem/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/BarCharts/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/BarCharts/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/BorrowerPenaltyWarning/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/MarketActions/LenderMlaModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/market/[address]/components/MarketActions/LenderMlaModal/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/MarketActions/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/MarketActions/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/MarketActions/styles.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/MarketSummary/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/market/[address]/components/Modals/ClaimModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/Modals/ClaimModal/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/Modals/DepositModal/EarningsProjection/index.tsx": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/market/[address]/components/Modals/DepositModal/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/Modals/DepositModal/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/Modals/DepositModal/useDepositGate.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/Modals/MobileMarketDescriptionModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/Modals/MobileMarketHistoryModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/Modals/NonMlaAcknowledgementModal/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/Modals/WithdrawModal/components/RoutingPanel.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/Modals/WithdrawModal/components/WithdrawDone.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/Modals/WithdrawModal/components/WithdrawForm.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/Modals/WithdrawModal/components/WithdrawSteps.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/Modals/WithdrawModal/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/Modals/WithdrawModal/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/SwitchChainAlert/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/SwitchChainAlert/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/SwitchChainAlert/style.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/WithdrawalRequests/ClaimableTable/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/WithdrawalRequests/OngoingTable/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/WithdrawalRequests/OutstandingTable/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/WithdrawalRequests/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/WithdrawalRequests/interface.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/WithdrawalRequests/style.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/WrapDebtToken/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/mobile/MobileLenderBanner/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/mobile/MobileMarketActions/index.tsx": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/mobile/MobileMlaAlert/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/components/mobile/MobileMlaModal/MobileMlaModal.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/hooks/useAddToken.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/hooks/useBorrowerPenaltyWarning.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/hooks/useClaim.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/hooks/useDeposit.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/hooks/useFaucet.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/hooks/useGetLenderWithdrawals.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/hooks/useLenderMarketAccount.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/market/[address]/hooks/useWithdrawFlow.ts": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/hooks/useWithdrawRouting.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/hooks/withdrawQueue.test.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/market/[address]/hooks/withdrawQueue.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 2
+  },
+  "src/app/[locale]/lender/market/[address]/style.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/market/[address]/utils.test.ts": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/market/[address]/utils.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/my-markets/components/MarketsTables/ActiveMarketsTables/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/my-markets/components/MarketsTables/ActiveMarketsTables/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/my-markets/components/MarketsTables/TerminatedMarketsTables/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/my-markets/components/MarketsTables/TerminatedMarketsTables/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/my-markets/components/MarketsTables/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/my-markets/components/MobileHeader/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/my-markets/components/MyMarketsSection/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/my-markets/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/profile/[address]/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 2
+  },
+  "src/app/[locale]/lender/profile/hooks/useGetBorrowerProfile.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/[locale]/lender/profile/page.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/[locale]/lender/profile/style.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/app/api/auth/login/dto.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/api/auth/login/interface.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/api/auth/login/route.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/api/auth/refresh/route.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/api/auth/verify-header.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/api/borrower-names/route.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/api/csp-report/route.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/api/invite/[address]/route.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 2
+  },
+  "src/app/api/invite/dto.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/api/invite/interface.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/api/invite/route.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/api/market-summary/[market]/dto.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/api/market-summary/[market]/route.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 3
+  },
+  "src/app/api/market/get/cache.test.ts": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 1
+  },
+  "src/app/api/market/get/cache.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/api/market/get/route.ts": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 2
+  },
+  "src/app/api/mla/[market]/[lender]/html/route.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/app/api/mla/[market]/[lender]/pdf/route.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/app/api/mla/[market]/[lender]/route.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/api/mla/[market]/[lender]/signed/route.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 1
+  },
+  "src/app/api/mla/[market]/acknowledgement/dto.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/api/mla/[market]/acknowledgement/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/api/mla/[market]/acknowledgement/route.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 2
+  },
+  "src/app/api/mla/[market]/decline/dto.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/api/mla/[market]/decline/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/api/mla/[market]/decline/route.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/api/mla/[market]/dto.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/api/mla/[market]/html/route.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/api/mla/[market]/lenders/route.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/api/mla/[market]/pdf/route.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/app/api/mla/[market]/route.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 2
+  },
+  "src/app/api/mla/[market]/signed/route.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/app/api/mla/interface.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/app/api/mla/lender-signature/dto.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/api/mla/lender-signature/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/api/mla/lender-signature/route.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/api/mla/mla.test.ts": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "src/app/api/mla/templates/[id]/route.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/app/api/mla/templates/dto.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/api/mla/templates/route.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/app/api/profiles/[address]/route.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 2
+  },
+  "src/app/api/profiles/interface.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/api/profiles/profile.test.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 1
+  },
+  "src/app/api/profiles/route.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/api/profiles/updates/dto.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/api/profiles/updates/interface.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 1
+  },
+  "src/app/api/profiles/updates/route.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/app/api/service-agreement/[address]/certificate/route.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/app/api/service-agreement/[address]/status/route.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/app/api/service-agreement/accept/dto.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/api/service-agreement/accept/route.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/api/service-agreement/current/download/route.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/api/service-agreement/current/route.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/api/service-agreement/decline/dto.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/api/service-agreement/decline/route.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/api/service-agreement/interface.ts": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 2
+  },
+  "src/app/api/service-agreement/reacceptance/route.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/api/sla/[address]/route.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 2
+  },
+  "src/app/api/sla/[address]/services.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/api/sla/dto.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/api/sla/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/api/sla/route.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/api/tokens-list/interface.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/app/api/tokens-list/route.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/app/api/tokens-list/services.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/app/api/tokens-list/tokens-list/plasma-testnet.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/api/tokens-list/tokens-list/sepolia.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/app/i18n.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/@extended/ExtendedRadio/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 1
+  },
+  "src/components/@extended/ExtendedSelect/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/@extended/ExtendedSelect/style.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/components/@extended/ExtendedSelect/type.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/components/@extended/ExtendedSwitch/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/@extended/ExtendedSwitch/type.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/components/@extended/Extended\u0421heckbox/index.tsx": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "src/components/@extended/MarketStatusAndTermChip/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/@extended/MarketStatusChip/HealthyStatusChip/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/@extended/MarketStatusChip/HealthyStatusChip/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/@extended/MarketStatusChip/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/@extended/MarketStatusChip/type.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/@extended/MarketTypeChip/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/@extended/MarketTypeChip/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Accordion/DetailsAccordion/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Accordion/DetailsAccordion/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Accordion/DetailsAccordion/style.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Accordion/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Accordion/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Accordion/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/AdsBanners/Common/AprTooltip/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/AdsBanners/Common/ProposalMarketParameter/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/components/AdsBanners/adsConfig.test.tsx": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 2
+  },
+  "src/components/AdsBanners/adsConfig.tsx": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/components/AdsBanners/adsHelpers.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/components/AdsBanners/components/AdsBanner/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/AdsBanners/components/AdsProposalChip/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Alert/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Alert/type.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/AprChip/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/AuthWrapper/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 2
+  },
+  "src/components/BackButton/index.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/components/BarChart/BarItem/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/BarChart/BarItem/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/BarChart/LegendItem/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/BarChart/LegendItem/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/BorrowerProfileChip/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/CookieBanner/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 2,
+   "oracle": 3,
+   "ours": 1,
+   "regions": 2
+  },
+  "src/components/DateRange/index.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/components/DateRange/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/DateRange/style.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/components/DateTextField/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/DateTextField/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/DateTextField/style.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/components/DepositAlert/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/FilterSelect/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/FilterTextfield/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Footer/index.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/components/Footer/style.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/components/Header/HeaderButton/ConnectWalletDialog/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/components/Header/HeaderButton/ConnectWalletDialog/style.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/components/Header/HeaderButton/ConnectWalletDialog/type.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Header/HeaderButton/ProfileDialog/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Header/HeaderButton/ProfileDialog/style.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/components/Header/HeaderButton/ProfileDialog/type.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Header/HeaderButton/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/components/Header/HeaderButton/style.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Header/HeaderNetworkButton/NetworkSelectDialog/index.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/components/Header/HeaderNetworkButton/NetworkSelectDialog/style.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/components/Header/HeaderNetworkButton/NetworkSelectDialog/type.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Header/HeaderNetworkButton/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/components/Header/HeaderNetworkButton/style.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Header/MobileMenu/index.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/components/Header/NotificationButton/NoUnreadDialog/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Header/NotificationButton/NoUnreadDialog/style.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/components/Header/NotificationButton/NoUnreadDialog/type.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Header/NotificationButton/UnreadDialog/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Header/NotificationButton/UnreadDialog/style.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/components/Header/NotificationButton/UnreadDialog/type.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Header/NotificationButton/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/components/Header/NotificationButton/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Header/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/components/Header/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/HelpModal/HelpMenuItems.tsx": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 3
+  },
+  "src/components/HelpModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/components/HelpModal/style.ts": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "src/components/HorisontalInputLabel/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/HotjarConsent/index.tsx": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 1
+  },
+  "src/components/InputLabel/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/InputLabel/style.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/components/InputLabel/type.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/LeadBanner/index.test.tsx": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 2
+  },
+  "src/components/LeadBanner/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/components/LendersMarketChip/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/LendersMarketChip/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/LinkComponent/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/LinkComponent/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/LinkComponent/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Loader/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Markdown/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/components/MarkdownEditor/InitializedMDXEditor.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 2
+  },
+  "src/components/MarkdownEditor/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 2
+  },
+  "src/components/MarketCycleChip/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/MarketHeader/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/MarketHeader/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/MarketHeader/style.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/components/MarketParameters/index.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/components/MarketParameters/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/MarketParameters/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/MarketsFilterSelect/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/MarketsFilterSelect/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/MarketsFilterSelect/style.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/components/MarketsTableAccordion/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/MarketsTableAccordion/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/MarketsTableWrapper/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Mobile/Card/OtherMarketsCard/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Mobile/MarketAssetsStatusesFilter/Filter/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/components/Mobile/MarketAssetsStatusesFilter/MarketAssetsStatusesFilterModal/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Mobile/MarketAssetsStatusesFilter/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Mobile/MarketAssetsStatusesFilter/types.tsx": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/components/Mobile/MarketAssetsStatusesFilter/useToggleParentChild.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/components/Mobile/MobileFilterButton/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Mobile/MobileMarketCard/index.tsx": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "src/components/Mobile/MobileMarketCard/style.ts": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "src/components/Mobile/MobileMarketList/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Mobile/MobileMarketRecordItem/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Mobile/MobileMoreButton/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Mobile/MobileSearchButton/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Mobile/SeeMoreButton/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Mobile/TransactionHeader/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Mobile/WithdrawalsMobileTableItem/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/MobileConnectWallet/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/components/MobileConnectWallet/style.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/components/MobileConnectWallet/type.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/MobileSelectNetwork/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/components/MobileSelectNetwork/style.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/components/MobileSelectNetwork/type.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/NetworkIcon/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Notification/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Notification/style.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/components/NumberTextfield/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/components/PaginatedMarketRecordsTable/MarketRecordsTable.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/components/PaginatedMarketRecordsTable/hooks/useMarketRecords.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 1
+  },
+  "src/components/PaginatedMarketRecordsTable/index.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/components/PaginatedMarketRecordsTable/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/ParametersItem/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/ParametersItem/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/ParametersItem/style.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Borrower/useAPRChanges.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Borrower/useBorrowerMarketIds.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Borrower/useBorrowerRegistrationChanges.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Borrower/useBorrows.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Borrower/useCapacityChanges.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Borrower/useDebtRepaids.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Borrower/useDepositeds.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Borrower/useLenderAuthorizationChanges.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Borrower/useLenderWithdrawalRequests.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Borrower/useMarketStatusChanges.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Borrower/useMarketTerminateds.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Borrower/useReserveRatioBipsUpdateds.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Borrower/useWithdrawalBatchCreateds.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Borrower/useWithdrawalBatchExpireds.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Borrower/useWithdrawalExecutions.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Lender/useAuthorizationChanges.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Lender/useLenderAPRChanges.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Lender/useLenderCapacityChanges.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Lender/useLenderDepositeds.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Lender/useLenderMarketIds.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Lender/useLenderMarketTerminateds.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Lender/useLenderTokensAvailables.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/hooks/Lender/useLenderWithdrawalResults.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/PollingRegistration/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/components/PollingRegistration/interface.ts": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "src/components/Profile/ProfilePage/components/MarketsBlock/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Profile/ProfilePage/components/MarketsBlock/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Profile/ProfilePage/components/MarketsBlock/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Profile/ProfilePage/components/MobileNamePageBlockWrapper/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Profile/ProfilePage/components/MobileNamePageBlockWrapper/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Profile/ProfilePage/components/MobileNamePageBlockWrapper/style.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/components/Profile/ProfilePage/components/PageSkeleton/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Profile/ProfilePage/components/PageSkeleton/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Profile/ProfilePage/components/PageSkeleton/style.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/components/Profile/ProfilePage/components/ProfileNamePageBlock/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Profile/ProfilePage/components/ProfileNamePageBlock/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Profile/ProfilePage/components/ProfileNamePageBlock/style.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/components/Profile/ProfilePage/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Profile/ProfilePage/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Profile/ProfilePage/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Profile/ProfileSection/components/ProfileSectionNameBlock/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Profile/ProfileSection/components/ProfileSectionNameBlock/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Profile/ProfileSection/components/ProfileSectionNameBlock/style.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/components/Profile/ProfileSection/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Profile/ProfileSection/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Profile/components/EmptyAlert/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Profile/components/EmptyAlert/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Profile/components/EmptyAlert/style.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/components/Profile/components/OverallBlock/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Profile/components/OverallBlock/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Profile/components/OverallBlock/style.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/components/Profile/components/ToUStatusBlock/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Profile/components/VerificationDisclosure/index.tsx": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 1
+  },
+  "src/components/Profile/components/VerificationDisclosure/style.ts": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "src/components/RepeatingSkeletons/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/SafeMessageCoordinator/index.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/components/ServiceAgreementVersionChip/index.tsx": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 1
+  },
+  "src/components/Sidebar/BorrowerDashboardSidebar/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Sidebar/BorrowerSidebar/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Sidebar/BorrowerSidebar/style.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/components/Sidebar/CreateMarketSidebar/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/components/Sidebar/DashboardSidebarComponents/index.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/components/Sidebar/EditPolicySidebar/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Sidebar/EditProfileSidebar/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Sidebar/LenderDashboardSidebar/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Sidebar/LenderMarketSidebar/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Sidebar/LenderNavSidebar/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/components/Sidebar/LendersListSidebar/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Sidebar/MarketSidebar/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Sidebar/MarketSidebar/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Sidebar/NewMarketSidebar/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/components/Sidebar/NotificationsSidebar/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/Sidebar/NotificationsSidebar/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/Sidebar/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/components/Sidebar/style.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/components/SmallFilterSelect/index.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/components/StoreProvider/index.test.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/components/StoreProvider/index.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 2
+  },
+  "src/components/StyledSwitch/input.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/TablePagination/index.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/components/TelegramBanner/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 1
+  },
+  "src/components/TextfieldAdornments/TextfieldButton/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/TextfieldAdornments/TextfieldChip/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/ThemeRegistry/EmotionCache.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/components/ThemeRegistry/ThemeRegistry.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 2
+  },
+  "src/components/ToUReacceptanceModal/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 1
+  },
+  "src/components/Toasts/index.tsx": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/components/Toasts/style.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/TooltipButton/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/TooltipButton/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/TransactionBlock/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/TransactionBlock/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/TransactionBlock/style.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/components/TranslationsProvider/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 2
+  },
+  "src/components/TxModalComponents/TxModalFooter/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/TxModalComponents/TxModalFooter/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/TxModalComponents/TxModalFooter/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/TxModalComponents/TxModalHeader/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/TxModalComponents/TxModalHeader/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/TxModalComponents/TxModalHeader/style.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/WrapDebtToken/ErrorWrapperAlert/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/WrapDebtToken/NoWrapperState/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/WrapDebtToken/NoWrapperState/style.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/components/WrapDebtToken/SuccessWrapperModal/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/WrapDebtToken/WrapperExchangeBanner/index.tsx": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/components/WrapDebtToken/WrapperHeader/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/WrapDebtToken/WrapperSection/index.tsx": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "src/components/WrapDebtToken/WrapperSection/transaction.test.ts": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 1
+  },
+  "src/components/WrapDebtToken/WrapperSection/transaction.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/components/WrapDebtToken/WrapperSkeleton/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/WrapDebtToken/mobile/WrapperSuccessBanner/index.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/components/WrongNetworkAlert/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/components/WrongNetworkAlert/style.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/config/api.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/config/market-duration.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/config/mla-acceptance.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/config/mla-rejection.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/config/network.ts": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 2
+  },
+  "src/config/non-mla-acknowledgement.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/config/polling.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/config/query-keys.ts": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "src/config/subgraph.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/constants/external-links.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/graphql/queries.ts": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "src/hooks/useAllTokensWithMarkets.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/hooks/useApiAuth.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/hooks/useBlockExplorer.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/hooks/useCurrentNetwork.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/hooks/useCurrentServiceAgreement.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/hooks/useDepositAgreementGate.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/hooks/useEthersSigner.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 3
+  },
+  "src/hooks/useGetBasicBorrowerData.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/hooks/useGetController.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/hooks/useGetMarket.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/hooks/useGetMarketAccount.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 1
+  },
+  "src/hooks/useGnosisSafeSDK.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/hooks/useIsRegisteredBorrower.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/hooks/useMarketMla.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/hooks/useMarketSummary.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/hooks/useMobileResolution.test.tsx": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 1
+  },
+  "src/hooks/useMobileResolution.ts": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "src/hooks/useNetworkGate.ts": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "src/hooks/usePolling.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/hooks/useSafeMessageSigning.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 1
+  },
+  "src/hooks/useSelectedNetwork.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/hooks/useToUReacceptance.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 1
+  },
+  "src/hooks/wrapper/useAdoptionData.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/hooks/wrapper/useTokenWrapper.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/hooks/wrapper/useWrapperAllowance.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/hooks/wrapper/useWrapperBalances.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/hooks/wrapper/useWrapperForMarket.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/hooks/wrapper/useWrapperLimits.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/lib/chains/plasma-mainnet.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/lib/chains/plasma-testnet.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/lib/config.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 1
+  },
+  "src/lib/db.ts": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 1
+  },
+  "src/lib/mla.ts": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 2
+  },
+  "src/lib/mlaPersistence.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/lib/protocol-stats/aggregate.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/lib/protocol-stats/format.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/lib/protocol-stats/queries.ts": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "src/lib/protocol-stats/subgraph.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/lib/protocol-stats/useProtocolStats.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/lib/provider.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/lib/puppeteer.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/lib/registrar.ts": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "src/lib/safeMessageSigning.test.ts": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 1
+  },
+  "src/lib/safeMessageSigning.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 1
+  },
+  "src/lib/serviceAgreement.test.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 3
+  },
+  "src/lib/serviceAgreement.ts": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 2
+  },
+  "src/lib/signatures/index.ts": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 3
+  },
+  "src/lib/signatures/interface.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 1
+  },
+  "src/lib/upload-profile-picture.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/lib/validateChainIdParam.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/lib/zod-error.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/middleware.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/mocks/mocks.ts": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "src/providers/RedirectsProvider/hooks/useHasSignedSla.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/providers/RedirectsProvider/hooks/useShouldRedirect.ts": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "src/providers/RedirectsProvider/index.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/providers/RedirectsProvider/utils/getRedirectPath.ts": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "src/providers/SafeProvider.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/providers/SubgraphProvider/index.tsx": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 2
+  },
+  "src/providers/WagmiQueryProviders.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 1
+  },
+  "src/providers/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/routes.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/store/hooks.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/store/slices/apiTokensSlice/apiTokensSlice.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/store/slices/apiTokensSlice/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/store/slices/borrowerDashboardAmountsSlice/borrowerDashboardAmountsSlice.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/store/slices/borrowerDashboardSlice/borrowerDashboardSlice.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/store/slices/borrowerLendersTabSidebarSlice/borrowerLendersTabSidebarSlice.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/store/slices/borrowerLendersTabSidebarSlice/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/store/slices/borrowerOverviewSlice/borrowerOverviewSlice.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/store/slices/borrowerOverviewSlice/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/store/slices/cookieBannerSlice/cookieBannerSlice.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/store/slices/createMarketSidebarSlice/createMarketSidebarSlice.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/store/slices/createMarketSigningDraftsSlice/createMarketSigningDraftsSlice.test.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/store/slices/createMarketSigningDraftsSlice/createMarketSigningDraftsSlice.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/store/slices/editLendersListSlice/editLendersListSlice.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/store/slices/editLendersListSlice/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/store/slices/editPolicySlice/editPolicySlice.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/store/slices/editPolicySlice/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/store/slices/hideMarketSectionsSlice/hideMarketSectionsSlice.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/store/slices/highlightSidebarSlice/highlightSidebarSlice.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/store/slices/highlightSidebarSlice/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/store/slices/lenderDashboardAmountSlice/lenderDashboardAmountsSlice.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/store/slices/lenderDashboardSlice/lenderDashboardSlice.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/store/slices/lenderMarketRoutingSlice/lenderMarketRoutingSlice.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/store/slices/lenderMlaSignaturesSlice/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/store/slices/lenderMlaSignaturesSlice/mlaSignaturesSlice.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/store/slices/marketFiltersSlice/marketFiltersSlice.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/store/slices/marketsOverviewSidebarSlice/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/store/slices/marketsOverviewSidebarSlice/marketsOverviewSidebarSlice.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/store/slices/notificationsSidebarSlice/interface.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/store/slices/notificationsSidebarSlice/notificationsSidebarSlice.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/store/slices/notificationsSlice/interface.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/store/slices/notificationsSlice/notificationsSlice.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/store/slices/pendingSafeMessagesSlice/pendingSafeMessagesSlice.test.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/store/slices/pendingSafeMessagesSlice/pendingSafeMessagesSlice.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 2
+  },
+  "src/store/slices/policyLendersSlice/policyLendersSlice.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/store/slices/routingSlice/flowsSteps.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/store/slices/routingSlice/routingSlice.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/store/slices/routingSlice/types.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/store/slices/selectedNetworkSlice/selectedNetworkSlice.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 1
+  },
+  "src/store/slices/touModalSlice/touModalSlice.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/store/slices/wrapDebtTokenFlowSlice/wrapDebtTokenFlowSlice.ts": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/store/store.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/stories/Button.stories.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/stories/Checkbox.stories.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/stories/Chip.stories.tsx": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/stories/DateRange.stories.tsx": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/stories/Divider.stories.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/stories/InfoBox.stories.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/stories/Radio.stories.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/stories/Select.stories.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/stories/Switch.stories.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/stories/Tabs.stories.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/stories/Textfield.stories.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/stories/Tooltip.stories.tsx": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/theme/breakpoints.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/theme/colors.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/theme/overrides/Buttons.ts": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "src/theme/palette.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/theme/theme.tsx": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "src/theme/typography.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/theme/units.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/utils/comparators.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/utils/constants.ts": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 4
+  },
+  "src/utils/dayjs.ts": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 1
+  },
+  "src/utils/errors.ts": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "src/utils/filters.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/utils/formatters.ts": {
+   "extra": 0,
+   "matched": 29,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 29,
+   "ours": 29,
+   "regions": 1
+  },
+  "src/utils/httpStatus.test.ts": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 1
+  },
+  "src/utils/httpStatus.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/utils/lenderAccess.test.ts": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 1
+  },
+  "src/utils/lenderAccess.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/utils/listeners.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 1
+  },
+  "src/utils/marketCapabilities.test.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 1
+  },
+  "src/utils/marketCapabilities.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/utils/marketOnboarding.test.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/utils/marketOnboarding.ts": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/utils/marketRecords.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/utils/marketSort.ts": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "src/utils/marketStatus.ts": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "src/utils/marketType.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/utils/nonMlaAcknowledgementMessage.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 1
+  },
+  "src/utils/pagination.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/utils/proposalMarkets.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/utils/serviceAgreementMessage.ts": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/utils/serviceAgreementParty.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/utils/serviceAgreementQueries.ts": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/utils/serviceAgreementState.test.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 4
+  },
+  "src/utils/serviceAgreementState.ts": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 7
+  },
+  "src/utils/serviceAgreementVersions.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/utils/subscriptions.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/utils/timestamp.ts": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/utils/types.ts": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "src/utils/validations.ts": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  }
+ },
+ "totals": {
+  "crashes": 0,
+  "extra": 0,
+  "files": 866,
+  "files_with_regions": 169,
+  "matched": 2237,
+  "missed": 0,
+  "missed_confessed": 2,
+  "oracle": 2239,
+  "ours": 2237
+ }
+}

--- a/plugins/horos/skills/horos/scripts/languages/typescript/typescript.py
+++ b/plugins/horos/skills/horos/scripts/languages/typescript/typescript.py
@@ -281,8 +281,10 @@ HEADED = frozenset({"function", "class", "interface", "enum", "namespace", "modu
 SIMPLE = frozenset({"import", "type", "const", "let", "var"})
 
 # Statement-final characters that suppress the newline statement end: a line
-# ending in one of these still owes the next line something.
-CONTINUERS = frozenset(",=&|+-*/<>?:.([{")
+# ending in one of these still owes the next line something. A bare `>` is
+# not here: it ends a generic or a JSX tag. The arrow survives as the
+# two-character token the scanner folds it into.
+CONTINUERS = frozenset(",=&|+-*/?:.([{") | {"=>"}
 
 
 def _line_of(source, offset):
@@ -291,14 +293,22 @@ def _line_of(source, offset):
 
 def _masked(source, spans):
     """The source with every non-code span blanked, newlines kept, so
-    structure tracking cannot be derailed by braces inside literals."""
+    structure tracking cannot be derailed by braces inside literals.
+
+    A string, template or regex is a value, so its first character becomes a
+    sentinel: without one, a semicolon-free line like `const K = "v"` ends
+    on a stale `=` and swallows the statements after it. Comments stay
+    fully blank; they are not values and must not end anything."""
     parts = []
     for kind, start, end in spans:
         segment = source[start:end]
         if kind == "code":
             parts.append(segment)
-        else:
-            parts.append("".join(ch if ch == "\n" else " " for ch in segment))
+            continue
+        blank = "".join(ch if ch == "\n" else " " for ch in segment)
+        if kind in ("string", "template", "regex") and blank[:1] == " ":
+            blank = "#" + blank[1:]
+        parts.append(blank)
     return "".join(parts)
 
 
@@ -311,6 +321,7 @@ def _statement_end(mask, i, end):
         c = mask[i]
         if c in OPENERS:
             depth += 1
+            last = c
         elif c in CLOSERS:
             depth -= 1
             if depth < 0:
@@ -322,7 +333,7 @@ def _statement_end(mask, i, end):
             if last and last not in CONTINUERS:
                 return i + 1
         elif not c.isspace():
-            last = c
+            last = "=>" if c == ">" and last == "=" else c
         i += 1
     return end
 

--- a/plugins/horos/tests/test_evidence.py
+++ b/plugins/horos/tests/test_evidence.py
@@ -11,6 +11,8 @@ BUNDLE = EVIDENCE / "wildcat-app-v2.md"
 BOUNDARY = EVIDENCE / "wildcat-app-v2.boundary.json"
 BUNDLE_2 = EVIDENCE / "wildcat-app-v2-rules.md"
 BOUNDARY_2 = EVIDENCE / "wildcat-app-v2-rules.boundary.json"
+BUNDLE_3 = EVIDENCE / "wildcat-app-v2-outline.md"
+RESULTS_3 = EVIDENCE / "wildcat-app-v2-outline.results.json"
 
 
 def capture_lines(bundle=BUNDLE, tag="evidence"):
@@ -83,6 +85,32 @@ class SecondCaptureTests(unittest.TestCase):
                 or (path.endswith(".sql") and "migrations" in path.split("/")),
                 path,
             )
+
+    def test_the_outline_bundle_matches_its_committed_results(self):
+        lines = capture_lines(BUNDLE_3, "outline")
+        totals = json.loads(RESULTS_3.read_text(encoding="utf-8"))["totals"]
+        for key in (
+            "files",
+            "crashes",
+            "oracle",
+            "matched",
+            "missed",
+            "missed_confessed",
+            "extra",
+            "files_with_regions",
+        ):
+            self.assertEqual(int(lines[key]), totals[key], key)
+
+    def test_the_outline_run_names_the_same_commit_as_the_captures(self):
+        self.assertEqual(
+            capture_lines()["commit"], capture_lines(BUNDLE_3, "outline")["commit"]
+        )
+
+    def test_the_outline_acceptance_holds(self):
+        totals = json.loads(RESULTS_3.read_text(encoding="utf-8"))["totals"]
+        self.assertEqual(totals["crashes"], 0)
+        self.assertEqual(totals["missed"], 0)
+        self.assertEqual(totals["extra"], 0)
 
     def test_the_second_share_exceeds_the_first(self):
         first = capture_lines()


### PR DESCRIPTION
All 866 hand-written TypeScript files in the wildcat-app-v2 clone at commit
9b8b6d5, outlined by Horos and independently parsed by the TypeScript
compiler API (typescript@5.9.3, installed outside the repository, driven by
the committed dev-time oracle at plugins/horos/dev/ts_oracle.mjs). At the
compared altitudes the compiler sees 2,239 declarations; the outliner names
2,237, misses none outside its own confessions, names nothing extra, and
crashes nowhere. The two unmatched names sit inside confessed regions of
one file, which is the confession contract working as designed.

The corpus surfaced three defects, each fixed and rerun: blanked string
literals left a stale continuation character that swallowed semicolon-free
declarations; a bare greater-than at line end was wrongly a continuation;
and a statement position could fail to advance. Nothing in the runtime or
test path imports or invokes the node tool; the consistency tests read only
the committed results JSON.

Stacks on step 3 (the outliner). Audit: one round, zero findings; log in
audit/AUDIT.md.

Proof: `python3 -m unittest plugins.horos.tests.test_evidence -v` (eleven
tests across the three bundles).

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
