### PR TITLE
Default the scan universe to git-tracked files

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1528,3 +1528,18 @@ Zero findings. Leads not pursued: the specification's closing note names
 nested .gitattributes and corroborated exclusions as the largest gains;
 both landed, and the recapture evidence for real trees belongs to the
 third job.
+
+## Refinement run, step 4, round 1 -- 2026-08-18
+
+Suite waived (no Solidity); lints phylax 0 (the git subprocess carries its
+allow comment naming fixed argv, no shell, pinned cwd), ephoros 0. Horos
+165/165, root 24/24, verified before the receipt. The review held the
+register's rows: ignored files never enter any universe, the widened mode
+still excludes them, aggregation counts only universe members, check
+reproduces the committed universe, and the fixture's tracked label is safe
+because running the suite presupposes a git clone.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.

--- a/plugins/horos/examples/fixture/.horos/boundary.json
+++ b/plugins/horos/examples/fixture/.horos/boundary.json
@@ -62,5 +62,6 @@
     }
   ],
   "schema": 2,
-  "tool": "horos"
+  "tool": "horos",
+  "universe": "tracked"
 }

--- a/plugins/horos/examples/fixture/.horos/candidates.json
+++ b/plugins/horos/examples/fixture/.horos/candidates.json
@@ -51,5 +51,6 @@
     }
   ],
   "schema": 2,
-  "tool": "horos"
+  "tool": "horos",
+  "universe": "tracked"
 }

--- a/plugins/horos/skills/horos/scripts/horos.py
+++ b/plugins/horos/skills/horos/scripts/horos.py
@@ -16,6 +16,7 @@ import argparse
 import fnmatch
 import json
 import os
+import subprocess
 import sys
 
 import languages
@@ -382,7 +383,7 @@ def corroborate_directory(fulldir, dirname):
     return None
 
 
-def directory_entry(root, relpath, category, evidence, tally=None, grade="hard"):
+def directory_entry(root, relpath, category, evidence, tally=None, grade="hard", universe=None):
     """Aggregate a vendored or generated directory into one entry."""
     total = 0
     files = 0
@@ -394,6 +395,10 @@ def directory_entry(root, relpath, category, evidence, tally=None, grade="hard")
             fullpath = os.path.join(dirpath, filename)
             if os.path.islink(fullpath):
                 continue
+            if universe is not None:
+                inner = os.path.relpath(fullpath, root).replace(os.sep, "/")
+                if inner not in universe:
+                    continue
             try:
                 size = os.stat(fullpath).st_size
             except OSError:
@@ -411,13 +416,36 @@ def directory_entry(root, relpath, category, evidence, tally=None, grade="hard")
     }
 
 
-def scan_tree(root, census=False):
+def resolve_universe(root, include_untracked=False):
+    """The file set a scan covers. Git-tracked by default so local build
+    products and caches never contaminate a committed boundary; the
+    filesystem walk is the fallback when git or the repository is absent.
+
+    Returns (label, relpath_set_or_None)."""
+    argv = ["git", "-C", root, "ls-files", "-z"]
+    if include_untracked:
+        argv += ["--cached", "--others", "--exclude-standard"]
+    try:
+        completed = subprocess.run(  # phylax: allow subprocess: fixed argv, no shell, cwd pinned by -C
+            argv, capture_output=True, check=False
+        )
+    except OSError:
+        return "filesystem", None
+    if completed.returncode != 0:
+        return "filesystem", None
+    paths = completed.stdout.decode("utf-8", errors="replace").split("\0")
+    label = "tracked+untracked" if include_untracked else "tracked"
+    return label, {p for p in paths if p}
+
+
+def scan_tree(root, census=False, include_untracked=False):
     """Walk the tree and return entries plus the counts a quiet run reports.
 
     With census=True the same walk also tallies every file by suffix, so the
     census can never describe a different tree than the boundary does; the
     result gains a "census" key and nothing else changes."""
     root = os.path.abspath(root)
+    universe_label, universe = resolve_universe(root, include_untracked)
     scopes = {}
     tally = {} if census else None
     entries = []
