### PR TITLE
Mark the skills repository with its own boundary

### DIFF
--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -1,0 +1,119 @@
+{
+  "counts": {
+    "bytes_binary": 17,
+    "bytes_generated": 111249,
+    "bytes_lockfile": 54,
+    "bytes_vendored": 94,
+    "files_skipped_unreadable": 0,
+    "files_walked": 1013
+  },
+  "entries": [
+    {
+      "bytes": 20086,
+      "category": "generated",
+      "evidence": "directory name out corroborated by sample: 2 of 2 files minified, binary or generated",
+      "files": 2,
+      "grade": "hard",
+      "path": "plugins/ariadne/tests/fixtures/forge-project/v1/out/"
+    },
+    {
+      "bytes": 44360,
+      "category": "generated",
+      "evidence": "directory name out corroborated by sample: 2 of 2 files minified, binary or generated",
+      "files": 2,
+      "grade": "hard",
+      "path": "plugins/ariadne/tests/fixtures/forge-project/v2/out/"
+    },
+    {
+      "bytes": 949,
+      "category": "generated",
+      "evidence": "marker 'auto-generated' in the first 4096 bytes",
+      "grade": "hard",
+      "path": "plugins/hexaemeron/skills/fizz/templates/FoundryTester.sol"
+    },
+    {
+      "bytes": 2991,
+      "category": "generated",
+      "evidence": "marker 'do not edit' in the first 4096 bytes",
+      "grade": "hard",
+      "path": "plugins/horos/docs/evidence/wildcat-app-v2.boundary.json"
+    },
+    {
+      "bytes": 53,
+      "category": "generated",
+      "evidence": "sourcemap: name ends .map and prefix carries \"mappings\"",
+      "grade": "hard",
+      "path": "plugins/horos/examples/fixture/app.js.map"
+    },
+    {
+      "bytes": 17,
+      "category": "binary",
+      "evidence": "file signature woff2",
+      "grade": "hard",
+      "path": "plugins/horos/examples/fixture/assets/font.woff2"
+    },
+    {
+      "bytes": 74,
+      "category": "generated",
+      "evidence": "directory name dist corroborated by sample: 1 of 1 files minified, binary or generated",
+      "files": 1,
+      "grade": "hard",
+      "path": "plugins/horos/examples/fixture/dist/"
+    },
+    {
+      "bytes": 63,
+      "category": "generated",
+      "evidence": "marker 'do not edit' in the first 4096 bytes",
+      "grade": "hard",
+      "path": "plugins/horos/examples/fixture/gen/api.py"
+    },
+    {
+      "bytes": 10,
+      "category": "vendored",
+      "evidence": "linguist-vendored for 'lib/**' in plugins/horos/examples/fixture/.gitattributes",
+      "files": 1,
+      "grade": "hard",
+      "path": "plugins/horos/examples/fixture/lib/"
+    },
+    {
+      "bytes": 84,
+      "category": "vendored",
+      "evidence": "directory name node_modules corroborated by package-manager structure (left-pad/package.json)",
+      "files": 2,
+      "grade": "hard",
+      "path": "plugins/horos/examples/fixture/node_modules/"
+    },
+    {
+      "bytes": 54,
+      "category": "lockfile",
+      "evidence": "lockfile name yarn.lock",
+      "grade": "hard",
+      "path": "plugins/horos/examples/fixture/yarn.lock"
+    },
+    {
+      "bytes": 30024,
+      "category": "generated",
+      "evidence": "marker 'do not edit' in the first 4096 bytes",
+      "grade": "hard",
+      "path": "plugins/horos/skills/horos/scripts/horos.py"
+    },
+    {
+      "bytes": 12649,
+      "category": "generated",
+      "evidence": "marker 'do not edit' in the first 4096 bytes",
+      "grade": "hard",
+      "path": "plugins/horos/tests/test_classify.py"
+    },
+    {
+      "bytes": 0,
+      "category": "generated",
+      "evidence": "directory name out corroborated by sample: 8 of 8 files minified, binary or generated",
+      "files": 0,
+      "grade": "hard",
+      "path": "plugins/pandects/out/"
+    }
+  ],
+  "schema": 2,
+  "tool": "horos",
+  "universe": "tracked"
+}

