### PR TITLE
Implement the Go outline extractor

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1292,3 +1292,20 @@ copies match the receipted artefacts.
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Go-extractor run, step 2, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0. Horos 116/116, root
+24/24. The review walked the study's risk rows: raw strings keep
+backslashes as plain bytes and span lines, runes holding quotes are pinned,
+iota members emit without types, receivers ride inside function slices, and
+the statement walker advances monotonically (the guard the TypeScript
+extractor learned the hard way is present from the start).
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: an anonymous struct in a result type
+(func f() struct{ x int } {) would mis-slice at the struct's brace; the
+step 3 corpus over 1,421 real files will show whether the pattern occurs
+before any fix is designed.

--- a/plugins/horos/examples/fixture-go/market.go
+++ b/plugins/horos/examples/fixture-go/market.go
@@ -1,0 +1,73 @@
+// Package market is a fixture for the Horos Go outliner.
+package market
+
+import (
+	"fmt"
+	"math/big"
+)
+
+import "errors"
+
+const DefaultTimeout = 30
+
+const (
+	StateOpen = iota
+	StateDelinquent
+	StateClosed
+)
+
+var registry = map[string]*Market{}
+
+var (
+	ErrNotFound = errors.New("market not found")
+	maxRetries  int
+)
+
+type Address [20]byte
+
+type MarketFilter = func(*Market) bool
+
+type Market struct {
+	Address  Address
+	Capacity *big.Int
+	APR      float64
+}
+
+type (
+	Snapshot struct {
+		Market *Market
+		Block  uint64
+	}
+	Watcher interface {
+		Refresh() error
+	}
+)
+
+func FetchSnapshot(addr Address, block uint64) (*Snapshot, error) {
+	m, ok := registry[fmt.Sprintf("%x", addr)]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return &Snapshot{Market: m, Block: block}, nil
+}
+
+func (m *Market) FormatAPR() string {
+	return fmt.Sprintf(`%.2f%% from func fake() { nothing`, m.APR)
+}
+
+func Filter[T any](items []T, keep func(T) bool) []T {
+	var out []T
+	for _, item := range items {
+		if keep(item) {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func joinLabels(
+	prefix string,
+	labels ...string,
+) string {
+	return prefix + fmt.Sprint(labels)
+}

--- a/plugins/horos/skills/horos/scripts/languages/__init__.py
+++ b/plugins/horos/skills/horos/scripts/languages/__init__.py
@@ -5,10 +5,12 @@ and returns an exit code; the registry maps file suffixes onto it. A suffix
 absent here is refused by map, never guessed at.
 """
 
+from .go import go
 from .python import python
 from .typescript import typescript
 
 EXTRACTORS = {
+    ".go": go.outline,
     ".py": python.outline,
     ".ts": typescript.outline,
     ".tsx": typescript.outline,

--- a/plugins/horos/skills/horos/scripts/languages/go/go.py
+++ b/plugins/horos/skills/horos/scripts/languages/go/go.py
@@ -1,0 +1,364 @@
+"""Go outline extraction for Horos's map verb.
+
+The TypeScript extractor's shape, sized for a kinder language: no regex
+ambiguity, raw strings without escapes, and keyword-led declarations. It
+lexes, slices verbatim, confesses what it does not recognise, and never
+imports or executes what it reads.
+"""
+
+WORD_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+)
+OPENERS = "([{"
+CLOSERS = ")]}"
+
+# A line ending in one of these still owes the next line something, which
+# mirrors Go's own semicolon-insertion rule closely enough for slicing.
+CONTINUERS = frozenset(",=&|+-*/?:.([{<>!%^")
+
+DECL_KEYWORDS = frozenset({"package", "import", "func", "type", "const", "var"})
+GROUPABLE = frozenset({"import", "type", "const", "var"})
+
+
+def lex(source):
+    """Classify the source into spans of code, line_comment, block_comment,
+    string (interpreted), raw (backtick) and rune. Returns (spans, errors);
+    an unterminated construct's span covers the remainder."""
+    spans = []
+    errors = []
+    n = len(source)
+    i = 0
+    code_start = 0
+
+    def flush_code(end):
+        if end > code_start:
+            spans.append(("code", code_start, end))
+
+    while i < n:
+        c = source[i]
+        if c == "/" and i + 1 < n and source[i + 1] == "/":
+            flush_code(i)
+            end = source.find("\n", i)
+            end = n if end == -1 else end
+            spans.append(("line_comment", i, end))
+            i = code_start = end
+            continue
+        if c == "/" and i + 1 < n and source[i + 1] == "*":
+            flush_code(i)
+            end = source.find("*/", i + 2)
+            if end == -1:
+                errors.append((i, "unterminated block comment"))
+                spans.append(("block_comment", i, n))
+                return spans, errors
+            spans.append(("block_comment", i, end + 2))
+            i = code_start = end + 2
+            continue
+        if c == '"':
+            flush_code(i)
+            end = _scan_interpreted(source, i)
+            if end is None:
+                errors.append((i, "unterminated string"))
+                spans.append(("string", i, n))
+                return spans, errors
+            spans.append(("string", i, end))
+            i = code_start = end
+            continue
+        if c == "`":
+            flush_code(i)
+            end = source.find("`", i + 1)
+            if end == -1:
+                errors.append((i, "unterminated raw string"))
+                spans.append(("raw", i, n))
+                return spans, errors
+            spans.append(("raw", i, end + 1))
+            i = code_start = end + 1
+            continue
+        if c == "'":
+            flush_code(i)
+            end = _scan_rune(source, i)
+            if end is None:
+                errors.append((i, "unterminated rune literal"))
+                spans.append(("rune", i, n))
+                return spans, errors
+            spans.append(("rune", i, end))
+            i = code_start = end
+            continue
+        i += 1
+
+    flush_code(n)
+    return spans, errors
+
+
+def _scan_interpreted(source, start):
+    n = len(source)
+    i = start + 1
+    while i < n:
+        c = source[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == '"':
+            return i + 1
+        if c == "\n":
+            return None
+        i += 1
+    return None
+
+
+def _scan_rune(source, start):
+    n = len(source)
+    i = start + 1
+    while i < n:
+        c = source[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == "'":
+            return i + 1
+        if c == "\n":
+            return None
+        i += 1
+    return None
+
+
+def _line_of(source, offset):
+    return source.count("\n", 0, offset) + 1
+
+
+def _masked(source, spans):
+    """Non-code spans blanked, newlines kept; value literals get a sentinel
+    first character so a line ending in one still ends its statement."""
+    parts = []
+    for kind, start, end in spans:
+        segment = source[start:end]
+        if kind == "code":
+            parts.append(segment)
+            continue
+        blank = "".join(ch if ch == "\n" else " " for ch in segment)
+        if kind in ("string", "raw", "rune") and blank[:1] == " ":
+            blank = "#" + blank[1:]
+        parts.append(blank)
+    return "".join(parts)
+
+
+def _statement_end(mask, i, end):
+    depth = 0
+    last = ""
+    while i < end:
+        c = mask[i]
+        if c in OPENERS:
+            depth += 1
+            last = c
+        elif c in CLOSERS:
+            depth -= 1
+            if depth < 0:
+                return i
+            last = c
+        elif depth == 0 and c == ";":
+            return i + 1
+        elif depth == 0 and c == "\n":
+            if last and last not in CONTINUERS:
+                return i + 1
+        elif not c.isspace():
+            last = c
+        i += 1
+    return end
+
+
+def _find_at_depth(mask, start, stop, target):
+    depth = 0
+    i = start
+    while i < stop:
+        c = mask[i]
+        if c in OPENERS:
+            if c == target and depth == 0:
+                return i
+            depth += 1
+        elif c in CLOSERS:
+            depth -= 1
+        elif c == target and depth == 0:
+            return i
+        i += 1
+    return -1
+
+
+def _matching_brace(mask, open_index, end):
+    depth = 0
+    i = open_index
+    while i < end:
+        c = mask[i]
+        if c in OPENERS:
+            depth += 1
+        elif c in CLOSERS:
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return end
+
+
+def _first_word(mask, i, end):
+    while i < end and mask[i] in " \t":
+        i += 1
+    j = i
+    while j < end and mask[j] in WORD_CHARS:
+        j += 1
+    return mask[i:j], i
+
+
+class _Outline:
+    def __init__(self, source, mask):
+        self.source = source
+        self.mask = mask
+        self.lines = []
+        self.regions = []
+        self.declarations = 0
+
+    def emit(self, text, depth=0):
+        pad = "    " * depth
+        for line in text.splitlines():
+            self.lines.append(pad + line.strip() if depth else line.rstrip())
+
+    def confess(self, start, stop):
+        first = _line_of(self.source, start)
+        last = _line_of(self.source, max(start, stop - 1))
+        if self.regions and self.regions[-1][1] >= first - 1:
+            self.regions[-1] = (self.regions[-1][0], max(self.regions[-1][1], last))
+        else:
+            self.regions.append((first, last))
+
+    def walk(self, start, end):
+        mask = self.mask
+        i = start
+        while i < end:
+            while i < end and (mask[i].isspace() or mask[i] == ";"):
+                i += 1
+            if i >= end:
+                break
+            if mask[i] in CLOSERS:
+                i += 1
+                continue
+            word, word_at = _first_word(mask, i, end)
+            if word not in DECL_KEYWORDS:
+                stop = _statement_end(mask, i, end)
+                self.confess(i, stop)
+                i = max(stop, i + 1)
+                continue
+            i = max(self._declaration(i, end, word, word_at + len(word)), i + 1)
+
+    def _declaration(self, i, end, keyword, after_kw):
+        mask = self.mask
+        stmt_stop = _statement_end(mask, i, end)
+
+        if keyword == "func":
+            brace = _find_at_depth(mask, i, stmt_stop, "{")
+            if brace == -1:
+                self.emit(self.source[i:stmt_stop].rstrip().rstrip(";").rstrip())
+                self.declarations += 1
+                return stmt_stop
+            self.emit(self.source[i:brace].rstrip())
+            self.declarations += 1
+            return _matching_brace(mask, brace, end) + 1
+
+        if keyword in GROUPABLE:
+            next_word, next_at = _first_word(mask, after_kw, stmt_stop)
+            if not next_word and mask[next_at : next_at + 1] == "(":
+                return self._group(i, end, keyword, next_at)
+
+        if keyword == "package" or keyword == "import":
+            self.emit(_head_line(self.source, i, stmt_stop))
+            self.declarations += 1
+            return stmt_stop
+
+        # A single type, const or var declaration. A type with a body keeps
+        # its head and skips the body; const and var stop before their
+        # initialiser, type aliases keep their whole line.
+        brace = _find_at_depth(mask, i, stmt_stop, "{")
+        if keyword == "type" and brace != -1:
+            self.emit(self.source[i:brace].rstrip())
+            self.declarations += 1
+            return _matching_brace(mask, brace, end) + 1
+        head_stop = stmt_stop
+        if keyword in ("const", "var"):
+            equals = _find_at_depth(mask, i, stmt_stop, "=")
+            if equals != -1:
+                head_stop = equals
+        self.emit(_head_line(self.source, i, head_stop))
+        self.declarations += 1
+        return stmt_stop
+
+    def _group(self, i, end, keyword, paren):
+        close = _matching_brace(self.mask, paren, end)
+        self.emit(f"{keyword} (")
+        self.declarations += 1
+        j = paren + 1
+        while j < close:
+            while j < close and (self.mask[j].isspace() or self.mask[j] == ";"):
+                j += 1
+            if j >= close:
+                break
+            member_stop = min(_statement_end(self.mask, j, close), close)
+            if not self.mask[j:member_stop].strip():
+                j = max(member_stop, j + 1)
+                continue
+            brace = _find_at_depth(self.mask, j, member_stop, "{")
+            if keyword == "type" and brace != -1:
+                self.emit(self.source[j:brace].rstrip(), depth=1)
+                self.declarations += 1
+                j = _matching_brace(self.mask, brace, close if brace < close else end) + 1
+                continue
+            head_stop = member_stop
+            if keyword in ("const", "var"):
+                equals = _find_at_depth(self.mask, j, member_stop, "=")
+                if equals != -1:
+                    head_stop = equals
+            self.emit(_head_line(self.source, j, head_stop), depth=1)
+            self.declarations += 1
+            j = max(member_stop, j + 1)
+        return close + 1
+
+
+def _head_line(source, start, stop):
+    newline = source.find("\n", start, stop)
+    cut = stop if newline == -1 else newline
+    return source[start:cut].rstrip().rstrip(";").rstrip()
+
+
+def _module_header(source, spans):
+    for kind, start, end in spans:
+        if kind == "code" and source[start:end].strip():
+            return None
+        if kind in ("line_comment", "block_comment"):
+            for raw in source[start:end].splitlines():
+                text = raw.strip().lstrip("/*").rstrip("*/").strip("* ").strip()
+                if text:
+                    return text
+            return None
+    return None
+
+
+def outline(path, source, out):
+    """Print the file's declaration outline; 0 clean, 1 when the lexer
+    confessed an unterminated construct."""
+    spans, errors = lex(source)
+    mask = _masked(source, spans)
+    header = _module_header(source, spans)
+    print(f"module: {header}" if header else "module: (no header comment)", file=out)
+
+    walker = _Outline(source, mask)
+    walker.walk(0, len(source) if not errors else spans[-1][1])
+    for offset, reason in errors:
+        print(f"lexer: {reason} at line {_line_of(source, offset)}", file=out)
+        walker.confess(offset, len(source))
+
+    for line in walker.lines:
+        print(line, file=out)
+    print(f"declarations: {walker.declarations}", file=out)
+    if walker.regions:
+        listed = ", ".join(
+            f"lines {a}-{b}" if a != b else f"line {a}" for a, b in walker.regions
+        )
+        print(f"unparsed: {len(walker.regions)} region(s): {listed}", file=out)
+    else:
+        print("unparsed: none", file=out)
+    return 1 if errors else 0

--- a/plugins/horos/tests/test_go_outline.py
+++ b/plugins/horos/tests/test_go_outline.py
@@ -1,0 +1,129 @@
+"""The Go outliner slices keyword-led declarations and confesses the rest."""
+
+from pathlib import Path
+import io
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "horos" / "scripts"))  # noqa: E402  (locates horos.py)
+
+from languages.go import go  # noqa: E402
+
+PLUGIN = Path(__file__).resolve().parents[1]
+FIXTURE = PLUGIN / "examples" / "fixture-go" / "market.go"
+
+EXPECTED = """module: Package market is a fixture for the Horos Go outliner.
+package market
+import (
+    "fmt"
+    "math/big"
+import "errors"
+const DefaultTimeout
+const (
+    StateOpen
+    StateDelinquent
+    StateClosed
+var registry
+var (
+    ErrNotFound
+    maxRetries  int
+type Address [20]byte
+type MarketFilter = func(*Market) bool
+type Market struct
+type (
+    Snapshot struct
+    Watcher interface
+func FetchSnapshot(addr Address, block uint64) (*Snapshot, error)
+func (m *Market) FormatAPR() string
+func Filter[T any](items []T, keep func(T) bool) []T
+func joinLabels(
+\tprefix string,
+\tlabels ...string,
+) string
+declarations: 24
+unparsed: none
+"""
+
+
+def run(source):
+    out = io.StringIO()
+    code = go.outline("test.go", source, out)
+    return code, out.getvalue()
+
+
+class GoOutlineTests(unittest.TestCase):
+    def test_the_fixture_outline_is_pinned(self):
+        source = FIXTURE.read_text(encoding="utf-8")
+        out = io.StringIO()
+        code = go.outline(str(FIXTURE), source, out)
+        self.assertEqual(code, 0)
+        self.assertEqual(out.getvalue(), EXPECTED)
+
+    def test_bodies_never_leak_into_the_outline(self):
+        source = FIXTURE.read_text(encoding="utf-8")
+        _, output = run(source)
+        self.assertNotIn("registry[fmt.Sprintf", output)
+        self.assertNotIn("out = append", output)
+
+    def test_a_raw_string_spans_lines_and_keeps_backslashes_plain(self):
+        code, output = run(
+            "package p\n\nvar tmpl = `line one \\n\nfunc fake() {\n`\n\nfunc Real() {}\n"
+        )
+        self.assertEqual(code, 0)
+        lines = output.splitlines()
+        self.assertIn("func Real()", lines)
+        self.assertNotIn("func fake()", output)
+        self.assertIn("var tmpl", lines)
+
+    def test_rune_literals_holding_quotes_do_not_derail(self):
+        code, output = run(
+            "package p\n\nconst quote = '\"'\nconst escaped = '\\''\n\nfunc F() {}\n"
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("func F()", output.splitlines())
+        self.assertIn("unparsed: none", output)
+
+    def test_a_method_keeps_its_receiver_in_the_slice(self):
+        _, output = run("package p\n\nfunc (s *Store) Get(k string) int { return 0 }\n")
+        self.assertIn("func (s *Store) Get(k string) int", output.splitlines())
+
+    def test_a_bodyless_func_is_sliced_whole(self):
+        _, output = run("package p\n\nfunc add(x, y int) int\n")
+        self.assertIn("func add(x, y int) int", output.splitlines())
+
+    def test_an_unmatched_statement_is_confessed_by_line(self):
+        code, output = run("package p\n\nfmt.Println(1)\n")
+        self.assertEqual(code, 0)
+        self.assertIn("unparsed: 1 region(s): line 3", output)
+
+    def test_an_unterminated_string_confesses_the_remainder(self):
+        code, output = run('package p\n\nvar s = "open\nfunc After() {}\n')
+        self.assertEqual(code, 1)
+        self.assertIn("lexer: unterminated string at line 3", output)
+        self.assertNotIn("unparsed: none", output)
+
+    def test_grouped_const_with_iota_emits_every_member(self):
+        _, output = run("package p\n\nconst (\n\tA = iota\n\tB\n\tC\n)\n")
+        lines = output.splitlines()
+        for name in ("A", "B", "C"):
+            self.assertIn(f"    {name}", lines)
+
+    def test_a_group_comment_line_emits_nothing(self):
+        _, output = run('package p\n\nimport (\n\t// stdlib\n\t"fmt"\n)\n')
+        lines = [line for line in output.splitlines() if line.startswith("    ")]
+        self.assertEqual(lines, ['    "fmt"'])
+
+    def test_the_go_suffix_dispatches_through_the_registry(self):
+        import horos  # noqa: E402  (registry dispatch under test)
+
+        out = io.StringIO()
+        self.assertEqual(horos.map_file(str(FIXTURE), out=out), 0)
+        self.assertIn(".go", __import__("languages").supported())
+
+    def test_module_header_falls_back_when_absent(self):
+        _, output = run("package p\n")
+        self.assertIn("module: (no header comment)", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The TypeScript shape sized for a kinder language. The lexer classifies
comments, interpreted strings, raw strings (no escapes, lines allowed) and
rune literals; the outliner slices keyword-led declarations verbatim, with
parenthesised groups emitting one line per member, iota members included,
receivers and generics riding in function slices, and bodyless assembly
stubs sliced whole. Everything else at statement position is confessed by
line range; an unterminated literal confesses the remainder and exits one.
The fixture outline is pinned byte for byte and the Python and TypeScript
fixtures are untouched.

Stacks on step 1 (the spec). Audit: one round, zero findings; one lead (an
anonymous struct in a result type) deferred to the step 3 corpus.

Proof: `python3 -m unittest plugins.horos.tests.test_go_outline -v` (twelve
tests) and both suites (horos 116, root 24).

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
