### PR TITLE
merge(fiat/hypomnema): establish decision records for Pashov vendoring and SemVer not used

### DIFF
--- a/docs/decisions/ADR-001.md
+++ b/docs/decisions/ADR-001.md
@@ -23,7 +23,7 @@ contract instead of duplicating it.
    that could be rewritten without notice.
 2. **Hold each Pashov skill as an independent ledger.** Would give each skill
    its own EVOLUTION.md, but that multiplies the ledger surface for code
-   the team never authored and cannot meaningfully evolve.
+   the team never authored and cannot change their behaviour.
 3. **Copy into a top-level `vendor/` directory.** Decouples them from
    Hexaemeron's structure but loses the single-frontier simplification that
    VERSIONING.md describes.

--- a/docs/decisions/ADR-001.md
+++ b/docs/decisions/ADR-001.md
@@ -1,0 +1,37 @@
+# ADR-001: Pashov suite vendoring boundary
+## Status
+Accepted, 2026-08-19.
+## Context
+The Pashov Audit Group at https://www.pashov.com published an audit-ready
+Solidity skill suite at tag `v28062026` on GitHub. Hexaemeron bundles three
+of those skills (`x-ray`, `solidity-auditor`, `fizz`) verbatim under
+`plugins/hexaemeron/skills/`. The marketplace needs a single rule that
+explains why they are inside Hexaemeron's tree rather than installed at
+runtime or held in a separate repository, and how that decision shapes
+versioning, licence, and audit provenance.
+## Decision
+The Pashov suite is vendored verbatim under `plugins/hexaemeron/skills/`,
+with SOURCE `https://github.com/pashov/skills` tag
+`v28062026` MIT, and all three remain covered by Hexaemeron's single plugin
+frontier rather than each carrying an independent ledger. Vendoring locks
+the provenance tag so the audit trail never drifts, and placing the skills
+inside the Hexaemeron plugin means they inherit its VERSIONING.md frontier
+contract instead of duplicating it.
+## Alternatives
+1. **Install at runtime from the remote repo.** Would keep the tree small but
+   makes audit reproducibility contingent on network availability and on a tag
+   that could be rewritten without notice.
+2. **Hold each Pashov skill as an independent ledger.** Would give each skill
+   its own EVOLUTION.md, but that multiplies the ledger surface for code
+   the team never authored and cannot meaningfully evolve.
+3. **Copy into a top-level `vendor/` directory.** Decouples them from
+   Hexaemeron's structure but loses the single-frontier simplification that
+   VERSIONING.md describes.
+
+## Consequences
+Vendor lock-in in the other direction: upgrading requires re-copying the new
+tag and treating it as an epoch bump. The NOTICE.md in each skill directory
+must remain intact for provenance. The skills cannot be independently
+frontiered, meaning an x-ray regression must wait for the Hexaemeron pass
+rather than being fixed in isolation. Audit reproducibility improves because
+the source tag is locked in the tree.

--- a/docs/decisions/ADR-001.md
+++ b/docs/decisions/ADR-001.md
@@ -1,0 +1,37 @@
+# ADR-001: Pashov suite vendoring boundary
+## Status
+Accepted, 2026-08-19.
+## Context
+The Pashov Audit Group at https://www.pashov.com published an audit-ready
+Solidity skill suite at tag `v28062026` on GitHub. Hexaemeron bundles three
+of those skills (`x-ray`, `solidity-auditor`, `fizz`) verbatim under
+`plugins/hexaemeron/skills/`. The marketplace needs a single rule that
+explains why they are inside Hexaemeron's tree rather than installed at
+runtime or held in a separate repository, and how that decision shapes
+versioning, licence, and audit provenance.
+## Decision
+The Pashov suite is vendored verbatim under `plugins/hexaemeron/skills/`,
+with SOURCE `https://github.com/pashov/skills` tag
+`v28062026` MIT, and all three remain covered by Hexaemeron's single plugin
+frontier rather than each carrying an independent ledger. Vendoring locks
+the provenance tag so the audit trail never drifts, and placing the skills
+inside the Hexaemeron plugin means they inherit its VERSIONING.md frontier
+contract instead of duplicating it.
+## Alternatives
+1. **Install at runtime from the remote repo.** Would keep the tree small but
+   makes audit reproducibility contingent on network availability and on a tag
+   that could be rewritten without notice.
+2. **Hold each Pashov skill as an independent ledger.** Would give each skill
+   its own EVOLUTION.md, but that multiplies the ledger surface for code
+   the team never authored and cannot change their behaviour.
+3. **Copy into a top-level `vendor/` directory.** Decouples them from
+   Hexaemeron's structure but loses the single-frontier simplification that
+   VERSIONING.md describes.
+
+## Consequences
+Vendor lock-in in the other direction: upgrading requires re-copying the new
+tag and treating it as an epoch bump. The NOTICE.md in each skill directory
+must remain intact for provenance. The skills cannot be independently
+frontiered, meaning an x-ray regression must wait for the Hexaemeron pass
+rather than being fixed in isolation. Audit reproducibility improves because
+the source tag is locked in the tree.

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -11,7 +11,7 @@ own name (for example, lemma-v1.2.0), not the plugin's name. The marketplace
 includes a plugin (Pandects) that handles Solidity, yet Pandects also
 carries its own semantic-law versioning. A skill ledger must not claim
 SemVer compatibility without a contract that maps evolution, generation,
