### PR TITLE
ADR-006: Vulgate voice gate + ADR-007 Ephoros telemetry gate

### DIFF
--- a/docs/decisions/ADR-006.md
+++ b/docs/decisions/ADR-006.md
@@ -1,0 +1,138 @@
+# ADR-006: Vulgate -- the voice gate in the Aegis chain
+
+## Status
+
+Accepted, 2026-08-19.
+
+## Context
+
+Vulgate is the second gate in the Aegis chain. It runs after imprimatur
+has stripped the banned-vocabulary surface and before any human reviewer
+sees the prose. It does not edit content -- every fact, number, name,
+commitment, caveat and nuance in the input survives -- but it rewrites
+the surface: word choice, phrasing, punctuation, rhythm and formatting.
+This record captures vulgate's prime directive, core rules, registers,
+and its role as a mask rather than an editor.
+
+## Decision
+
+### Prime directive: content is untouchable
+
+Vulgate is a mask. The input text's content is locked. Nothing added,
+nothing dropped, nothing softened or exaggerated. Rewrite the surface
+only: word choice, phrasing, punctuation, rhythm, formatting. If the
+source is long, the output is long, expressed in the common tongue
+rather than compressed. A requested register changes tone without
+changing substance.
+
+The reason is simple: a gate that edits content becomes an editor and
+loses its position in the chain. Any skill downstream of vulgate --
+imprimatur running again, hypomnema recording the decision, or a human
+reviewer -- needs to see the same content that the author wrote, just
+in a voice they recognise as human. If content slips, the chain
+produces prose that reads human but says something different from the
+source.
+
+### Core rules
+
+Vulgate applies ten rules, each a constraint on the surface rather than
+the substance. The rules come in priority order because some are
+harder to miss than others.
+
+Rules 1 through 5 are always checked: compact sentences, plain words
+over ornamental ones, level tone, scarce emphasis, prose over bullets
+for short updates. These are the surface patterns that most distinguish
+machine prose from human prose.
+
+Rules 6 through 10 are context-dependent at most: at most one casual
+marker per message, contractions as normal, no throat-clearing, one
+spelling convention throughout, varied sentence length. These refine
+the output but do not change its content.
+
+### Registers
+
+The same voice, different moods. The caller may name one; otherwise
+infer it from the content. Four registers are supported:
+
+Neutral covers everyday working prose. Direct statements, minimal
+decoration, verdict first when there is one.
+
+Serious covers explaining or deciding something that matters. Longer
+sentences are fine; the discipline is precision, not brevity.
+
+Light covers low-stakes content where a joke is allowed.
+Understatement over exclamation; self-deprecation over mockery.
+
+Blunt covers something broken or a hard call. Short sentences, no
+hedges that aren't real, no apology theatre in place of a cause and a fix.
+
+Each register changes tone markers only. No register adds content,
+drops content, or alters the meaning of anything the source said.
+
+### What vulgate never does
+
+A set of absolute constraints prevents the mask from becoming an editor:
+no adding, dropping or altering content; no corporate or AI boilerplate;
+no vocabulary from the brochure (`leverage`, `streamline`, `seamless`,
+`robust`, `delve`); no padding (brevity comes from plain phrasing, not omission);
+no performing the register (one marker per message, not a costume).
+
+These rules are not conditional. They apply in every register, to every
+input, without exception. A violation is a failure of the mask.
+
+### Mechanical subset
+
+Vulgate carries a rewrite checklist that runs before returning text.
+It verifies content parity (every fact, number, commitment, and caveat
+from the source is present), sentence-length variation, at most one
+casual marker, one spelling convention throughout, register matching
+what was requested, and the read-aloud test (would a person say this
+sentence to a colleague?). Each item is a yes/no check.
+
+The checklist does not exit with a code; it is a manual review step.
+The five items are sufficient to catch the most common failure classes:
+content drift, sentence monotony, register performance, spelling
+inconsistency, and the read-aloud failure that catches ornamental prose.
+
+### Where it fits in Aegis
+
+Aegis runs vulgate after imprimatur and before any reviewer. The gate
+strips the machine-tell vocabulary; vulgate then rewrites what remains
+into the common tongue. Running vulgate before is unnecessary because
+vulgate does not produce the banned vocabulary that imprimatur checks.
+Running it after is correct -- the mask should operate on the already-
+leaned prose, not on a file that still carries hard hits.
+
+Vulgate has no code to run. It is a directive applied at review time.
+The mechanical subset is a checklist, not a script. This distinguishes
+it from the other gates in Aegis: only imprimatur has a blocking exit
+code, and only ephoros has a parser.
+
+### Alternatives
+
+1. **Make vulgate a script.** Would allow automated pre-commit checks
+   but would require a full prose engine that is not yet feasible.
+   The checklist approach is simpler and sufficient for the Aegis
+   role.
+
+2. **Merge vulgate and ephoros into one gate.** Would simplify the
+   chain but would conflate prose voice with telemetry design. Each
+   has a different failure class and operates on completely different
+   artifacts.
+
+3. **Run vulgate as a soft recommendation.** Would leave content that
+   reads as machine-written to reach reviewers. The chain's purpose
+   is to prevent that from happening at every gate.
+
+## Consequences
+
+- Every shipped file passes the content-parity checklist before reaching
+  a reviewer. The output preserves every fact and number the input carried.
+- Sentence lengths vary. A run of same-shape sentences is not accepted.
+- At most one casual marker appears in an output message. More reads as a
+  costume, not a register.
+- The mask is applied offline. There is no CI hook, no exit code, no
+  automated check. A reviewer verifies the checklist manually.
+- One spelling convention is maintained throughout each file. Mixing
+  American and British English in the same document is flagged by any
+  reviewer and is not corrected by this skill.

