### PR TITLE
Teach scan the filetype census

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1231,3 +1231,22 @@ copies match the receipted artefacts.
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Census run, step 2, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0 over the
+changed README. Horos 101/101, root 24/24. The review held the register's
+rows: one walk produces both artefacts (the tally rides the existing loops
+rather than a parallel implementation), the frozen boundary is reproduced
+byte for byte by test, rows sum to the totals with the boundary column
+bounded by its row, symlinks and skipped directories appear in neither
+walk, and the census writer is the boundary's own atomic writer refactored,
+not a copy.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: readable files are statted twice when the
+census is on (once inside classify_file, once for the tally); measured
+against Metron's rule it is noise on real trees and not worth plumbing size
+out of the classifier.

--- a/plugins/horos/examples/README.md
+++ b/plugins/horos/examples/README.md
@@ -39,6 +39,18 @@ failure fires in the other direction when a new sink appears that the
 committed boundary lacks, which is the control against a boundary edited to
 hide something.
 
+## The census
+
+```bash
+python3 plugins/horos/skills/horos/scripts/horos.py scan plugins/horos/examples/fixture --census
+```
+
+prints one row per filetype (files, bytes, share, and the bytes already
+inside the boundary), and with `--json` reproduces the committed
+`fixture/.horos/census.json` byte for byte. The census shares the scan's
+walk exactly, so it can never describe a different tree than the boundary
+does.
+
 ## The skeleton map
 
 ```bash

--- a/plugins/horos/examples/fixture/.horos/census.json
+++ b/plugins/horos/examples/fixture/.horos/census.json
@@ -1,0 +1,62 @@
+{
+  "rows": [
+    {
+      "boundary_bytes": 32258,
+      "bytes": 32258,
+      "files": 3,
+      "suffix": ".js"
+    },
+    {
+      "boundary_bytes": 18091,
+      "bytes": 18091,
+      "files": 1,
+      "suffix": ".json"
+    },
+    {
+      "boundary_bytes": 138,
+      "bytes": 138,
+      "files": 1,
+      "suffix": ".svg"
+    },
+    {
+      "boundary_bytes": 73,
+      "bytes": 98,
+      "files": 3,
+      "suffix": ".py"
+    },
+    {
+      "boundary_bytes": 71,
+      "bytes": 71,
+      "files": 1,
+      "suffix": ".sql"
+    },
+    {
+      "boundary_bytes": 54,
+      "bytes": 54,
+      "files": 1,
+      "suffix": ".lock"
+    },
+    {
+      "boundary_bytes": 53,
+      "bytes": 53,
+      "files": 1,
+      "suffix": ".map"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 25,
+      "files": 1,
+      "suffix": "(no suffix)"
+    },
+    {
+      "boundary_bytes": 11,
+      "bytes": 11,
+      "files": 1,
+      "suffix": ".bin"
+    }
+  ],
+  "schema": 1,
+  "tool": "horos",
+  "total_bytes": 50799,
+  "total_files": 13
+}

--- a/plugins/horos/skills/horos/scripts/horos.py
+++ b/plugins/horos/skills/horos/scripts/horos.py
@@ -187,7 +187,24 @@ def classify_file(root, relpath):
     return {"path": relpath, "category": category, "bytes": size, "evidence": evidence}
 
 
-def directory_entry(root, relpath, category, evidence):
+def _suffix_of(name):
+    """The name's last suffix, lowercased; a leading dot is not a suffix."""
+    if "." in name[1:]:
+        return "." + name.rsplit(".", 1)[1].lower()
+    return "(no suffix)"
+
+
+def _census_add(tally, name, size, in_boundary):
+    if tally is None:
+        return
+    row = tally.setdefault(_suffix_of(name), {"files": 0, "bytes": 0, "boundary_bytes": 0})
+    row["files"] += 1
+    row["bytes"] += size
+    if in_boundary:
+        row["boundary_bytes"] += size
+
+
+def directory_entry(root, relpath, category, evidence, tally=None):
     """Aggregate a vendored or generated directory into one entry."""
     total = 0
     files = 0
@@ -200,10 +217,12 @@ def directory_entry(root, relpath, category, evidence):
             if os.path.islink(fullpath):
                 continue
             try:
-                total += os.stat(fullpath).st_size
+                size = os.stat(fullpath).st_size
             except OSError:
                 continue
+            total += size
             files += 1
+            _census_add(tally, filename, size, in_boundary=True)
     return {
         "path": relpath + "/",
         "category": category,
@@ -213,10 +232,15 @@ def directory_entry(root, relpath, category, evidence):
     }
 
 
-def scan_tree(root):
-    """Walk the tree and return entries plus the counts a quiet run reports."""
+def scan_tree(root, census=False):
+    """Walk the tree and return entries plus the counts a quiet run reports.
+
+    With census=True the same walk also tallies every file by suffix, so the
+    census can never describe a different tree than the boundary does; the
+    result gains a "census" key and nothing else changes."""
     root = os.path.abspath(root)
     rules = gitattributes_rules(root)
+    tally = {} if census else None
     entries = []
     walked = 0
     skipped_unreadable = 0
@@ -234,17 +258,23 @@ def scan_tree(root):
             relpath = relpath.replace(os.sep, "/")
             if dirname in VENDORED_DIR_NAMES:
                 entries.append(
-                    directory_entry(root, relpath, "vendored", f"directory name {dirname}")
+                    directory_entry(
+                        root, relpath, "vendored", f"directory name {dirname}", tally
+                    )
                 )
                 continue
             if dirname in GENERATED_DIR_NAMES:
                 entries.append(
-                    directory_entry(root, relpath, "generated", f"directory name {dirname}")
+                    directory_entry(
+                        root, relpath, "generated", f"directory name {dirname}", tally
+                    )
                 )
                 continue
             matched = match_gitattributes(rules, relpath + "/")
             if matched is not None:
-                entries.append(directory_entry(root, relpath, matched[0], matched[1]))
+                entries.append(
+                    directory_entry(root, relpath, matched[0], matched[1], tally)
+                )
                 continue
             keep.append(dirname)
         dirnames[:] = keep
@@ -271,6 +301,7 @@ def scan_tree(root):
                         "evidence": matched[1],
                     }
                 )
+                _census_add(tally, filename, size, in_boundary=True)
                 continue
             try:
                 entry = classify_file(root, relpath)
@@ -279,13 +310,24 @@ def scan_tree(root):
                 continue
             if entry is not None:
                 entries.append(entry)
+                _census_add(tally, filename, entry["bytes"], in_boundary=True)
+            elif tally is not None:
+                try:
+                    _census_add(
+                        tally, filename, os.stat(fullpath).st_size, in_boundary=False
+                    )
+                except OSError:
+                    skipped_unreadable += 1
 
     entries.sort(key=lambda entry: entry["path"])
     counts = {"files_walked": walked, "files_skipped_unreadable": skipped_unreadable}
     for entry in entries:
         key = "bytes_" + entry["category"]
         counts[key] = counts.get(key, 0) + entry["bytes"]
-    return {"entries": entries, "counts": counts}
+    result = {"entries": entries, "counts": counts}
+    if tally is not None:
+        result["census"] = tally
+    return result
 
 
 BOUNDARY_RELPATH = ".horos/boundary.json"
@@ -325,21 +367,48 @@ def render(document):
     return json.dumps(document, indent=2, sort_keys=True) + "\n"
 
 
-def write_boundary(root, document):
-    """Write atomically: a killed run leaves the old boundary or the new one."""
-    directory = os.path.join(root, os.path.dirname(BOUNDARY_RELPATH))
+def _write_atomic(root, relpath, text):
+    """Write atomically: a killed run leaves the old artefact or the new one."""
+    directory = os.path.join(root, os.path.dirname(relpath))
     os.makedirs(directory, exist_ok=True)
-    final = os.path.join(root, BOUNDARY_RELPATH)
+    final = os.path.join(root, relpath)
     # Per-process name: two concurrent scans must not unlink each other's
     # half-written temporary in the finally block below.
     temporary = f"{final}.{os.getpid()}.tmp"
     try:
         with open(temporary, "w", encoding="utf-8") as handle:
-            handle.write(render(document))
+            handle.write(text)
         os.replace(temporary, final)
     finally:
         if os.path.exists(temporary):
             os.unlink(temporary)
+
+
+def write_boundary(root, document):
+    _write_atomic(root, BOUNDARY_RELPATH, render(document))
+
+
+CENSUS_RELPATH = ".horos/census.json"
+CENSUS_SCHEMA = 1
+
+
+def census_document(result):
+    """The per-filetype breakdown: exact integers, sorted rows, no clocks."""
+    rows = [
+        {"suffix": suffix, **row} for suffix, row in result["census"].items()
+    ]
+    rows.sort(key=lambda row: (-row["bytes"], row["suffix"]))
+    return {
+        "schema": CENSUS_SCHEMA,
+        "tool": "horos",
+        "total_files": sum(row["files"] for row in rows),
+        "total_bytes": sum(row["bytes"] for row in rows),
+        "rows": rows,
+    }
+
+
+def write_census(root, document):
+    _write_atomic(root, CENSUS_RELPATH, render(document))
 
 
 def load_boundary(root):
@@ -417,6 +486,11 @@ def main(argv=None):
     scan.add_argument(
         "--write", action="store_true", help=f"write {BOUNDARY_RELPATH} atomically"
     )
+    scan.add_argument(
+        "--census",
+        action="store_true",
+        help=f"per-filetype breakdown; with --write it goes to {CENSUS_RELPATH}",
+    )
     checker = subparsers.add_parser("check", help="verify the committed boundary")
     checker.add_argument("root", help="directory to check")
     mapper = subparsers.add_parser("map", help="print a Python file's skeleton")
@@ -433,7 +507,26 @@ def main(argv=None):
     if args.command == "check":
         return check_tree(args.root)
 
-    document = boundary_document(scan_tree(args.root))
+    result = scan_tree(args.root, census=args.census)
+
+    if args.census:
+        document = census_document(result)
+        if args.write:
+            write_census(args.root, document)
+        if args.json:
+            sys.stdout.write(render(document))
+        else:
+            total = document["total_bytes"] or 1
+            for row in document["rows"]:
+                share = 100 * row["bytes"] / total
+                print(
+                    f"{row['suffix']}  files={row['files']}  bytes={row['bytes']}"
+                    f"  share={share:.1f}%  boundary_bytes={row['boundary_bytes']}"
+                )
+            print(f"total: {document['total_files']} files, {document['total_bytes']} bytes")
+        return 0
+
+    document = boundary_document(result)
     if args.write:
         write_boundary(args.root, document)
     if args.json:

--- a/plugins/horos/tests/test_census.py
+++ b/plugins/horos/tests/test_census.py
@@ -1,0 +1,124 @@
+"""The census shares the boundary's walk and its numbers add up."""
+
+from pathlib import Path
+from unittest import mock
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "horos" / "scripts"))  # noqa: E402  (locates horos.py)
+
+import horos  # noqa: E402
+
+PLUGIN = Path(__file__).resolve().parents[1]
+FIXTURE = PLUGIN / "examples" / "fixture"
+
+
+def write(root, relpath, content):
+    path = Path(root) / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, str):
+        content = content.encode("utf-8")
+    path.write_bytes(content)
+    return path
+
+
+class CensusTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.addCleanup(self._tmp.cleanup)
+
+    def census(self):
+        return horos.census_document(horos.scan_tree(self.root, census=True))
+
+    def rows(self):
+        return {row["suffix"]: row for row in self.census()["rows"]}
+
+    def test_files_bucket_by_lowercased_last_suffix(self):
+        write(self.root, "a.PY", "x = 1\n")
+        write(self.root, "b.py", "y = 2\n")
+        write(self.root, "notes.txt", "words\n")
+        rows = self.rows()
+        self.assertEqual(rows[".py"]["files"], 2)
+        self.assertEqual(rows[".txt"]["files"], 1)
+
+    def test_a_dotless_or_dotfile_name_is_no_suffix(self):
+        write(self.root, "Makefile", "all:\n")
+        write(self.root, ".gitignore", "dist\n")
+        rows = self.rows()
+        self.assertEqual(rows["(no suffix)"]["files"], 2)
+
+    def test_a_vendored_file_lands_in_its_suffix_row_as_boundary_bytes(self):
+        write(self.root, "node_modules/dep/index.js", "module.exports = 1\n")
+        write(self.root, "src/app.js", "const a = 1\n")
+        rows = self.rows()
+        self.assertEqual(rows[".js"]["files"], 2)
+        self.assertEqual(rows[".js"]["boundary_bytes"], 19)
+        self.assertEqual(rows[".js"]["bytes"], 19 + 12)
+
+    def test_rows_sum_to_the_totals_and_boundary_never_exceeds_bytes(self):
+        write(self.root, "yarn.lock", "lock\n")
+        write(self.root, "src/app.py", "x = 1\n")
+        write(self.root, "assets/logo.bin", b"\x00" * 9)
+        document = self.census()
+        self.assertEqual(
+            sum(row["bytes"] for row in document["rows"]), document["total_bytes"]
+        )
+        self.assertEqual(
+            sum(row["files"] for row in document["rows"]), document["total_files"]
+        )
+        for row in document["rows"]:
+            self.assertLessEqual(row["boundary_bytes"], row["bytes"])
+
+    def test_symlinks_and_skipped_directories_are_in_neither_walk(self):
+        outside = tempfile.TemporaryDirectory()
+        self.addCleanup(outside.cleanup)
+        write(outside.name, "big.dat", b"z" * 100)
+        os.symlink(os.path.join(outside.name, "big.dat"), os.path.join(self.root, "alias.dat"))
+        write(self.root, ".horos/census.json", "{}")
+        write(self.root, "__pycache__/x.pyc", b"\x00")
+        write(self.root, "kept.py", "x = 1\n")
+        rows = self.rows()
+        self.assertEqual(set(rows), {".py"})
+
+    def test_the_census_is_deterministic_and_sorted(self):
+        write(self.root, "b.ts", "const b = 2\n")
+        write(self.root, "a.ts", "const a = 1\n")
+        write(self.root, "big.bin", b"\x00" * 500)
+        first = horos.render(self.census())
+        second = horos.render(self.census())
+        self.assertEqual(first, second)
+        rows = self.census()["rows"]
+        self.assertEqual(rows[0]["suffix"], ".bin")
+
+    def test_scan_without_the_flag_is_byte_for_byte_unchanged(self):
+        committed = (FIXTURE / horos.BOUNDARY_RELPATH).read_text(encoding="utf-8")
+        with mock.patch.object(sys, "stdout", new=io.StringIO()) as stdout:
+            code = horos.main(["scan", str(FIXTURE), "--json"])
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout.getvalue(), committed)
+
+    def test_the_committed_fixture_census_matches_a_fresh_run(self):
+        committed = (FIXTURE / horos.CENSUS_RELPATH).read_text(encoding="utf-8")
+        fresh = horos.render(
+            horos.census_document(horos.scan_tree(str(FIXTURE), census=True))
+        )
+        self.assertEqual(committed, fresh)
+
+    def test_census_write_commits_the_artefact_atomically(self):
+        write(self.root, "app.py", "x = 1\n")
+        with mock.patch.object(sys, "stdout", new=io.StringIO()):
+            code = horos.main(["scan", self.root, "--census", "--write"])
+        self.assertEqual(code, 0)
+        path = Path(self.root) / horos.CENSUS_RELPATH
+        document = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(document["schema"], horos.CENSUS_SCHEMA)
+        self.assertEqual(list(path.parent.glob("*.tmp")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
scan --census tallies every file the walk touches by lowercased last
suffix, including the contents of boundary-aggregated directories, one row
per filetype with total bytes and the part already inside the boundary. One
walk produces both artefacts, so the census can never describe a different
tree than the boundary does. --write commits .horos/census.json through the
shared atomic writer; scan without the flag is proven byte-for-byte
unchanged against the committed fixture boundary, and the fixture's census
is committed and reproduced exactly.

Stacks on step 1 (the spec). Audit: one round, zero findings; log in
audit/AUDIT.md.

Proof: `python3 -m unittest plugins.horos.tests.test_census -v` (nine
tests) and both suites.

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