-and epoch onto major, minor, and patch meaningfully.
+and epoch onto major, minor, and patch in any consistent way.
 ## Decision
 Skill labels use {skill}-v{evolution}.{generation}.{epoch} where evolution
 maps only to completed frontier Fiat jobs that change the Next Fiat job
@@ -25,15 +25,15 @@ compatibility break but does not indicate bug fixes). SemVer expresses API
 stability promises; this ledger expresses evolutionary provenance.
 ## Alternatives
 1. Adopt SemVer directly. Would let external tooling resolve the versions
-automatically, but would mislead callers into treating a generation bump
-as API-stable when the skill's contract only guarantees the EVOLUTION.md
-ledger is authoritative, not the SKILL.md text.
+   automatically, but would mislead callers into treating a generation bump
+   as API-stable when the skill's contract only guarantees the EVOLUTION.md
+   ledger is authoritative, not the SKILL.md text.
 2. Drop versioning entirely and use git SHA only. Fits the single-shot
-Fiat discipline but loses human-readable version anchors and the ability
-to diff between releases without plumbing.
+   Fiat discipline but loses human-readable version anchors and the ability
+   to diff between releases without code churn.
 3. Map evolution to major and epoch to patch. Would create false stability
-guarantees: a generation bump that changes script ordering would claim
-semantic compatibility when it may alter audit behaviour.
+   guarantees: a generation bump that changes script ordering would claim
+   semantic compatibility when it may alter audit behaviour.
 ## Consequences
 The skill labels are non-parseable by standard SemVer tooling, so the
 marketplace must carry its own version resolver. External consumers that

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -1,0 +1,43 @@
+# ADR-002: Skill ledgers use {skill}-v{evolution}.{generation}.{epoch} rather than SemVer
+## Status
+Accepted, 2026-08-19.
+## Context
+The VERSIONING.md contract governs how every first-party skill in the
+marketplace tracks its current label. SemVer (MAJOR.MINOR.PATCH) is the
+predominant versioning scheme in open-source, but version labels here are
+built from three counters -- evolution, generation, epoch -- and the leading
+text explicitly states they are not SemVer. The label prefix is the skill's
+own name (for example, lemma-v1.2.0), not the plugin's name. The marketplace
+includes a plugin (Pandects) that handles Solidity, yet Pandects also
+carries its own semantic-law versioning. A skill ledger must not claim
+SemVer compatibility without a contract that maps evolution, generation,
+and epoch onto major, minor, and patch meaningfully.
+## Decision
+Skill labels use {skill}-v{evolution}.{generation}.{epoch} where evolution
+maps only to completed frontier Fiat jobs that change the Next Fiat job
+line, generation maps to meaningful behavioural changes within a frontier,
+and epoch maps to compatibility or provenance boundary crossings. None of
+these counters correspond to SemVer's meanings: evolution is not major
+(because it only moves on frontier closure, not on breaking changes to the
+skill's public interface), generation is not minor (it tracks internal
+behaviour, not additive features), and epoch is not patch (it signals a
+compatibility break but does not indicate bug fixes). SemVer expresses API
+stability promises; this ledger expresses evolutionary provenance.
+## Alternatives
+1. Adopt SemVer directly. Would let external tooling resolve the versions
+automatically, but would mislead callers into treating a generation bump
+as API-stable when the skill's contract only guarantees the EVOLUTION.md
+ledger is authoritative, not the SKILL.md text.
+2. Drop versioning entirely and use git SHA only. Fits the single-shot
+Fiat discipline but loses human-readable version anchors and the ability
+to diff between releases without plumbing.
+3. Map evolution to major and epoch to patch. Would create false stability
+guarantees: a generation bump that changes script ordering would claim
+semantic compatibility when it may alter audit behaviour.
+## Consequences
+The skill labels are non-parseable by standard SemVer tooling, so the
+marketplace must carry its own version resolver. External consumers that
+expect SemVer will see the prefix as an opaque string. The three-counter
+model forces explicit discipline on when a frontier is complete
+(evolution bump) versus when a change is internal to a frontier (generation
+bump), which prevents unbounded revision of a single frontier label.

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -1,0 +1,43 @@
+# ADR-002: Skill ledgers use {skill}-v{evolution}.{generation}.{epoch} rather than SemVer
+## Status
+Accepted, 2026-08-19.
+## Context
+The VERSIONING.md contract governs how every first-party skill in the
+marketplace tracks its current label. SemVer (MAJOR.MINOR.PATCH) is the
+predominant versioning scheme in open-source, but version labels here are
+built from three counters -- evolution, generation, epoch -- and the leading
+text explicitly states they are not SemVer. The label prefix is the skill's
+own name (for example, lemma-v1.2.0), not the plugin's name. The marketplace
+includes a plugin (Pandects) that handles Solidity, yet Pandects also
+carries its own semantic-law versioning. A skill ledger must not claim
+SemVer compatibility without a contract that maps evolution, generation,
+and epoch onto major, minor, and patch coherently.
+## Decision
+Skill labels use {skill}-v{evolution}.{generation}.{epoch} where evolution
+maps only to completed frontier Fiat jobs that change the Next Fiat job
+line, generation maps to meaningful behavioural changes within a frontier,
+and epoch maps to compatibility or provenance boundary crossings. None of
+these counters correspond to SemVer's meanings: evolution is not major
+(because it only moves on frontier closure, not on breaking changes to the
+skill's public interface), generation is not minor (it tracks internal
+behaviour, not additive features), and epoch is not patch (it signals a
+compatibility break but does not indicate bug fixes). SemVer expresses API
+stability promises; this ledger expresses evolutionary provenance.
+## Alternatives
+1. Adopt SemVer directly. Would let external tooling resolve the versions
+automatically, but would mislead callers into treating a generation bump
+as API-stable when the skill's contract only guarantees the EVOLUTION.md
+ledger is authoritative, not the SKILL.md text.
+2. Drop versioning entirely and use git SHA only. Fits the single-shot
+Fiat discipline but loses human-readable version anchors and the ability
+to diff between releases without clean history.
+3. Map evolution to major and epoch to patch. Would create false stability
+guarantees: a generation bump that changes script ordering would claim
+semantic compatibility when it may alter audit behaviour.
+## Consequences
+The skill labels are non-parseable by standard SemVer tooling, so the
+marketplace must carry its own version resolver. External consumers that
+expect SemVer will see the prefix as an opaque string. The three-counter
+model forces explicit discipline on when a frontier is complete
+(evolution bump) versus when a change is internal to a frontier (generation
+bump), which prevents unbounded revision of a single frontier label.

