### PR TITLE
Implement the Solidity outline extractor

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1418,3 +1418,19 @@ receipted artefacts.
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Solidity-extractor run, step 2, round 1 -- 2026-08-18
+
+Suite waived (the run ships Python that reads Solidity, none of its own);
+lints phylax 0, ephoros 0. Horos 149/149, root 24/24. The review walked the
+study's risk rows: hex and unicode strings lex through the ordinary quote
+scanner with prefixes staying in code harmlessly, attribute chains and
+override lists ride in verbatim heads, the walker inherits the monotonic
+advance and Allman peeks its three predecessors learned, and constructors
+are outlined but excluded from the differential's compared set like C++
+destructors.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.

--- a/plugins/horos/examples/fixture-sol/Market.sol
+++ b/plugins/horos/examples/fixture-sol/Market.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+// A fixture market contract for the Horos Solidity outliner.
+pragma solidity ^0.8.20;
+
+import { IERC20 } from "./interfaces/IERC20.sol";
+import "./libraries/MathUtils.sol";
+
+type Duration is uint32;
+
+using MathUtils for uint256;
+
+error MarketClosed(address market);
+
+struct LenderStatus {
+    bool isBlockedFromDeposits;
+    uint256 scaledBalance;
+}
+
+enum MarketState {
+    Open,
+    Delinquent,
+    Closed
+}
+
+uint256 constant BIP = 1e4;
+
+interface IMarketEvents {
+    event Borrow(uint256 assetAmount);
+    event DebtRepaid(address indexed from, uint256 assetAmount);
+}
+
+abstract contract MarketBase is IMarketEvents {
+    IERC20 public immutable asset;
+    uint256 public totalSupply = 0;
+    mapping(address => LenderStatus) internal _lenders;
+
+    modifier onlyOpen() {
+        if (state() == MarketState.Closed) revert MarketClosed(address(this));
+        _;
+    }
+
+    constructor(IERC20 _asset) {
+        asset = _asset;
+    }
+
+    function state() public view virtual returns (MarketState);
+
+    receive() external payable {}
+
+    function borrow(
+        uint256 assetAmount
+    ) external onlyOpen returns (uint256 normalized) {
+        string memory tag = "function fake() public { // not a declaration";
+        normalized = assetAmount.bipMul(BIP);
+        unchecked {
+            totalSupply += normalized;
+        }
+        emit Borrow(assetAmount);
+        assembly {
+            mstore(0x00, normalized)
+        }
+        return normalized;
+    }
+}
+
+library MarketMath {
+    function rayDiv(uint256 x, uint256 y) internal pure returns (uint256) {
+        return (x * 1e27) / y;
+    }
+}
+
+contract Market is MarketBase {
+    constructor(IERC20 _asset) MarketBase(_asset) {}
+
+    function state() public pure override returns (MarketState) {
+        return MarketState.Open;
+    }
+}

--- a/plugins/horos/skills/horos/scripts/languages/__init__.py
+++ b/plugins/horos/skills/horos/scripts/languages/__init__.py
@@ -8,9 +8,11 @@ absent here is refused by map, never guessed at.
 from .cpp import cpp
 from .go import go
 from .python import python
