### PR TITLE
Record the Go differential corpus against tree-sitter

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1309,3 +1309,21 @@ Zero findings. Leads not pursued: an anonymous struct in a result type
 (func f() struct{ x int } {) would mis-slice at the struct's brace; the
 step 3 corpus over 1,421 real files will show whether the pattern occurs
 before any fix is designed.
+
+## Go-extractor run, step 3, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0. Horos
+118/118, root 24/24. The review held the register's rows: the venv and
+oracle stay outside every runtime and test path (the consistency tests read
+only the committed results JSON), the bundle names its commit, oracle and
+the compiler-absence trade, the acceptance numbers are asserted by test,
+and the step 2 lead (an anonymous struct in a result type) did not occur in
+1,421 real files. The three dev-side tooling defects the run surfaced are
+named in the bundle; the shipped outliner needed no fix at all.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: the corpus is gofmt-regular by
+construction; hand-mangled Go would exercise the confession paths harder,
+and can join the evidence when such a tree matters.

--- a/plugins/horos/dev/go_oracle.py
+++ b/plugins/horos/dev/go_oracle.py
@@ -1,0 +1,77 @@
+"""Dev-time oracle for the Horos Go outliner. Never imported or executed by
+the shipped plugin or its test suite: the differential corpus run drives it
+by hand inside a scratchpad virtualenv holding `tree-sitter` and
+`tree-sitter-go`, and only the recorded results are committed.
+
+Usage: <venv-python> go_oracle.py <file.go> [...] > oracle.json
+
+Emits, per file, the declarations tree-sitter sees at the altitudes the
+outliner claims: top-level functions, methods, types, consts and vars,
+grouped members included. Function-body locals are absent on both sides.
+"""
+
+import json
+import sys
+
+import tree_sitter_go
+from tree_sitter import Language, Parser
+
+PARSER = Parser(Language(tree_sitter_go.language()))
+
+
+def names_from(node, source):
+    decls = []
+
+    def ident(n):
+        return source[n.start_byte : n.end_byte].decode("utf-8", errors="replace")
+
+    def push(n, kind):
+        decls.append({"name": ident(n), "line": n.start_point[0] + 1, "kind": kind})
+
+    for child in node.children:
+        if child.type == "function_declaration":
+            name = child.child_by_field_name("name")
+            if name is not None:
+                push(name, "function")
+        elif child.type == "method_declaration":
+            name = child.child_by_field_name("name")
+            if name is not None:
+                push(name, "method")
+        elif child.type == "type_declaration":
+            for spec in child.children:
+                if spec.type in ("type_spec", "type_alias"):
+                    name = spec.child_by_field_name("name")
+                    if name is not None:
+                        push(name, "type")
+        elif child.type in ("const_declaration", "var_declaration"):
+            kind = child.type.split("_", 1)[0]
+            # Grouped var blocks nest their specs under a var_spec_list
+            # node, so walk a small stack instead of one level.
+            stack = list(child.children)
+            while stack:
+                spec = stack.pop()
+                if spec.type in ("const_spec", "var_spec"):
+                    seen = set()
+                    for part in spec.children:
+                        if part.type == "identifier" and id(part) not in seen:
+                            seen.add(id(part))
+                            push(part, kind)
+                        if part.type not in ("identifier", ","):
+                            break
+                elif spec.type == "var_spec_list":
+                    stack.extend(spec.children)
+    return decls
+
+
+def main():
+    out = {}
+    for path in sys.argv[1:]:
+        with open(path, "rb") as handle:
+            source = handle.read()
+        tree = PARSER.parse(source)
+        out[path] = names_from(tree.root_node, source)
+    sys.stdout.write(json.dumps(out))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/horos/docs/evidence/go-ethereum-outline.md
+++ b/plugins/horos/docs/evidence/go-ethereum-outline.md
@@ -1,0 +1,48 @@
+# Evidence bundle: the Go outliner against tree-sitter
+
+The differential corpus run the Go extractor's acceptance demanded: every
+Go file in a live external repository, outlined by Horos and independently
+parsed by tree-sitter's Go grammar, with the two declaration lists compared
+per file.
+
+## The run
+
+- Corpus: `ethereum/go-ethereum` at
+  `26d0b2171c17339bb8fd164d8ed6830738d3bf13`, all 1,421 `.go` files
+- Captured: 2026-08-18
+- Outliner: `languages/go/go.py` as shipped in this delivery
+- Oracle: `tree-sitter` with `tree-sitter-go`, installed in a scratchpad
+  virtualenv and driven by the committed dev-time tool
+  [../../dev/go_oracle.py](../../dev/go_oracle.py); absent from every
+  runtime and test path. The Go compiler's own parser would have been
+  preferred; the toolchain is absent on this machine and the study records
+  that trade.
+- Altitudes compared on both sides: top-level declarations and their
+  grouped members; function-body locals excluded by design
+- Per-file results: [go-ethereum-outline.results.json](./go-ethereum-outline.results.json)
+
+## The result
+
+The oracle sees 21,648 declarations at the compared altitudes. The outliner
+names all 21,648, misses none, names nothing extra, and crashes nowhere. 38
+files carry confessed regions (cgo preambles and the like), and none of
+those regions hid a declaration the oracle could see. Every mismatch the
+run surfaced along the way was a defect in the dev-side oracle or driver
+(grouped var blocks nested under a spec-list node; generic parameters and
+alias targets leaking through the name splitter; continuation lines of
+verbatim multiline slices re-parsed as heads), each fixed in the tooling
+with the shipped outliner untouched.
+
+## Machine-readable capture lines
+
+The consistency test parses these against the committed results document.
+
+<!-- gooutline:commit 26d0b2171c17339bb8fd164d8ed6830738d3bf13 -->
+<!-- gooutline:files 1421 -->
+<!-- gooutline:crashes 0 -->
+<!-- gooutline:oracle 21648 -->
+<!-- gooutline:matched 21648 -->
+<!-- gooutline:missed 0 -->
+<!-- gooutline:missed_confessed 0 -->
+<!-- gooutline:extra 0 -->
+<!-- gooutline:files_with_regions 38 -->

--- a/plugins/horos/docs/evidence/go-ethereum-outline.results.json
+++ b/plugins/horos/docs/evidence/go-ethereum-outline.results.json
@@ -1,0 +1,12804 @@
+{
+ "files": {
+  "accounts/abi/abi.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "accounts/abi/abi_test.go": {
+   "extra": 0,
+   "matched": 49,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 49,
+   "ours": 49,
+   "regions": 0
+  },
+  "accounts/abi/abifuzzer_test.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "accounts/abi/abigen/bind.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "accounts/abi/abigen/bind_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "accounts/abi/abigen/bindv2.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "accounts/abi/abigen/bindv2_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "accounts/abi/abigen/template.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "accounts/abi/argument.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "accounts/abi/bind/backends/simulated.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "accounts/abi/bind/old.go": {
+   "extra": 0,
+   "matched": 38,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 38,
+   "ours": 38,
+   "regions": 0
+  },
+  "accounts/abi/bind/v2/auth.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "accounts/abi/bind/v2/backend.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "accounts/abi/bind/v2/base.go": {
+   "extra": 0,
+   "matched": 30,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 30,
+   "ours": 30,
+   "regions": 0
+  },
+  "accounts/abi/bind/v2/base_test.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "accounts/abi/bind/v2/dep_tree.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "accounts/abi/bind/v2/dep_tree_test.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "accounts/abi/bind/v2/generate_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "accounts/abi/bind/v2/internal/contracts/db/bindings.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "accounts/abi/bind/v2/internal/contracts/events/bindings.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "accounts/abi/bind/v2/internal/contracts/nested_libraries/bindings.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "accounts/abi/bind/v2/internal/contracts/solc_errors/bindings.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "accounts/abi/bind/v2/internal/contracts/uint256arrayreturn/bindings.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "accounts/abi/bind/v2/lib.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "accounts/abi/bind/v2/lib_test.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "accounts/abi/bind/v2/util.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "accounts/abi/bind/v2/util_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "accounts/abi/doc.go": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "accounts/abi/error.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "accounts/abi/error_handling.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "accounts/abi/event.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "accounts/abi/event_test.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "accounts/abi/method.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "accounts/abi/method_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "accounts/abi/pack.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "accounts/abi/pack_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "accounts/abi/packing_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "accounts/abi/reflect.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 1
+  },
+  "accounts/abi/reflect_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "accounts/abi/selector_parser.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "accounts/abi/selector_parser_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "accounts/abi/topics.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "accounts/abi/topics_test.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "accounts/abi/type.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "accounts/abi/type_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "accounts/abi/unpack.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "accounts/abi/unpack_test.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "accounts/abi/utils.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "accounts/accounts.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "accounts/accounts_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "accounts/errors.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "accounts/external/backend.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "accounts/hd.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "accounts/hd_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "accounts/keystore/account_cache.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "accounts/keystore/account_cache_test.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "accounts/keystore/file_cache.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "accounts/keystore/key.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "accounts/keystore/keystore.go": {
+   "extra": 0,
+   "matched": 37,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 37,
+   "ours": 37,
+   "regions": 0
+  },
+  "accounts/keystore/keystore_fuzzing_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "accounts/keystore/keystore_test.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "accounts/keystore/passphrase.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "accounts/keystore/passphrase_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "accounts/keystore/plain.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "accounts/keystore/plain_test.go": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "accounts/keystore/presale.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "accounts/keystore/wallet.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "accounts/keystore/watch.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "accounts/keystore/watch_fallback.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "accounts/manager.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "accounts/manager_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "accounts/scwallet/apdu.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "accounts/scwallet/hub.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "accounts/scwallet/securechannel.go": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "accounts/scwallet/wallet.go": {
+   "extra": 0,
+   "matched": 79,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 79,
+   "ours": 79,
+   "regions": 0
+  },
+  "accounts/sort.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "accounts/url.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "accounts/url_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "accounts/usbwallet/hub.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "accounts/usbwallet/ledger.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "accounts/usbwallet/trezor.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "accounts/usbwallet/trezor/messages-common.pb.go": {
+   "extra": 0,
+   "matched": 87,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 87,
+   "ours": 87,
+   "regions": 0
+  },
+  "accounts/usbwallet/trezor/messages-ethereum.pb.go": {
+   "extra": 0,
+   "matched": 48,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 48,
+   "ours": 48,
+   "regions": 0
+  },
+  "accounts/usbwallet/trezor/messages-management.pb.go": {
+   "extra": 0,
+   "matched": 115,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 115,
+   "ours": 115,
+   "regions": 0
+  },
+  "accounts/usbwallet/trezor/messages.pb.go": {
+   "extra": 0,
+   "matched": 222,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 222,
+   "ours": 222,
+   "regions": 0
+  },
+  "accounts/usbwallet/trezor/trezor.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "accounts/usbwallet/wallet.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "beacon/blsync/block_sync.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "beacon/blsync/block_sync_test.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "beacon/blsync/client.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "beacon/blsync/engineclient.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "beacon/engine/bapl_encode.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "beacon/engine/ed_codec.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "beacon/engine/epe_decode.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "beacon/engine/epe_encode.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "beacon/engine/epe_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "beacon/engine/errors.go": {
+   "extra": 0,
+   "matched": 21,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 21,
+   "ours": 21,
+   "regions": 1
+  },
+  "beacon/engine/pa_codec.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "beacon/engine/types.go": {
+   "extra": 0,
+   "matched": 38,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 38,
+   "ours": 38,
+   "regions": 0
+  },
+  "beacon/engine/types_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "beacon/light/api/api_server.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "beacon/light/api/light_api.go": {
+   "extra": 0,
+   "matched": 26,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 26,
+   "ours": 26,
+   "regions": 0
+  },
+  "beacon/light/canonical.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "beacon/light/committee_chain.go": {
+   "extra": 0,
+   "matched": 26,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 26,
+   "ours": 26,
+   "regions": 0
+  },
+  "beacon/light/committee_chain_test.go": {
+   "extra": 0,
+   "matched": 34,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 34,
+   "ours": 34,
+   "regions": 0
+  },
+  "beacon/light/head_tracker.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "beacon/light/range.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "beacon/light/request/scheduler.go": {
+   "extra": 0,
+   "matched": 28,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 28,
+   "ours": 28,
+   "regions": 0
+  },
+  "beacon/light/request/scheduler_test.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "beacon/light/request/server.go": {
+   "extra": 0,
+   "matched": 38,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 38,
+   "ours": 38,
+   "regions": 0
+  },
+  "beacon/light/request/server_test.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "beacon/light/sync/head_sync.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "beacon/light/sync/head_sync_test.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "beacon/light/sync/test_helpers.go": {
+   "extra": 0,
+   "matched": 28,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 28,
+   "ours": 28,
+   "regions": 0
+  },
+  "beacon/light/sync/types.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "beacon/light/sync/update_sync.go": {
+   "extra": 0,
+   "matched": 26,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 26,
+   "ours": 26,
+   "regions": 0
+  },
+  "beacon/light/sync/update_sync_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "beacon/light/test_helpers.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "beacon/merkle/merkle.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "beacon/params/config.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "beacon/params/config_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "beacon/params/networks.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "beacon/params/params.go": {
+   "extra": 0,
+   "matched": 26,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 26,
+   "ours": 26,
+   "regions": 0
+  },
+  "beacon/types/beacon_block.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "beacon/types/beacon_block_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "beacon/types/committee.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "beacon/types/exec_header.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "beacon/types/exec_payload.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "beacon/types/gen_header_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "beacon/types/gen_syncaggregate_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "beacon/types/header.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "beacon/types/light_sync.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "build/ci.go": {
+   "extra": 0,
+   "matched": 57,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 57,
+   "ours": 57,
+   "regions": 0
+  },
+  "build/update-license.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "cmd/abidump/main.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "cmd/abigen/main.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "cmd/abigen/namefilter.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "cmd/abigen/namefilter_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "cmd/blsync/main.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "cmd/devp2p/crawl.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "cmd/devp2p/discv4cmd.go": {
+   "extra": 0,
+   "matched": 34,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 34,
+   "ours": 34,
+   "regions": 0
+  },
+  "cmd/devp2p/discv5cmd.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "cmd/devp2p/dns_cloudflare.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "cmd/devp2p/dns_route53.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "cmd/devp2p/dns_route53_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "cmd/devp2p/dnscmd.go": {
+   "extra": 0,
+   "matched": 32,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 32,
+   "ours": 32,
+   "regions": 0
+  },
+  "cmd/devp2p/enrcmd.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "cmd/devp2p/internal/ethtest/chain.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "cmd/devp2p/internal/ethtest/chain_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "cmd/devp2p/internal/ethtest/conn.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "cmd/devp2p/internal/ethtest/engine.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "cmd/devp2p/internal/ethtest/protocol.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "cmd/devp2p/internal/ethtest/snap.go": {
+   "extra": 0,
+   "matched": 21,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 21,
+   "ours": 21,
+   "regions": 0
+  },
+  "cmd/devp2p/internal/ethtest/snap2.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "cmd/devp2p/internal/ethtest/suite.go": {
+   "extra": 0,
+   "matched": 35,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 35,
+   "ours": 35,
+   "regions": 0
+  },
+  "cmd/devp2p/internal/ethtest/suite_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "cmd/devp2p/internal/ethtest/transaction.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "cmd/devp2p/internal/v4test/discv4tests.go": {
+   "extra": 0,
+   "matched": 30,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 30,
+   "ours": 30,
+   "regions": 0
+  },
+  "cmd/devp2p/internal/v4test/framework.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "cmd/devp2p/internal/v5test/discv5tests.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "cmd/devp2p/internal/v5test/framework.go": {
+   "extra": 0,
+   "matched": 26,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 26,
+   "ours": 26,
+   "regions": 1
+  },
+  "cmd/devp2p/keycmd.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "cmd/devp2p/main.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "cmd/devp2p/nodeset.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "cmd/devp2p/nodesetcmd.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "cmd/devp2p/nodesetcmd_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "cmd/devp2p/rlpxcmd.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "cmd/devp2p/rlpxcmd_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "cmd/devp2p/runtest.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "cmd/era/main.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "cmd/ethkey/changepassword.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "cmd/ethkey/generate.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "cmd/ethkey/inspect.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "cmd/ethkey/main.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "cmd/ethkey/message.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "cmd/ethkey/message_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "cmd/ethkey/run_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "cmd/ethkey/utils.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "cmd/evm/blockrunner.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "cmd/evm/eest.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "cmd/evm/internal/t8ntool/block.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "cmd/evm/internal/t8ntool/execution.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "cmd/evm/internal/t8ntool/file_tracer.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "cmd/evm/internal/t8ntool/flags.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "cmd/evm/internal/t8ntool/gen_execresult.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "cmd/evm/internal/t8ntool/gen_header.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "cmd/evm/internal/t8ntool/gen_stenv.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "cmd/evm/internal/t8ntool/transaction.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "cmd/evm/internal/t8ntool/transition.go": {
+   "extra": 0,
+   "matched": 37,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 37,
+   "ours": 37,
+   "regions": 0
+  },
+  "cmd/evm/internal/t8ntool/tx_iterator.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "cmd/evm/internal/t8ntool/utils.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "cmd/evm/main.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "cmd/evm/reporter.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "cmd/evm/runner.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "cmd/evm/staterunner.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "cmd/evm/t8n_test.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "cmd/fetchpayload/main.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "cmd/geth/accountcmd.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "cmd/geth/accountcmd_test.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "cmd/geth/attach_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "cmd/geth/bintrie_convert.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "cmd/geth/bintrie_convert_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "cmd/geth/chaincmd.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "cmd/geth/chaincmd_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "cmd/geth/config.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "cmd/geth/consolecmd.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "cmd/geth/consolecmd_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "cmd/geth/dbcmd.go": {
+   "extra": 0,
+   "matched": 54,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 54,
+   "ours": 54,
+   "regions": 0
+  },
+  "cmd/geth/exportcmd_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "cmd/geth/genesis_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "cmd/geth/logging_test.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "cmd/geth/logtestcmd_active.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "cmd/geth/logtestcmd_inactive.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "cmd/geth/main.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "cmd/geth/misccmd.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "cmd/geth/run_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "cmd/geth/snapshot.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "cmd/keeper/chainconfig.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "cmd/keeper/getpayload_example.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "cmd/keeper/getpayload_wasm.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "cmd/keeper/getpayload_womir.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "cmd/keeper/getpayload_ziren.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "cmd/keeper/main.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "cmd/keeper/stubs.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "cmd/rlpdump/main.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "cmd/rlpdump/rlpdump_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "cmd/utils/cmd.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "cmd/utils/diskusage.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "cmd/utils/diskusage_openbsd.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "cmd/utils/diskusage_windows.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "cmd/utils/export_test.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "cmd/utils/flags.go": {
+   "extra": 0,
+   "matched": 231,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 231,
+   "ours": 231,
+   "regions": 0
+  },
+  "cmd/utils/flags_legacy.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "cmd/utils/flags_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "cmd/utils/history_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "cmd/utils/prompt.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "cmd/workload/client.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "cmd/workload/filtertest.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "cmd/workload/filtertestfuzz.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "cmd/workload/filtertestgen.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "cmd/workload/filtertestperf.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "cmd/workload/historytest.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "cmd/workload/historytestgen.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "cmd/workload/main.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "cmd/workload/prooftest.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "cmd/workload/prooftestgen.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "cmd/workload/testsuite.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "cmd/workload/tracetest.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "cmd/workload/tracetestgen.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "common/big.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "common/bitutil/bitutil.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "common/bitutil/bitutil_test.go": {
+   "extra": 0,
+   "matched": 38,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 38,
+   "ours": 38,
+   "regions": 0
+  },
+  "common/bitutil/compress.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "common/bitutil/compress_test.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "common/bytes.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "common/bytes_test.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "common/compiler/helpers.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "common/compiler/solidity.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "common/debug.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "common/eta.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "common/eta_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "common/fdlimit/fdlimit_bsd.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "common/fdlimit/fdlimit_darwin.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "common/fdlimit/fdlimit_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "common/fdlimit/fdlimit_unix.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "common/fdlimit/fdlimit_windows.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "common/format.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "common/hexutil/hexutil.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "common/hexutil/hexutil_test.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "common/hexutil/json.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "common/hexutil/json_example_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "common/hexutil/json_test.go": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "common/lru/basiclru.go": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "common/lru/basiclru_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "common/lru/blob_lru.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "common/lru/blob_lru_test.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "common/lru/lru.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "common/math/big.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "common/math/big_test.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "common/math/integer.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "common/math/integer_test.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "common/mclock/alarm.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 1
+  },
+  "common/mclock/alarm_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "common/mclock/mclock.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "common/mclock/simclock.go": {
+   "extra": 0,
+   "matched": 21,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 21,
+   "ours": 21,
+   "regions": 1
+  },
+  "common/mclock/simclock_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "common/path.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "common/prque/lazyqueue.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "common/prque/lazyqueue_test.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "common/prque/prque.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "common/prque/prque_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "common/prque/sstack.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "common/prque/sstack_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "common/range.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "common/range_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "common/size.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "common/size_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "common/test_utils.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "common/types.go": {
+   "extra": 0,
+   "matched": 46,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 46,
+   "ours": 46,
+   "regions": 0
+  },
+  "common/types_test.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "consensus/beacon/consensus.go": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "consensus/clique/clique.go": {
+   "extra": 0,
+   "matched": 49,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 49,
+   "ours": 49,
+   "regions": 0
+  },
+  "consensus/clique/clique_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "consensus/clique/snapshot.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "consensus/clique/snapshot_test.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "consensus/consensus.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "consensus/errors.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "consensus/ethash/consensus.go": {
+   "extra": 0,
+   "matched": 38,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 38,
+   "ours": 38,
+   "regions": 0
+  },
+  "consensus/ethash/consensus_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "consensus/ethash/difficulty.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "consensus/ethash/ethash.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "consensus/misc/dao.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "consensus/misc/eip1559/eip1559.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "consensus/misc/eip1559/eip1559_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "consensus/misc/eip4844/eip4844.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "consensus/misc/eip4844/eip4844_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "consensus/misc/gaslimit.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "console/bridge.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "console/console.go": {
+   "extra": 0,
+   "matched": 28,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 28,
+   "ours": 28,
+   "regions": 0
+  },
+  "console/console_test.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "console/prompt/prompter.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "core/bench_test.go": {
+   "extra": 0,
+   "matched": 38,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 38,
+   "ours": 38,
+   "regions": 0
+  },
+  "core/bintrie_witness_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "core/block_validator.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/block_validator_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "core/blockchain.go": {
+   "extra": 0,
+   "matched": 122,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 122,
+   "ours": 122,
+   "regions": 0
+  },
+  "core/blockchain_insert.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "core/blockchain_reader.go": {
+   "extra": 0,
+   "matched": 60,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 60,
+   "ours": 60,
+   "regions": 0
+  },
+  "core/blockchain_repair_test.go": {
+   "extra": 0,
+   "matched": 112,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 112,
+   "ours": 112,
+   "regions": 0
+  },
+  "core/blockchain_sethead_test.go": {
+   "extra": 0,
+   "matched": 115,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 115,
+   "ours": 115,
+   "regions": 0
+  },
+  "core/blockchain_snapshot_test.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "core/blockchain_stats.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "core/blockchain_test.go": {
+   "extra": 0,
+   "matched": 135,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 135,
+   "ours": 135,
+   "regions": 0
+  },
+  "core/chain_makers.go": {
+   "extra": 0,
+   "matched": 46,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 46,
+   "ours": 46,
+   "regions": 0
+  },
+  "core/chain_makers_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "core/dao_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/eip2780_test.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "core/eip7708_test.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "core/eip7928_test.go": {
+   "extra": 0,
+   "matched": 91,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 91,
+   "ours": 91,
+   "regions": 0
+  },
+  "core/eip8037_test.go": {
+   "extra": 0,
+   "matched": 66,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 66,
+   "ours": 66,
+   "regions": 0
+  },
+  "core/eip8038_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "core/eip8246_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/error.go": {
+   "extra": 0,
+   "matched": 32,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 32,
+   "ours": 32,
+   "regions": 0
+  },
+  "core/eth_transfer_logs_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/events.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/evm.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "core/filtermaps/chain_view.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "core/filtermaps/checkpoints.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "core/filtermaps/filtermaps.go": {
+   "extra": 0,
+   "matched": 53,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 53,
+   "ours": 53,
+   "regions": 0
+  },
+  "core/filtermaps/indexer.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "core/filtermaps/indexer_test.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "core/filtermaps/map_renderer.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "core/filtermaps/matcher.go": {
+   "extra": 0,
+   "matched": 49,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 49,
+   "ours": 49,
+   "regions": 0
+  },
+  "core/filtermaps/matcher_backend.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "core/filtermaps/matcher_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/filtermaps/math.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "core/filtermaps/math_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "core/forkid/forkid.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "core/forkid/forkid_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "core/gaspool.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "core/gen_genesis.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/genesis.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "core/genesis_alloc.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "core/genesis_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "core/headerchain.go": {
+   "extra": 0,
+   "matched": 29,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 29,
+   "ours": 29,
+   "regions": 0
+  },
+  "core/headerchain_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/history/historymode.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "core/history/historymode_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/jumpdest.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "core/mkalloc.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "core/overlay/state_transition.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/rawdb/accessors_chain.go": {
+   "extra": 0,
+   "matched": 75,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 75,
+   "ours": 75,
+   "regions": 0
+  },
+  "core/rawdb/accessors_chain_test.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "core/rawdb/accessors_history.go": {
+   "extra": 0,
+   "matched": 28,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 28,
+   "ours": 28,
+   "regions": 0
+  },
+  "core/rawdb/accessors_indexes.go": {
+   "extra": 0,
+   "matched": 34,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 34,
+   "ours": 34,
+   "regions": 0
+  },
+  "core/rawdb/accessors_indexes_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "core/rawdb/accessors_metadata.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "core/rawdb/accessors_overlay.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "core/rawdb/accessors_snapshot.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "core/rawdb/accessors_state.go": {
+   "extra": 0,
+   "matched": 29,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 29,
+   "ours": 29,
+   "regions": 0
+  },
+  "core/rawdb/accessors_sync.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "core/rawdb/accessors_trie.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "core/rawdb/ancient_scheme.go": {
+   "extra": 0,
+   "matched": 29,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 29,
+   "ours": 29,
+   "regions": 0
+  },
+  "core/rawdb/ancient_utils.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "core/rawdb/ancienttest/testsuite.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "core/rawdb/chain_freezer.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "core/rawdb/chain_iterator.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "core/rawdb/chain_iterator_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/rawdb/database.go": {
+   "extra": 0,
+   "matched": 42,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 42,
+   "ours": 42,
+   "regions": 0
+  },
+  "core/rawdb/eradb/eradb.go": {
+   "extra": 0,
+   "matched": 21,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 21,
+   "ours": 21,
+   "regions": 0
+  },
+  "core/rawdb/eradb/eradb_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "core/rawdb/freezer.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "core/rawdb/freezer_batch.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "core/rawdb/freezer_memory.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "core/rawdb/freezer_memory_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/rawdb/freezer_meta.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "core/rawdb/freezer_meta_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/rawdb/freezer_resettable.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "core/rawdb/freezer_resettable_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "core/rawdb/freezer_table.go": {
+   "extra": 0,
+   "matched": 38,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 38,
+   "ours": 38,
+   "regions": 0
+  },
+  "core/rawdb/freezer_table_test.go": {
+   "extra": 0,
+   "matched": 43,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 43,
+   "ours": 43,
+   "regions": 0
+  },
+  "core/rawdb/freezer_test.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "core/rawdb/freezer_utils.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "core/rawdb/freezer_utils_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/rawdb/freezer_utils_unix.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/rawdb/freezer_utils_windows.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/rawdb/key_length_iterator.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/rawdb/key_length_iterator_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/rawdb/schema.go": {
+   "extra": 0,
+   "matched": 102,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 102,
+   "ours": 102,
+   "regions": 0
+  },
+  "core/rawdb/table.go": {
+   "extra": 0,
+   "matched": 38,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 38,
+   "ours": 38,
+   "regions": 0
+  },
+  "core/rawdb/table_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "core/rlp_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "core/sender_cacher.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "core/state/access_events.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "core/state/access_events_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "core/state/access_list.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "core/state/database.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "core/state/database_code.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "core/state/database_history.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "core/state/database_iterator.go": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "core/state/database_iterator_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "core/state/database_mpt.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "core/state/database_ubt.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "core/state/dump.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "core/state/iterator.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/state/iterator_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/state/journal.go": {
+   "extra": 0,
+   "matched": 54,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 54,
+   "ours": 54,
+   "regions": 0
+  },
+  "core/state/journal_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/state/metrics.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "core/state/pruner/bloom.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "core/state/pruner/pruner.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "core/state/reader.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "core/state/reader_eip_7928.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "core/state/reader_eip_7928_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "core/state/reader_stater.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "core/state/snapshot/context.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "core/state/snapshot/conversion.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "core/state/snapshot/difflayer.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "core/state/snapshot/difflayer_test.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "core/state/snapshot/disklayer.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "core/state/snapshot/disklayer_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "core/state/snapshot/generate.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "core/state/snapshot/generate_test.go": {
+   "extra": 0,
+   "matched": 48,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 48,
+   "ours": 48,
+   "regions": 0
+  },
+  "core/state/snapshot/holdable_iterator.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "core/state/snapshot/holdable_iterator_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "core/state/snapshot/iterator.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "core/state/snapshot/iterator_binary.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "core/state/snapshot/iterator_fast.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "core/state/snapshot/iterator_test.go": {
+   "extra": 0,
+   "matched": 34,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 34,
+   "ours": 34,
+   "regions": 0
+  },
+  "core/state/snapshot/journal.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "core/state/snapshot/metrics.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "core/state/snapshot/snapshot.go": {
+   "extra": 0,
+   "matched": 61,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 61,
+   "ours": 61,
+   "regions": 0
+  },
+  "core/state/snapshot/snapshot_test.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "core/state/snapshot/utils.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "core/state/state_object.go": {
+   "extra": 0,
+   "matched": 35,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 35,
+   "ours": 35,
+   "regions": 0
+  },
+  "core/state/state_object_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/state/state_test.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "core/state/statedb.go": {
+   "extra": 0,
+   "matched": 84,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 84,
+   "ours": 84,
+   "regions": 0
+  },
+  "core/state/statedb_eip_7928.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "core/state/statedb_eip_7928_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "core/state/statedb_fuzz_test.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "core/state/statedb_hooked.go": {
+   "extra": 0,
+   "matched": 40,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 40,
+   "ours": 40,
+   "regions": 0
+  },
+  "core/state/statedb_hooked_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/state/statedb_test.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "core/state/stateupdate.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "core/state/sync.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/state/sync_test.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "core/state/transient_storage.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "core/state/trie_prefetcher.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "core/state/trie_prefetcher_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/state_prefetcher.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/state_processor.go": {
+   "extra": 0,
+   "matched": 21,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 21,
+   "ours": 21,
+   "regions": 0
+  },
+  "core/state_processor_parallel.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "core/state_processor_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/state_transition.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "core/state_transition_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "core/stateless.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/stateless/database.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/stateless/encoding.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/stateless/encoding_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "core/stateless/stats.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "core/stateless/stats_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "core/stateless/witness.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "core/tracing/gen_balance_change_reason_stringer.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "core/tracing/gen_code_change_reason_stringer.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "core/tracing/gen_gas_change_reason_stringer.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/tracing/gen_nonce_change_reason_stringer.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "core/tracing/hooks.go": {
+   "extra": 0,
+   "matched": 99,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 99,
+   "ours": 99,
+   "regions": 0
+  },
+  "core/tracing/journal.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "core/tracing/journal_test.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "core/txindexer.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "core/txindexer_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "core/txpool/blobpool/blobpool.go": {
+   "extra": 0,
+   "matched": 70,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 70,
+   "ours": 70,
+   "regions": 0
+  },
+  "core/txpool/blobpool/blobpool_test.go": {
+   "extra": 0,
+   "matched": 48,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 48,
+   "ours": 48,
+   "regions": 0
+  },
+  "core/txpool/blobpool/buffer.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "core/txpool/blobpool/buffer_test.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "core/txpool/blobpool/cache.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "core/txpool/blobpool/cache_test.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "core/txpool/blobpool/config.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/txpool/blobpool/conversion.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "core/txpool/blobpool/conversion_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "core/txpool/blobpool/evictheap.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "core/txpool/blobpool/evictheap_test.go": {
+   "extra": 0,
+   "matched": 21,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 21,
+   "ours": 21,
+   "regions": 0
+  },
+  "core/txpool/blobpool/interface.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/txpool/blobpool/limbo.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "core/txpool/blobpool/limbo_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/txpool/blobpool/lookup.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "core/txpool/blobpool/metrics.go": {
+   "extra": 0,
+   "matched": 54,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 54,
+   "ours": 54,
+   "regions": 0
+  },
+  "core/txpool/blobpool/priority.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "core/txpool/blobpool/priority_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/txpool/blobpool/slotter.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/txpool/blobpool/slotter_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/txpool/errors.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "core/txpool/legacypool/legacypool.go": {
+   "extra": 0,
+   "matched": 101,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 101,
+   "ours": 101,
+   "regions": 2
+  },
+  "core/txpool/legacypool/legacypool2_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "core/txpool/legacypool/legacypool_test.go": {
+   "extra": 0,
+   "matched": 82,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 82,
+   "ours": 82,
+   "regions": 0
+  },
+  "core/txpool/legacypool/list.go": {
+   "extra": 0,
+   "matched": 38,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 38,
+   "ours": 38,
+   "regions": 2
+  },
+  "core/txpool/legacypool/list_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/txpool/legacypool/noncer.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "core/txpool/legacypool/queue.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "core/txpool/locals/errors.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/txpool/locals/journal.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "core/txpool/locals/tx_tracker.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "core/txpool/locals/tx_tracker_test.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "core/txpool/reserver.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "core/txpool/subpool.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "core/txpool/txorder/ordering.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 1
+  },
+  "core/txpool/txorder/ordering_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "core/txpool/txpool.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "core/txpool/validation.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "core/txpool/validation_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "core/types.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "core/types/account.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "core/types/bal/bal.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "core/types/bal/bal_encoding.go": {
+   "extra": 0,
+   "matched": 26,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 26,
+   "ours": 26,
+   "regions": 0
+  },
+  "core/types/bal/bal_encoding_rlp_generated.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "core/types/bal/bal_lookup.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "core/types/bal/bal_test.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "core/types/bal/gen_account_access_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/types/bal/gen_encoding_account_nonce_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/types/bal/gen_encoding_balance_change_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/types/bal/gen_encoding_code_change_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/types/bal/gen_encoding_slot_changes_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/types/bal/gen_encoding_storage_write_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/types/block.go": {
+   "extra": 0,
+   "matched": 59,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 59,
+   "ours": 59,
+   "regions": 0
+  },
+  "core/types/block_test.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "core/types/bloom9.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "core/types/bloom9_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/types/custody_bitmap.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "core/types/deposit.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "core/types/deposit_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/types/gen_access_tuple.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "core/types/gen_account.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/types/gen_account_rlp.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/types/gen_authorization.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/types/gen_header_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/types/gen_header_rlp.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/types/gen_log_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/types/gen_log_rlp.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/types/gen_receipt_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/types/gen_withdrawal_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/types/gen_withdrawal_rlp.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/types/hashes.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "core/types/hashing.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "core/types/hashing_test.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "core/types/log.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/types/log_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/types/receipt.go": {
+   "extra": 0,
+   "matched": 29,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 29,
+   "ours": 29,
+   "regions": 0
+  },
+  "core/types/receipt_test.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "core/types/rlp_fuzzer_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/types/state_account.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "core/types/transaction.go": {
+   "extra": 0,
+   "matched": 73,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 73,
+   "ours": 73,
+   "regions": 0
+  },
+  "core/types/transaction_marshalling.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "core/types/transaction_signing.go": {
+   "extra": 0,
+   "matched": 32,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 32,
+   "ours": 32,
+   "regions": 0
+  },
+  "core/types/transaction_signing_test.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "core/types/transaction_test.go": {
+   "extra": 0,
+   "matched": 28,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 28,
+   "ours": 28,
+   "regions": 0
+  },
+  "core/types/tx_access_list.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "core/types/tx_blob.go": {
+   "extra": 0,
+   "matched": 38,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 38,
+   "ours": 38,
+   "regions": 0
+  },
+  "core/types/tx_blob_test.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "core/types/tx_dynamic_fee.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "core/types/tx_legacy.go": {
+   "extra": 0,
+   "matched": 21,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 21,
+   "ours": 21,
+   "regions": 0
+  },
+  "core/types/tx_setcode.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "core/types/tx_setcode_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/types/types_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/types/withdrawal.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "core/vm/analysis_legacy.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "core/vm/analysis_legacy_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/vm/common.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "core/vm/contract.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "core/vm/contracts.go": {
+   "extra": 0,
+   "matched": 91,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 91,
+   "ours": 91,
+   "regions": 0
+  },
+  "core/vm/contracts_fuzz_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/vm/contracts_test.go": {
+   "extra": 0,
+   "matched": 65,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 65,
+   "ours": 65,
+   "regions": 0
+  },
+  "core/vm/doc.go": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "core/vm/eip7610.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/vm/eip7610_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/vm/eip8037_test.go": {
+   "extra": 0,
+   "matched": 64,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 64,
+   "ours": 64,
+   "regions": 0
+  },
+  "core/vm/eip8038_test.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "core/vm/eips.go": {
+   "extra": 0,
+   "matched": 37,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 37,
+   "ours": 37,
+   "regions": 0
+  },
+  "core/vm/errors.go": {
+   "extra": 0,
+   "matched": 43,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 43,
+   "ours": 43,
+   "regions": 0
+  },
+  "core/vm/evm.go": {
+   "extra": 0,
+   "matched": 34,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 34,
+   "ours": 34,
+   "regions": 0
+  },
+  "core/vm/gas.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "core/vm/gas_table.go": {
+   "extra": 0,
+   "matched": 40,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 40,
+   "ours": 40,
+   "regions": 0
+  },
+  "core/vm/gas_table_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/vm/gascosts.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "core/vm/instructions.go": {
+   "extra": 0,
+   "matched": 99,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 99,
+   "ours": 99,
+   "regions": 0
+  },
+  "core/vm/instructions_test.go": {
+   "extra": 0,
+   "matched": 58,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 58,
+   "ours": 58,
+   "regions": 0
+  },
+  "core/vm/interface.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/vm/interpreter.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "core/vm/interpreter_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/vm/jump_table.go": {
+   "extra": 0,
+   "matched": 44,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 44,
+   "ours": 44,
+   "regions": 0
+  },
+  "core/vm/jump_table_export.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "core/vm/jump_table_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/vm/jumpdests.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/vm/memory.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "core/vm/memory_table.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "core/vm/memory_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "core/vm/opcodes.go": {
+   "extra": 0,
+   "matched": 178,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 178,
+   "ours": 178,
+   "regions": 0
+  },
+  "core/vm/operations_acl.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "core/vm/operations_verkle.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "core/vm/precompile_cache.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "core/vm/precompile_cache_test.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "core/vm/program/program.go": {
+   "extra": 0,
+   "matched": 33,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 33,
+   "ours": 33,
+   "regions": 0
+  },
+  "core/vm/program/program_test.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "core/vm/runtime/doc.go": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "core/vm/runtime/env.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/vm/runtime/runtime.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "core/vm/runtime/runtime_example_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/vm/runtime/runtime_fuzz_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "core/vm/runtime/runtime_test.go": {
+   "extra": 0,
+   "matched": 33,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 33,
+   "ours": 33,
+   "regions": 0
+  },
+  "core/vm/stack.go": {
+   "extra": 0,
+   "matched": 40,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 40,
+   "ours": 40,
+   "regions": 0
+  },
+  "core/vm/stack_table.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "crypto/blake2b/blake2b.go": {
+   "extra": 0,
+   "matched": 34,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 34,
+   "ours": 34,
+   "regions": 0
+  },
+  "crypto/blake2b/blake2bAVX2_amd64.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "crypto/blake2b/blake2b_amd64.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "crypto/blake2b/blake2b_f_fuzz_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "crypto/blake2b/blake2b_f_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "crypto/blake2b/blake2b_generic.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "crypto/blake2b/blake2b_ref.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "crypto/blake2b/blake2b_test.go": {
+   "extra": 0,
+   "matched": 29,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 29,
+   "ours": 29,
+   "regions": 0
+  },
+  "crypto/blake2b/blake2x.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "crypto/blake2b/register.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "crypto/bn256/bn256_fast.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "crypto/bn256/bn256_slow.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/bn256.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/bn256_test.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/constants.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/curve.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/example_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/gfp.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/gfp12.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/gfp2.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/gfp6.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/gfp_decl.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/gfp_generic.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/gfp_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/lattice.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/lattice_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/main_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/optate.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "crypto/bn256/cloudflare/twist.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "crypto/bn256/gnark/g1.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "crypto/bn256/gnark/g2.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "crypto/bn256/gnark/gt.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "crypto/bn256/gnark/native_format_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "crypto/bn256/gnark/pairing.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "crypto/bn256/google/bn256.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "crypto/bn256/google/bn256_test.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "crypto/bn256/google/constants.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "crypto/bn256/google/curve.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "crypto/bn256/google/example_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "crypto/bn256/google/gfp12.go": {
+   "extra": 0,
+   "matched": 21,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 21,
+   "ours": 21,
+   "regions": 0
+  },
+  "crypto/bn256/google/gfp2.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "crypto/bn256/google/gfp6.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "crypto/bn256/google/main_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "crypto/bn256/google/optate.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "crypto/bn256/google/twist.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "crypto/crypto.go": {
+   "extra": 0,
+   "matched": 26,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 26,
+   "ours": 26,
+   "regions": 0
+  },
+  "crypto/crypto_test.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "crypto/ecies/ecies.go": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "crypto/ecies/ecies_test.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "crypto/ecies/params.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "crypto/keccak.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "crypto/keccak/hashes.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "crypto/keccak/keccakf.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "crypto/keccak/keccakf_amd64.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "crypto/keccak/sha3.go": {
+   "extra": 0,
+   "matched": 21,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 21,
+   "ours": 21,
+   "regions": 0
+  },
+  "crypto/keccak/sha3_test.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "crypto/keccak_ziren.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "crypto/kzg4844/kzg4844.go": {
+   "extra": 0,
+   "matched": 34,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 34,
+   "ours": 34,
+   "regions": 0
+  },
+  "crypto/kzg4844/kzg4844_ckzg_cgo.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "crypto/kzg4844/kzg4844_ckzg_nocgo.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "crypto/kzg4844/kzg4844_gokzg.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "crypto/kzg4844/kzg4844_test.go": {
+   "extra": 0,
+   "matched": 54,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 54,
+   "ours": 54,
+   "regions": 0
+  },
+  "crypto/secp256k1/curve.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "crypto/secp256k1/dummy.go": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "crypto/secp256k1/libsecp256k1/contrib/dummy.go": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "crypto/secp256k1/libsecp256k1/dummy.go": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "crypto/secp256k1/libsecp256k1/include/dummy.go": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "crypto/secp256k1/libsecp256k1/src/dummy.go": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "crypto/secp256k1/libsecp256k1/src/modules/dummy.go": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "crypto/secp256k1/libsecp256k1/src/modules/ecdh/dummy.go": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "crypto/secp256k1/libsecp256k1/src/modules/recovery/dummy.go": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "crypto/secp256k1/panic_cb.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "crypto/secp256k1/scalar_mult_cgo.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "crypto/secp256k1/scalar_mult_nocgo.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "crypto/secp256k1/secp256.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "crypto/secp256k1/secp256_test.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "crypto/secp256r1/verifier.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "crypto/signature_cgo.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "crypto/signature_nocgo.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "crypto/signature_test.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "crypto/signify/signify.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "crypto/signify/signify_fuzz.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "crypto/signify/signify_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "eth/api_admin.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "eth/api_backend.go": {
+   "extra": 0,
+   "matched": 56,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 56,
+   "ours": 56,
+   "regions": 0
+  },
+  "eth/api_backend_test.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "eth/api_debug.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "eth/api_debug_replay.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "eth/api_debug_test.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "eth/api_miner.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "eth/backend.go": {
+   "extra": 0,
+   "matched": 30,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 30,
+   "ours": 30,
+   "regions": 0
+  },
+  "eth/catalyst/api.go": {
+   "extra": 0,
+   "matched": 56,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 56,
+   "ours": 56,
+   "regions": 0
+  },
+  "eth/catalyst/api_benchmark_test.go": {
+   "extra": 0,
+   "matched": 36,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 36,
+   "ours": 36,
+   "regions": 0
+  },
+  "eth/catalyst/api_forks_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "eth/catalyst/api_test.go": {
+   "extra": 0,
+   "matched": 61,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 61,
+   "ours": 61,
+   "regions": 0
+  },
+  "eth/catalyst/api_testing.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "eth/catalyst/api_testing_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "eth/catalyst/metrics.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "eth/catalyst/queue.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "eth/catalyst/simulated_beacon.go": {
+   "extra": 0,
+   "matched": 21,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 21,
+   "ours": 21,
+   "regions": 0
+  },
+  "eth/catalyst/simulated_beacon_api.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "eth/catalyst/simulated_beacon_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "eth/catalyst/witness.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "eth/catalyst/witness_fork_test.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "eth/downloader/api.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "eth/downloader/beacondevsync.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "eth/downloader/beaconsync.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "eth/downloader/downloader.go": {
+   "extra": 0,
+   "matched": 60,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 60,
+   "ours": 60,
+   "regions": 0
+  },
+  "eth/downloader/downloader_test.go": {
+   "extra": 0,
+   "matched": 57,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 57,
+   "ours": 57,
+   "regions": 0
+  },
+  "eth/downloader/events.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "eth/downloader/fetchers.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "eth/downloader/fetchers_concurrent.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "eth/downloader/fetchers_concurrent_bals.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "eth/downloader/fetchers_concurrent_bodies.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "eth/downloader/fetchers_concurrent_receipts.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "eth/downloader/metrics.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "eth/downloader/peer.go": {
+   "extra": 0,
+   "matched": 30,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 30,
+   "ours": 30,
+   "regions": 0
+  },
+  "eth/downloader/queue.go": {
+   "extra": 0,
+   "matched": 54,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 54,
+   "ours": 54,
+   "regions": 2
+  },
+  "eth/downloader/queue_test.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "eth/downloader/resultstore.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "eth/downloader/skeleton.go": {
+   "extra": 0,
+   "matched": 38,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 38,
+   "ours": 38,
+   "regions": 0
+  },
+  "eth/downloader/skeleton_test.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "eth/downloader/statesync.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "eth/downloader/syncmode.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "eth/downloader/testchain_test.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "eth/dropper.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "eth/dropper_test.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "eth/ethconfig/config.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "eth/ethconfig/gen_config.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "eth/ethconfig/syncmode.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "eth/fetcher/blob_fetcher.go": {
+   "extra": 0,
+   "matched": 34,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 34,
+   "ours": 34,
+   "regions": 0
+  },
+  "eth/fetcher/blob_fetcher_test.go": {
+   "extra": 0,
+   "matched": 36,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 36,
+   "ours": 36,
+   "regions": 0
+  },
+  "eth/fetcher/metrics.go": {
+   "extra": 0,
+   "matched": 41,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 41,
+   "ours": 41,
+   "regions": 0
+  },
+  "eth/fetcher/tx_fetcher.go": {
+   "extra": 0,
+   "matched": 38,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 38,
+   "ours": 38,
+   "regions": 0
+  },
+  "eth/fetcher/tx_fetcher_test.go": {
+   "extra": 0,
+   "matched": 50,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 50,
+   "ours": 50,
+   "regions": 0
+  },
+  "eth/filters/api.go": {
+   "extra": 0,
+   "matched": 39,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 39,
+   "ours": 39,
+   "regions": 0
+  },
+  "eth/filters/api_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "eth/filters/filter.go": {
+   "extra": 0,
+   "matched": 28,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 28,
+   "ours": 28,
+   "regions": 0
+  },
+  "eth/filters/filter_system.go": {
+   "extra": 0,
+   "matched": 36,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 36,
+   "ours": 36,
+   "regions": 0
+  },
+  "eth/filters/filter_system_test.go": {
+   "extra": 0,
+   "matched": 36,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 36,
+   "ours": 36,
+   "regions": 0
+  },
+  "eth/filters/filter_test.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "eth/gasestimator/gasestimator.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "eth/gasprice/feehistory.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "eth/gasprice/feehistory_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "eth/gasprice/gasprice.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "eth/gasprice/gasprice_test.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "eth/handler.go": {
+   "extra": 0,
+   "matched": 35,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 35,
+   "ours": 35,
+   "regions": 1
+  },
+  "eth/handler_eth.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 1
+  },
+  "eth/handler_eth_test.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 1
+  },
+  "eth/handler_snap.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 1
+  },
+  "eth/handler_test.go": {
+   "extra": 0,
+   "matched": 29,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 29,
+   "ours": 29,
+   "regions": 0
+  },
+  "eth/peer.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "eth/peerset.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "eth/protocols/eth/broadcast.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "eth/protocols/eth/discovery.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "eth/protocols/eth/dispatcher.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "eth/protocols/eth/handler.go": {
+   "extra": 0,
+   "matched": 21,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 21,
+   "ours": 21,
+   "regions": 0
+  },
+  "eth/protocols/eth/handler_test.go": {
+   "extra": 0,
+   "matched": 37,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 37,
+   "ours": 37,
+   "regions": 1
+  },
+  "eth/protocols/eth/handlers.go": {
+   "extra": 0,
+   "matched": 35,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 35,
+   "ours": 35,
+   "regions": 0
+  },
+  "eth/protocols/eth/handshake.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "eth/protocols/eth/handshake_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "eth/protocols/eth/metrics.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "eth/protocols/eth/peer.go": {
+   "extra": 0,
+   "matched": 41,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 41,
+   "ours": 41,
+   "regions": 0
+  },
+  "eth/protocols/eth/peer_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "eth/protocols/eth/protocol.go": {
+   "extra": 0,
+   "matched": 80,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 80,
+   "ours": 80,
+   "regions": 0
+  },
+  "eth/protocols/eth/protocol_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "eth/protocols/eth/receipt.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "eth/protocols/eth/receipt_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "eth/protocols/snap/bal_apply.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "eth/protocols/snap/bal_apply_test.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "eth/protocols/snap/discovery.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "eth/protocols/snap/gentrie.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "eth/protocols/snap/gentrie_test.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "eth/protocols/snap/handler.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "eth/protocols/snap/handler_fuzzing_test.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 1
+  },
+  "eth/protocols/snap/handler_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "eth/protocols/snap/handlers.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "eth/protocols/snap/metrics.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "eth/protocols/snap/peer.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "eth/protocols/snap/progress_test.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "eth/protocols/snap/protocol.go": {
+   "extra": 0,
+   "matched": 41,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 41,
+   "ours": 41,
+   "regions": 0
+  },
+  "eth/protocols/snap/range.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "eth/protocols/snap/range_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "eth/protocols/snap/sort_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "eth/protocols/snap/sync.go": {
+   "extra": 0,
+   "matched": 82,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 82,
+   "ours": 82,
+   "regions": 0
+  },
+  "eth/protocols/snap/sync_test.go": {
+   "extra": 0,
+   "matched": 95,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 95,
+   "ours": 95,
+   "regions": 1
+  },
+  "eth/protocols/snap/syncer.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "eth/protocols/snap/syncv2.go": {
+   "extra": 0,
+   "matched": 79,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 79,
+   "ours": 79,
+   "regions": 0
+  },
+  "eth/protocols/snap/syncv2_test.go": {
+   "extra": 0,
+   "matched": 129,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 129,
+   "ours": 129,
+   "regions": 0
+  },
+  "eth/state_accessor.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "eth/sync.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "eth/sync_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "eth/syncer/syncer.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "eth/tracers/api.go": {
+   "extra": 0,
+   "matched": 38,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 38,
+   "ours": 38,
+   "regions": 0
+  },
+  "eth/tracers/api_test.go": {
+   "extra": 0,
+   "matched": 41,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 41,
+   "ours": 41,
+   "regions": 0
+  },
+  "eth/tracers/dir.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "eth/tracers/internal/tracetest/calltrace_test.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "eth/tracers/internal/tracetest/erc7562_tracer_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "eth/tracers/internal/tracetest/flat_calltrace_test.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "eth/tracers/internal/tracetest/prestate_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "eth/tracers/internal/tracetest/selfdestruct_state_test.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "eth/tracers/internal/tracetest/supply_test.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "eth/tracers/internal/tracetest/util.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "eth/tracers/internal/util.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "eth/tracers/internal/util_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "eth/tracers/js/bigint.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "eth/tracers/js/goja.go": {
+   "extra": 0,
+   "matched": 65,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 65,
+   "ours": 65,
+   "regions": 0
+  },
+  "eth/tracers/js/internal/tracers/tracers.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "eth/tracers/js/tracer_test.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "eth/tracers/live.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "eth/tracers/live/gen_supplyinfoburn.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "eth/tracers/live/gen_supplyinfoissuance.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "eth/tracers/live/noop.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "eth/tracers/live/supply.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "eth/tracers/logger/access_list_tracer.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "eth/tracers/logger/access_list_tracer_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "eth/tracers/logger/gen_callframe.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "eth/tracers/logger/gen_structlog.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "eth/tracers/logger/logger.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "eth/tracers/logger/logger_json.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "eth/tracers/logger/logger_test.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "eth/tracers/native/4byte.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "eth/tracers/native/call.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "eth/tracers/native/call_flat.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "eth/tracers/native/call_flat_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "eth/tracers/native/erc7562.go": {
+   "extra": 0,
+   "matched": 37,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 37,
+   "ours": 37,
+   "regions": 0
+  },
+  "eth/tracers/native/gen_account_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "eth/tracers/native/gen_callframe_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "eth/tracers/native/gen_callframewithopcodes_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "eth/tracers/native/gen_flatcallaction_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "eth/tracers/native/gen_flatcallresult_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "eth/tracers/native/keccak256_preimage.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "eth/tracers/native/keccak256_preimage_test.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "eth/tracers/native/mux.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "eth/tracers/native/mux_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "eth/tracers/native/noop.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "eth/tracers/native/opcode_counter.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "eth/tracers/native/prestate.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "eth/tracers/native/tracer_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "eth/tracers/tracers_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "eth/tracers/tracker.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "eth/tracers/tracker_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "eth/txtracker/tracker.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "eth/txtracker/tracker_test.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "ethclient/ethclient.go": {
+   "extra": 0,
+   "matched": 71,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 71,
+   "ours": 71,
+   "regions": 1
+  },
+  "ethclient/ethclient_test.go": {
+   "extra": 0,
+   "matched": 33,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 33,
+   "ours": 33,
+   "regions": 0
+  },
+  "ethclient/example_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "ethclient/gen_simulate_block_result.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "ethclient/gen_simulate_call_result.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "ethclient/gethclient/gen_callframe_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "ethclient/gethclient/gen_calllog_json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "ethclient/gethclient/gethclient.go": {
+   "extra": 0,
+   "matched": 29,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 29,
+   "ours": 29,
+   "regions": 2
+  },
+  "ethclient/gethclient/gethclient_test.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "ethclient/signer.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "ethclient/simulated/backend.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "ethclient/simulated/backend_test.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "ethclient/simulated/options.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "ethclient/simulated/options_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "ethclient/simulated/rollback_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "ethclient/types_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "ethdb/batch.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "ethdb/database.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "ethdb/dbtest/testsuite.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "ethdb/iterator.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "ethdb/leveldb/leveldb.go": {
+   "extra": 0,
+   "matched": 29,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 29,
+   "ours": 29,
+   "regions": 0
+  },
+  "ethdb/leveldb/leveldb_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "ethdb/memorydb/memorydb.go": {
+   "extra": 0,
+   "matched": 30,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 30,
+   "ours": 30,
+   "regions": 0
+  },
+  "ethdb/memorydb/memorydb_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "ethdb/pebble/pebble.go": {
+   "extra": 0,
+   "matched": 40,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 40,
+   "ours": 40,
+   "regions": 0
+  },
+  "ethdb/pebble/pebble_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "ethdb/pebble/pebble_v1.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "ethdb/pebble/version.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "ethdb/pebble/version_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "ethdb/remotedb/remotedb.go": {
+   "extra": 0,
+   "matched": 26,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 26,
+   "ours": 26,
+   "regions": 0
+  },
+  "ethstats/ethstats.go": {
+   "extra": 0,
+   "matched": 36,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 36,
+   "ours": 36,
+   "regions": 0
+  },
+  "ethstats/ethstats_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "event/event.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "event/event_test.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "event/example_feed_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "event/example_scope_test.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "event/example_subscription_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "event/example_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "event/feed.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "event/feed_test.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "event/feedof.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "event/feedof_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "event/multisub.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "event/multisub_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "event/subscription.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "event/subscription_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "graphql/graphiql.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "graphql/graphql.go": {
+   "extra": 0,
+   "matched": 120,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 120,
+   "ours": 120,
+   "regions": 0
+  },
+  "graphql/graphql_test.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "graphql/internal/graphiql/build.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "graphql/schema.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "graphql/service.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "interfaces.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "internal/blocktest/test_hash.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "internal/build/archive.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "internal/build/azure.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "internal/build/env.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "internal/build/file.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "internal/build/gotool.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "internal/build/pgp.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "internal/build/util.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "internal/cmdtest/test_cmd.go": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "internal/debug/api.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "internal/debug/flags.go": {
+   "extra": 0,
+   "matched": 26,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 26,
+   "ours": 26,
+   "regions": 0
+  },
+  "internal/debug/loudpanic.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "internal/debug/pyroscope.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "internal/debug/trace.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "internal/download/download.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "internal/era/accumulator.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "internal/era/e2store/e2store.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "internal/era/e2store/e2store_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "internal/era/era.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "internal/era/eradl/eradl.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "internal/era/execdb/builder.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "internal/era/execdb/era_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "internal/era/execdb/iterator.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "internal/era/execdb/reader.go": {
+   "extra": 0,
+   "matched": 34,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 34,
+   "ours": 34,
+   "regions": 0
+  },
+  "internal/era/onedb/builder.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "internal/era/onedb/builder_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "internal/era/onedb/iterator.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "internal/era/onedb/reader.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "internal/era/proof.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "internal/ethapi/addrlock.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "internal/ethapi/api.go": {
+   "extra": 0,
+   "matched": 118,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 118,
+   "ours": 118,
+   "regions": 4
+  },
+  "internal/ethapi/api_test.go": {
+   "extra": 0,
+   "matched": 98,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 98,
+   "ours": 98,
+   "regions": 0
+  },
+  "internal/ethapi/backend.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "internal/ethapi/capabilities.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "internal/ethapi/capabilities_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "internal/ethapi/dbapi.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "internal/ethapi/errors.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 3
+  },
+  "internal/ethapi/logtracer.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "internal/ethapi/override/override.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "internal/ethapi/override/override_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "internal/ethapi/simulate.go": {
+   "extra": 0,
+   "matched": 33,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 33,
+   "ours": 33,
+   "regions": 0
+  },
+  "internal/ethapi/simulate_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "internal/ethapi/transaction_args.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "internal/ethapi/transaction_args_test.go": {
+   "extra": 0,
+   "matched": 53,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 53,
+   "ours": 53,
+   "regions": 0
+  },
+  "internal/flags/categories.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "internal/flags/flags.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "internal/flags/flags_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "internal/flags/helpers.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "internal/guide/guide.go": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "internal/guide/guide_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "internal/jsre/completion.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "internal/jsre/completion_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "internal/jsre/deps/deps.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "internal/jsre/jsre.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "internal/jsre/jsre_test.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "internal/jsre/pretty.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "internal/memlimit/probe.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "internal/memlimit/probe_linux.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "internal/memlimit/probe_linux_test.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "internal/memlimit/probe_other.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "internal/memlimit/probe_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "internal/reexec/reexec.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "internal/reexec/self_linux.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "internal/reexec/self_others.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "internal/shutdowncheck/shutdown_tracker.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "internal/syncx/mutex.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "internal/tablewriter/database_tablewriter.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "internal/tablewriter/database_tablewriter_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "internal/telemetry/telemetry.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "internal/telemetry/telemetry_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "internal/telemetry/tracesetup/setup.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "internal/testlog/testlog.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "internal/testlog/testlog_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "internal/testrand/rand.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "internal/utesting/utesting.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "internal/utesting/utesting_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "internal/version/vcs.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "internal/version/version.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "internal/web3ext/web3ext.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "log/format.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "log/format_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "log/handler.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "log/handler_glog.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "log/logger.go": {
+   "extra": 0,
+   "matched": 35,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 35,
+   "ours": 35,
+   "regions": 0
+  },
+  "log/logger_test.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "log/root.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "log/root_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "metrics/config.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "metrics/counter.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "metrics/counter_float64.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "metrics/counter_float_64_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "metrics/counter_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "metrics/cpu.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "metrics/cpu_disabled.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "metrics/cpu_enabled.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "metrics/cputime_nop.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "metrics/cputime_unix.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "metrics/debug.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "metrics/debug_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "metrics/disk.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "metrics/disk_linux.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "metrics/disk_nop.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "metrics/ewma.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "metrics/ewma_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "metrics/exp/exp.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "metrics/gauge.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "metrics/gauge_float64.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "metrics/gauge_float64_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "metrics/gauge_info.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "metrics/gauge_info_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "metrics/gauge_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "metrics/healthcheck.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "metrics/histogram.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "metrics/histogram_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "metrics/influxdb/influxdb.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "metrics/influxdb/influxdb_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "metrics/influxdb/influxdbv1.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "metrics/influxdb/influxdbv2.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "metrics/init_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "metrics/internal/sampledata.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "metrics/internal/sampledata_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "metrics/json.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "metrics/json_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "metrics/log.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "metrics/meter.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "metrics/meter_test.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "metrics/metrics.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "metrics/metrics_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "metrics/opentsdb.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "metrics/opentsdb_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "metrics/prometheus/collector.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "metrics/prometheus/collector_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "metrics/prometheus/prometheus.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "metrics/registry.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 9
+  },
+  "metrics/registry_test.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "metrics/resetting_sample.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "metrics/resetting_timer.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "metrics/resetting_timer_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "metrics/runtimehistogram.go": {
+   "extra": 0,
+   "matched": 28,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 28,
+   "ours": 28,
+   "regions": 0
+  },
+  "metrics/runtimehistogram_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "metrics/sample.go": {
+   "extra": 0,
+   "matched": 36,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 36,
+   "ours": 36,
+   "regions": 0
+  },
+  "metrics/sample_test.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "metrics/syslog.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "metrics/timer.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "metrics/timer_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "metrics/writer.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "metrics/writer_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "miner/miner.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "miner/miner_test.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "miner/payload_building.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "miner/payload_building_test.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "miner/pending.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "miner/stress/main.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "miner/worker.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "node/api.go": {
+   "extra": 0,
+   "matched": 21,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 21,
+   "ours": 21,
+   "regions": 0
+  },
+  "node/api_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "node/config.go": {
+   "extra": 0,
+   "matched": 26,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 26,
+   "ours": 26,
+   "regions": 0
+  },
+  "node/config_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "node/database.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "node/defaults.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "node/doc.go": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "node/endpoints.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "node/errors.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "node/jwt_auth.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "node/jwt_handler.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "node/lifecycle.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "node/node.go": {
+   "extra": 0,
+   "matched": 46,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 46,
+   "ours": 46,
+   "regions": 0
+  },
+  "node/node_auth_test.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "node/node_example_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "node/node_test.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "node/rpcstack.go": {
+   "extra": 0,
+   "matched": 40,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 40,
+   "ours": 40,
+   "regions": 0
+  },
+  "node/rpcstack_test.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "node/utils_test.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "p2p/config.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "p2p/config_toml.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "p2p/dial.go": {
+   "extra": 0,
+   "matched": 53,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 53,
+   "ours": 53,
+   "regions": 0
+  },
+  "p2p/dial_test.go": {
+   "extra": 0,
+   "matched": 28,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 28,
+   "ours": 28,
+   "regions": 0
+  },
+  "p2p/discover/common.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "p2p/discover/lookup.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "p2p/discover/metrics.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "p2p/discover/node.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "p2p/discover/ntp.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "p2p/discover/table.go": {
+   "extra": 0,
+   "matched": 49,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 49,
+   "ours": 49,
+   "regions": 1
+  },
+  "p2p/discover/table_reval.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "p2p/discover/table_reval_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "p2p/discover/table_test.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 1
+  },
+  "p2p/discover/table_util_test.go": {
+   "extra": 0,
+   "matched": 35,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 35,
+   "ours": 35,
+   "regions": 0
+  },
+  "p2p/discover/v4_lookup_test.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "p2p/discover/v4_udp.go": {
+   "extra": 0,
+   "matched": 60,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 60,
+   "ours": 60,
+   "regions": 0
+  },
+  "p2p/discover/v4_udp_test.go": {
+   "extra": 0,
+   "matched": 35,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 35,
+   "ours": 35,
+   "regions": 0
+  },
+  "p2p/discover/v4wire/v4wire.go": {
+   "extra": 0,
+   "matched": 34,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 34,
+   "ours": 34,
+   "regions": 0
+  },
+  "p2p/discover/v4wire/v4wire_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "p2p/discover/v5_talk.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "p2p/discover/v5_udp.go": {
+   "extra": 0,
+   "matched": 62,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 62,
+   "ours": 62,
+   "regions": 0
+  },
+  "p2p/discover/v5_udp_test.go": {
+   "extra": 0,
+   "matched": 37,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 37,
+   "ours": 37,
+   "regions": 0
+  },
+  "p2p/discover/v5wire/crypto.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "p2p/discover/v5wire/crypto_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "p2p/discover/v5wire/encoding.go": {
+   "extra": 0,
+   "matched": 60,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 60,
+   "ours": 60,
+   "regions": 0
+  },
+  "p2p/discover/v5wire/encoding_test.go": {
+   "extra": 0,
+   "matched": 35,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 35,
+   "ours": 35,
+   "regions": 0
+  },
+  "p2p/discover/v5wire/msg.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 8
+  },
+  "p2p/discover/v5wire/session.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "p2p/dnsdisc/client.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "p2p/dnsdisc/client_test.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "p2p/dnsdisc/doc.go": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "p2p/dnsdisc/error.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "p2p/dnsdisc/sync.go": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "p2p/dnsdisc/sync_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "p2p/dnsdisc/tree.go": {
+   "extra": 0,
+   "matched": 41,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 41,
+   "ours": 41,
+   "regions": 0
+  },
+  "p2p/dnsdisc/tree_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "p2p/enode/idscheme.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "p2p/enode/idscheme_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "p2p/enode/iter.go": {
+   "extra": 0,
+   "matched": 29,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 29,
+   "ours": 29,
+   "regions": 0
+  },
+  "p2p/enode/iter_test.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "p2p/enode/localnode.go": {
+   "extra": 0,
+   "matched": 26,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 26,
+   "ours": 26,
+   "regions": 0
+  },
+  "p2p/enode/localnode_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "p2p/enode/node.go": {
+   "extra": 0,
+   "matched": 36,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 36,
+   "ours": 36,
+   "regions": 0
+  },
+  "p2p/enode/node_test.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "p2p/enode/nodedb.go": {
+   "extra": 0,
+   "matched": 52,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 52,
+   "ours": 52,
+   "regions": 0
+  },
+  "p2p/enode/nodedb_test.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "p2p/enode/urlv4.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "p2p/enode/urlv4_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "p2p/enr/enr.go": {
+   "extra": 0,
+   "matched": 30,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 30,
+   "ours": 30,
+   "regions": 1
+  },
+  "p2p/enr/enr_test.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "p2p/enr/entries.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "p2p/message.go": {
+   "extra": 0,
+   "matched": 21,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 21,
+   "ours": 21,
+   "regions": 0
+  },
+  "p2p/message_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "p2p/metrics.go": {
+   "extra": 0,
+   "matched": 37,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 37,
+   "ours": 37,
+   "regions": 0
+  },
+  "p2p/msgrate/msgrate.go": {
+   "extra": 0,
+   "matched": 28,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 28,
+   "ours": 28,
+   "regions": 0
+  },
+  "p2p/msgrate/msgrate_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "p2p/nat/nat.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "p2p/nat/nat_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "p2p/nat/natpmp.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "p2p/nat/natupnp.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "p2p/nat/natupnp_test.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "p2p/nat/stun.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "p2p/nat/stun_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "p2p/netutil/addrutil.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "p2p/netutil/addrutil_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "p2p/netutil/error.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "p2p/netutil/error_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "p2p/netutil/iptrack.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "p2p/netutil/iptrack_test.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "p2p/netutil/net.go": {
+   "extra": 0,
+   "matched": 30,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 30,
+   "ours": 30,
+   "regions": 1
+  },
+  "p2p/netutil/net_test.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "p2p/netutil/toobig_notwindows.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "p2p/netutil/toobig_windows.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "p2p/peer.go": {
+   "extra": 0,
+   "matched": 51,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 51,
+   "ours": 51,
+   "regions": 0
+  },
+  "p2p/peer_error.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "p2p/peer_test.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "p2p/pipes/pipe.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "p2p/protocol.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "p2p/rlpx/buffer.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "p2p/rlpx/buffer_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "p2p/rlpx/rlpx.go": {
+   "extra": 0,
+   "matched": 43,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 43,
+   "ours": 43,
+   "regions": 0
+  },
+  "p2p/rlpx/rlpx_oracle_poc_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "p2p/rlpx/rlpx_test.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "p2p/server.go": {
+   "extra": 0,
+   "matched": 61,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 61,
+   "ours": 61,
+   "regions": 0
+  },
+  "p2p/server_nat.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "p2p/server_nat_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "p2p/server_test.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "p2p/tracker/tracker.go": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "p2p/tracker/tracker_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "p2p/transport.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "p2p/transport_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "p2p/util.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 1
+  },
+  "p2p/util_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "params/bootnodes.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "params/config.go": {
+   "extra": 0,
+   "matched": 84,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 84,
+   "ours": 84,
+   "regions": 0
+  },
+  "params/config_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "params/dao.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "params/denomination.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "params/forks/forks.go": {
+   "extra": 0,
+   "matched": 30,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 30,
+   "ours": 30,
+   "regions": 0
+  },
+  "params/network_params.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "params/protocol_params.go": {
+   "extra": 0,
+   "matched": 160,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 160,
+   "ours": 160,
+   "regions": 0
+  },
+  "params/verkle_params.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "rlp/decode.go": {
+   "extra": 0,
+   "matched": 80,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 80,
+   "ours": 80,
+   "regions": 0
+  },
+  "rlp/decode_tail_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "rlp/decode_test.go": {
+   "extra": 0,
+   "matched": 63,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 63,
+   "ours": 63,
+   "regions": 0
+  },
+  "rlp/doc.go": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "rlp/encbuffer.go": {
+   "extra": 0,
+   "matched": 38,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 38,
+   "ours": 38,
+   "regions": 0
+  },
+  "rlp/encbuffer_example_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "rlp/encode.go": {
+   "extra": 0,
+   "matched": 33,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 33,
+   "ours": 33,
+   "regions": 0
+  },
+  "rlp/encode_test.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "rlp/encoder_example_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "rlp/internal/rlpstruct/rlpstruct.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "rlp/iterator.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "rlp/iterator_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "rlp/raw.go": {
+   "extra": 0,
+   "matched": 28,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 28,
+   "ours": 28,
+   "regions": 0
+  },
+  "rlp/raw_test.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "rlp/rlpgen/gen.go": {
+   "extra": 0,
+   "matched": 44,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 44,
+   "ours": 44,
+   "regions": 0
+  },
+  "rlp/rlpgen/gen_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "rlp/rlpgen/main.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "rlp/rlpgen/types.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "rlp/typecache.go": {
+   "extra": 0,
+   "matched": 21,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 21,
+   "ours": 21,
+   "regions": 0
+  },
+  "rpc/client.go": {
+   "extra": 0,
+   "matched": 48,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 48,
+   "ours": 48,
+   "regions": 0
+  },
+  "rpc/client_example_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "rpc/client_opt.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "rpc/client_opt_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "rpc/client_test.go": {
+   "extra": 0,
+   "matched": 30,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 30,
+   "ours": 30,
+   "regions": 0
+  },
+  "rpc/context_headers.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "rpc/doc.go": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "rpc/endpoints.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "rpc/errors.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "rpc/handler.go": {
+   "extra": 0,
+   "matched": 35,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 35,
+   "ours": 35,
+   "regions": 0
+  },
+  "rpc/http.go": {
+   "extra": 0,
+   "matched": 29,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 29,
+   "ours": 29,
+   "regions": 1
+  },
+  "rpc/http_test.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "rpc/inproc.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "rpc/ipc.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "rpc/ipc_js.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "rpc/ipc_unix.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "rpc/ipc_wasip1.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "rpc/ipc_windows.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "rpc/json.go": {
+   "extra": 0,
+   "matched": 51,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 51,
+   "ours": 51,
+   "regions": 2
+  },
+  "rpc/metrics.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "rpc/server.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "rpc/server_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "rpc/service.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "rpc/stdio.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "rpc/subscription.go": {
+   "extra": 0,
+   "matched": 28,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 28,
+   "ours": 28,
+   "regions": 0
+  },
+  "rpc/subscription_test.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 1
+  },
+  "rpc/testservice_test.go": {
+   "extra": 0,
+   "matched": 35,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 35,
+   "ours": 35,
+   "regions": 1
+  },
+  "rpc/tracing_test.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "rpc/types.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "rpc/types_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "rpc/websocket.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "rpc/websocket_test.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "signer/core/apitypes/signed_data_internal_test.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "signer/core/apitypes/types.go": {
+   "extra": 0,
+   "matched": 51,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 51,
+   "ours": 51,
+   "regions": 2
+  },
+  "signer/core/apitypes/types_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "signer/fourbyte/abi.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "signer/fourbyte/abi_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "signer/fourbyte/fourbyte.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "signer/fourbyte/fourbyte_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "signer/fourbyte/validation.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "signer/fourbyte/validation_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "signer/storage/aes_gcm_storage.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "signer/storage/aes_gcm_storage_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "signer/storage/storage.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "tests/block_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "tests/block_test_util.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "tests/difficulty_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "tests/difficulty_test_util.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "tests/fuzzers/bls12381/bls12381_fuzz.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "tests/fuzzers/bls12381/bls12381_test.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "tests/fuzzers/bls12381/precompile_fuzzer.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "tests/fuzzers/bn256/bn256_fuzz.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "tests/fuzzers/bn256/bn256_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "tests/fuzzers/difficulty/difficulty-fuzz.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "tests/fuzzers/difficulty/difficulty_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "tests/fuzzers/rangeproof/rangeproof-fuzzer.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "tests/fuzzers/rangeproof/rangeproof_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "tests/fuzzers/secp256k1/secp_test.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "tests/fuzzers/txfetcher/txfetcher_fuzzer.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "tests/fuzzers/txfetcher/txfetcher_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "tests/gen_btheader.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "tests/gen_difficultytest.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "tests/gen_stauthorization.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "tests/gen_stenv.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "tests/gen_sttransaction.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "tests/init.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "tests/init_test.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "tests/rlp_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "tests/rlp_test_util.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 1
+  },
+  "tests/state_test.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "tests/state_test_util.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "tests/transaction_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "tests/transaction_test_util.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "trie/bintrie/binary_node.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "trie/bintrie/binary_node_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "trie/bintrie/bitarray.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "trie/bintrie/bitarray_test.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "trie/bintrie/format_test.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "trie/bintrie/hashed_node.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "trie/bintrie/hashed_node_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "trie/bintrie/hasher.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "trie/bintrie/internal_node.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "trie/bintrie/internal_node_test.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "trie/bintrie/iterator.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "trie/bintrie/iterator_test.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "trie/bintrie/key_encoding.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "trie/bintrie/node_ref.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "trie/bintrie/node_store.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "trie/bintrie/recorder.go": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "trie/bintrie/recorder_test.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "trie/bintrie/stem_node.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "trie/bintrie/stem_node_test.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "trie/bintrie/store_commit.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "trie/bintrie/store_ops.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "trie/bintrie/trie.go": {
+   "extra": 0,
+   "matched": 32,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 32,
+   "ours": 32,
+   "regions": 0
+  },
+  "trie/bintrie/trie_test.go": {
+   "extra": 0,
+   "matched": 32,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 32,
+   "ours": 32,
+   "regions": 0
+  },
+  "trie/bytepool.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "trie/committer.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "trie/database_test.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "trie/encoding.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "trie/encoding_test.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "trie/errors.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "trie/hasher.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "trie/inspect.go": {
+   "extra": 0,
+   "matched": 44,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 44,
+   "ours": 44,
+   "regions": 0
+  },
+  "trie/inspect_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "trie/iterator.go": {
+   "extra": 0,
+   "matched": 53,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 53,
+   "ours": 53,
+   "regions": 1
+  },
+  "trie/iterator_test.go": {
+   "extra": 0,
+   "matched": 32,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 32,
+   "ours": 32,
+   "regions": 0
+  },
+  "trie/levelstats.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "trie/levelstats_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "trie/list_hasher.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "trie/node.go": {
+   "extra": 0,
+   "matched": 32,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 32,
+   "ours": 32,
+   "regions": 0
+  },
+  "trie/node_enc.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "trie/node_test.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 1
+  },
+  "trie/proof.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "trie/proof_test.go": {
+   "extra": 0,
+   "matched": 40,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 40,
+   "ours": 40,
+   "regions": 0
+  },
+  "trie/secure_trie.go": {
+   "extra": 0,
+   "matched": 29,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 29,
+   "ours": 29,
+   "regions": 0
+  },
+  "trie/secure_trie_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "trie/stacktrie.go": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "trie/stacktrie_fuzzer_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "trie/stacktrie_partial.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "trie/stacktrie_partial_test.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "trie/stacktrie_test.go": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "trie/sync.go": {
+   "extra": 0,
+   "matched": 41,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 41,
+   "ours": 41,
+   "regions": 0
+  },
+  "trie/sync_test.go": {
+   "extra": 0,
+   "matched": 30,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 30,
+   "ours": 30,
+   "regions": 0
+  },
+  "trie/tracer.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "trie/tracer_test.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 2
+  },
+  "trie/transitiontrie/transition.go": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "trie/trie.go": {
+   "extra": 0,
+   "matched": 35,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 35,
+   "ours": 35,
+   "regions": 0
+  },
+  "trie/trie_id.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "trie/trie_reader.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "trie/trie_test.go": {
+   "extra": 0,
+   "matched": 91,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 91,
+   "ours": 91,
+   "regions": 0
+  },
+  "trie/trienode/node.go": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "trie/trienode/node_test.go": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "trie/trienode/proof.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "triedb/database.go": {
+   "extra": 0,
+   "matched": 37,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 37,
+   "ours": 37,
+   "regions": 0
+  },
+  "triedb/database/database.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "triedb/generate.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "triedb/generate_test.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 1
+  },
+  "triedb/hashdb/database.go": {
+   "extra": 0,
+   "matched": 43,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 43,
+   "ours": 43,
+   "regions": 0
+  },
+  "triedb/history.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "triedb/internal/conversion.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "triedb/internal/conversion_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "triedb/internal/holdable_iterator.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "triedb/internal/holdable_iterator_test.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "triedb/pathdb/buffer.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "triedb/pathdb/config.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 1
+  },
+  "triedb/pathdb/context.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "triedb/pathdb/database.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "triedb/pathdb/database_test.go": {
+   "extra": 0,
+   "matched": 45,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 45,
+   "ours": 45,
+   "regions": 0
+  },
+  "triedb/pathdb/difflayer.go": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "triedb/pathdb/difflayer_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "triedb/pathdb/disklayer.go": {
+   "extra": 0,
+   "matched": 20,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 20,
+   "ours": 20,
+   "regions": 0
+  },
+  "triedb/pathdb/errors.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "triedb/pathdb/execute.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "triedb/pathdb/fileutils_unix.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "triedb/pathdb/fileutils_windows.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "triedb/pathdb/flush.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "triedb/pathdb/generate.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "triedb/pathdb/generate_test.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "triedb/pathdb/history.go": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "triedb/pathdb/history_index.go": {
+   "extra": 0,
+   "matched": 21,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 21,
+   "ours": 21,
+   "regions": 0
+  },
+  "triedb/pathdb/history_index_block.go": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "triedb/pathdb/history_index_block_test.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "triedb/pathdb/history_index_iterator.go": {
+   "extra": 0,
+   "matched": 27,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 27,
+   "ours": 27,
+   "regions": 0
+  },
+  "triedb/pathdb/history_index_iterator_test.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "triedb/pathdb/history_index_pruner.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "triedb/pathdb/history_index_pruner_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "triedb/pathdb/history_index_test.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "triedb/pathdb/history_indexer.go": {
+   "extra": 0,
+   "matched": 35,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 35,
+   "ours": 35,
+   "regions": 0
+  },
+  "triedb/pathdb/history_indexer_state.go": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "triedb/pathdb/history_indexer_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "triedb/pathdb/history_inspect.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "triedb/pathdb/history_reader.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "triedb/pathdb/history_reader_test.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "triedb/pathdb/history_state.go": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "triedb/pathdb/history_state_test.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "triedb/pathdb/history_trienode.go": {
+   "extra": 0,
+   "matched": 30,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 30,
+   "ours": 30,
+   "regions": 0
+  },
+  "triedb/pathdb/history_trienode_test.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "triedb/pathdb/history_trienode_utils.go": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "triedb/pathdb/history_trienode_utils_test.go": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "triedb/pathdb/iterator.go": {
+   "extra": 0,
+   "matched": 19,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 19,
+   "ours": 19,
+   "regions": 0
+  },
+  "triedb/pathdb/iterator_binary.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "triedb/pathdb/iterator_fast.go": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "triedb/pathdb/iterator_test.go": {
+   "extra": 0,
+   "matched": 37,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 37,
+   "ours": 37,
+   "regions": 0
+  },
+  "triedb/pathdb/journal.go": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "triedb/pathdb/layertree.go": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "triedb/pathdb/layertree_test.go": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "triedb/pathdb/lookup.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "triedb/pathdb/metrics.go": {
+   "extra": 0,
+   "matched": 78,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 78,
+   "ours": 78,
+   "regions": 0
+  },
+  "triedb/pathdb/nodes.go": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "triedb/pathdb/nodes_test.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "triedb/pathdb/reader.go": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "triedb/pathdb/states.go": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "triedb/pathdb/states_test.go": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "triedb/pathdb/verifier.go": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "triedb/preimages.go": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "triedb/preimages_test.go": {
+   "extra": 0,
+   "matched": 1,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 1,
+   "ours": 1,
+   "regions": 0
+  },
+  "triedb/states.go": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "version/version.go": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  }
+ },
+ "totals": {
+  "crashes": 0,
+  "extra": 0,
+  "files": 1421,
+  "files_with_regions": 38,
+  "matched": 21648,
+  "missed": 0,
+  "missed_confessed": 0,
+  "oracle": 21648,
+  "ours": 21648
+ }
+}