@@ -456,6 +484,7 @@ def scan_tree(root, census=False):
                             named_category,
                             f"directory name {dirname} corroborated by {corroboration}",
                             tally,
+                            universe=universe,
                         )
                     )
                     continue
@@ -469,6 +498,7 @@ def scan_tree(root, census=False):
                         f"directory name {dirname} alone, uncorroborated",
                         None,
                         grade="candidate",
+                        universe=universe,
                     )
                 )
                 keep.append(dirname)
@@ -476,7 +506,9 @@ def scan_tree(root, census=False):
             matched = match_attribute_scopes(scopes, relpath + "/")
             if matched is not None:
                 entries.append(
-                    directory_entry(root, relpath, matched[0], matched[1], tally)
+                    directory_entry(
+                        root, relpath, matched[0], matched[1], tally, universe=universe
+                    )
                 )
                 continue
             keep.append(dirname)
@@ -488,6 +520,8 @@ def scan_tree(root, census=False):
                 continue
             relpath = filename if relative_dir == "." else f"{relative_dir}/{filename}"
             relpath = relpath.replace(os.sep, "/")
+            if universe is not None and relpath not in universe:
+                continue
             walked += 1
             matched = match_attribute_scopes(scopes, relpath)
             if matched is not None:
@@ -532,7 +566,12 @@ def scan_tree(root, census=False):
     for entry in entries:
         key = "bytes_" + entry["category"]
         counts[key] = counts.get(key, 0) + entry["bytes"]
-    result = {"entries": entries, "candidates": candidates, "counts": counts}
+    result = {
+        "entries": entries,
+        "candidates": candidates,
+        "counts": counts,
+        "universe": universe_label,
+    }
     if tally is not None:
         result["census"] = tally
     return result
@@ -566,6 +605,7 @@ def boundary_document(result):
     return {
         "schema": BOUNDARY_SCHEMA,
         "tool": "horos",
+        "universe": result["universe"],
         "entries": result["entries"],
         "counts": result["counts"],
     }
@@ -607,6 +647,7 @@ def candidates_document(result):
     return {
         "schema": BOUNDARY_SCHEMA,
         "tool": "horos",
+        "universe": result["universe"],
         "entries": result["candidates"],
         "counts": counts,
     }
@@ -671,7 +712,8 @@ def check_tree(root, out=None):
     except (OSError, json.JSONDecodeError) as error:
         print(f"horos: unreadable boundary: {error}", file=out)
         return 2
-    result = scan_tree(root)
+    include_untracked = committed.get("universe") == "tracked+untracked"
+    result = scan_tree(root, include_untracked=include_untracked)
     fresh = boundary_document(result)
     drifted = diff_documents(committed, fresh)
     candidate_drift = []
