### PR TITLE
Commit the Solidity-extractor frontier spec

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1407,3 +1407,14 @@ ledger rows are byte-identical.
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Solidity-extractor run, step 1, round 1 -- 2026-08-18
+
+Suite waived (no Solidity shipped); lints phylax 0, ephoros 0, hypomnema 0.
+Horos 136/136, root 24/24. Prose-only step; the committed copies match the
+receipted artefacts.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.

--- a/plugins/horos/docs/sol-outline/runbook.md
+++ b/plugins/horos/docs/sol-outline/runbook.md
@@ -1,0 +1,62 @@
+# The Solidity outline extractor, the runbook
+
+Four steps, dependency order, one pull request each. The study committed
+beside this runbook is the spec; both land in step 1.
+
+## Step 1: Commit the frontier spec
+
+**Goal.** The study and runbook are in the tree the later steps build on.
+**Entry.** The run branch, cut from `main` at `c17bc05`.
+**Exit.** Both suites green, three tree lints clean, imprimatur clean on
+both documents.
+**Files.** `plugins/horos/docs/sol-outline/study.md` and
+`plugins/horos/docs/sol-outline/runbook.md`.
+**Tests.** None new; the existing suites hold.
+
+## Step 2: The lexer and the outliner
+
+**Goal.** map reads `.sol`: comments and all string forms lexed;
+keyword-led declarations sliced verbatim at file and contract depth with
+attribute chains riding along; everything else confessed.
+**Entry.** Step 1's exit state.
+**Exit.** Plugin suite green; the pinned Solidity fixture outline matches
+byte for byte; the other four fixtures untouched.
+**Files.** `plugins/horos/skills/horos/scripts/languages/solidity/solidity.py`;
+`languages/__init__.py` gains one registry line;
+`plugins/horos/examples/fixture-sol/Market.sol`;
+`plugins/horos/tests/test_sol_outline.py`.
+**Tests.** Hex and unicode strings; a contract keyword inside a string
+never a declaration; inheritance lists in contract heads; multiline
+function heads with attribute chains and override lists; events, errors,
+structs, enums, using-for and file-level type declarations; state variables
+cut before initialisers; an assembly block skipped with its body; an
+unmatched statement confessed; an unterminated string confessing the
+remainder; the fixture pin. Expected count: about thirteen.
+
+## Step 3: The differential corpus
+
+**Goal.** The outliner is held against tree-sitter-solidity over all 151
+`.sol` files of the v2-protocol clone at declared altitudes and recorded as
+a machine-checked bundle.
+**Entry.** Step 2's exit state.
+**Exit.** Zero crashes; zero unconfessed misses and zero extras at the
+declared altitudes;
+`python3 -m unittest plugins.horos.tests.test_evidence -v` green.
+**Files.** `plugins/horos/dev/sol_oracle.py` (dev-time, venv-run);
+`plugins/horos/docs/evidence/v2-protocol-outline.md` and its results JSON;
+`plugins/horos/tests/test_evidence.py` extended; fixes to
+`languages/solidity/solidity.py` as the corpus demands.
+**Tests.** Bundle-consistency checks in the shape of the prior
+differentials'. Expected count: about three.
+
+## Step 4: Reledger and reconcile
+
+**Goal.** The ledger advances to `horos-v7.2.2` holding the classifier
+refinement as the next job, and every surface agrees.
+**Entry.** Step 3's exit state.
+**Exit.** Study success criteria 1 through 4 all pass as written.
+**Files.** `EVOLUTION.md`; `SKILL.md` (metadata `7.2.2`, map's five
+languages); `plugins/horos/README.md`; `.agents/skills/horos/SKILL.md`;
+root `README.md`.
+**Tests.** None new; the evolution and marketplace-prose contracts are the
+check.

