### PR TITLE
Record the Solidity differential corpus against tree-sitter

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1434,3 +1434,19 @@ destructors.
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Solidity-extractor run, step 3, round 1 -- 2026-08-18
+
+Suite waived (Python reading Solidity, none shipped); lints phylax 0,
+ephoros 0, hypomnema 0. Horos 152/152, root 24/24. The review held the
+register's rows: the venv and oracle stay outside every runtime and test
+path, the bundle declares its altitudes and exclusions, the acceptance
+numbers are asserted by test, and the one corpus defect (the multiline
+inheritance swallow, exactly the silent-consumption class this loop exists
+to catch) landed with a pinned regression and a structural fix rather than
+a heuristic patch.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.

--- a/plugins/horos/dev/sol_oracle.py
+++ b/plugins/horos/dev/sol_oracle.py
@@ -1,0 +1,81 @@
+"""Dev-time oracle for the Horos Solidity outliner. Never imported or
+executed by the shipped plugin or its test suite: the differential corpus
+run drives it by hand inside a scratchpad virtualenv holding `tree-sitter`
+and `tree-sitter-solidity`, and only the recorded results are committed.
+
+Usage: <venv-python> sol_oracle.py <file.sol> [...] > oracle.json
+
+Emits, per file, the declarations tree-sitter sees at the declared
+altitudes: contracts, interfaces and libraries; named functions, events,
+errors, structs and enums at file and container depth. Constructors,
+receive and fallback functions, modifiers, state variables, using-for and
+user-defined value types are excluded by declaration, matching the
+differential's declared comparison.
+"""
+
+import json
+import sys
+
+import tree_sitter_solidity
+from tree_sitter import Language, Parser
+
+PARSER = Parser(Language(tree_sitter_solidity.language()))
+
+NAMED_NODES = {
+    "contract_declaration": "container",
+    "interface_declaration": "container",
+    "library_declaration": "container",
+    "function_definition": "function",
+    "event_definition": "event",
+    "error_declaration": "error",
+    "struct_declaration": "struct",
+    "enum_declaration": "enum",
+}
+SCOPE_NODES = {
+    "source_file",
+    "contract_declaration",
+    "interface_declaration",
+    "library_declaration",
+    "contract_body",
+}
+
+
+def text_of(node, source):
+    return source[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+
+
+def collect(node, source, decls):
+    for child in node.children:
+        kind = NAMED_NODES.get(child.type)
+        if kind is not None:
+            name = child.child_by_field_name("name")
+            if name is not None:
+                decls.append(
+                    {
+                        "name": text_of(name, source),
+                        "line": name.start_point[0] + 1,
+                        "kind": kind,
+                    }
+                )
+        if child.type in SCOPE_NODES:
+            collect(child, source, decls)
+
+
+def main():
+    out = {}
+    for path in sys.argv[1:]:
+        with open(path, "rb") as handle:
+            source = handle.read()
+        tree = PARSER.parse(source)
+        decls = []
+        collect(tree.root_node, source, decls)
+        unique = {(d["name"], d["line"]): d for d in decls}
+        out[path] = {
+            "decls": list(unique.values()),
+            "parse_errors": bool(tree.root_node.has_error),
+        }
+    sys.stdout.write(json.dumps(out))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/horos/docs/evidence/v2-protocol-outline.md
+++ b/plugins/horos/docs/evidence/v2-protocol-outline.md
@@ -1,0 +1,52 @@
+# Evidence bundle: the Solidity outliner against tree-sitter
+
+The differential corpus run the Solidity extractor's acceptance demanded:
+every Solidity file in the protocol repository, outlined by Horos and
+independently parsed by tree-sitter's Solidity grammar, with the two
+declaration lists compared per file at declared altitudes.
+
+## The run
+
+- Corpus: `wildcat-finance/v2-protocol` at
+  `c7be4039f8f383a9dda4e45f63331c17d63f9ed9`, all 151 `.sol` files,
+  contracts and Foundry tests alike
+- Captured: 2026-08-18
+- Outliner: `languages/solidity/solidity.py` as shipped in this delivery
+- Oracle: `tree-sitter` with `tree-sitter-solidity`, installed in a
+  scratchpad virtualenv and driven by the committed dev-time tool
+  [../../dev/sol_oracle.py](../../dev/sol_oracle.py); absent from every
+  runtime and test path
+- Declared altitudes: contracts, interfaces and libraries; named functions,
+  events, errors, structs and enums at file and container depth. Excluded
+  by declaration on both sides: constructors, receive and fallback
+  functions, modifiers, state variables, using-for and user-defined value
+  types.
+- Per-file results: [v2-protocol-outline.results.json](./v2-protocol-outline.results.json)
+
+## The result
+
+The oracle sees 2,329 declarations at the declared altitudes and parses
+every file. The outliner names all 2,329, misses none, names nothing extra,
+and crashes nowhere. Zero confessed regions across the corpus: every
+statement in 151 files of live protocol Solidity fell to a recogniser.
+
+One defect was found by the corpus and fixed with a pinned regression: a
+multiline inheritance list broke the container head at the newline after
+`is`, orphaning the body brace and silently swallowing every member of the
+two main market contracts. Container braces are now found structurally (the
+first depth-zero brace before any depth-zero semicolon) rather than by line
+heuristics, and an orphan brace steps over its own close and nothing more.
+
+## Machine-readable capture lines
+
+The consistency test parses these against the committed results document.
+
+<!-- soloutline:commit c7be4039f8f383a9dda4e45f63331c17d63f9ed9 -->
+<!-- soloutline:files 151 -->
+<!-- soloutline:crashes 0 -->
+<!-- soloutline:oracle 2329 -->
+<!-- soloutline:matched 2329 -->
+<!-- soloutline:missed 0 -->
+<!-- soloutline:missed_confessed 0 -->
+<!-- soloutline:extra 0 -->
+<!-- soloutline:oracle_unparsed 0 -->

--- a/plugins/horos/docs/evidence/v2-protocol-outline.results.json
+++ b/plugins/horos/docs/evidence/v2-protocol-outline.results.json
@@ -1,0 +1,1375 @@
+{
+ "files": {
+  "script/Deploy4626Factory.sol": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "script/DeployAndExercise4626.sol": {
+   "extra": 0,
+   "matched": 26,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 26,
+   "ours": 26,
+   "regions": 0
+  },
+  "script/DeployTypes.sol": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "script/DeployV2.sol": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "script/DeployV2Mainnet.sol": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "script/Lender.sol": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "script/LibDeployment.sol": {
+   "extra": 0,
+   "matched": 39,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 39,
+   "ours": 39,
+   "regions": 0
+  },
+  "script/MintTokens.sol": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "script/SeedSphereX.sol": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "script/SeedSubgraphData.sol": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "script/Test12.sol": {
+   "extra": 0,
+   "matched": 38,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 38,
+   "ours": 38,
+   "regions": 0
+  },
+  "script/mock/MockArchControllerOwner.sol": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "script/mock/MockBorrower.sol": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "script/mock/MockCaller.sol": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "script/mock/MockERC20.sol": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "script/mock/MockERC20Factory.sol": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "script/mock/UniversalProvider.sol": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/HooksFactory.sol": {
+   "extra": 0,
+   "matched": 31,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 31,
+   "ours": 31,
+   "regions": 0
+  },
+  "src/IHooksFactory.sol": {
+   "extra": 0,
+   "matched": 50,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 50,
+   "ours": 50,
+   "regions": 0
+  },
+  "src/ReentrancyGuard.sol": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/WildcatArchController.sol": {
+   "extra": 0,
+   "matched": 51,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 51,
+   "ours": 51,
+   "regions": 0
+  },
+  "src/WildcatSanctionsEscrow.sol": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/WildcatSanctionsSentinel.sol": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "src/access/BaseAccessControls.sol": {
+   "extra": 0,
+   "matched": 51,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 51,
+   "ours": 51,
+   "regions": 0
+  },
+  "src/access/FixedTermHooks.sol": {
+   "extra": 0,
+   "matched": 34,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 34,
+   "ours": 34,
+   "regions": 0
+  },
+  "src/access/IHooks.sol": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "src/access/IRoleProvider.sol": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/access/IRoleProviderFactory.sol": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/access/MarketConstraintHooks.sol": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "src/access/OpenTermHooks.sol": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "src/access/ProviderStructs.sol": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/interfaces/IChainalysisSanctionsList.sol": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/interfaces/IERC20.sol": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "src/interfaces/IMarketEventsAndErrors.sol": {
+   "extra": 0,
+   "matched": 57,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 57,
+   "ours": 57,
+   "regions": 0
+  },
+  "src/interfaces/ISphereXProtectedRegisteredBase.sol": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/interfaces/IWildcatArchController.sol": {
+   "extra": 0,
+   "matched": 57,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 57,
+   "ours": 57,
+   "regions": 0
+  },
+  "src/interfaces/IWildcatSanctionsEscrow.sol": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "src/interfaces/IWildcatSanctionsSentinel.sol": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "src/interfaces/WildcatStructsAndEnums.sol": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/lens/HooksConfigData.sol": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/lens/HooksDataForBorrower.sol": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/lens/HooksInstanceData.sol": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "src/lens/HooksTemplateData.sol": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/lens/LenderAccountData.sol": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/lens/MarketData.sol": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "src/lens/MarketLens.sol": {
+   "extra": 0,
+   "matched": 24,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 24,
+   "ours": 24,
+   "regions": 0
+  },
+  "src/lens/RoleProviderData.sol": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/lens/TokenData.sol": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/lens/WithdrawalBatchData.sol": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/libraries/BoolUtils.sol": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/libraries/Errors.sol": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/libraries/FIFOQueue.sol": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "src/libraries/FeeMath.sol": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/libraries/FunctionTypeCasts.sol": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "src/libraries/LibERC20.sol": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "src/libraries/LibStoredInitCode.sol": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "src/libraries/MarketErrors.sol": {
+   "extra": 0,
+   "matched": 33,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 33,
+   "ours": 33,
+   "regions": 0
+  },
+  "src/libraries/MarketEvents.sol": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "src/libraries/MarketState.sol": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "src/libraries/MathUtils.sol": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "src/libraries/SafeCastLib.sol": {
+   "extra": 0,
+   "matched": 33,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 33,
+   "ours": 33,
+   "regions": 0
+  },
+  "src/libraries/StringQuery.sol": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "src/libraries/Withdrawal.sol": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "src/market/WildcatMarket.sol": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "src/market/WildcatMarketBase.sol": {
+   "extra": 0,
+   "matched": 30,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 30,
+   "ours": 30,
+   "regions": 0
+  },
+  "src/market/WildcatMarketConfig.sol": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "src/market/WildcatMarketToken.sol": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "src/market/WildcatMarketWithdrawals.sol": {
+   "extra": 0,
+   "matched": 13,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 13,
+   "ours": 13,
+   "regions": 0
+  },
+  "src/spherex/ISphereXEngine.sol": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "src/spherex/SphereXConfig.sol": {
+   "extra": 0,
+   "matched": 23,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 23,
+   "ours": 23,
+   "regions": 0
+  },
+  "src/spherex/SphereXProtectedErrors.sol": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/spherex/SphereXProtectedEvents.sol": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/spherex/SphereXProtectedRegisteredBase.sol": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "src/types/HooksConfig.sol": {
+   "extra": 0,
+   "matched": 35,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 35,
+   "ours": 35,
+   "regions": 0
+  },
+  "src/types/LenderStatus.sol": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "src/types/RoleProvider.sol": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "src/types/TransientBytesArray.sol": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "src/vault/Wildcat4626Wrapper.sol": {
+   "extra": 0,
+   "matched": 50,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 50,
+   "ours": 50,
+   "regions": 0
+  },
+  "src/vault/Wildcat4626WrapperFactory.sol": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "test/BaseMarketTest.sol": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "test/EscrowTest.sol": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "test/HooksFactory.t.sol": {
+   "extra": 0,
+   "matched": 48,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 48,
+   "ours": 48,
+   "regions": 0
+  },
+  "test/HooksIntegration.t.sol": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "test/InvariantTests.sol": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "test/LogTest.sol": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "test/ReentrancyGuard.t.sol": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "test/SentinelTest.sol": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "test/WildcatArchController.t.sol": {
+   "extra": 0,
+   "matched": 54,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 54,
+   "ours": 54,
+   "regions": 0
+  },
+  "test/WildcatArchControllerIntegration.t.sol": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "test/access/BaseAccessControls.t.sol": {
+   "extra": 0,
+   "matched": 53,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 53,
+   "ours": 53,
+   "regions": 0
+  },
+  "test/access/FixedTermHooks.t.sol": {
+   "extra": 0,
+   "matched": 34,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 34,
+   "ours": 34,
+   "regions": 0
+  },
+  "test/access/OpenTermHooks.t.sol": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "test/handlers/BaseHandler.sol": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "test/handlers/ERC20Handler.sol": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "test/helpers/AddressSet.sol": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "test/helpers/Assertions.sol": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "test/helpers/BaseERC20Test.sol": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "test/helpers/ExpectedBalances.sol": {
+   "extra": 0,
+   "matched": 40,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 40,
+   "ours": 40,
+   "regions": 0
+  },
+  "test/helpers/ExpectedStateTracker.sol": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "test/helpers/Labeler.sol": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "test/helpers/Metrics.sol": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "test/helpers/PRNG.sol": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "test/helpers/StandardStructs.sol": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "test/helpers/VmUtils.sol": {
+   "extra": 0,
+   "matched": 15,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 15,
+   "ours": 15,
+   "regions": 0
+  },
+  "test/helpers/fuzz/AccessControlHooksFuzzContext.sol": {
+   "extra": 0,
+   "matched": 22,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 22,
+   "ours": 22,
+   "regions": 0
+  },
+  "test/helpers/fuzz/MarketConfigFuzzInputs.sol": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "test/helpers/fuzz/MarketStateFuzzInputs.sol": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "test/lens/MarketLens.t.sol": {
+   "extra": 0,
+   "matched": 25,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 25,
+   "ours": 25,
+   "regions": 0
+  },
+  "test/libraries/FIFOQueue.t.sol": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "test/libraries/FeeMath.t.sol": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "test/libraries/LibStoredInitCode.t.sol": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "test/libraries/MarketState.t.sol": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "test/libraries/MathUtils.t.sol": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "test/libraries/SafeCastLib.t.sol": {
+   "extra": 0,
+   "matched": 32,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 32,
+   "ours": 32,
+   "regions": 0
+  },
+  "test/libraries/StringQuery.t.sol": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "test/libraries/Withdrawal.t.sol": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "test/libraries/wrappers/FIFOQueueLibExternal.sol": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "test/libraries/wrappers/FeeMathExternal.sol": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  },
+  "test/libraries/wrappers/LibStoredInitCodeExternal.sol": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "test/libraries/wrappers/MarketStateLibExternal.sol": {
+   "extra": 0,
+   "matched": 9,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 9,
+   "ours": 9,
+   "regions": 0
+  },
+  "test/libraries/wrappers/MathUtilsExternal.sol": {
+   "extra": 0,
+   "matched": 14,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 14,
+   "ours": 14,
+   "regions": 0
+  },
+  "test/libraries/wrappers/SafeCastLibExternal.sol": {
+   "extra": 0,
+   "matched": 32,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 32,
+   "ours": 32,
+   "regions": 0
+  },
+  "test/libraries/wrappers/WithdrawalLibExternal.sol": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "test/market/FixedTermEquivalenceTests.t.sol": {
+   "extra": 0,
+   "matched": 6,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 6,
+   "ours": 6,
+   "regions": 0
+  },
+  "test/market/WildcatMarket.t.sol": {
+   "extra": 0,
+   "matched": 48,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 48,
+   "ours": 48,
+   "regions": 0
+  },
+  "test/market/WildcatMarketBase.t.sol": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "test/market/WildcatMarketConfig.t.sol": {
+   "extra": 0,
+   "matched": 37,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 37,
+   "ours": 37,
+   "regions": 0
+  },
+  "test/market/WildcatMarketToken.t.sol": {
+   "extra": 0,
+   "matched": 11,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 11,
+   "ours": 11,
+   "regions": 0
+  },
+  "test/market/WildcatMarketWithdrawals.t.sol": {
+   "extra": 0,
+   "matched": 54,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 54,
+   "ours": 54,
+   "regions": 0
+  },
+  "test/shared/Test.sol": {
+   "extra": 0,
+   "matched": 28,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 28,
+   "ours": 28,
+   "regions": 0
+  },
+  "test/shared/TestConstants.sol": {
+   "extra": 0,
+   "matched": 0,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 0,
+   "ours": 0,
+   "regions": 0
+  },
+  "test/shared/mocks/AlwaysAuthorizedRoleProvider.sol": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "test/shared/mocks/MockChainalysis.sol": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "test/shared/mocks/MockERC20.sol": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "test/shared/mocks/MockEngine.sol": {
+   "extra": 0,
+   "matched": 8,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 8,
+   "ours": 8,
+   "regions": 0
+  },
+  "test/shared/mocks/MockFixedTermHooks.sol": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "test/shared/mocks/MockHookCaller.sol": {
+   "extra": 0,
+   "matched": 16,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 16,
+   "ours": 16,
+   "regions": 0
+  },
+  "test/shared/mocks/MockHooks.sol": {
+   "extra": 0,
+   "matched": 34,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 34,
+   "ours": 34,
+   "regions": 0
+  },
+  "test/shared/mocks/MockOpenTermHooks.sol": {
+   "extra": 0,
+   "matched": 3,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 3,
+   "ours": 3,
+   "regions": 0
+  },
+  "test/shared/mocks/MockRoleProvider.sol": {
+   "extra": 0,
+   "matched": 10,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 10,
+   "ours": 10,
+   "regions": 0
+  },
+  "test/shared/mocks/MockRoleProviderFactory.sol": {
+   "extra": 0,
+   "matched": 5,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 5,
+   "ours": 5,
+   "regions": 0
+  },
+  "test/shared/mocks/MockSanctionsSentinel.sol": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "test/spherex/SphereXConfig.t.sol": {
+   "extra": 0,
+   "matched": 33,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 33,
+   "ours": 33,
+   "regions": 0
+  },
+  "test/types/HooksConfig.t.sol": {
+   "extra": 0,
+   "matched": 17,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 17,
+   "ours": 17,
+   "regions": 0
+  },
+  "test/types/LenderStatus.t.sol": {
+   "extra": 0,
+   "matched": 2,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 2,
+   "ours": 2,
+   "regions": 0
+  },
+  "test/types/RoleProvider.t.sol": {
+   "extra": 0,
+   "matched": 12,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 12,
+   "ours": 12,
+   "regions": 0
+  },
+  "test/types/TransientBytesArray.t.sol": {
+   "extra": 0,
+   "matched": 4,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 4,
+   "ours": 4,
+   "regions": 0
+  },
+  "test/vault/Wildcat4626Wrapper.t.sol": {
+   "extra": 0,
+   "matched": 59,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 59,
+   "ours": 59,
+   "regions": 0
+  },
+  "test/vault/Wildcat4626WrapperFactory.t.sol": {
+   "extra": 0,
+   "matched": 18,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 18,
+   "ours": 18,
+   "regions": 0
+  },
+  "test/vault/Wildcat4626WrapperRounding.t.sol": {
+   "extra": 0,
+   "matched": 43,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 43,
+   "ours": 43,
+   "regions": 0
+  },
+  "test/vault/Wildcat4626WrapperStandard.t.sol": {
+   "extra": 0,
+   "matched": 7,
+   "missed": 0,
+   "missed_confessed": 0,
+   "oracle": 7,
+   "ours": 7,
+   "regions": 0
+  }
+ },
+ "totals": {
+  "crashes": 0,
+  "extra": 0,
+  "files": 151,
+  "files_with_regions": 0,
+  "matched": 2329,
+  "missed": 0,
+  "missed_confessed": 0,
+  "oracle": 2329,
+  "oracle_unparsed": 0,
+  "ours": 2329
+ }
+}