--- a/.horos/candidates.json
+++ b/.horos/candidates.json
@@ -1,0 +1,259 @@
+{
+  "counts": {
+    "bytes_asset": 138,
+    "bytes_binary": 11,
+    "bytes_blob": 16956767,
+    "bytes_generated": 98
+  },
+  "entries": [
+    {
+      "bytes": 59394,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 59394 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/input/capture-plan.json"
+    },
+    {
+      "bytes": 28233,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 28233 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/input/registry.json"
+    },
+    {
+      "bytes": 18567,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 18567 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/input/responses/finalized-block.json"
+    },
+    {
+      "bytes": 37485,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 37485 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/input/responses/old-implementation-code.json"
+    },
+    {
+      "bytes": 1100695,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 1100695 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/input/responses/old-opcode-trace.json"
+    },
+    {
+      "bytes": 17874,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 17874 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/input/responses/recent-block.json"
+    },
+    {
+      "bytes": 21905,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 21905 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/input/responses/recent-flat-trace.json"
+    },
+    {
+      "bytes": 37237,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 37237 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/input/responses/recent-implementation-code.json"
+    },
+    {
+      "bytes": 6452358,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 6452358 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/input/responses/recent-opcode-trace.json"
+    },
+    {
+      "bytes": 36681,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 36681 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/input/responses/recent-prestate-trace.json"
+    },
+    {
+      "bytes": 76773,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 76773 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/release/manifest.json"
+    },
+    {
+      "bytes": 36681,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 36681 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/release/objects/sha256/16/161c368768c75d84de8d61e8d1e4d6665ae26420e361dbd997f15ed4b7947b55"
+    },
+    {
+      "bytes": 37485,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 37485 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/release/objects/sha256/1d/1dc095c08f94cd276881f7e205c970ef3f736da7564a30acf793fa8c62393d5a"
+    },
+    {
+      "bytes": 18567,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 18567 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/release/objects/sha256/2f/2f4ece5352ee5d130142e9e1d6bc145f32b283779222fcd5c36844bf7dbaec17"
+    },
+    {
+      "bytes": 28233,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 28233 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/release/objects/sha256/3e/3eff07d0c032d8ab1b614d5ee7691b77e198daa31fa824c739ee7056340b848e"
+    },
+    {
+      "bytes": 1100695,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 1100695 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/release/objects/sha256/6f/6fe9baa091cfe659e7f3901cab27621926d4e3167fdccac95263b3536da56646"
+    },
+    {
+      "bytes": 21905,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 21905 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/release/objects/sha256/89/893f3645e1e1b11be0d08888af64229dda8046322d8146f58d700d02747a50c9"
+    },
+    {
+      "bytes": 6452358,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 6452358 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/release/objects/sha256/96/9658c3ec9a9befdfa3c05b1c835fb01b932363a1a7818ee69f49e9341f6e44c4"
+    },
+    {
+      "bytes": 17874,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 17874 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/release/objects/sha256/c3/c3925c14f3ca31d7fed79b75a841401ae1241fea9236c62edf6616f0b0a59d94"
+    },
+    {
+      "bytes": 37237,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 37237 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/release/objects/sha256/fb/fb7ba74282e1d0b353322515c8378b437b8ac28cb7a839cf56998c4085e6695a"
+    },
+    {
+      "bytes": 28233,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 28233 bytes",
+      "grade": "candidate",
+      "path": "plugins/alexandria/examples/compound-v3-phase0-v0/source/registry.json"
+    },
+    {
+      "bytes": 38122,
+      "category": "blob",
+      "evidence": "mean line length above 400 in the first 4096 bytes",
+      "grade": "candidate",
+      "path": "plugins/hexaemeron/skills/imprimatur/evals/labelled-prose-v1/adjudication.jsonl"
+    },
+    {
+      "bytes": 42094,
+      "category": "blob",
+      "evidence": "mean line length above 400 in the first 4096 bytes",
+      "grade": "candidate",
+      "path": "plugins/hexaemeron/skills/imprimatur/evals/labelled-prose-v1/labels.jsonl"
+    },
+    {
+      "bytes": 27878,
+      "category": "blob",
+      "evidence": "mean line length above 400 in the first 4096 bytes",
+      "grade": "candidate",
+      "path": "plugins/hexaemeron/skills/imprimatur/evals/labelled-prose-v1/raw-label-a.jsonl"
+    },
+    {
+      "bytes": 100603,
+      "category": "blob",
+      "evidence": "mean line length above 400 in the first 4096 bytes",
+      "grade": "candidate",
+      "path": "plugins/hexaemeron/skills/imprimatur/evals/labelled-prose-v1/samples.jsonl"
+    },
+    {
+      "bytes": 11,
+      "category": "binary",
+      "evidence": "null byte in the first 4096 bytes",
+      "grade": "candidate",
+      "path": "plugins/horos/examples/fixture/assets/logo.bin"
+    },
+    {
+      "bytes": 27,
+      "category": "generated",
+      "evidence": "directory name build alone, uncorroborated",
+      "files": 1,
+      "grade": "candidate",
+      "path": "plugins/horos/examples/fixture/build/"
+    },
+    {
+      "bytes": 18091,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 18091 bytes",
+      "grade": "candidate",
+      "path": "plugins/horos/examples/fixture/data/blob.json"
+    },
+    {
+      "bytes": 32184,
+      "category": "blob",
+      "evidence": "mean line length above 400 in the first 4096 bytes",
+      "grade": "candidate",
+      "path": "plugins/horos/examples/fixture/data/min.js"
+    },
+    {
+      "bytes": 138,
+      "category": "asset",
+      "evidence": "svg root element in the first 4096 bytes",
+      "grade": "candidate",
+      "path": "plugins/horos/examples/fixture/icons/logo.svg"
+    },
+    {
+      "bytes": 71,
+      "category": "generated",
+      "evidence": "sql file under a migrations directory segment",
+      "grade": "candidate",
+      "path": "plugins/horos/examples/fixture/prisma/migrations/0001_init/migration.sql"
+    },
+    {
+      "bytes": 17204,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 17204 bytes",
+      "grade": "candidate",
+      "path": "plugins/lazarus/examples/goldfinch-v0/header.json"
+    },
+    {
+      "bytes": 78175,
+      "category": "blob",
+      "evidence": "mean line length above 400 in the first 4096 bytes",
+      "grade": "candidate",
+      "path": "plugins/lazarus/examples/goldfinch-v0/rpc.jsonl"
+    },
+    {
+      "bytes": 732267,
+      "category": "blob",
+      "evidence": "mean line length above 400 in the first 4096 bytes",
+      "grade": "candidate",
+      "path": "plugins/tabularium/examples/goldfinch-v0/events.jsonl"
+    },
+    {
+      "bytes": 203679,
+      "category": "blob",
+      "evidence": "no newline in the first 4096 bytes of 203679 bytes",
+      "grade": "candidate",
+      "path": "plugins/tabularium/examples/goldfinch-v0/source.json"
+    }
+  ],
+  "schema": 2,
+  "tool": "horos",
+  "universe": "tracked"
+}