--- a/plugins/horos/docs/sol-outline/study.md
+++ b/plugins/horos/docs/sol-outline/study.md
@@ -1,0 +1,142 @@
+# The Solidity outline extractor, the study
+
+This run executes the first of the reopened frontier's three named jobs:
+teach map to read Solidity, in the extractor shape now fixed three times.
+The classifier refinement and the three-repository boundary marking follow
+in their own runs.
+
+## Assumptions
+
+Proceeding on these unless corrected:
+
+1. The extractor lives at `languages/solidity/solidity.py` behind the
+   registry, covering `.sol`. The output register, confession contract and
+   bundle shape are unchanged from the other extractors.
+2. The differential oracle is tree-sitter's Solidity grammar
+   (`tree-sitter-solidity`, already in the scratchpad virtualenv, dev-time
+   only). The corpus is the v2-protocol clone at
+   `c7be4039f8f383a9dda4e45f63331c17d63f9ed9`: 151 `.sol` files, contracts
+   and Foundry tests alike.
+3. Lemma's Solidity chunker (`plugins/lemma/chunkers/solidity.py`) is the
+   in-repo prior art for the comment-and-string discipline; its
+   `strip_comments(code, keep_ranges=())` walks the same hazards. Horos
+   does not import it: the extractors are self-contained by pattern, and
+   the two skills ship independently.
+4. The completed job increments evolution: `horos-v6.2.2` becomes
+   `horos-v7.2.2`, generation and epoch retained, and the next held job is
+   the classifier refinement from the maintainer's committed specification.
+
+## 1. Problem statement
+
+Solidity lexes like a small C++ without the preprocessor: line and block
+comments, single- and double-quoted strings with escapes, hex and unicode
+string literals, and no regex or raw-string ambiguity at all. Its
+declarations are keyword-led like Go's: `pragma`, `import`, `contract`,
+`interface`, `library`, `abstract contract`, `function`, `constructor`,
+`modifier`, `event`, `error`, `struct`, `enum`, `type`, `using`, and
+state-variable declarations inside contract bodies.
+
+The extractor:
+
+- Lexes comments and all string forms; an unterminated literal confesses
+  the remainder.
+- Slices declarations verbatim: pragma and import lines; contract,
+  interface, library and abstract-contract heads to their body brace, with
+  inheritance lists riding along, then bodies walked for members; function,
+  constructor, receive, fallback and modifier heads through their parameter
+  lists and attribute chains up to the body brace or semicolon; event,
+  error, struct, enum, type and using declarations; state variables cut
+  before their initialisers.
+- Confesses anything else at statement position by line range, exactly as
+  the other extractors do.
+
+A working prototype means: the pinned fixture outline matches byte for
+byte; the corpus run over all 151 files completes with zero crashes; the
+differential against tree-sitter-solidity is recorded as a machine-checked
+bundle with zero unconfessed misses and zero extras at declared altitudes;
+and every suite and lint is green.
+
+## 2. Prior art
+
+The three shipped extractors fix everything structural. Lemma's Solidity
+chunker and Pandects' stripper tests pin the comment-and-string traps in
+this exact language, in this exact marketplace. tree-sitter-solidity is the
+oracle; solc's own AST would demand import resolution the ingested tree
+does not owe us, the same trade the C++ study recorded.
+
+## 3. Constraints and non-goals
+
+- Stdlib only in everything that ships; the venv stays in the scratchpad.
+- No changes to the other extractors, scan, check or census.
+- Non-goals: assembly block internals (`assembly { ... }` bodies are
+  skipped whole like any body), NatSpec interpretation (comments are
+  comments), version-pragma semantics, and Yul as a separate suffix.
+
+## 4. Design options
+
+**A. The fixed extractor shape with Go-style keyword recognisers.** Chosen.
+Trade: recall is bounded by the recogniser list; unusual top-level
+constructs confess rather than slice, and the differential prices it.
+
+**B. Reuse Lemma's chunker inside Horos.** Rejected: a cross-plugin import
+couples two independently shipped skills for fifty lines of lexer; the
+pattern stays, the code does not.
+
+**C. solc as oracle.** Rejected: import resolution and version pinning an
+ingested tree does not owe us; tree-sitter parses standalone files.
+
+## 5. Risk register seed
+
+- Hex and unicode string literals (`hex"00ff"`, `unicode"..."`) lex as
+  strings with their prefixes, pinned by test.
+- Function attribute chains (visibility, mutability, `virtual`,
+  `override(A, B)`, custom modifiers with arguments) ride in the head
+  slice up to the body brace or semicolon, pinned with a multiline case.
+- `using X for Y;` and file-level `type U is V;` slice whole.
+- An `unchecked { ... }` or `assembly { ... }` block inside a body never
+  reaches the walker: bodies are skipped whole from the head's brace.
+- The declared altitudes for the differential: contract-level types
+  (contract, interface, library), their members (functions, constructors
+  treated as named by their contract? no: constructors are anonymous and
+  excluded on both sides, like C++ destructors), events, errors, structs,
+  enums, and file-level functions, errors, structs and enums. State
+  variables outlined but not compared, like C++ fields.
+- The corpus's Foundry tests import forge-std from uninitialised
+  submodules; imports are lines, not resolutions, so nothing breaks.
+
+## 6. Glossary seeds
+
+- Attribute chain: everything between a function's parameter list and its
+  body brace or semicolon.
+- Declared altitudes: the declaration kinds the differential compares,
+  named in the bundle.
+
+## 7. Boundaries
+
+- **Always.** Both suites and the three tree lints before a commit;
+  imprimatur on every shipped document; pinned fixtures are the contract.
+- **Ask first.** Any runtime dependency; widening the compared altitudes;
+  a Yul suffix.
+- **Never.** Import or execute scanned code; import Lemma's chunker; report
+  a corpus run that did not happen.
+
+## 8. Success criteria
+
+1. `python3 -m unittest discover -s tests` passes.
+2. `python3 -m unittest discover -s plugins/horos/tests -t plugins/horos`
+   passes, including the Solidity tests, with the other four fixtures
+   untouched.
+3. `python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests`
+   and the ephoros equivalent exit clean.
+4. Demo path: `python3 plugins/horos/skills/horos/scripts/horos.py map
+   plugins/horos/examples/fixture-sol/Market.sol` prints the pinned
+   outline, and the committed differential bundle at
+   `plugins/horos/docs/evidence/v2-protocol-outline.md` is machine-checked
+   by the suite with zero unconfessed misses, zero extras, zero crashes.
+
+## 9. Sources
+
+The v6.2.2 epoch row and the maintainer's reopening directive. The three
+shipped extractors and their bundles. Lemma's Solidity chunker and
+Pandects' stripper tests as in-repo prior art. The v2-protocol clone at
+`c7be4039f8f383a9dda4e45f63331c17d63f9ed9`. tree-sitter-solidity as oracle.


### PR DESCRIPTION
Step 1 of the reopened frontier's first job. The study and runbook land at
plugins/horos/docs/sol-outline/: teach map to read Solidity in the
thrice-fixed extractor shape, hold it against tree-sitter-solidity over all
151 .sol files of the v2-protocol clone at declared altitudes, then hand
the ledger to the classifier refinement the maintainer specified.

Audit: one round, zero findings; log in audit/AUDIT.md.

Proof: both suites (horos 136, root 24) and the three tree lints, all
green.

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