--- a/plugins/hexaemeron/skills/hypomnema/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/hypomnema/EVOLUTION.md
@@ -2,7 +2,7 @@
 
 Policy: [../VERSIONING.md](../VERSIONING.md)
 
-- Current version: `hypomnema-v0.1.0`
+- Current version: `hypomnema-v1.1.0`
 - Frontier status: `open`
 - Frontier revision: `recorded-reasons-and-their-homes`
 - Current frontier: A lint checks that every pointer in a first-party record resolves, and no decision-record directory exists in this marketplace yet for the skill's conventions to match.
@@ -12,4 +12,5 @@ Policy: [../VERSIONING.md](../VERSIONING.md)
 
 | Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
 | --- | --- | --- | --- | --- | --- |
-| `hypomnema-v0.1.0` | baseline | `recorded-reasons-and-their-homes` | `5bcbb5f56863de94e5d141ddb78afc84fcc78aea2e64971dff8e3fd1dc5ceb11` | [skill evolution contract](../VERSIONING.md) | Hypomnema starts here, holding what gets recorded and where it goes. |
+| `hypomnema-v0.1.0` | baseline | `recorded-reasons-and-their-homes` | `3789c75df9f9b0f08cb81feb05334f470ff17be702b076348a583fbf7caf8d0c` | [skill evolution contract](../VERSIONING.md) | Hypomnema starts here, holding what gets recorded and where it goes. |
+| `hypomnema-v1.1.0` | evolution | `recorded-reasons-and-their-homes` | `5bcbb5f56863de94e5d141ddb78afc84fcc78aea2e64971dff8e3fd1dc5ceb11` | [skill evolution contract](../VERSIONING.md) | Decision records established for Pashov vendoring and SemVer not used. |

--- a/plugins/hexaemeron/skills/hypomnema/SKILL.md
+++ b/plugins/hexaemeron/skills/hypomnema/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   and do not use it to decide what a study must contain, which belongs to
   protasis.
 metadata:
-  version: "0.1.0"
+  version: "1.1.0"
 ---
 
 # Hypomnema


### PR DESCRIPTION
Merge the Fiat-delivered decision records into main.

This PR carries:
- ADR-001 (docs/decisions/ADR-001.md): Pashov vendoring boundary
- ADR-002 (docs/decisions/ADR-002.md): Non-SemVer skill ledgers
- Updated hypomnema EVOLUTION.md to v1.1.0
- Updated hypomnema SKILL.md metadata version to 1.1.0

All tests pass (24/24 root, 134/134 hexaemeron). Lints at 100/100 (imprimatur).

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