--- a/.horos/census.json
+++ b/.horos/census.json
@@ -1,0 +1,146 @@
+{
+  "rows": [
+    {
+      "boundary_bytes": 67478,
+      "bytes": 9225289,
+      "files": 275,
+      "suffix": ".json"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 7922875,
+      "files": 90,
+      "suffix": "(no suffix)"
+    },
+    {
+      "boundary_bytes": 42746,
+      "bytes": 2132610,
+      "files": 257,
+      "suffix": ".py"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 1750606,
+      "files": 255,
+      "suffix": ".md"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 1067793,
+      "files": 12,
+      "suffix": ".jsonl"
+    },
+    {
+      "boundary_bytes": 949,
+      "bytes": 293391,
+      "files": 69,
+      "suffix": ".sol"
+    },
+    {
+      "boundary_bytes": 117,
+      "bytes": 183526,
+      "files": 13,
+      "suffix": ".js"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 33767,
+      "files": 2,
+      "suffix": ".graphql"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 18483,
+      "files": 3,
+      "suffix": ".sh"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 7919,
+      "files": 24,
+      "suffix": ".yaml"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 7058,
+      "files": 3,
+      "suffix": ".ts"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 3538,
+      "files": 3,
+      "suffix": ".yml"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 2497,
+      "files": 1,
+      "suffix": ".mjs"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 2252,
+      "files": 2,
+      "suffix": ".sql"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 1367,
+      "files": 1,
+      "suffix": ".hpp"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 1139,
+      "files": 1,
+      "suffix": ".go"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 811,
+      "files": 3,
+      "suffix": ".toml"
+    },
+    {
+      "boundary_bytes": 54,
+      "bytes": 576,
+      "files": 2,
+      "suffix": ".lock"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 152,
+      "files": 1,
+      "suffix": ".txt"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 138,
+      "files": 1,
+      "suffix": ".svg"
+    },
+    {
+      "boundary_bytes": 53,
+      "bytes": 53,
+      "files": 1,
+      "suffix": ".map"
+    },
+    {
+      "boundary_bytes": 17,
+      "bytes": 17,
+      "files": 1,
+      "suffix": ".woff2"
+    },
+    {
+      "boundary_bytes": 0,
+      "bytes": 11,
+      "files": 1,
+      "suffix": ".bin"
+    }
+  ],
+  "schema": 1,
+  "tool": "horos",
+  "total_bytes": 22655868,
+  "total_files": 1021
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,3 +121,12 @@ python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENT
 Validate every changed skill directory against the Agent Skills frontmatter
 rules. Keep `SKILL.md` names equal to their parent directory names and keep
 descriptions precise enough to select the skill without reading its body.
+
+## Reading boundary
+
+Before reading this repository broadly, consult `.horos/boundary.json`.
+Every path listed there is a classified token sink carrying the evidence
+that earned its entry; leave those paths unread unless the task demands
+one. The boundary is fail-open: what it omits is merely unproven. It never
+applies during security review; during any audit, review or incident work,
+read as if no boundary exists.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1566,3 +1566,19 @@ Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0. Horos
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Marking run, step 2, round 1 -- 2026-08-18
+
+Suite waived; lints phylax 0, ephoros 0, hypomnema 0 over the changed
+AGENTS.md. Root 24/24 with the stanza in place, horos 165/165, check from
+the root clean, all verified before the receipt. The review read the
+committed boundary's 14 hard entries and spot-checked them against the
+tree: the fixture's own specimens, the shipped example artefacts and the
+evidence JSONs classify exactly as the rules say, and no hand-written
+plugin source appears in the hard set. The 35 candidates are advisory and
+say so.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.


### PR DESCRIPTION
The repository now carries what the plugin only preached: a graded boundary
(14 hard entries), a candidates report (35 advisory findings) and a census
at .horos/, all under the tracked universe, with the adoption stanza in
AGENTS.md so any instruction-following agent inherits the discipline. check
from the root verifies the boundary clean, and the marketplace prose
contracts hold with the stanza in place.

Stacks on step 1 (the spec). Audit: one round, zero findings; log in
audit/AUDIT.md.

Proof: `python3 plugins/horos/skills/horos/scripts/horos.py check .` and
both suites, verified green before the receipt.

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
