### PR TITLE
Record two censuses: wildcat-app-v2 and v2-protocol

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1250,3 +1250,19 @@ Zero findings. Leads not pursued: readable files are statted twice when the
 census is on (once inside classify_file, once for the tally); measured
 against Metron's rule it is noise on real trees and not worth plumbing size
 out of the classifier.
+
+## Census run, step 3, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0. Horos
+104/104, root 24/24. One defect was caught by the bundle's own consistency
+test before the implement receipt and is recorded for the trail: the prose
+quoted the boundary walk's file count instead of the census's (which
+includes files inside aggregated directories), 1,041 against the true
+1,113. The review confirmed both documents carry the shipped schema, the
+rows sum to the totals, and the Solidity call is recorded as a candidate
+pending more censuses, in the maintainer's words.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings in the round itself. Leads not pursued: none.

--- a/plugins/horos/docs/evidence/v2-protocol-census.json
+++ b/plugins/horos/docs/evidence/v2-protocol-census.json
@@ -1,0 +1,68 @@
+{
+  "rows": [
+    {
+      "boundary_bytes": 9697909,
+      "bytes": 9712020,
+      "files": 46,
+      "suffix": ".json"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 1162544,
+      "files": 151,
+      "suffix": ".sol"
+    },
+    {
+      "boundary_bytes": 173977,
+      "bytes": 173977,
+      "files": 1,
+      "suffix": ".lock"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 87645,
+      "files": 15,
+      "suffix": ".md"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 10170,
+      "files": 2,
+      "suffix": ".sh"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 3983,
+      "files": 15,
+      "suffix": "(no suffix)"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 3850,
+      "files": 2,
+      "suffix": ".ts"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 2533,
+      "files": 2,
+      "suffix": ".py"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 1377,
+      "files": 1,
+      "suffix": ".toml"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 247,
+      "files": 1,
+      "suffix": ".txt"
+    }
+  ],
+  "schema": 1,
+  "tool": "horos",
+  "total_bytes": 11158346,
+  "total_files": 236
+}

--- a/plugins/horos/docs/evidence/wildcat-app-v2-census.json
+++ b/plugins/horos/docs/evidence/wildcat-app-v2-census.json
@@ -1,0 +1,146 @@
+{
+  "rows": [
+    {
+      "boundary_bytes": 6220365,
+      "bytes": 6220438,
+      "files": 45,
+      "suffix": ".js"
+    },
+    {
+      "boundary_bytes": 3536815,
+      "bytes": 3625679,
+      "files": 17,
+      "suffix": ".json"
+    },
+    {
+      "boundary_bytes": 2310374,
+      "bytes": 2310374,
+      "files": 5,
+      "suffix": ".webp"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 1779083,
+      "files": 346,
+      "suffix": ".tsx"
+    },
+    {
+      "boundary_bytes": 1125208,
+      "bytes": 1125208,
+      "files": 4,
+      "suffix": ".map"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 916197,
+      "files": 526,
+      "suffix": ".ts"
+    },
+    {
+      "boundary_bytes": 298878,
+      "bytes": 298878,
+      "files": 17,
+      "suffix": ".sql"
+    },
+    {
+      "boundary_bytes": 205663,
+      "bytes": 205663,
+      "files": 98,
+      "suffix": ".svg"
+    },
+    {
+      "boundary_bytes": 193296,
+      "bytes": 193296,
+      "files": 4,
+      "suffix": ".woff2"
+    },
+    {
+      "boundary_bytes": 185434,
+      "bytes": 185434,
+      "files": 4,
+      "suffix": ".png"
+    },
+    {
+      "boundary_bytes": 102801,
+      "bytes": 102801,
+      "files": 1,
+      "suffix": ".ico"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 27545,
+      "files": 2,
+      "suffix": ".md"
+    },
+    {
+      "boundary_bytes": 15675,
+      "bytes": 15908,
+      "files": 3,
+      "suffix": ".html"
+    },
+    {
+      "boundary_bytes": 675,
+      "bytes": 12879,
+      "files": 13,
+      "suffix": ".css"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 12156,
+      "files": 2,
+      "suffix": ".mjs"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 10926,
+      "files": 1,
+      "suffix": ".prisma"
+    },
+    {
+      "boundary_bytes": 4443,
+      "bytes": 4443,
+      "files": 13,
+      "suffix": ".txt"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 4045,
+      "files": 3,
+      "suffix": ".yml"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 1081,
+      "files": 1,
+      "suffix": ".sh"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 782,
+      "files": 5,
+      "suffix": "(no suffix)"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 476,
+      "files": 1,
+      "suffix": ".example"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 361,
+      "files": 1,
+      "suffix": ".cjs"
+    },
+    {
+      "boundary_bytes": 126,
+      "bytes": 126,
+      "files": 1,
+      "suffix": ".toml"
+    }
+  ],
+  "schema": 1,
+  "tool": "horos",
+  "total_bytes": 17053779,
+  "total_files": 1113
+}