--- a/plugins/horos/skills/horos/scripts/languages/solidity/solidity.py
+++ b/plugins/horos/skills/horos/scripts/languages/solidity/solidity.py
@@ -261,8 +261,12 @@ class _Outline:
                 word = inner
 
         if word in CONTAINER_KEYWORDS:
-            stmt_stop = _statement_end(mask, i, end)
-            brace = _body_brace(mask, i, stmt_stop, end)
+            # A container always owns a brace, and its inheritance list may
+            # break lines after `is`, so the brace is found structurally:
+            # the first depth-zero brace before any depth-zero semicolon.
+            semi = _find_at_depth(mask, i, end, ";")
+            brace = _find_at_depth(mask, i, semi if semi != -1 else end, "{")
+            stmt_stop = _statement_end(mask, i, end) if brace == -1 else brace
             if brace == -1:
                 self.emit(_head_line(self.source, i, stmt_stop), depth)
                 self.declarations += 1
@@ -315,6 +319,10 @@ class _Outline:
 
     def _generic(self, i, end, depth):
         mask = self.mask
+        if mask[i] == "{":
+            # An orphan brace block names nothing and owns nothing beyond
+            # its own close; stepping over it keeps a mis-slice bounded.
+            return _matching_brace(mask, i, end) + 1
         stmt_stop = _statement_end(mask, i, end)
         equals = _find_at_depth(mask, i, stmt_stop, "=")
         head_stop = equals if equals != -1 else stmt_stop