@@ -728,6 +770,11 @@ def main(argv=None):
         "--write", action="store_true", help=f"write {BOUNDARY_RELPATH} atomically"
     )
     scan.add_argument(
+        "--include-untracked",
+        action="store_true",
+        help="widen the universe to untracked-but-not-ignored files",
+    )
+    scan.add_argument(
         "--census",
         action="store_true",
         help=f"per-filetype breakdown; with --write it goes to {CENSUS_RELPATH}",
@@ -748,7 +795,9 @@ def main(argv=None):
     if args.command == "check":
         return check_tree(args.root)
 
-    result = scan_tree(args.root, census=args.census)
+    result = scan_tree(
+        args.root, census=args.census, include_untracked=args.include_untracked
+    )
 
     if args.census:
         document = census_document(result)

--- a/plugins/horos/tests/test_universe.py
+++ b/plugins/horos/tests/test_universe.py
@@ -1,0 +1,108 @@
+"""The scan's universe: tracked by default, widened on request, walked
+when git cannot answer."""
+
+from pathlib import Path
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "horos" / "scripts"))  # noqa: E402  (locates horos.py)
+
+import horos  # noqa: E402
+
+GIT = shutil.which("git")
+
+
+def write(root, relpath, content):
+    path = Path(root) / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, str):
+        content = content.encode("utf-8")
+    path.write_bytes(content)
+    return path
+
+
+def git(root, *args):
+    subprocess.run(  # phylax: allow subprocess: fixed argv git in a test tempdir, no shell
+        ["git", "-C", root, *args],
+        capture_output=True,
+        check=True,
+        env={**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"},
+    )
+
+
+@unittest.skipIf(GIT is None, "git unavailable")
+class UniverseTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.addCleanup(self._tmp.cleanup)
+        git(self.root, "init", "-q")
+        write(self.root, ".gitignore", "ignored.wasm\n")
+        write(self.root, "src/app.py", "x = 1\n")
+        write(self.root, "tracked.wasm", b"\x00asm\x01\x00\x00\x00")
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-q", "-m", "seed")
+        # Local products that never entered git.
+        write(self.root, "untracked.wasm", b"\x00asm\x01\x00\x00\x00")
+        write(self.root, "ignored.wasm", b"\x00asm\x01\x00\x00\x00")
+
+    def paths(self, include_untracked=False):
+        result = horos.scan_tree(self.root, include_untracked=include_untracked)
+        listed = [entry["path"] for entry in result["entries"]]
+        return result, listed
+
+    def test_the_default_universe_is_tracked_only(self):
+        result, listed = self.paths()
+        self.assertEqual(result["universe"], "tracked")
+        self.assertIn("tracked.wasm", listed)
+        self.assertNotIn("untracked.wasm", listed)
+        self.assertNotIn("ignored.wasm", listed)
+
+    def test_include_untracked_widens_but_never_to_ignored(self):
+        result, listed = self.paths(include_untracked=True)
+        self.assertEqual(result["universe"], "tracked+untracked")
+        self.assertIn("tracked.wasm", listed)
+        self.assertIn("untracked.wasm", listed)
+        self.assertNotIn("ignored.wasm", listed)
+
+    def test_a_non_git_tree_walks_the_filesystem(self):
+        with tempfile.TemporaryDirectory() as plain:
+            write(plain, "loose.wasm", b"\x00asm\x01\x00\x00\x00")
+            result = horos.scan_tree(plain)
+            self.assertEqual(result["universe"], "filesystem")
+            self.assertIn(
+                "loose.wasm", [entry["path"] for entry in result["entries"]]
+            )
+
+    def test_the_boundary_document_records_its_universe(self):
+        document = horos.boundary_document(horos.scan_tree(self.root))
+        self.assertEqual(document["universe"], "tracked")
+
+    def test_check_reproduces_the_committed_universe(self):
+        result = horos.scan_tree(self.root, include_untracked=True)
+        horos.write_boundary(self.root, horos.boundary_document(result))
+        out = io.StringIO()
+        code = horos.check_tree(self.root, out=out)
+        self.assertEqual(code, 0)
+        self.assertIn("boundary matches the tree", out.getvalue())
+
+    def test_an_aggregated_directory_counts_only_universe_files(self):
+        write(self.root, "node_modules/dep/package.json", '{"name": "dep"}\n')
+        write(self.root, "node_modules/dep/index.js", "module.exports = 1\n")
+        git(self.root, "add", "-f", "node_modules")
+        git(self.root, "commit", "-q", "-m", "vendor")
+        write(self.root, "node_modules/dep/local-cache.js", "cache\n" * 10)
+        result = horos.scan_tree(self.root)
+        entry = {e["path"]: e for e in result["entries"]}["node_modules/"]
+        self.assertEqual(entry["files"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Horos's first subprocess: git ls-files -z with a fixed argument list, no
shell, the root pinned by -C, and a clean filesystem fallback when git or
the repository is absent, so a committed boundary never inherits local
build products or caches. --include-untracked widens to
untracked-but-not-ignored; ignored files never enter any universe.
Aggregated directories count only universe files; both artefacts record
which universe produced them and check reproduces it.

Stacks on step 3 (the graded pipeline). Audit: one round, zero findings;
log in audit/AUDIT.md.

Proof: `python3 -m unittest plugins.horos.tests.test_universe -v` (six
tests over real temp repositories, skipped cleanly where git is absent)
and both suites (horos 165, root 24), verified green before the receipt.

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