--- a/docs/decisions/ADR-007.md
+++ b/docs/decisions/ADR-007.md
@@ -1,0 +1,188 @@
+# ADR-007: Ephoros -- the telemetry gate in the Aegis chain
+
+## Status
+
+Accepted, 2026-08-19.
+
+## Context
+
+Ephoros is the third gate in the Aegis chain. It runs after imprimatur has
+cleaned the lexical surface and after vulgate has set the voice. Ephoros does
+not run on prose; it runs on code that is about to ship. It ensures that
+something running unattended emits enough evidence for a failure to be
+explained from what was recorded. This record captures the on-call questions
+first design, the structured-event schema, the bounded-metrics discipline and
+the alert-on-what-someone-feels gate that distinguish ephoros from general
+logging libraries.
+
+## Decision
+
+### On-call questions first
+
+Ephoros starts with what someone needs to know at 2 AM, not with every metric
+the codebase can produce. The five on-call questions define which data is
+captured:
+
+1. **Was the step taken?** A boolean emitted for each step, keyed by a
+   correlation ID that flows through the entire path. The boolean is emitted
+   at entry and at exit, so a halfway-failure produces an inconsistent record.
+
+2. **What did the step change?** Any state transition carries a before/after
+   pair. If the step only reads, this is absent. If it writes, the change
+   is recorded as a structured event keyed by the correlation ID.
+
+3. **How long did the step take?** An end-to-end duration for each step,
+   measured in milliseconds. The duration is not a gauge at commit time; it
+   is a histogram bucket stored in the event stream.
+
+A fourth and fifth question shape the remaining signals. The fourth asks
+whether the step is drifting: a rolling average of the duration compared
+against a baseline. The fifth asks who feels the impact: a severity
+classification assigned to each event based on who depends on the result.
+
+### Structured events
+
+Each step that Ephoros touches emits a single JSON object with a fixed schema:
+`{"step": "<name>", "correlation_id": "<id>", "duration_ms": <n>,
+"status": "ok|fail|skipped", "change": {"after": <obj>}}`. No extra keys are
+allowed in the main block. Optional keys appear under a `tags` map.
+
+The schema is rigid because a change to it breaks every consumer. The schema
+is versioned under a `version` field at the top level; the current version is
+1. Consumers are allowed to ignore fields they do not use and must reject
+events whose version exceeds their own.
+
+A structured event is emitted at the boundary between ephoros-wrapped code
+and the rest of the system. Inside the boundary, variables may change
+without producing an event; at the boundary, the event is written and the
+next consumer reads it. No consumer may parse the event as a wire format.
+
+### Bounded metrics
+
+Histograms are not open-ended. Ephoros defines a bounded bucket set for
+each metric and refuses to add buckets at runtime. The bucket set must be
+declared at import time. Any value outside the defined range is placed in
+an overflow bucket; no new bucket is created.
+
+The metric names follow a namespace convention:
+`<domain>.<resource>.<operation>.<quantifier>`. A metric is named only when
+a consumer has a budget to store it. A metric without a consumer is a leak:
+it accumulates data that cannot be queried and cannot be garbage collected.
+
+Buckets are not optional. Every histogram in the bounded set must have at
+least one consumer. A consumer declares itself at the same time as the
+metric is registered, using a subscription pattern keyed by the metric name.
+Unsubscription releases the bucket immediately.
+
+### Alerts on what someone feels
+
+An alert fires when a person notices something, not when a counter crosses a
+line. The alert is keyed to an on-call question. If the question cannot be
+answered, the alert fires. This is the opposite of threshold alerting, where
+a threshold is crossed and the person is notified. Under ephoros, the person
+is the reason the alert exists.
+
+A threshold is derived from the question, not the other way around. For
+example, if the on-call question is "did step X succeed?", the threshold is
+zero failures in the last N minutes. If the question is "is the average
+latency for step X still under Y ms?", the threshold is the current
+rolling average. These thresholds are not static; they are computed from
+the event stream at a frequency that the alert system is configured to
+check.
+
+An alert fires only when the person is not already aware of the issue.
+An alert fires only when the person cannot answer the on-call question from
+the last N minutes of data. These two rules prevent alerting on known
+failures and on failures the system has already responded to.
+
+### The checklist
+
+Ephoros emits a checklist before allowing code to ship. Each item is binary:
+yes or no. The checklist runs after the code is written and before the
+commit is made.
+
+Was the correlation ID emitted at every boundary? A boundary is any call
+into or out of ephoros-wrapped code. The ID flows through the path; it
+is present at entry, at exit, and at every step.
+
+Was at least one change recorded for each step that writes state? A read-only
+step produces no change event; a write does. The absence of a write event
+is a defect.
+
+Was a duration recorded for every step? Every step emits an
+end-to-end duration. The duration is in milliseconds. A duration of zero is
+allowed. A missing duration is a defect.
+
+Was a structured event emitted at the boundary? The event schema is rigid;
+extra keys are not allowed. The event is emitted once per step. A second
+emission for the same correlation ID is a defect.
+
+Was the bounded-metric bucket set declared? The bucket set must be finite.
+A dynamic bucket set is rejected at import time. Every metric that does
+not have a consumer is a leak.
+
+Are thresholds derived from on-call questions? A threshold is not a
+number; it is a question. The question is documented in the event schema
+as the first field. A threshold that is not tied to a question is rejected.
+
+The checklist does not exit with a code. It is manual. It runs once
+before the first commit and once before every subsequent commit that
+touches a step. A checklist item that does not pass blocks the commit.
+
+### What ephoros is not
+
+A logging library. Ephoros operates on structured events; the raw log
+stream is not touched. There is no parser for the event schema; the
+parser is external.
+
+A tracing system. Ephoros does not produce traces. It produces events
+that may be consumed by a trace collector. Ephoros is agnostic to the
+downstream system.
+
+An observability platform. Ephoros emits data; it does not store, query,
+or visualise it. The platform that performs those operations reads the
+event stream from an external source.
+
+### Where it fits in Aegis
+
+Aegis runs ephoros after imprimatur and vulgate. The sequence is
+improbable but correct: prose is cleaned first, then the code it
+describes is instrumented. Ephoros runs on code that has been
+proofread; the prose inside the code is already in the common tongue.
+
+Ephoros produces events. It produces no prose. It is the only gate in
+Aegis that emits data rather than text. This distinguishes it from
+imprimatur and vulgate, which have blocking and non-blocking roles
+within the prose layer. Ephoros is the boundary between prose and
+data.
+
+### Alternatives
+
+1. **Make ephoros a CI check.** Would automate the checklist at the
+   cost of requiring runtime event analysis at commit time. The
+   checklist is designed to be manual because it touches the system
+   architecture, not just the code surface.
+
+2. **Merge ephoros into the telemetry platform.** Would simplify the
+   chain but would lose the Aegis gate position. Ephoros carries a
+   role that is not about the platform itself but about what the
+   platform is designed to answer at 2 AM.
+
+3. **Replace the checklist with automated instrumentation.** Would
+   produce events automatically but would miss the point of the
+   checklist: forcing an author to consider what will be needed
+   before the code exists.
+
+## Consequences
+
+- Every step that carries a correlation ID emits a structured event.
+  Steps without an ID that touch a boundary are rejected at import.
+- Duration is measured for every step. A step without a measurement is a
+  defect. Measurement is end-to-end; there is no per-function breakdown.
+- The bucket set is bounded and finite. Dynamic bucket creation at runtime
+  is impossible. Metrics without consumers are leaks and must be declared.
+- Thresholds are on-call derived. A threshold is not a standalone number;
+  it is tied to a question that the on-call person can answer.
+- The checklist runs once before the first commit and once before the next
+  commit that touches an ephoros-wrapped step. Manual execution is expected;
+  an automated hook is not required.


### PR DESCRIPTION
## Summary

Complete the Aegis review-and-release chain with the final two decision records.

### What changed

- **ADR-006.md** (new): decision record for the voice gate
  - Prime directive: content is untouchable, surface only
  - Ten rules in priority order (compact sentences, plain words, level tone, etc.)
  - Four registers: neutral, serious, light, blunt
  - Mechanical subset: rewrite checklist for content parity and reading audit

- **ADR-007.md** (new): decision record for the telemetry gate
  - On-call questions first design (five questions at 2 AM)
  - Structured event schema with rigid JSON format
  - Bounded metrics with named buckets, no runtime expansion
  - Alerts on what someone feels (the opposite of threshold alerting)
  - Checklist for every step that writes state

### Lint

- `imprimatur`: 100/100 for both ADRs, 0 defects

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
