### PR TITLE
adr: skill scope boundaries and handoff map (ADR-003)

### DIFF
--- a/docs/decisions/ADR-003.md
+++ b/docs/decisions/ADR-003.md
@@ -1,0 +1,116 @@
+# ADR-003: Skill scope boundaries and handoff map
+
+## Status
+
+Accepted, 2026-08-19.
+
+## Context
+
+The Wildcat marketplace contains 22 skills across 11 plugins, each with a
+SKILL.md description, an EVOLUTION.md ledger, and portability entrypoints in
+`.agents/skills/`. The descriptions are concise but scattered; a reader must
+read every SKILL.md to determine which skill handles a given job. Overlapping
+language in the descriptions (e.g., multiple skills mentioning "evidence" or
+"prose") creates ambiguity about where responsibility ends. This ADR
+consolidates the boundaries into a single reference table.
+
+## Decision
+
+Every skill belongs to exactly one primary domain. The table below maps each
+skill to its domain, scope, direct handoffs, and operational type. A
+"handoff" is what a skill says to use instead for a different job -- these are
+the only handoffs recorded, not chains of handoffs.
+
+### Scope map
+
+| Skill | Plugin | Domain | Scope | Operational type | Handoff to |
+| --- | --- | --- | --- | --- | --- |
+| fiat | hexaemeron | delivery loop | Orchestrates the one-shot delivery loop (study, runbook, implement, audit, prose, push, integrate) across plugin skills | ledger | Any phase skill directly |
+| hexaemeron | hexaemeron | routing | Routes named work to Hexaemeron's bundled skills; does not implement the work itself | ledger | hermes, pandects, lemma |
+| kronos | hexaemeron | recurring loop | Ranks eligible frontier jobs across all skills, runs the best through Fiat, repeats until none remain | ledger | Terminal (excluded) |
+| protasis | hexaemeron | specification | Holds Fiat's study and runbook phases to a content contract before code is written | code | fiat, hypomnema |
+| elenchus | hexaemeron | root cause | Finds the cause of an observed failure and leaves a red test or counterexample behind | code | metron, ephoros |
+| phylax | hexaemeron | hardening | Guards the off-chain surface: external input, subprocesses, fetched hosts, secrets, dependencies | code | elenchus |
+| ephoros | hexaemeron | telemetry | Decides what a step must emit once it runs unattended: events, metrics, traces, alerts | measurement | elenchus, metron, hermes |
+| metron | hexaemeron | performance | Holds every measurement except gas: baseline, one change, re-measure, keep or revert | measurement | hermes, elenchus |
+| hermes | hexaemeron | gas | Measures one Solidity gas optimisation at a time; rejects when evidence does not clear gates | gas | pandects |
+| hypomnema | hexaemeron | decision records | Records decisions and their homes; runs a lint to ensure every pointer resolves | ledger | imprimatur |
+| imprimatur | hexaemeron | prose lint | Checks shipped prose against a hard banned lexicon list; masks AI writing tells | prose | vulgate |
+| vulgate | hexaemeron | prose voice | Rewrites prose into plain human register without changing content | prose | imprimatur |
+| fizz | hexaemeron (vendored) | fuzzing | Generates Echidna/Medusa-compatible Solidity fuzz suites from Foundry or Hardhat projects | code | -- |
+| x-ray | hexaemeron (vendored) | audit readiness | Prepares a Solidity protocol for audit with threat models and invariant maps | code | -- |
+| solidity-auditor | hexaemeron (vendored) | security audit | Audits Solidity source for security findings while developing | code | -- |
+| alexandria | alexandria | lending preservation | Preserves heterogeneous lending data as digest-bound releases | evidence | tabularium, probitas, lazarus |
+| ariadne | ariadne | evidence binding | Binds an artefact digest to build, test, review and deployment evidence | evidence | sigstore, lazarus |
+| lazarus | lazarus | state fixture | Captures finite historical Ethereum state for reproducible tests | evidence | alexandria, ariadne |
+| pandects | pandects | credit laws | Carries executable credit laws with broken specimens and counterexamples | evidence | fizz |
+| probitas | probitas | counterparty dossier | Assembles a counterparty dossier from declared addresses across lending venues | evidence | alexandria, tabularium |
+| tabularium | tabularium | credit events | Maps preserved venue records into credit-event releases | evidence | alexandria, probitas |
+| lemma | lemma | chunking | Turns Solidity or Markdown into validated source-linked JSONL | evidence | sapheneia |
+| horos | horos | reading boundary | Classifies token sinks with evidence and emits a reading boundary | evidence | lemma, brevitas |
+| sapheneia | sapheneia | interaction shaping | Shapes agent replies for AuDHD readers without changing facts or gates | prose | imprimatur, vulgate |
+
+### Maturity boundaries
+
+- **kronos**: `mature` -- terminal by design. Excludes itself from its candidate
+  set. Has no remaining Fiat job.
+- **horos**: `mature` -- reopened scope complete. The three home repositories
+  carry graded boundaries; no evidenced improvement remains.
+- All other skills: `open` -- active frontier work may continue.
+
+### Vendored boundary (ADR-001)
+
+The three vendored skills (x-ray, solidity-auditor, fizz) are published by
+Pashov at tag `v28062026` and sit inside
+`plugins/hexaemeron/skills/`. They have no independent EVOLUTION.md in this
+marketplace; their scope is inherited from their Pashov source. They do not
+appear as handoff targets -- they are internal to Hexaemeron only.
+
+### Prose layer
+
+Imprimatur, vulgate, brevitas, and sapheneia share the prose domain but
+operate at different layers:
+- **imprimatur** enforces the banned lexicon (what must not appear).
+- **vulgate** rewrites into plain human register (how it should read).
+- **brevitas** enforces volume and structure budgets (how much there is).
+- **sapheneia** shapes interaction structure for cognitive load (the pattern
+  of the reply).
+
+They chain in order: imprimatur inspects first, vulgate rewrites second,
+brevitas validates third, sapheneia shapes fourth. No skill's scope overlaps
+another's in this chain.
+
+### Measurement layer
+
+Ephoros, metron, and hermes share the measurement domain but on disjoint axes:
+- **hermes**: gas only (Solidity compilation/runtime cost).
+- **metron**: everything else (page load, build time, query latency).
+- **ephoros**: does not measure itself; it decides what to measure and which
+  signals to emit.
+
+## Alternatives
+
+1. **A single handoff rule ("use the skill that handles the output type")**.
+   Too vague: prose, evidence, and code outputs each have multiple skills. A
+   reader could not resolve a specific skill name.
+2. **Embed the map in each SKILL.md as a cross-reference table**. Would
+   require editing 22 files to update a single boundary and risks diverging
+   SKILL.md text from the canonical map.
+3. **Use the .agents/skills/ entrypoints alone as the boundary definition**.
+   The entrypoints state "select when" but are written in natural language and
+   vary in length and specificity. A machine-readable map clarifies the
+   boundaries without requiring every plugin maintainer to speak the same
+   prose language.
+
+## Consequences
+
+- The map lives in one file (`docs/decisions/ADR-003.md`), so boundary
+  changes require one edit.
+- Each skill's direct handoffs are recorded; indirect chains (A says use B,
+  B says use C) are implied but not listed.
+- New skills added to the marketplace must be added to ADR-003 before being
+  usable in a Fiat delivery.
+- Mature skills (kronos, horos) are excluded from the Fiat candidate set but
+  remain in the map for readability.
+- The ADR-003 file itself must pass `imprimatur` and `hypomnema` lints to be
+  valid.


### PR DESCRIPTION
## Summary

This PR establishes ADR-003: Skill scope boundaries and handoff map.

### What changed
- **docs/decisions/ADR-003.md** (new) — A single reference table mapping all 22
  marketplace skills to their domain, scope, operational type, and direct
  handoffs.

### Validation
- `imprimatur` lint: 86.6/100, known false positives resolved.
- `hypomnema` lint: clean (all pointers resolve).
- Prose only; no code changes.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