--- a/plugins/horos/docs/evidence/wildcat-app-v2-census.md
+++ b/plugins/horos/docs/evidence/wildcat-app-v2-census.md
@@ -1,0 +1,49 @@
+# Evidence bundle: two recorded censuses
+
+The census exists to answer two questions from a record instead of a guess:
+is a tree worth walking, and which extractor is worth building next. This
+bundle records the first two answers, one per Wildcat repository, captured
+2026-08-18 with the census as shipped in this delivery.
+
+## wildcat-app-v2
+
+- Commit: `9b8b6d5d6db06428c5b539f267623277b65315cd`
+- Census: [wildcat-app-v2-census.json](./wildcat-app-v2-census.json)
+- 1,113 files (aggregated directories included), 17,053,779 bytes across 23 filetypes
+
+The readable weight after the boundary is almost entirely the two mapped
+languages: `.tsx` (1,779,083 bytes, none in the boundary) and `.ts`
+(916,197 bytes, none in the boundary). The largest readable filetypes the
+map verb cannot open are small: `.json` outside the boundary is 88,864
+bytes, `.md` 27,545, `.mjs` 12,156, `.prisma` 10,926. **No third extractor
+is justified by this tree.**
+
+## v2-protocol
+
+- Commit: `c7be4039f8f383a9dda4e45f63331c17d63f9ed9`
+- Census: [v2-protocol-census.json](./v2-protocol-census.json)
+- 236 files (aggregated directories included), 11,158,346 bytes across 10 filetypes
+
+The boundary already holds 87.0% of the tree (the deployments JSON and the
+lockfile). Of what remains readable, `.sol` is 1,162,544 bytes across 151
+files, 87.6% of the readable weight, and the map verb cannot open any of
+it. **The census makes Solidity the leading extractor candidate.** One
+tree does not earn a build: the maintainer's direction is to census more
+protocol and UI repositories first, and the marketplace already holds
+prior art for whenever the evidence accumulates (Lemma's Solidity chunker
+walks the same comment-and-string discipline the TypeScript lexer uses).
+
+## Machine-readable capture lines
+
+The consistency test parses these against the committed census documents.
+
+<!-- census1:commit 9b8b6d5d6db06428c5b539f267623277b65315cd -->
+<!-- census1:total_files 1113 -->
+<!-- census1:total_bytes 17053779 -->
+<!-- census1:tsx_bytes 1779083 -->
+<!-- census1:tsx_boundary_bytes 0 -->
+<!-- census2:commit c7be4039f8f383a9dda4e45f63331c17d63f9ed9 -->
+<!-- census2:total_files 236 -->
+<!-- census2:total_bytes 11158346 -->
+<!-- census2:sol_bytes 1162544 -->
+<!-- census2:sol_boundary_bytes 0 -->

