### PR TITLE
Mark the product repositories and record the evidence

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1582,3 +1582,18 @@ say so.
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Marking run, step 3, round 1 -- 2026-08-18
+
+Suite waived; lints phylax 0, ephoros 0, hypomnema 0. Horos 168/168, root
+24/24, verified before the receipt. The review held the register's rows:
+one branch and one pull request per product repository and nothing merged
+past their gates; the gitattributes promotions ride inside the reviewable
+diffs exactly as the specification intends candidates to be promoted; the
+bundle's numbers are asserted against the committed boundary copies; and
+the stanza text in both product AGENTS.md files is the scanner's verbatim.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.

--- a/plugins/horos/docs/evidence/three-repository-marking.md
+++ b/plugins/horos/docs/evidence/three-repository-marking.md
@@ -1,0 +1,57 @@
+# Evidence bundle: the three-repository marking
+
+The reopened frontier's last job: Horos stopped being a tool that could
+mark repositories and became the tool that has marked them. Each of the
+three home repositories now carries a graded boundary, a candidates
+report, a census and the adoption stanza, scanned under the git-tracked
+universe with the refined classifier, on 2026-08-18.
+
+## The skills repository
+
+- Marked in place on this run's own branch; the boundary lives at
+  [.horos/boundary.json](../../../../.horos/boundary.json) and the stanza
+  in `AGENTS.md`
+- 14 hard entries binding 111,414 bytes, 35 candidates; `check .` verifies
+  clean from the root
+
+## wildcat-finance/v2-protocol
+
+- Commit `c7be4039f8f383a9dda4e45f63331c17d63f9ed9`, marked through
+  [v2-protocol#134](https://github.com/wildcat-finance/v2-protocol/pull/134)
+- Boundary copy: [v2-protocol.boundary.json](./v2-protocol.boundary.json)
+- 2 hard entries binding 9,885,998 bytes (88.6% of the tree), zero
+  candidates remaining. The refined grades initially left the 9.7 MB of
+  solc output in `deployments/` as 38 geometry-only candidates; the pull
+  request carries the one-line `.gitattributes` promotion
+  (`deployments/** linguist-generated`) the candidates report exists to
+  propose, converting them to hard attribute evidence under review.
+
+## wildcat-finance/wildcat-app-v2
+
+- Commit `9b8b6d5d6db06428c5b539f267623277b65315cd`, marked through
+  [wildcat-app-v2#360](https://github.com/wildcat-finance/wildcat-app-v2/pull/360)
+- Boundary copy: [wildcat-app-v2.boundary.v2.json](./wildcat-app-v2.boundary.v2.json)
+- 13 hard entries binding 13,407,224 bytes (78.6% of the tree), 117
+  advisory candidates (the SVG family, null-byte binaries without
+  signatures, and small blobs). The pull request promotes the single-line
+  legal-entity dataset to hard attribute evidence the same way. Against
+  the schema-1 capture of the same commit, the hard set now carries its
+  grades, its universe and its corroborations on every entry.
+
+Both product pull requests await their repositories' own review gates;
+this run does not merge past them, and maturity does not pretend they
+merged.
+
+## Machine-readable capture lines
+
+The consistency test parses these against the committed boundary copies
+and the repository's own boundary.
+
+<!-- marking:skills_entries 14 -->
+<!-- marking:skills_hard_bytes 111414 -->
+<!-- marking:v2p_commit c7be4039f8f383a9dda4e45f63331c17d63f9ed9 -->
+<!-- marking:v2p_entries 2 -->
+<!-- marking:v2p_hard_bytes 9885998 -->
+<!-- marking:app_commit 9b8b6d5d6db06428c5b539f267623277b65315cd -->
+<!-- marking:app_entries 13 -->
+<!-- marking:app_hard_bytes 13407224 -->

--- a/plugins/horos/docs/evidence/v2-protocol.boundary.json
+++ b/plugins/horos/docs/evidence/v2-protocol.boundary.json
@@ -1,0 +1,28 @@
+{
+  "counts": {
+    "bytes_generated": 9712021,
+    "bytes_lockfile": 173977,
+    "files_skipped_unreadable": 0,
+    "files_walked": 182
+  },
+  "entries": [
+    {
+      "bytes": 9712021,
+      "category": "generated",
+      "evidence": "linguist-generated for 'deployments/**' in .gitattributes",
+      "files": 54,
+      "grade": "hard",
+      "path": "deployments/"
+    },
+    {
+      "bytes": 173977,
+      "category": "lockfile",
+      "evidence": "lockfile name yarn.lock",
+      "grade": "hard",
+      "path": "yarn.lock"
+    }
+  ],
+  "schema": 2,
+  "tool": "horos",
+  "universe": "tracked"
+}

--- a/plugins/horos/docs/evidence/wildcat-app-v2.boundary.v2.json
+++ b/plugins/horos/docs/evidence/wildcat-app-v2.boundary.v2.json
@@ -1,0 +1,106 @@
+{
+  "counts": {
+    "bytes_binary": 2495808,
+    "bytes_generated": 9015991,
+    "bytes_lockfile": 1895425,
+    "files_skipped_unreadable": 0,
+    "files_walked": 1041
+  },
+  "entries": [
+    {
+      "bytes": 1895425,
+      "category": "lockfile",
+      "evidence": "lockfile name package-lock.json",
+      "grade": "hard",
+      "path": "package-lock.json"
+    },
+    {
+      "bytes": 126,
+      "category": "generated",
+      "evidence": "marker 'do not edit' in the first 4096 bytes",
+      "grade": "hard",
+      "path": "prisma/migrations/migration_lock.toml"
+    },
+    {
+      "bytes": 3434,
+      "category": "binary",
+      "evidence": "file signature png",
+      "grade": "hard",
+      "path": "src/assets/icons/avatarmob_icon.png"
+    },
+    {
+      "bytes": 2785,
+      "category": "binary",
+      "evidence": "file signature png",
+      "grade": "hard",
+      "path": "src/assets/icons/fire_icon.png"
+    },
+    {
+      "bytes": 1299338,
+      "category": "binary",
+      "evidence": "file signature riff",
+      "grade": "hard",
+      "path": "src/assets/pictures/background.webp"
+    },
+    {
+      "bytes": 10410,
+      "category": "binary",
+      "evidence": "file signature riff",
+      "grade": "hard",
+      "path": "src/assets/pictures/bannerBG.webp"
+    },
+    {
+      "bytes": 167999,
+      "category": "binary",
+      "evidence": "file signature png",
+      "grade": "hard",
+      "path": "src/assets/pictures/banner_bg.png"
+    },
+    {
+      "bytes": 6478,
+      "category": "binary",
+      "evidence": "file signature riff",
+      "grade": "hard",
+      "path": "src/assets/pictures/ethereum-icon.webp"
+    },
+    {
+      "bytes": 94370,
+      "category": "binary",
+      "evidence": "file signature riff",
+      "grade": "hard",
+      "path": "src/assets/pictures/login_page.webp"
+    },
+    {
+      "bytes": 899778,
+      "category": "binary",
+      "evidence": "file signature riff",
+      "grade": "hard",
+      "path": "src/assets/pictures/overviewBG.webp"
+    },
+    {
+      "bytes": 11216,
+      "category": "binary",
+      "evidence": "file signature png",
+      "grade": "hard",
+      "path": "src/assets/pictures/plasma-icon.png"
+    },
+    {
+      "bytes": 1448802,
+      "category": "generated",
+      "evidence": "linguist-generated for 'src/config/elfs-by-country.json' in .gitattributes",
+      "grade": "hard",
+      "path": "src/config/elfs-by-country.json"
+    },
+    {
+      "bytes": 7567063,
+      "category": "generated",
+      "evidence": "directory name storybook-static corroborated by sample: 6 of 8 files minified, binary or generated",
+      "files": 72,
+      "grade": "hard",
+      "path": "storybook-static/"
+    }
+  ],
+  "schema": 2,
+  "tool": "horos",
+  "universe": "tracked"
+}

--- a/plugins/horos/tests/test_evidence.py
+++ b/plugins/horos/tests/test_evidence.py
@@ -22,6 +22,10 @@ BUNDLE_6 = EVIDENCE / "solidity-outline.md"
 RESULTS_6 = EVIDENCE / "solidity-outline.results.json"
 BUNDLE_7 = EVIDENCE / "v2-protocol-outline.md"
 RESULTS_7 = EVIDENCE / "v2-protocol-outline.results.json"
+BUNDLE_8 = EVIDENCE / "three-repository-marking.md"
+MARKING_V2P = EVIDENCE / "v2-protocol.boundary.json"
+MARKING_APP = EVIDENCE / "wildcat-app-v2.boundary.v2.json"
+MARKING_SKILLS = PLUGIN.parents[1] / ".horos" / "boundary.json"
 
 
 def capture_lines(bundle=BUNDLE, tag="evidence"):
@@ -220,6 +224,28 @@ class SecondCaptureTests(unittest.TestCase):
         self.assertEqual(totals["extra"], 0)
         self.assertEqual(totals["oracle_unparsed"], 0)
         self.assertEqual(totals["matched"], totals["oracle"])
+
+    def test_the_marking_bundle_matches_the_committed_boundaries(self):
+        lines = capture_lines(BUNDLE_8, "marking")
+        for prefix, path in (
+            ("skills", MARKING_SKILLS),
+            ("v2p", MARKING_V2P),
+            ("app", MARKING_APP),
+        ):
+            document = json.loads(path.read_text(encoding="utf-8"))
+            with self.subTest(repository=prefix):
+                self.assertEqual(document["schema"], 2)
+                self.assertEqual(document["universe"], "tracked")
+                self.assertEqual(
+                    int(lines[f"{prefix}_entries"]), len(document["entries"])
+                )
+                self.assertEqual(
+                    int(lines[f"{prefix}_hard_bytes"]),
+                    sum(entry["bytes"] for entry in document["entries"]),
+                )
+                self.assertTrue(
+                    all(entry["grade"] == "hard" for entry in document["entries"])
+                )
 
     def test_the_second_share_exceeds_the_first(self):
         first = capture_lines()


### PR DESCRIPTION
v2-protocol#134 and wildcat-app-v2#360 each add a graded boundary, a
candidates report, a census and the adoption stanza, plus the one-line
gitattributes promotion the candidates report exists to propose:
v2-protocol's 9.7 MB of solc output rises from 38 geometry-only candidates
to hard attribute evidence under review, binding 88.6% of that tree; the
app binds 78.6% across 13 hard entries with 117 advisory candidates. The
bundle records all three markings with machine lines the suite checks, and
says plainly that the product pull requests await their own review gates.

Stacks on step 2 (the skills marking). Audit: one round, zero findings;
log in audit/AUDIT.md.

Proof: `python3 -m unittest plugins.horos.tests.test_evidence -v`
(twenty-one tests across eight bundles), verified green before the
receipt.

<!-- wildcat-origin: shoggoth -->
<!-- Generated with Claude Code (https://claude.com/claude-code) -->
