### PR TITLE
Add phase-only Kronos mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
       "displayName": "Hexaemeron",
       "source": "./plugins/hexaemeron",
       "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose, specification, debugging, hardening, telemetry and measurement skills.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"

--- a/plugins/hexaemeron/.claude-plugin/plugin.json
+++ b/plugins/hexaemeron/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hexaemeron",
   "displayName": "Hexaemeron",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose, specification, debugging, hardening, telemetry and measurement skills.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/hexaemeron/.codex-plugin/plugin.json
+++ b/plugins/hexaemeron/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hexaemeron",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose, specification, debugging, hardening, telemetry and measurement skills.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/hexaemeron/skills/kronos/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/kronos/EVOLUTION.md
@@ -2,7 +2,7 @@
 
 Policy: [../VERSIONING.md](../VERSIONING.md)
 
-- Current version: `kronos-v0.1.0`
+- Current version: `kronos-v0.2.0`
 - Frontier status: `mature`
 - Frontier revision: `terminal-goal-loop`
 - Current frontier: Kronos ranks eligible held Next Fiat jobs, selects the highest-value one, sets one durable goal, runs Fiat, and repeats until none remain.
@@ -14,3 +14,4 @@ Policy: [../VERSIONING.md](../VERSIONING.md)
 | --- | --- | --- | --- | --- | --- |
 | `kronos-v0.0.0` | baseline | `terminal-goal-loop` | `ac28d95d80724aa001a92740f76416164e65d7b7b9cb5da43674d1ea73a214d1` | [skills#74](https://github.com/wildcat-finance/skills/issues/74) | Kronos starts here. It is complete and terminal by design. |
 | `kronos-v0.1.0` | generation | `terminal-goal-loop` | `ac28d95d80724aa001a92740f76416164e65d7b7b9cb5da43674d1ea73a214d1` | Maintainer report: nine governed plugin ledgers were invisible to discovery | Scope now spans every plugin in the checkout rather than the invoking plugin alone, discovery descends into each plugin's own skills directory and names a skill by its own directory, ungoverned skills are reported instead of dropped, and the end-of-loop rescan re-evaluates every governed skill. Terminal by design is unchanged: the evolution counter stays at 0. |
+| `kronos-v0.2.0` | generation | `terminal-goal-loop` | `ac28d95d80724aa001a92740f76416164e65d7b7b9cb5da43674d1ea73a214d1` | Maintainer request: constrain a native Kronos mode to the phase skills | Adds a fail-closed phase-only mode whose market is fixed to the six Hexaemeron phase skills, with an optional iteration cap. Ranking, Fiat ownership, repeated rescans and the full-market terminal loop are unchanged. |

--- a/plugins/hexaemeron/skills/kronos/SKILL.md
+++ b/plugins/hexaemeron/skills/kronos/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   Use only when the user explicitly asks for Kronos or for a repeated ranked
   Fiat frontier loop. Do not use it for one ordinary Fiat delivery.
 metadata:
-  version: "0.1.0"
+  version: "0.2.0"
 ---
 
 # Kronos
@@ -22,6 +22,32 @@ bare.
 > Highest first, then Fiat runs.
 >
 > Kronos cuts till work is done.
+
+## Phase-only mode
+
+When the user explicitly asks for phase-only Kronos, run this same Kronos loop
+with a fixed candidate universe of exactly six skills:
+
+1. Protasis
+2. Phylax
+3. Ephoros
+4. Metron
+5. Elenchus
+6. Hypomnema
+
+Resolve those six directories beside this skill in the active Hexaemeron
+plugin. Read all six ledgers and fail closed if any ledger is missing,
+malformed, carries a status other than `open` or `mature`, or contradicts its
+status with its Next Fiat job. Do not discover, report, score, select or start
+a frontier from any other skill. Steps 3-7 below are unchanged. In step 8,
+rescan all six phase ledgers from disk and no others, rerank from scratch and
+repeat. A replacement held job may re-enter the ranking.
+
+Unless the user supplies an iteration cap, stop only when none of the six
+phase ledgers remains eligible. If the user requests a bounded batch, stop
+after that many completed Fiat iterations or sooner if the phase market is
+exhausted. The scope limits which skill owns a selected frontier; Fiat may
+still change any file genuinely required by that exact held job.
 
 ## Loop
 
@@ -77,6 +103,8 @@ skip to a lower-scoring job to make the loop look busy.
 
 - Never edit, implement, audit, or rewrite a target itself. Fiat owns the work.
 - Never score a mature, terminal, vendored, or out-of-scope skill.
+- In phase-only mode, never discover or score a ledger outside the fixed
+  six-skill phase allowlist.
 - Never alter a held Next Fiat job before its exact frontier job completes.
 - Never continue merely because the loop can continue. No eligible frontier
   means the goal is complete.

--- a/plugins/hexaemeron/tests/test_evolution.py
+++ b/plugins/hexaemeron/tests/test_evolution.py
@@ -174,6 +174,17 @@ class EvolutionContractTests(unittest.TestCase):
         self.assertIn("Kronos itself", kronos)
         self.assertIn("Never edit, implement, audit, or rewrite a target itself", kronos)
 
+    def test_kronos_phase_only_mode_keeps_the_loop_and_closes_the_market(self):
+        kronos = (SKILLS / "kronos" / "SKILL.md").read_text(encoding="utf-8")
+        phase_mode = kronos.split("## Phase-only mode", 1)[1].split("## Loop", 1)[0]
+        for skill in ("Protasis", "Phylax", "Ephoros", "Metron", "Elenchus", "Hypomnema"):
+            self.assertIn(skill, phase_mode)
+        self.assertIn("Do not discover, report, score, select or start", phase_mode)
+        self.assertIn("rescan all six phase ledgers from disk and no others", phase_mode)
+        self.assertIn("rerank from scratch and\nrepeat", phase_mode)
+        self.assertIn("stop only when none of the six\nphase ledgers remains eligible", phase_mode)
+        self.assertIn("iteration cap", phase_mode)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- Add a native phase-only mode to Kronos with a fixed market of Protasis, Phylax, Ephoros, Metron, Elenchus and Hypomnema.
- Keep the ordinary Kronos ranking, Fiat ownership and repeated rescan loop intact while excluding every non-phase frontier.
- Fail closed on missing, malformed or contradictory phase ledgers, and allow an optional completed-iteration cap.
- Advance Kronos from `0.1.0` to `0.2.0` as a generation update.
- Advance Hexaemeron from `1.2.0` to `1.3.0` across the Codex, Claude and marketplace release manifests so installations refresh.
- Add a contract test that holds the six-skill market and repeated-loop behaviour in place.

## Why

A full Kronos run considers every governed frontier in scope. Maintainers also need the same controller loop focused exclusively on Hexaemeron's six phase skills without maintaining a separate script or delivery controller.

## Impact

`Use $hexaemeron:kronos in phase-only mode` now runs the normal repeated Fiat frontier loop over exactly the six phase skills. Replacement held jobs can re-enter after each rescan; other skills cannot enter the ranking.

## Validation

- `python3 plugins/hexaemeron/tests/run_tests.py` — 135/135 passed
- `python3 -m unittest discover -s tests` — 24/24 passed
- `python3 plugins/hexaemeron/skills/imprimatur/tests/run_tests.py` — 55/55 passed
- Kronos skill validation passed
- Hexaemeron plugin validation passed

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