+from .solidity import solidity
 from .typescript import typescript
 
 EXTRACTORS = {
+    ".sol": solidity.outline,
     ".cc": cpp.outline,
     ".cpp": cpp.outline,
     ".cxx": cpp.outline,

--- a/plugins/horos/skills/horos/scripts/languages/solidity/solidity.py
+++ b/plugins/horos/skills/horos/scripts/languages/solidity/solidity.py
@@ -1,0 +1,365 @@
+"""Solidity outline extraction for Horos's map verb.
+
+The extractor shape fixed three times, sized for a language that lexes like
+a small C++ without the preprocessor and declares like Go: keyword-led at
+every depth. It lexes, slices verbatim, confesses what it does not
+recognise, and never imports or executes what it reads.
+"""
+
+WORD_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_$"
+)
+OPENERS = "([{"
+CLOSERS = ")]}"
+
+# A line ending in one of these still owes the next line something; the
+# two-character mapping arrow survives via the same fold TypeScript uses.
+CONTINUERS = frozenset(",=&|+-*/?:.([{<>!%^") | {"=>"}
+
+# Container declarations whose bodies are walked for members.
+CONTAINER_KEYWORDS = frozenset({"contract", "interface", "library"})
+
+# Declarations whose head runs through parameters and attributes to the
+# body brace or terminating semicolon.
+CALLABLE_KEYWORDS = frozenset(
+    {"function", "constructor", "receive", "fallback", "modifier", "event", "error"}
+)
+
+# Declarations whose head stops at their body brace, body skipped whole.
+BODIED_KEYWORDS = frozenset({"struct", "enum"})
+
+# Single-statement declarations quoted to their semicolon.
+LINE_KEYWORDS = frozenset({"pragma", "import", "using", "type"})
+
+# Statement-position words that can never head a declaration.
+CONFESS_KEYWORDS = frozenset(
+    {"if", "for", "while", "do", "return", "emit", "revert", "require",
+     "assembly", "unchecked", "try", "catch", "else"}
+)
+
+MODIFIER_WORDS = frozenset({"abstract"})
+
+
+def lex(source):
+    """Classify the source into spans of code, line_comment, block_comment
+    and string. Returns (spans, errors); an unterminated construct's span
+    covers the remainder."""
+    spans = []
+    errors = []
+    n = len(source)
+    i = 0
+    code_start = 0
+
+    def flush_code(end):
+        if end > code_start:
+            spans.append(("code", code_start, end))
+
+    while i < n:
+        c = source[i]
+        if c == "/" and i + 1 < n and source[i + 1] == "/":
+            flush_code(i)
+            end = source.find("\n", i)
+            end = n if end == -1 else end
+            spans.append(("line_comment", i, end))
+            i = code_start = end
+            continue
+        if c == "/" and i + 1 < n and source[i + 1] == "*":
+            flush_code(i)
+            end = source.find("*/", i + 2)
+            if end == -1:
+                errors.append((i, "unterminated block comment"))
+                spans.append(("block_comment", i, n))
+                return spans, errors
+            spans.append(("block_comment", i, end + 2))
+            i = code_start = end + 2
+            continue
+        if c in "'\"":
+            flush_code(i)
+            end = _scan_quoted(source, i, c)
+            if end is None:
+                errors.append((i, "unterminated string"))
+                spans.append(("string", i, n))
+                return spans, errors
+            spans.append(("string", i, end))
+            i = code_start = end
+            continue
+        i += 1
+
+    flush_code(n)
+    return spans, errors
+
+
+def _scan_quoted(source, start, quote):
+    n = len(source)
+    i = start + 1
+    while i < n:
+        c = source[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == quote:
+            return i + 1
+        if c == "\n":
+            return None
+        i += 1
+    return None
+
+
+def _line_of(source, offset):
+    return source.count("\n", 0, offset) + 1
+
+
+def _masked(source, spans):
+    """Non-code spans blanked, newlines kept; strings get a sentinel first
+    character so a line ending in one still ends its statement."""
+    parts = []
+    for kind, start, end in spans:
+        segment = source[start:end]
+        if kind == "code":
+            parts.append(segment)
+            continue
+        blank = "".join(ch if ch == "\n" else " " for ch in segment)
+        if kind == "string" and blank[:1] == " ":
+            blank = "#" + blank[1:]
+        parts.append(blank)
+    return "".join(parts)
+
+
+def _statement_end(mask, i, end):
+    depth = 0
+    last = ""
+    while i < end:
+        c = mask[i]
+        if c in OPENERS:
+            depth += 1
+            last = c
+        elif c in CLOSERS:
+            depth -= 1
+            if depth < 0:
+                return i
+            last = c
+        elif depth == 0 and c == ";":
+            return i + 1
+        elif depth == 0 and c == "\n":
+            if last and last not in CONTINUERS:
+                return i + 1
+        elif not c.isspace():
+            last = "=>" if c == ">" and last == "=" else c
+        i += 1
+    return end
+
+
+def _find_at_depth(mask, start, stop, target):
+    depth = 0
+    i = start
+    while i < stop:
+        c = mask[i]
+        if c in OPENERS:
+            if c == target and depth == 0:
+                return i
+            depth += 1
+        elif c in CLOSERS:
+            depth -= 1
+        elif c == target and depth == 0:
+            return i
+        i += 1
+    return -1
+
+
+def _matching_brace(mask, open_index, end):
+    depth = 0
+    i = open_index
+    while i < end:
+        c = mask[i]
+        if c in OPENERS:
+            depth += 1
+        elif c in CLOSERS:
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return end
+
+
+def _body_brace(mask, i, stmt_stop, end):
+    """The declaration's body brace: inside the statement, or Allman-style
+    alone on the following line."""
+    brace = _find_at_depth(mask, i, stmt_stop, "{")
+    if brace != -1:
+        return brace
+    j = stmt_stop
+    while j < end and mask[j].isspace():
+        j += 1
+    if j < end and mask[j] == "{":
+        return j
+    return -1
+
+
+def _first_word(mask, i, end):
+    while i < end and mask[i] in " \t":
+        i += 1
+    j = i
+    while j < end and mask[j] in WORD_CHARS:
+        j += 1
+    return mask[i:j], i
+
+
+def _head_line(source, start, stop):
+    newline = source.find("\n", start, stop)
+    cut = stop if newline == -1 else newline
+    return source[start:cut].rstrip().rstrip(";").rstrip()
+
+
+class _Outline:
+    def __init__(self, source, mask):
+        self.source = source
+        self.mask = mask
+        self.lines = []
+        self.regions = []
+        self.declarations = 0
+
+    def emit(self, text, depth=0):
+        pad = "    " * depth
+        for line in text.splitlines():
+            if not line.strip():
+                continue
+            self.lines.append(pad + line.strip() if depth else line.rstrip())
+
+    def confess(self, start, stop):
+        first = _line_of(self.source, start)
+        last = _line_of(self.source, max(start, stop - 1))
+        if self.regions and self.regions[-1][1] >= first - 1:
+            self.regions[-1] = (self.regions[-1][0], max(self.regions[-1][1], last))
+        else:
+            self.regions.append((first, last))
+
+    def walk(self, start, end, depth=0):
+        mask = self.mask
+        i = start
+        while i < end:
+            while i < end and (mask[i].isspace() or mask[i] == ";"):
+                i += 1
+            if i >= end:
+                break
+            if mask[i] in CLOSERS:
+                i += 1
+                continue
+            i = max(self._statement(i, end, depth), i + 1)
+
+    def _statement(self, i, end, depth):
+        mask = self.mask
+        word, word_at = _first_word(mask, i, end)
+
+        if word in CONFESS_KEYWORDS:
+            stop = _statement_end(mask, i, end)
+            self.confess(i, stop)
+            return stop
+
+        if word in MODIFIER_WORDS:
+            inner, _ = _first_word(mask, word_at + len(word), end)
+            if inner in CONTAINER_KEYWORDS:
+                word = inner
+
+        if word in CONTAINER_KEYWORDS:
+            stmt_stop = _statement_end(mask, i, end)
+            brace = _body_brace(mask, i, stmt_stop, end)
+            if brace == -1:
+                self.emit(_head_line(self.source, i, stmt_stop), depth)
+                self.declarations += 1
+                return stmt_stop
+            self.emit(self.source[i:brace].rstrip(), depth)
+            self.declarations += 1
+            close = _matching_brace(mask, brace, end)
+            self.walk(brace + 1, close, depth + 1)
+            return close + 1
+
+        if word in BODIED_KEYWORDS:
+            stmt_stop = _statement_end(mask, i, end)
+            brace = _body_brace(mask, i, stmt_stop, end)
+            if brace == -1:
+                self.emit(_head_line(self.source, i, stmt_stop), depth)
+                self.declarations += 1
+                return stmt_stop
+            self.emit(self.source[i:brace].rstrip(), depth)
+            self.declarations += 1
+            return _matching_brace(mask, brace, end) + 1
+
+        if word in LINE_KEYWORDS:
+            stmt_stop = _statement_end(mask, i, end)
+            self.emit(_head_line(self.source, i, stmt_stop), depth)
+            self.declarations += 1
+            return stmt_stop
+
+        if word in CALLABLE_KEYWORDS:
+            return self._callable(i, end, depth)
+
+        return self._generic(i, end, depth)
+
+    def _callable(self, i, end, depth):
+        mask = self.mask
+        stmt_stop = _statement_end(mask, i, end)
+        paren = _find_at_depth(mask, i, stmt_stop, "(")
+        if paren == -1:
+            self.emit(_head_line(self.source, i, stmt_stop), depth)
+            self.declarations += 1
+            return stmt_stop
+        after = _matching_brace(mask, paren, end) + 1
+        rest_stop = _statement_end(mask, after, end)
+        body = _body_brace(mask, after, rest_stop, end)
+        head_stop = body if body != -1 else rest_stop
+        self.emit(self.source[i:head_stop].rstrip().rstrip(";").rstrip(), depth)
+        self.declarations += 1
+        if body != -1:
+            return _matching_brace(mask, body, end) + 1
+        return rest_stop
+
+    def _generic(self, i, end, depth):
+        mask = self.mask
+        stmt_stop = _statement_end(mask, i, end)
+        equals = _find_at_depth(mask, i, stmt_stop, "=")
+        head_stop = equals if equals != -1 else stmt_stop
+        head = _head_line(self.source, i, head_stop)
+        if head.strip():
+            self.emit(head, depth)
+            self.declarations += 1
+        return stmt_stop
+
+
+def _module_header(source, spans):
+    for kind, start, end in spans:
+        if kind == "code" and source[start:end].strip():
+            return None
+        if kind in ("line_comment", "block_comment"):
+            for raw in source[start:end].splitlines():
+                text = raw.strip().lstrip("/*").rstrip("*/").strip("* ").strip()
+                if text:
+                    return text
+            return None
+    return None
+
+
+def outline(path, source, out):
+    """Print the file's declaration outline; 0 clean, 1 when the lexer
+    confessed an unterminated construct."""
+    spans, errors = lex(source)
+    mask = _masked(source, spans)
+    header = _module_header(source, spans)
+    print(f"module: {header}" if header else "module: (no header comment)", file=out)
+
+    walker = _Outline(source, mask)
+    walker.walk(0, len(source) if not errors else spans[-1][1])
+    for offset, reason in errors:
+        print(f"lexer: {reason} at line {_line_of(source, offset)}", file=out)
+        walker.confess(offset, len(source))
+
+    for line in walker.lines:
+        print(line, file=out)
+    print(f"declarations: {walker.declarations}", file=out)
+    if walker.regions:
+        listed = ", ".join(
+            f"lines {a}-{b}" if a != b else f"line {a}" for a, b in walker.regions
+        )
+        print(f"unparsed: {len(walker.regions)} region(s): {listed}", file=out)
+    else:
+        print("unparsed: none", file=out)
+    return 1 if errors else 0

--- a/plugins/horos/tests/test_sol_outline.py
+++ b/plugins/horos/tests/test_sol_outline.py
@@ -1,0 +1,138 @@
+"""The Solidity outliner slices keyword-led declarations and confesses the rest."""
+
+from pathlib import Path
+import io
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "horos" / "scripts"))  # noqa: E402  (locates horos.py)
+
+from languages.solidity import solidity as sol  # noqa: E402
+
+PLUGIN = Path(__file__).resolve().parents[1]
+FIXTURE = PLUGIN / "examples" / "fixture-sol" / "Market.sol"
+
+EXPECTED = """module: SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20
+import { IERC20 } from "./interfaces/IERC20.sol"
+import "./libraries/MathUtils.sol"
+type Duration is uint32
+using MathUtils for uint256
+error MarketClosed(address market)
+struct LenderStatus
+enum MarketState
+uint256 constant BIP
+interface IMarketEvents
+    event Borrow(uint256 assetAmount)
+    event DebtRepaid(address indexed from, uint256 assetAmount)
+abstract contract MarketBase is IMarketEvents
+    IERC20 public immutable asset
+    uint256 public totalSupply
+    mapping(address => LenderStatus) internal _lenders
+    modifier onlyOpen()
+    constructor(IERC20 _asset)
+    function state() public view virtual returns (MarketState)
+    receive() external payable
+    function borrow(
+    uint256 assetAmount
+    ) external onlyOpen returns (uint256 normalized)
+library MarketMath
+    function rayDiv(uint256 x, uint256 y) internal pure returns (uint256)
+contract Market is MarketBase
+    constructor(IERC20 _asset) MarketBase(_asset)
+    function state() public pure override returns (MarketState)
+declarations: 26
+unparsed: none
+"""
+
+
+def run(source):
+    out = io.StringIO()
+    code = sol.outline("Test.sol", source, out)
+    return code, out.getvalue()
+
+
+class SolOutlineTests(unittest.TestCase):
+    def test_the_fixture_outline_is_pinned(self):
+        source = FIXTURE.read_text(encoding="utf-8")
+        out = io.StringIO()
+        code = sol.outline(str(FIXTURE), source, out)
+        self.assertEqual(code, 0)
+        self.assertEqual(out.getvalue(), EXPECTED)
+
+    def test_bodies_never_leak_into_the_outline(self):
+        source = FIXTURE.read_text(encoding="utf-8")
+        _, output = run(source)
+        self.assertNotIn("mstore", output)
+        self.assertNotIn("totalSupply +=", output)
+        self.assertNotIn("function fake()", output)
+
+    def test_hex_and_unicode_strings_are_inert(self):
+        code, output = run(
+            'contract C {\n\tbytes constant B = hex"00ff";\n'
+            '\tstring constant U = unicode"gm \\u2603";\n'
+            "\tfunction f() external {}\n}\n"
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("    function f() external", output.splitlines())
+        self.assertIn("unparsed: none", output)
+
+    def test_a_contract_keyword_inside_a_string_is_not_a_declaration(self):
+        _, output = run('string constant S = "contract Fake {";\ncontract Real {}\n')
+        lines = output.splitlines()
+        self.assertIn("contract Real", lines)
+        self.assertFalse(any(line.startswith("contract Fake") for line in lines))
+
+    def test_an_inheritance_list_rides_in_the_head(self):
+        _, output = run("contract C is A, B(1) {\n\tuint256 x;\n}\n")
+        self.assertIn("contract C is A, B(1)", output.splitlines())
+
+    def test_a_multiline_head_with_override_list_slices_whole(self):
+        code, output = run(
+            "contract C is A {\n\tfunction f(\n\t\tuint256 x\n\t) public virtual"
+            " override(A) returns (uint256) {\n\t\treturn x;\n\t}\n}\n"
+        )
+        self.assertEqual(code, 0)
+        self.assertIn(") public virtual override(A) returns (uint256)", output)
+        self.assertNotIn("return x", output)
+
+    def test_state_variables_stop_before_initialisers(self):
+        _, output = run("contract C {\n\tuint256 public fee = 500;\n}\n")
+        self.assertIn("    uint256 public fee", output.splitlines())
+        self.assertNotIn("500", output)
+
+    def test_an_abstract_contract_walks_its_members(self):
+        _, output = run("abstract contract A {\n\tfunction f() external virtual;\n}\n")
+        lines = output.splitlines()
+        self.assertIn("abstract contract A", lines)
+        self.assertIn("    function f() external virtual", lines)
+
+    def test_an_unmatched_statement_is_confessed_by_line(self):
+        code, output = run("uint256 constant X = 1;\nif (true) { revert(); }\n")
+        self.assertEqual(code, 0)
+        self.assertIn("unparsed: 1 region(s): line 2", output)
+
+    def test_an_unterminated_string_confesses_the_remainder(self):
+        code, output = run('contract C {}\nstring constant S = "open\ncontract D {}\n')
+        self.assertEqual(code, 1)
+        self.assertIn("lexer: unterminated string at line 2", output)
+        self.assertNotIn("unparsed: none", output)
+
+    def test_a_bodyless_interface_function_slices_to_its_semicolon(self):
+        _, output = run("interface I {\n\tfunction f() external returns (uint256);\n}\n")
+        self.assertIn("    function f() external returns (uint256)", output.splitlines())
+
+    def test_the_sol_suffix_dispatches_through_the_registry(self):
+        import horos  # noqa: E402  (registry dispatch under test)
+
+        out = io.StringIO()
+        self.assertEqual(horos.map_file(str(FIXTURE), out=out), 0)
+        self.assertIn(".sol", __import__("languages").supported())
+
+    def test_module_header_falls_back_when_absent(self):
+        _, output = run("pragma solidity ^0.8.0;\n")
+        self.assertIn("module: (no header comment)", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The extractor shape fixed three times, sized for a language that lexes like
a small C++ without the preprocessor and declares like Go. Containers walk
their members with inheritance lists riding in heads; callables slice
through parameter lists and attribute chains to the body brace or
semicolon; events, errors, structs, enums, using-for, file-level types and
state variables slice at their own rules; assembly and unchecked blocks
never reach the walker because bodies are skipped whole. Thirteen tests pin
the traps, the fixture byte for byte among them.

Stacks on step 1 (the spec). Audit: one round, zero findings; log in
audit/AUDIT.md.

Proof: `python3 -m unittest plugins.horos.tests.test_sol_outline -v` and
both suites (horos 149, root 24).

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