--- a/plugins/horos/tests/test_evidence.py
+++ b/plugins/horos/tests/test_evidence.py
@@ -16,6 +16,8 @@ RESULTS_3 = EVIDENCE / "wildcat-app-v2-outline.results.json"
 BUNDLE_4 = EVIDENCE / "wildcat-app-v2-census.md"
 CENSUS_APP = EVIDENCE / "wildcat-app-v2-census.json"
 CENSUS_PROTOCOL = EVIDENCE / "v2-protocol-census.json"
+BUNDLE_5 = EVIDENCE / "go-ethereum-outline.md"
+RESULTS_5 = EVIDENCE / "go-ethereum-outline.results.json"
 
 
 def capture_lines(bundle=BUNDLE, tag="evidence"):
@@ -147,6 +149,28 @@ class SecondCaptureTests(unittest.TestCase):
                     sum(row["bytes"] for row in document["rows"]),
                     document["total_bytes"],
                 )
+
+    def test_the_go_outline_bundle_matches_its_committed_results(self):
+        lines = capture_lines(BUNDLE_5, "gooutline")
+        totals = json.loads(RESULTS_5.read_text(encoding="utf-8"))["totals"]
+        for key in (
+            "files",
+            "crashes",
+            "oracle",
+            "matched",
+            "missed",
+            "missed_confessed",
+            "extra",
+            "files_with_regions",
+        ):
+            self.assertEqual(int(lines[key]), totals[key], key)
+
+    def test_the_go_outline_acceptance_holds(self):
+        totals = json.loads(RESULTS_5.read_text(encoding="utf-8"))["totals"]
+        self.assertEqual(totals["crashes"], 0)
+        self.assertEqual(totals["missed"], 0)
+        self.assertEqual(totals["extra"], 0)
+        self.assertEqual(totals["matched"], totals["oracle"])
 
     def test_the_second_share_exceeds_the_first(self):
         first = capture_lines()


### PR DESCRIPTION
All 1,421 Go files of the go-ethereum clone at commit 26d0b21, outlined by
Horos and independently parsed by tree-sitter's Go grammar
(tree-sitter-go in a scratchpad virtualenv, driven by the committed
dev-time oracle at plugins/horos/dev/go_oracle.py). The oracle sees 21,648
declarations at the compared altitudes; the outliner names all 21,648,
misses none, names nothing extra and crashes nowhere. Every mismatch the
run surfaced was a defect in the dev-side oracle or driver, each named in
the bundle and fixed in the tooling with the shipped outliner untouched.

Stacks on step 2 (the extractor). Audit: one round, zero findings; log in
audit/AUDIT.md.

Proof: `python3 -m unittest plugins.horos.tests.test_evidence -v` (sixteen
tests across five bundles).

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