--- a/plugins/horos/tests/test_evidence.py
+++ b/plugins/horos/tests/test_evidence.py
@@ -20,6 +20,8 @@ BUNDLE_5 = EVIDENCE / "go-ethereum-outline.md"
 RESULTS_5 = EVIDENCE / "go-ethereum-outline.results.json"
 BUNDLE_6 = EVIDENCE / "solidity-outline.md"
 RESULTS_6 = EVIDENCE / "solidity-outline.results.json"
+BUNDLE_7 = EVIDENCE / "v2-protocol-outline.md"
+RESULTS_7 = EVIDENCE / "v2-protocol-outline.results.json"
 
 
 def capture_lines(bundle=BUNDLE, tag="evidence"):
@@ -194,6 +196,29 @@ class SecondCaptureTests(unittest.TestCase):
         self.assertEqual(totals["crashes"], 0)
         self.assertEqual(totals["missed"], 0)
         self.assertEqual(totals["extra"], 0)
+        self.assertEqual(totals["matched"], totals["oracle"])
+
+    def test_the_sol_outline_bundle_matches_its_committed_results(self):
+        lines = capture_lines(BUNDLE_7, "soloutline")
+        totals = json.loads(RESULTS_7.read_text(encoding="utf-8"))["totals"]
+        for key in (
+            "files",
+            "crashes",
+            "oracle",
+            "matched",
+            "missed",
+            "missed_confessed",
+            "extra",
+            "oracle_unparsed",
+        ):
+            self.assertEqual(int(lines[key]), totals[key], key)
+
+    def test_the_sol_outline_acceptance_holds(self):
+        totals = json.loads(RESULTS_7.read_text(encoding="utf-8"))["totals"]
+        self.assertEqual(totals["crashes"], 0)
+        self.assertEqual(totals["missed"], 0)
+        self.assertEqual(totals["extra"], 0)
+        self.assertEqual(totals["oracle_unparsed"], 0)
         self.assertEqual(totals["matched"], totals["oracle"])
 
     def test_the_second_share_exceeds_the_first(self):

