### PR TITLE
Implement the C++ outline extractor

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1351,3 +1351,24 @@ metaphor) was fixed before the copies were committed.
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Cpp-extractor run, step 2, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0. Horos 132/132, root
+24/24. Three defects were found and fixed during the step's own build,
+before the implement receipt, recorded for the trail: a broken template
+reattachment vestige replaced with the decorator pattern; a function body's
+close consuming the following statement (refresh, fromQuery and formatApr
+vanished from the fixture until the tail scan was cut back to the brace);
+and Allman-style bodies orphaned from their heads until a one-line peek
+joined them, with the orphan-brace branch defused from eating statements.
+The round's review walked the fixture against the source and found the
+slices verbatim, the raw-string containment exact and the confession
+correct.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings in the round itself. Leads not pursued: preprocessor
+conditionals that unbalance braces mis-slice until the next recogniser, as
+the study prices; the step 3 corpus reports how often real code does it.

--- a/plugins/horos/examples/fixture-cpp/market.hpp
+++ b/plugins/horos/examples/fixture-cpp/market.hpp
@@ -1,0 +1,71 @@
+// A fixture market header for the Horos C++ outliner.
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+
+#define MARKET_VERSION 2
+#define MARKET_JOIN(a, b) \
+	a##b
+
+namespace wildcat::market {
+
+enum class State : uint8_t {
+	Open,
+	Delinquent,
+	Closed,
+};
+
+struct Snapshot {
+	std::string address;
+	uint64_t capacity = 0;
+	double apr;
+};
+
+using SnapshotMap = std::map<std::string, Snapshot>;
+typedef unsigned int BasisPoints;
+
+constexpr char const* kQuery = R"sql(
+SELECT * FROM markets; -- class Fake { not a declaration
+)sql";
+
+class MarketWatcher {
+public:
+	explicit MarketWatcher(SnapshotMap initial):
+		m_snapshots(std::move(initial)) {}
+
+	Snapshot const& refresh(std::string const& address);
+
+	template <typename Predicate>
+	SnapshotMap filtered(Predicate _keep) const
+	{
+		SnapshotMap out;
+		for (auto const& [address, snapshot]: m_snapshots)
+			if (_keep(snapshot))
+				out[address] = snapshot;
+		return out;
+	}
+
+	static MarketWatcher fromQuery(std::string const& query = kQuery);
+
+private:
+	SnapshotMap m_snapshots;
+	uint64_t m_refreshes = 0;
+};
+
+template <typename T>
+T clampApr(T value, T low, T high)
+{
+	return value < low ? low : (value > high ? high : value);
+}
+
+std::string formatApr(double apr);
+
+} // namespace wildcat::market
+
+extern "C" {
+int market_abi_version(void);
+}
+
+static_assert(MARKET_VERSION == 2, "fixture version drift");