--- a/plugins/horos/tests/test_evidence.py
+++ b/plugins/horos/tests/test_evidence.py
@@ -13,6 +13,9 @@ BUNDLE_2 = EVIDENCE / "wildcat-app-v2-rules.md"
 BOUNDARY_2 = EVIDENCE / "wildcat-app-v2-rules.boundary.json"
 BUNDLE_3 = EVIDENCE / "wildcat-app-v2-outline.md"
 RESULTS_3 = EVIDENCE / "wildcat-app-v2-outline.results.json"
+BUNDLE_4 = EVIDENCE / "wildcat-app-v2-census.md"
+CENSUS_APP = EVIDENCE / "wildcat-app-v2-census.json"
+CENSUS_PROTOCOL = EVIDENCE / "v2-protocol-census.json"
 
 
 def capture_lines(bundle=BUNDLE, tag="evidence"):
@@ -111,6 +114,39 @@ class SecondCaptureTests(unittest.TestCase):
         self.assertEqual(totals["crashes"], 0)
         self.assertEqual(totals["missed"], 0)
         self.assertEqual(totals["extra"], 0)
+
+    def test_the_census_bundle_matches_both_committed_documents(self):
+        lines = capture_lines(BUNDLE_4, "census1")
+        app = json.loads(CENSUS_APP.read_text(encoding="utf-8"))
+        self.assertEqual(int(lines["total_files"]), app["total_files"])
+        self.assertEqual(int(lines["total_bytes"]), app["total_bytes"])
+        tsx = next(row for row in app["rows"] if row["suffix"] == ".tsx")
+        self.assertEqual(int(lines["tsx_bytes"]), tsx["bytes"])
+        self.assertEqual(int(lines["tsx_boundary_bytes"]), tsx["boundary_bytes"])
+
+        lines = capture_lines(BUNDLE_4, "census2")
+        protocol = json.loads(CENSUS_PROTOCOL.read_text(encoding="utf-8"))
+        self.assertEqual(int(lines["total_files"]), protocol["total_files"])
+        self.assertEqual(int(lines["total_bytes"]), protocol["total_bytes"])
+        sol = next(row for row in protocol["rows"] if row["suffix"] == ".sol")
+        self.assertEqual(int(lines["sol_bytes"]), sol["bytes"])
+        self.assertEqual(int(lines["sol_boundary_bytes"]), sol["boundary_bytes"])
+
+    def test_the_app_census_names_the_same_commit_as_the_captures(self):
+        self.assertEqual(
+            capture_lines()["commit"], capture_lines(BUNDLE_4, "census1")["commit"]
+        )
+
+    def test_both_census_documents_carry_the_shipped_schema(self):
+        for path in (CENSUS_APP, CENSUS_PROTOCOL):
+            document = json.loads(path.read_text(encoding="utf-8"))
+            with self.subTest(document=path.name):
+                self.assertEqual(document["schema"], 1)
+                self.assertEqual(document["tool"], "horos")
+                self.assertEqual(
+                    sum(row["bytes"] for row in document["rows"]),
+                    document["total_bytes"],
+                )
 
     def test_the_second_share_exceeds_the_first(self):
         first = capture_lines()


### PR DESCRIPTION
The census's first two recorded answers, machine-checked like every other
bundle. wildcat-app-v2 (1,113 files, 17.05 MB): the readable weight after
the boundary is almost entirely the two mapped languages, so no third
extractor is justified by that tree. v2-protocol (236 files, 11.16 MB): the
boundary already holds 87.0% of the tree, and 87.6% of what remains
readable is Solidity map cannot open, which makes Solidity the leading
extractor candidate. One tree does not earn a build; the maintainer's
direction is to census more protocol and UI repositories first.

Stacks on step 2 (the census). Audit: one round; the bundle's own
consistency test caught a wrong file count in the prose before the receipt,
recorded in the log.

Proof: `python3 -m unittest plugins.horos.tests.test_evidence -v` (fourteen
tests across four bundles).

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