--- a/plugins/horos/tests/test_sol_outline.py
+++ b/plugins/horos/tests/test_sol_outline.py
@@ -87,6 +87,16 @@ class SolOutlineTests(unittest.TestCase):
         _, output = run("contract C is A, B(1) {\n\tuint256 x;\n}\n")
         self.assertIn("contract C is A, B(1)", output.splitlines())
 
+    def test_a_multiline_inheritance_list_keeps_the_body(self):
+        code, output = run(
+            "contract C is\n\tA,\n\tB\n{\n\tfunction f() external {}\n}\n"
+        )
+        self.assertEqual(code, 0)
+        lines = output.splitlines()
+        self.assertIn("contract C is", lines)
+        self.assertIn("    function f() external", lines)
+        self.assertIn("unparsed: none", output)
+
     def test_a_multiline_head_with_override_list_slices_whole(self):
         code, output = run(
             "contract C is A {\n\tfunction f(\n\t\tuint256 x\n\t) public virtual"


### PR DESCRIPTION
All 151 Solidity files of wildcat-finance/v2-protocol at commit c7be403,
outlined by Horos and independently parsed by tree-sitter's Solidity
grammar through the committed dev-time oracle. The oracle sees 2,329
declarations at the declared altitudes and parses every file; the outliner
names all 2,329, misses none, names nothing extra, crashes nowhere, and
confesses nothing: every statement in the live protocol fell to a
recogniser.

The one corpus-found defect is the exact silent-consumption class this loop
exists to catch: a multiline inheritance list orphaned its body brace and
silently swallowed every member of the two main market contracts. Fixed
structurally (a container's brace is the first depth-zero brace before any
depth-zero semicolon) with a pinned regression.

Stacks on step 2 (the extractor). Audit: one round, zero findings; log in
audit/AUDIT.md.

Proof: `python3 -m unittest plugins.horos.tests.test_evidence -v`
(twenty-two tests across seven bundles).

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