--- a/plugins/horos/skills/horos/scripts/languages/__init__.py
+++ b/plugins/horos/skills/horos/scripts/languages/__init__.py
@@ -5,12 +5,19 @@ and returns an exit code; the registry maps file suffixes onto it. A suffix
 absent here is refused by map, never guessed at.
 """
 
+from .cpp import cpp
 from .go import go
 from .python import python
 from .typescript import typescript
 
 EXTRACTORS = {
+    ".cc": cpp.outline,
+    ".cpp": cpp.outline,
+    ".cxx": cpp.outline,
     ".go": go.outline,
+    ".h": cpp.outline,
+    ".hh": cpp.outline,
+    ".hpp": cpp.outline,
     ".py": python.outline,
     ".ts": typescript.outline,
     ".tsx": typescript.outline,

--- a/plugins/horos/skills/horos/scripts/languages/cpp/cpp.py
+++ b/plugins/horos/skills/horos/scripts/languages/cpp/cpp.py
@@ -1,0 +1,547 @@
+"""C++ outline extraction for Horos's map verb.
+
+The extractor shape fixed by TypeScript and Go, sized for the hardest
+lexing target of the four: raw strings with custom delimiters, digit
+separators inside numbers, and preprocessor directives that are lexed as
+their own span kind and removed from the structural mask entirely. It
+lexes, slices verbatim, confesses what it does not recognise, and never
+imports or executes what it reads.
+"""
+
+WORD_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+)
+OPENERS = "([{"
+CLOSERS = ")]}"
+
+# A line ending in one of these still owes the next line something.
+CONTINUERS = frozenset(",=&|+-*/?:.([{<>!%^~")
+
+TYPE_KEYWORDS = frozenset({"class", "struct", "union", "enum"})
+ACCESS_LABELS = frozenset({"public", "protected", "private"})
+
+# Statement-position words that can never head a declaration; anything they
+# lead is confessed rather than sliced as a counterfeit function.
+CONFESS_KEYWORDS = frozenset(
+    {
+        "for",
+        "while",
+        "if",
+        "else",
+        "do",
+        "switch",
+        "return",
+        "goto",
+        "case",
+        "default",
+        "break",
+        "continue",
+        "try",
+        "catch",
+        "throw",
+        "delete",
+    }
+)
+
+
+def lex(source):
+    """Classify the source into spans of code, line_comment, block_comment,
+    string, char, raw and directive. Returns (spans, errors); an
+    unterminated construct's span covers the remainder."""
+    spans = []
+    errors = []
+    n = len(source)
+    i = 0
+    code_start = 0
+    line_start = True  # only whitespace seen since the last newline
+
+    def flush_code(end):
+        if end > code_start:
+            spans.append(("code", code_start, end))
+
+    while i < n:
+        c = source[i]
+
+        if c == "#" and line_start:
+            flush_code(i)
+            end = _scan_directive(source, i)
+            spans.append(("directive", i, end))
+            i = code_start = end
+            line_start = True
+            continue
+
+        if c == "/" and i + 1 < n and source[i + 1] == "/":
+            flush_code(i)
+            end = source.find("\n", i)
+            end = n if end == -1 else end
+            spans.append(("line_comment", i, end))
+            i = code_start = end
+            continue
+
+        if c == "/" and i + 1 < n and source[i + 1] == "*":
+            flush_code(i)
+            end = source.find("*/", i + 2)
+            if end == -1:
+                errors.append((i, "unterminated block comment"))
+                spans.append(("block_comment", i, n))
+                return spans, errors
+            spans.append(("block_comment", i, end + 2))
+            i = code_start = end + 2
+            continue
+
+        if c == '"':
+            raw = _raw_prefix(source, i)
+            flush_code(i)
+            if raw:
+                end = _scan_raw(source, i)
+                if end is None:
+                    errors.append((i, "unterminated raw string"))
+                    spans.append(("raw", i, n))
+                    return spans, errors
+                spans.append(("raw", i, end))
+            else:
+                end = _scan_quoted(source, i, '"')
+                if end is None:
+                    errors.append((i, "unterminated string"))
+                    spans.append(("string", i, n))
+                    return spans, errors
+                spans.append(("string", i, end))
+            i = code_start = end
+            line_start = False
+            continue
+
+        if c == "'":
+            # A quote between alphanumerics is a digit separator (1'000'000),
+            # not a character literal.
+            before = source[i - 1] if i > 0 else ""
+            after = source[i + 1] if i + 1 < n else ""
+            if before.isalnum() and (after.isalnum() or after == "_"):
+                i += 1
+                line_start = False
+                continue
+            flush_code(i)
+            end = _scan_quoted(source, i, "'")
+            if end is None:
+                errors.append((i, "unterminated character literal"))
+                spans.append(("char", i, n))
+                return spans, errors
+            spans.append(("char", i, end))
+            i = code_start = end
+            line_start = False
+            continue
+
+        if c == "\n":
+            line_start = True
+        elif not c.isspace():
+            line_start = False
+        i += 1
+
+    flush_code(n)
+    return spans, errors
+
+
+def _scan_directive(source, start):
+    """One preprocessor line including backslash continuations."""
+    n = len(source)
+    i = start
+    while i < n:
+        end = source.find("\n", i)
+        if end == -1:
+            return n
+        j = end - 1
+        if j >= 0 and source[j] == "\r":
+            j -= 1
+        if j >= start and source[j] == "\\":
+            i = end + 1
+            continue
+        return end
+    return n
+
+
+def _raw_prefix(source, quote_index):
+    """True when the quote at quote_index opens a raw string: preceded by R
+    with at most an encoding prefix (u8, u, U, L) before it."""
+    i = quote_index
+    if i < 1 or source[i - 1] != "R":
+        return False
+    j = i - 2
+    prefix = ""
+    while j >= 0 and source[j] in WORD_CHARS and len(prefix) < 2:
+        prefix = source[j] + prefix
+        j -= 1
+    if j >= 0 and source[j] in WORD_CHARS:
+        return False
+    return prefix in ("", "u", "U", "L", "u8")
+
+
+def _scan_raw(source, start):
+    """From the opening quote of R"delim( past )delim"; None if unclosed."""
+    n = len(source)
+    open_paren = source.find("(", start + 1)
+    if open_paren == -1 or open_paren - start - 1 > 16:
+        return None
+    delim = source[start + 1 : open_paren]
+    closer = ")" + delim + '"'
+    end = source.find(closer, open_paren + 1)
+    if end == -1:
+        return None
+    return end + len(closer)
+
+
+def _scan_quoted(source, start, quote):
+    n = len(source)
+    i = start + 1
+    while i < n:
+        c = source[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == quote:
+            return i + 1
+        if c == "\n":
+            return None
+        i += 1
+    return None
+
+
+def _line_of(source, offset):
+    return source.count("\n", 0, offset) + 1
+
+
+def _masked(source, spans):
+    """Non-code spans blanked, newlines kept; string, char and raw literals
+    get a sentinel first character; directives stay fully blank so a brace
+    inside a define never leaks into the structural mask."""
+    parts = []
+    for kind, start, end in spans:
+        segment = source[start:end]
+        if kind == "code":
+            parts.append(segment)
+            continue
+        blank = "".join(ch if ch == "\n" else " " for ch in segment)
+        if kind in ("string", "char", "raw") and blank[:1] == " ":
+            blank = "#" + blank[1:]
+        parts.append(blank)
+    return "".join(parts)
+
+
+def _statement_end(mask, i, end):
+    depth = 0
+    last = ""
+    while i < end:
+        c = mask[i]
+        if c in OPENERS:
+            depth += 1
+            last = c
+        elif c in CLOSERS:
+            depth -= 1
+            if depth < 0:
+                return i
+            last = c
+        elif depth == 0 and c == ";":
+            return i + 1
+        elif depth == 0 and c == "\n":
+            if last and last not in CONTINUERS:
+                return i + 1
+        elif not c.isspace():
+            last = c
+        i += 1
+    return end
+
+
+def _find_at_depth(mask, start, stop, target):
+    depth = 0
+    i = start
+    while i < stop:
+        c = mask[i]
+        if c in OPENERS:
+            if c == target and depth == 0:
+                return i
+            depth += 1
+        elif c in CLOSERS:
+            depth -= 1
+        elif c == target and depth == 0:
+            return i
+        i += 1
+    return -1
+
+
+def _matching_brace(mask, open_index, end):
+    depth = 0
+    i = open_index
+    while i < end:
+        c = mask[i]
+        if c in OPENERS:
+            depth += 1
+        elif c in CLOSERS:
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return end
+
+
+def _first_word(mask, i, end):
+    while i < end and mask[i] in " \t":
+        i += 1
+    j = i
+    while j < end and mask[j] in WORD_CHARS:
+        j += 1
+    return mask[i:j], i, j
+
+
+def _skip_template_prefix(mask, i, end):
+    """Past `template < ... >` including nested angles; i sits at 'template'."""
+    j = i + len("template")
+    while j < end and mask[j].isspace():
+        j += 1
+    if j >= end or mask[j] != "<":
+        return i + len("template")
+    depth = 0
+    while j < end:
+        c = mask[j]
+        if c == "<":
+            depth += 1
+        elif c == ">":
+            depth -= 1
+            if depth == 0:
+                return j + 1
+        elif c in OPENERS:
+            j = _matching_brace(mask, j, end)
+        j += 1
+    return j
+
+
+def _body_brace(mask, i, stmt_stop, end):
+    """The declaration's body brace: inside the statement, or an
+    Allman-style brace alone on the following line."""
+    brace = _find_at_depth(mask, i, stmt_stop, "{")
+    if brace != -1:
+        return brace
+    j = stmt_stop
+    while j < end and mask[j].isspace():
+        j += 1
+    if j < end and mask[j] == "{":
+        return j
+    return -1
+
+
+def _head_line(source, start, stop):
+    newline = source.find("\n", start, stop)
+    cut = stop if newline == -1 else newline
+    return source[start:cut].rstrip().rstrip(";").rstrip()
+
+
+class _Outline:
+    def __init__(self, source, mask, directives):
+        self.source = source
+        self.mask = mask
+        self.directives = directives  # sorted (start, end), emitted in order
+        self.next_directive = 0
+        self.lines = []
+        self.regions = []
+        self.declarations = 0
+
+    def emit(self, text, depth=0):
+        pad = "    " * depth
+        for line in text.splitlines():
+            if not line.strip():
+                continue
+            self.lines.append(pad + line.strip() if depth else line.rstrip())
+
+    def confess(self, start, stop):
+        first = _line_of(self.source, start)
+        last = _line_of(self.source, max(start, stop - 1))
+        if self.regions and self.regions[-1][1] >= first - 1:
+            self.regions[-1] = (self.regions[-1][0], max(self.regions[-1][1], last))
+        else:
+            self.regions.append((first, last))
+
+    def _flush_directives(self, upto, depth):
+        while self.next_directive < len(self.directives):
+            start, end = self.directives[self.next_directive]
+            if start >= upto:
+                return
+            head = _head_line(self.source, start, end).rstrip("\\").rstrip()
+            if head.startswith(("#include", "#define")):
+                self.emit(head, depth)
+                self.declarations += 1
+            self.next_directive += 1
+
+    def walk(self, start, end, depth=0, in_class=False):
+        mask = self.mask
+        i = start
+        while i < end:
+            while i < end and (mask[i].isspace() or mask[i] == ";"):
+                i += 1
+            if i >= end:
+                break
+            if depth == 0:
+                self._flush_directives(i, depth)
+            if mask[i] in CLOSERS:
+                i += 1
+                continue
+            i = max(self._statement(i, end, depth, in_class), i + 1)
+        if depth == 0:
+            self._flush_directives(end, depth)
+
+    def _statement(self, i, end, depth, in_class):
+        mask = self.mask
+        slice_start = i
+        word, word_at, word_end = _first_word(mask, i, end)
+
+        if in_class and word in ACCESS_LABELS:
+            colon = mask.find(":", word_end, _statement_end(mask, i, end))
+            return colon + 1 if colon != -1 else word_end
+
+        if word in CONFESS_KEYWORDS:
+            stop = _statement_end(mask, i, end)
+            self.confess(i, stop)
+            return stop
+
+        if word == "template":
+            # The prefix emits as its own line, the way TypeScript emits
+            # decorators; the declaration it introduces follows.
+            after = _skip_template_prefix(mask, word_at, end)
+            self.emit(self.source[slice_start:after].strip(), depth)
+            return self._statement(after, end, depth, in_class)
+
+        if word == "namespace":
+            stmt_stop = _statement_end(mask, i, end)
+            brace = _body_brace(mask, i, stmt_stop, end)
+            if brace == -1:
+                self.emit(_head_line(self.source, i, stmt_stop), depth)
+                self.declarations += 1
+                return stmt_stop
+            self.emit(self.source[i:brace].rstrip(), depth)
+            self.declarations += 1
+            close = _matching_brace(mask, brace, end)
+            self.walk(brace + 1, close, depth, in_class=False)
+            return close + 1
+
+        if word == "extern":
+            stmt_stop = _statement_end(mask, i, end)
+            brace = _body_brace(mask, i, stmt_stop, end)
+            if brace != -1 and mask.find("(", i, brace) == -1:
+                self.emit(self.source[i:brace].rstrip(), depth)
+                self.declarations += 1
+                close = _matching_brace(mask, brace, end)
+                self.walk(brace + 1, close, depth, in_class=False)
+                return close + 1
+
+        if word in TYPE_KEYWORDS or (
+            word in ("typedef", "using") and self._has_type_keyword(word_end, end)
+        ):
+            return self._type_declaration(i, end, depth)
+
+        if word in ("using", "typedef"):
+            stmt_stop = _statement_end(mask, i, end)
+            self.emit(_head_line(self.source, i, stmt_stop), depth)
+            self.declarations += 1
+            return stmt_stop
+
+        return self._generic(i, end, depth)
+
+    def _has_type_keyword(self, i, end):
+        word, _, _ = _first_word(self.mask, i, end)
+        return word in TYPE_KEYWORDS
+
+    def _type_declaration(self, i, end, depth):
+        mask = self.mask
+        stmt_stop = _statement_end(mask, i, end)
+        brace = _body_brace(mask, i, stmt_stop, end)
+        if brace == -1:
+            self.emit(_head_line(self.source, i, stmt_stop), depth)
+            self.declarations += 1
+            return stmt_stop
+        self.emit(self.source[i:brace].rstrip(), depth)
+        self.declarations += 1
+        close = _matching_brace(mask, brace, end)
+        words = set(self.mask[i:brace].split())
+        if not words & {"enum"}:
+            self.walk(brace + 1, close, depth + 1, in_class=True)
+        tail_stop = _statement_end(mask, close + 1, end)
+        tail = _head_line(self.source, close + 1, tail_stop).lstrip("} \t")
+        if tail:
+            self.emit(tail, depth)
+        return tail_stop
+
+    def _generic(self, i, end, depth):
+        mask = self.mask
+        stmt_stop = _statement_end(mask, i, end)
+        paren = _find_at_depth(mask, i, stmt_stop, "(")
+        equals = _find_at_depth(mask, i, stmt_stop, "=")
+        brace = _find_at_depth(mask, i, stmt_stop, "{")
+        first = min(x for x in (paren, equals, brace, stmt_stop) if x != -1)
+
+        if first == paren:
+            after = _matching_brace(mask, paren, end) + 1
+            rest_stop = _statement_end(mask, after, end)
+            body = _body_brace(mask, after, rest_stop, end)
+            head_stop = body if body != -1 else rest_stop
+            self.emit(
+                self.source[i:head_stop].rstrip().rstrip(";").rstrip(), depth
+            )
+            self.declarations += 1
+            if body != -1:
+                # The body's closing brace ends a function outright; only
+                # type declarations own a trailing declarator.
+                return _matching_brace(mask, body, end) + 1
+            return rest_stop
+        if first == brace:
+            head = self.source[i:brace].rstrip()
+            close = _matching_brace(mask, brace, end)
+            if not head.strip():
+                # An orphan brace block names nothing and owns nothing
+                # beyond its own close.
+                return close + 1
+            self.emit(head, depth)
+            self.declarations += 1
+            return _statement_end(mask, close + 1, end)
+        head_stop = equals if first == equals else stmt_stop
+        self.emit(_head_line(self.source, i, head_stop), depth)
+        self.declarations += 1
+        return stmt_stop
+
+
+def _module_header(source, spans):
+    for kind, start, end in spans:
+        if kind == "code" and source[start:end].strip():
+            return None
+        if kind in ("line_comment", "block_comment"):
+            for raw in source[start:end].splitlines():
+                text = raw.strip().lstrip("/*").rstrip("*/").strip("* ").strip()
+                if text:
+                    return text
+            return None
+        if kind == "directive":
+            return None
+    return None
+
+
+def outline(path, source, out):
+    """Print the file's declaration outline; 0 clean, 1 when the lexer
+    confessed an unterminated construct."""
+    spans, errors = lex(source)
+    mask = _masked(source, spans)
+    directives = [(s, e) for kind, s, e in spans if kind == "directive"]
+    header = _module_header(source, spans)
+    print(f"module: {header}" if header else "module: (no header comment)", file=out)
+
+    walker = _Outline(source, mask, directives)
+    walker.walk(0, len(source) if not errors else spans[-1][1])
+    for offset, reason in errors:
+        print(f"lexer: {reason} at line {_line_of(source, offset)}", file=out)
+        walker.confess(offset, len(source))
+
+    for line in walker.lines:
+        print(line, file=out)
+    print(f"declarations: {walker.declarations}", file=out)
+    if walker.regions:
+        listed = ", ".join(
+            f"lines {a}-{b}" if a != b else f"line {a}" for a, b in walker.regions
+        )
+        print(f"unparsed: {len(walker.regions)} region(s): {listed}", file=out)
+    else:
+        print("unparsed: none", file=out)
+    return 1 if errors else 0

--- a/plugins/horos/tests/test_cpp_outline.py
+++ b/plugins/horos/tests/test_cpp_outline.py
@@ -1,0 +1,155 @@
+"""The C++ outliner slices declarations verbatim and confesses the rest."""
+
+from pathlib import Path
+import io
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "horos" / "scripts"))  # noqa: E402  (locates horos.py)
+
+from languages.cpp import cpp  # noqa: E402
+
+PLUGIN = Path(__file__).resolve().parents[1]
+FIXTURE = PLUGIN / "examples" / "fixture-cpp" / "market.hpp"
+
+EXPECTED = """module: A fixture market header for the Horos C++ outliner.
+#include <cstdint>
+#include <map>
+#include <string>
+#define MARKET_VERSION 2
+#define MARKET_JOIN(a, b)
+namespace wildcat::market
+enum class State : uint8_t
+struct Snapshot
+    std::string address
+    uint64_t capacity
+    double apr
+using SnapshotMap = std::map<std::string, Snapshot>
+typedef unsigned int BasisPoints
+constexpr char const* kQuery
+class MarketWatcher
+    explicit MarketWatcher(SnapshotMap initial):
+    m_snapshots(std::move(initial))
+    Snapshot const& refresh(std::string const& address)
+    template <typename Predicate>
+    SnapshotMap filtered(Predicate _keep) const
+    static MarketWatcher fromQuery(std::string const& query = kQuery)
+    SnapshotMap m_snapshots
+    uint64_t m_refreshes
+template <typename T>
+T clampApr(T value, T low, T high)
+std::string formatApr(double apr)
+extern "C"
+int market_abi_version(void)
+static_assert(MARKET_VERSION == 2, "fixture version drift")
+declarations: 26
+unparsed: none
+"""
+
+
+def run(source):
+    out = io.StringIO()
+    code = cpp.outline("test.hpp", source, out)
+    return code, out.getvalue()
+
+
+class CppOutlineTests(unittest.TestCase):
+    def test_the_fixture_outline_is_pinned(self):
+        source = FIXTURE.read_text(encoding="utf-8")
+        out = io.StringIO()
+        code = cpp.outline(str(FIXTURE), source, out)
+        self.assertEqual(code, 0)
+        self.assertEqual(out.getvalue(), EXPECTED)
+
+    def test_bodies_never_leak_into_the_outline(self):
+        source = FIXTURE.read_text(encoding="utf-8")
+        _, output = run(source)
+        self.assertNotIn("out[address] = snapshot", output)
+        self.assertNotIn("value < low", output)
+
+    def test_a_raw_string_with_a_custom_delimiter_is_inert(self):
+        code, output = run(
+            'const char* q = R"x(quote " and paren ) and class Fake { )" )x";\n'
+            "int real();\n"
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("int real()", output.splitlines())
+        self.assertNotIn("class Fake", "\n".join(
+            line for line in output.splitlines() if line.startswith("class")
+        ))
+        self.assertIn("unparsed: none", output)
+
+    def test_a_define_with_a_brace_never_leaks_into_the_mask(self):
+        code, output = run("#define OPEN {\nint f();\nint g();\n")
+        self.assertEqual(code, 0)
+        lines = output.splitlines()
+        self.assertIn("int f()", lines)
+        self.assertIn("int g()", lines)
+        self.assertIn("#define OPEN {", lines)
+
+    def test_a_multiline_directive_is_one_span(self):
+        code, output = run("#define JOIN(a, b) \\\n\ta##b\nint after();\n")
+        self.assertEqual(code, 0)
+        self.assertIn("int after()", output.splitlines())
+        self.assertIn("unparsed: none", output)
+
+    def test_a_digit_separator_is_not_a_character_literal(self):
+        code, output = run("int big = 1'000'000;\nint after();\n")
+        self.assertEqual(code, 0)
+        self.assertIn("int after()", output.splitlines())
+        self.assertIn("unparsed: none", output)
+
+    def test_allman_braces_keep_the_body_with_its_head(self):
+        code, output = run("int f(int x)\n{\n\treturn x;\n}\nint g();\n")
+        self.assertEqual(code, 0)
+        lines = output.splitlines()
+        self.assertIn("int f(int x)", lines)
+        self.assertIn("int g()", lines)
+        self.assertNotIn("return x;", output)
+
+    def test_a_template_prefix_emits_like_a_decorator(self):
+        _, output = run("template <typename T>\nclass Box { T value; };\n")
+        lines = output.splitlines()
+        self.assertIn("template <typename T>", lines)
+        self.assertIn("class Box", lines)
+
+    def test_access_labels_are_skipped_without_confession(self):
+        _, output = run("class C {\npublic:\n\tint f();\nprivate:\n\tint x;\n};\n")
+        self.assertNotIn("public", output)
+        self.assertIn("    int f()", output.splitlines())
+        self.assertIn("unparsed: none", output)
+
+    def test_a_constructor_without_a_return_type_slices(self):
+        _, output = run("class C {\n\tC(int x): m_x(x) {}\n};\n")
+        self.assertIn("    C(int x):", output.splitlines()[2])
+
+    def test_namespaces_recurse(self):
+        _, output = run("namespace a {\nnamespace b {\nint f();\n}\n}\n")
+        lines = output.splitlines()
+        self.assertIn("namespace a", lines)
+        self.assertIn("namespace b", lines)
+        self.assertIn("int f()", lines)
+
+    def test_an_unmatched_statement_is_confessed_by_line(self):
+        code, output = run("int x = 1;\nfor (;;) { spin(); }\n")
+        self.assertEqual(code, 0)
+        self.assertIn("unparsed: 1 region(s): line 2", output)
+
+    def test_an_unterminated_raw_string_confesses_the_remainder(self):
+        code, output = run('int a = 1;\nconst char* q = R"x(open\nint later();\n')
+        self.assertEqual(code, 1)
+        self.assertIn("lexer: unterminated raw string at line 2", output)
+        self.assertNotIn("unparsed: none", output)
+
+    def test_the_cpp_suffixes_dispatch_through_the_registry(self):
+        import horos  # noqa: E402  (registry dispatch under test)
+
+        out = io.StringIO()
+        self.assertEqual(horos.map_file(str(FIXTURE), out=out), 0)
+        supported = __import__("languages").supported()
+        for suffix in (".cpp", ".h", ".hpp"):
+            self.assertIn(suffix, supported)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The hardest lexing target of the four. Raw strings with custom delimiters,
digit separators guarded from character literals, and preprocessor
directives lexed as their own continuation-aware span kind and removed from
the structural mask, so a brace inside a define never lies to the walker.
Declarations slice verbatim at translation-unit, namespace and class depth;
Allman-style bodies stay with their heads; template prefixes emit like
decorators; access labels skip silently; include and define heads quote in
file order; control-flow words at statement position confess rather than
counterfeit a function.

Three build-time defects are recorded in the audit log, the notable one
being a function body's close consuming the following statement until the
tail scan was cut back to the brace.

Stacks on step 1 (the spec). Audit: one round, zero further findings; the
preprocessor-conditional trade stays priced by the step 3 corpus.

Proof: `python3 -m unittest plugins.horos.tests.test_cpp_outline -v`
(fourteen tests) and both suites (horos 132, root 24).

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
