### PR TITLE
Add TypeScript boundary checks to Phylax

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1623,3 +1623,14 @@ Location: `plugins/hexaemeron/skills/phylax/scripts/phylax.py:610`
 Mechanism: The checker read each untrusted `.ts` or `.tsx` file in full before the linear lexer ran.
 Impact: An oversized tracked file could consume unbounded memory and analysis time.
 Fix: Read at most 1 MiB plus one byte, fail closed with `P000`, and guard the limit with a regression test.
+
+## Phylax TypeScript boundaries, step 1, round 2 -- 2026-08-19
+
+Suite waived (no Solidity); Phylax, Ephoros and Hypomnema lints clean.
+Hexaemeron 167/167, root 24/24, pinned application clean and unchanged.
+Manual review of `bff0eb6460e8f682e230ee6d982456121a33e2cc` found no further issue.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1615,3 +1615,11 @@ rows are byte-identical.
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Phylax TypeScript boundaries, step 1, round 1 -- 2026-08-19
+
+[Medium] TypeScript input had no work bound.
+Location: `plugins/hexaemeron/skills/phylax/scripts/phylax.py:610`
+Mechanism: The checker read each untrusted `.ts` or `.tsx` file in full before the linear lexer ran.
+Impact: An oversized tracked file could consume unbounded memory and analysis time.
+Fix: Read at most 1 MiB plus one byte, fail closed with `P000`, and guard the limit with a regression test.

--- a/docs/phylax-typescript-boundaries/runbook.md
+++ b/docs/phylax-typescript-boundaries/runbook.md
@@ -35,8 +35,9 @@ The shared lexer copy retains Horos provenance and the source offsets, span
 kinds and error behaviour used by `lex(source)`. The Phylax checker emits
 `P005`, `P006` and `P007` for the unsafe fixtures defined in the study, preserves
 `P000` through `P004`, applies reason-bearing TypeScript suppressions, and keeps
-text and JSON output compatible. The committed study and runbook describe the
-source-local limit. `SKILL.md` describes the expanded mechanical subset. The
+text and JSON output compatible. It reads at most 1 MiB from each TypeScript
+file and emits `P000` above that limit. The committed study and runbook describe
+the source-local limit. `SKILL.md` describes the expanded mechanical subset. The
 Phylax ledger advances exactly once under `VERSIONING.md` and records either one
 evidenced next job or `None -- mature`.
 

--- a/docs/phylax-typescript-boundaries/runbook.md
+++ b/docs/phylax-typescript-boundaries/runbook.md
@@ -1,0 +1,76 @@
+# Runbook: Phylax TypeScript boundary checks
+
+## Build order
+
+This topic is one capability. The shared lexer, the three rules, their fixtures,
+the application scan and the frontier receipt form one review boundary. Splitting
+the lexer from its first consumer would leave an unused module on a green branch
+and make neither half demonstrate the held job.
+
+## Step 1: Reuse the Horos lexer and enforce TypeScript boundaries
+
+**Goal.** Add source-local TypeScript checks for unsafe raw HTML, persisted
+session credentials and runtime-selected fetch hosts, using Horos's proven lexer
+contract without creating a runtime dependency on the separately installed
+Horos plugin.
+
+**Entry.** Start from `b95f332379a9ed9fdacbbbd26fc194eb93ad757a` on
+the controller's run branch `fiat/extend-the-lint-to-the-typescript-surface-coveri`.
+The validation copy of `wildcat-app-v2` is read-only at
+`9b8b6d5d6db06428c5b539f267623277b65315cd`.
+
+**Exit.** The step is complete when all of the following commands exit zero,
+the app command prints `clean`, and the final status command prints nothing:
+
+```bash
+python3 -m unittest plugins.hexaemeron.tests.test_typescript_lexer
+python3 -m unittest plugins.hexaemeron.tests.test_phylax_checker
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py .hexaemeron/validation/wildcat-app-v2
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 -m unittest discover -s tests
+git -C .hexaemeron/validation/wildcat-app-v2 status --porcelain
+```
+
+The shared lexer copy retains Horos provenance and the source offsets, span
+kinds and error behaviour used by `lex(source)`. The Phylax checker emits
+`P005`, `P006` and `P007` for the unsafe fixtures defined in the study, preserves
+`P000` through `P004`, applies reason-bearing TypeScript suppressions, and keeps
+text and JSON output compatible. The committed study and runbook describe the
+source-local limit. `SKILL.md` describes the expanded mechanical subset. The
+Phylax ledger advances exactly once under `VERSIONING.md` and records either one
+evidenced next job or `None -- mature`.
+
+**Files.** Create or change only these planned paths, plus audit and pull-request
+artefacts required by later Fiat phases:
+
+- `plugins/hexaemeron/lib/typescript_lexer.py`
+- `plugins/hexaemeron/skills/phylax/scripts/phylax.py`
+- `plugins/hexaemeron/tests/test_typescript_lexer.py`
+- `plugins/hexaemeron/tests/test_phylax_checker.py`
+- `plugins/hexaemeron/skills/phylax/SKILL.md`
+- `plugins/hexaemeron/skills/phylax/EVOLUTION.md`
+- `docs/phylax-typescript-boundaries/study.md`
+- `docs/phylax-typescript-boundaries/runbook.md`
+
+If the repository's import layout requires an empty
+`plugins/hexaemeron/lib/__init__.py`, it is part of the shared-module scaffold.
+Do not change Horos source, the pinned application, CI, dependencies or vendored
+files.
+
+**Tests.** Add a focused shared-lexer test module derived from Horos's lexer
+fixtures. It must cover complete span reconstruction, strings, comments, nested
+templates, regex versus division and unterminated input. Extend the Phylax test
+module with at least one unsafe fixture and two safe neighbours for each of
+`P005`, `P006` and `P007`, TypeScript suppression cases, exact finding lines,
+secret-free text and JSON output, and a mixed Python/TypeScript invocation.
+The current Hexaemeron suite has 135 test methods and the root suite has 24;
+both totals must stay at or above those baselines and every test must pass.
+
+## Step checks
+
+Protasis runbook checks: 10 of 10 satisfied. The study answers all seven study
+items; assumptions and checkable criteria are recorded; the chosen design names
+its source-copy trade; always, ask-first and never boundaries are concrete; the
+single step has goal, entry, exit, files and tests; every exit names a command;
+the step provides its own scaffold and demonstration; dependency order is
+trivial; and no module decomposition was required.

--- a/docs/phylax-typescript-boundaries/study.md
+++ b/docs/phylax-typescript-boundaries/study.md
@@ -90,6 +90,7 @@ The pinned validation tree contains 872 tracked `.ts` and `.tsx` files. These fi
 - Apply reason-bearing suppression to TypeScript with `// phylax: allow <reason>` on the finding line or the line above. A bare pragma must not suppress. Existing `#` suppression stays valid for Python.
 - Read `.ts` and `.tsx`; do not turn on `.js`, `.jsx`, `.mjs`, generated Storybook output or source maps in this frontier.
 - Fail with `P000` for unreadable input or an unterminated lexical construct needed by a rule. The scanner is not a TypeScript type checker and must not reject otherwise valid syntax merely because it does not understand a construct.
+- Read at most 1 MiB from each TypeScript file and fail closed with `P000` when the file is larger. This bounds memory use and the lexer’s linear work on untrusted source.
 - Keep the app validation tree at head `9b8b6d5d6db06428c5b539f267623277b65315cd` and make no write there.
 - Keep each rule’s unsafe specimen beside safe neighbours in `plugins/hexaemeron/tests/test_phylax_checker.py` so a future widening has an immediate false-positive cost.
 

--- a/docs/phylax-typescript-boundaries/study.md
+++ b/docs/phylax-typescript-boundaries/study.md
@@ -1,0 +1,206 @@
+# Study: TypeScript boundary checks for Phylax
+
+## Assumptions
+
+Assuming, unless corrected:
+
+1. The implementation starts at `b95f332379a9ed9fdacbbbd26fc194eb93ad757a` in the Wildcat Skills repository.
+2. The checker remains a Python standard-library program. It reuses the proven lexer layer from Horos as attributed first-party source inside Hexaemeron; it does not install a JavaScript parser, invoke Node, or use packages from the repository being checked.
+3. “Both suites” means `python3 plugins/hexaemeron/tests/run_tests.py` and `python3 -m unittest discover -s tests`, run from the Wildcat Skills root.
+4. The validation copy of `wildcat-app-v2` is read-only at `.hexaemeron/validation/wildcat-app-v2`, pinned at `9b8b6d5d6db06428c5b539f267623277b65315cd`. The lint may read it but must not format, install, build, or edit it.
+5. The prototype TypeScript surface is tracked `.ts` and `.tsx` source. JavaScript variants, source maps, generated bundles and declaration-only analysis are outside this frontier.
+6. “Session token” is read narrowly: a persistence site must carry an explicit session/authentication marker such as `sessionToken`, `authToken`, `accessToken`, `jwt` or `bearer`. A generic domain `token` or `signature` is not enough. This keeps `apiTokensSlice` and `pendingSafeMessagesSlice` from becoming findings by name alone.
+7. “Fetch against a host” means a fetch whose absolute host can be selected at runtime. A relative URL and a URL built from `window.location.origin` are same-origin neighbours. A fixed absolute literal is a closed one-host choice. A bare `fetch(url)` with no same-file construction evidence is not enough for this prototype to conclude that a caller supplied the host.
+8. “A sanitiser after it” means ordering in the render pipeline: every recognised raw-HTML step must be followed by a recognised sanitising step before rendering. For `dangerouslySetInnerHTML`, the value itself must visibly be the result of a sanitiser call. This reading follows `rehype-sanitize`’s own security guidance and makes the condition mechanically checkable.
+
+These readings favour findings that a person can understand from one source file. They give up inter-file taint analysis rather than turn names such as `token`, `url` and `style` into routine false positives.
+
+## Problem statement
+
+Phylax currently checks Python and requirements files only. Its four rules, `P001` through `P004`, cover shell use, string subprocess commands, unpinned Python requirements and credentials in Python source or output. The skill already states three application controls that the checker cannot enforce:
+
+- raw HTML must be sanitised after the last unsafe transform;
+- a session credential must not reach persisted browser storage; and
+- a host selected outside the program must not reach `fetch` without an allowlist check.
+
+Build a standard-library extension to `plugins/hexaemeron/skills/phylax/scripts/phylax.py` that recognises those three TypeScript cases without changing the existing Python findings, output formats, suppression contract or exit codes. The users are contributors running Phylax on a changed tree and reviewers who need a small, source-located finding they can verify without learning a second tool.
+
+A working prototype has three new finding codes, one isolated failing specimen and at least one close safe neighbour for each code. It also produces no finding over the pinned `wildcat-app-v2` copy and leaves both repository suites green.
+
+### Demo and success criteria
+
+The demo path is the following command sequence from the Wildcat Skills root:
+
+```bash
+python3 -m unittest plugins.hexaemeron.tests.test_phylax_checker
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py .hexaemeron/validation/wildcat-app-v2
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 -m unittest discover -s tests
+git -C .hexaemeron/validation/wildcat-app-v2 status --porcelain
+```
+
+It succeeds only when:
+
+1. an unsafe raw-HTML fixture reports `P005`, while `[rehypeRaw, rehypeSanitize]` and Emotion style injection do not;
+2. an explicit session/auth token written through browser storage or a persisted reducer reports `P006`, while ordinary UI storage, an API-token domain slice and a pending-signature slice do not;
+3. a runtime-selected absolute host passed to `fetch` without a host membership check reports `P007`, while relative, same-origin, fixed-host and allowlist-guarded fetches do not;
+4. the focused test reports all specimens passing;
+5. the app lint exits zero and prints `clean` at validation head `9b8b6d5d6db06428c5b539f267623277b65315cd`;
+6. both named suites exit zero; and
+7. the final status command prints nothing, proving that validation did not alter the app copy.
+
+## Prior art
+
+### In this repository
+
+- `plugins/hexaemeron/skills/phylax/scripts/phylax.py` is the compatibility boundary. `check(path)` dispatches by file type, `Finding` fixes the text and JSON shape, `suppressed` accepts a reason on the finding line or the line above, and `main` fixes exit codes 0, 1 and 2.
+- `plugins/hexaemeron/tests/test_phylax_checker.py` establishes the fixture idiom. Each rule has a specimen it must flag and a close neighbour it must allow; `codes(source, name)` writes an isolated temporary file and calls the checker directly. `OverTheMarketplace` is the existing whole-tree no-finding guard.
+- `plugins/hexaemeron/skills/phylax/SKILL.md` names the three application boundaries and the intended controls. In particular, it requires `rehype-sanitize` after `rehype-raw`, keeps session tokens out of persisted slices, and requires an allowlist for supplied hosts.
+- `plugins/hexaemeron/skills/phylax/EVOLUTION.md` holds this exact frontier and its acceptance condition under revision `off-chain-boundary-controls`.
+- Commit `a112860` (`add Phylax, the guard on the off-chain surface`) introduced the checker, its tests and the ledger together. There is no later checker history to preserve beyond the current file contract.
+- `plugins/hexaemeron/tests/run_tests.py` discovers every `test_*.py` under the Hexaemeron tests directory and prints a pass count. The root suite covers portable entrypoints, prose and evolution contracts that may be affected by a completed frontier update.
+- `plugins/horos/skills/horos/scripts/languages/typescript/typescript.py` already supplies the lexical foundation this job needs. Its `lex(source)` classifies the full input into ordered code, line-comment, block-comment, string, template and regex spans; preserves source offsets and newlines; handles nested template expressions; and returns explicit errors for unterminated constructs. Horos's recorded differential run held the outliner built on this lexer against 866 hand-written TypeScript files, matching 2,237 of 2,239 compiler-visible declarations with no unconfessed misses, extras or crashes.
+- `plugins/horos/tests/test_ts_lexer.py` fixes the lexer boundary with coverage for strings, nested templates, both comment forms, regex-versus-division, malformed input and complete span coverage. Reusing this source is cheaper and better evidenced than designing another TypeScript lexer inside Phylax.
+
+### In the Wildcat application
+
+The pinned validation tree contains 872 tracked `.ts` and `.tsx` files. These files supply real safe neighbours that the fixture set must preserve:
+
+- `src/components/Markdown/index.tsx` imports `rehype-raw` and `rehype-sanitize`, then orders `rehypePlugins={[rehypeRaw, rehypeSanitize]}`. This is the positive control for safe raw HTML.
+- `src/components/ThemeRegistry/EmotionCache.tsx` uses `dangerouslySetInnerHTML` to insert Emotion-generated `style` and `styles`. A rule that flags every occurrence of the React property is too broad.
+- `src/store/slices/apiTokensSlice/apiTokensSlice.ts` and `src/store/slices/pendingSafeMessagesSlice/pendingSafeMessagesSlice.ts` use `persistReducer`; `lenderMlaSignaturesSlice` also persists signatures. These show why `token` and `signature` substrings alone cannot establish that a stored value is a session credential.
+- `src/utils/timestamp.ts` and several UI components write names, timestamps and acknowledgement flags to browser storage. These are storage neighbours, not credentials.
+- `src/hooks/useGetMarket.ts` builds a URL from `window.location.origin`; most application fetches use relative `/api/...` paths. `src/lib/protocol-stats/subgraph.ts` accepts a `url` parameter whose call sites use fixed exported Goldsky constants. A one-file prototype should not invent an external host where it cannot see one.
+
+### Outside both repositories
+
+- The Microsoft TypeScript Compiler API exposes each file as a `SourceFile` AST through `createSourceFile` and is the normal high-fidelity base for TypeScript linting. It is useful prior art, but adding or locating a Node dependency would break the standard-library and target-independence constraints.
+- `rehype-sanitize` says to place sanitation after the last unsafe transform because anything after it can make the tree unsafe again. This supplies the ordering rule for `P005`.
+- `redux-persist` documents `blacklist`, `whitelist`, nested persists and transforms. Those are the recognised ways to keep a sensitive field out of persisted state and supply the safe side of `P006`.
+- The browser URL model distinguishes same-origin relative references from absolute URLs with a separately selectable host. The prototype uses that syntactic distinction rather than attempting DNS or network policy checks.
+
+## Constraints and non-goals
+
+### Constraints
+
+- Preserve the current command line, text/JSON result shape, `Finding` fields, exit codes and Python rules `P000` through `P004`.
+- Use only the Python standard library and do not execute the TypeScript being inspected.
+- Preserve Horos provenance on any absorbed lexer code. Keep the shared copy inside Hexaemeron so the Hexaemeron plugin remains independently installable; a runtime import from a separately installed Horos plugin is not a supported dependency boundary.
+- Keep findings source-located. The scanner must preserve line numbers while skipping comments and recognising strings, template substitutions and balanced brackets.
+- Apply reason-bearing suppression to TypeScript with `// phylax: allow <reason>` on the finding line or the line above. A bare pragma must not suppress. Existing `#` suppression stays valid for Python.
+- Read `.ts` and `.tsx`; do not turn on `.js`, `.jsx`, `.mjs`, generated Storybook output or source maps in this frontier.
+- Fail with `P000` for unreadable input or an unterminated lexical construct needed by a rule. The scanner is not a TypeScript type checker and must not reject otherwise valid syntax merely because it does not understand a construct.
+- Keep the app validation tree at head `9b8b6d5d6db06428c5b539f267623277b65315cd` and make no write there.
+- Keep each rule’s unsafe specimen beside safe neighbours in `plugins/hexaemeron/tests/test_phylax_checker.py` so a future widening has an immediate false-positive cost.
+
+### Non-goals
+
+- Full TypeScript parsing, module resolution, type checking or cross-file taint tracking.
+- Proving that arbitrary HTML is safe, that a token is harmless, or that a DNS name resolves only to public addresses.
+- Inferring that every value called `token`, `signature`, `url`, `data`, `content`, `style` or `html` is hostile.
+- Recognising custom state persistence frameworks, IndexedDB wrappers, service-worker caches, Axios, GraphQL clients or non-`fetch` HTTP libraries.
+- Rewriting unsafe code, adding application suppressions, editing `wildcat-app-v2`, installing its packages, or running its build.
+- Expanding the checker to JavaScript or changing the four established Python rules.
+- Changing the next frontier until implementation, audit, tests and evidence establish this one as complete under `skills/VERSIONING.md`.
+
+### Operational boundaries
+
+**Always.** Run the focused fixture test, the lint against the pinned app, and both repository suites before a commit. Run the Imprimatur lint on any shipped prose changed by the delivery. Record a baseline before claiming a performance change.
+
+**Ask first.** Add any dependency; inspect a different app revision; touch CI; widen the scanned suffixes or the meaning of a session token; add a recognised sanitizer or allowlist idiom that changes the trust boundary.
+
+**Never.** Execute inspected TypeScript; write to the validation app; print credential values in a finding; edit generated or vendored output; delete a failing neighbour to make the fixture test pass; claim a validation command ran when it did not.
+
+## Design options
+
+### Option A: TypeScript Compiler API helper
+
+Invoke a small Node helper from the Python command and use `ts.createSourceFile` to inspect a real TypeScript AST. This gives the best syntax coverage and makes JSX, imports and nested expressions explicit. The trade is a new runtime boundary: Phylax would depend on Node and a resolvable TypeScript package, execute a subprocess for source inspection, and either add a dependency or borrow one from the target. That conflicts with the standard-library assumption and makes the checker least portable where it is most needed.
+
+### Option B: import Horos at runtime
+
+Load `languages.typescript.typescript.lex` directly from the sibling Horos plugin and build the three Phylax recognisers over its spans. This has the smallest source delta and uses the mature implementation without a copy. The trade is packaging: Hexaemeron and Horos install independently, plugin cache paths and versions are host-owned, and Hexaemeron cannot make its lint contract conditional on another plugin being present. A checkout-relative import would pass here and fail for a standalone Hexaemeron installation.
+
+### Option C: absorb Horos's lexer into a shared Hexaemeron utility (chosen)
+
+Copy the proven Horos lexer layer, with provenance, into a small shared Hexaemeron module and use it from Phylax. Preserve its span and error contract rather than designing a new scanner. Build the three narrow Phylax recognisers over the code mask and balanced token ranges. The module sits outside Phylax's rule code so Ephoros's later held TypeScript job can reuse the same lexical boundary.
+
+The trade is a first-party source copy that must be reconciled if Horos's lexer later changes. In return, Hexaemeron stays independently installable, the implementation inherits Horos's recorded lexer evidence, target source is never executed, and Phylax does not acquire a Node or cross-plugin runtime dependency. This is the lowest comprehension cost that meets the prototype, packaging and clean-tree criteria.
+
+### Option D: regular expressions over raw source
+
+Search for `rehypeRaw`, storage calls and `fetch` text with multiline regular expressions. This is the smallest patch. Its trade is that comments, strings, nested expressions, alias imports and array order quickly become indistinguishable from code. It would either miss the `rehype` ordering rule or flag examples and generated text, breaking the required neighbour coverage.
+
+### Option E: a new general JavaScript parser
+
+Write a broader ECMAScript/TypeScript parser in Python. It avoids Node at runtime but ignores the first-party lexer already held against real compiler output, creates a large parser maintenance burden inside a security lint and makes the three controls harder to review than their target code. It is disproportionate to this frontier.
+
+## Chosen construction
+
+Keep `check(path)` as the sole dispatcher and add `check_typescript(path, text)`. Start from Horos's `lex(source)` span contract in an attributed shared Hexaemeron utility: ordered full-source spans for code, comments, strings, templates and regex literals plus explicit lexer errors. Derive a newline-preserving code mask from those spans, then let Phylax's local recognisers add only the import, call, array, object and guard structure needed by `P005` through `P007`. Do not copy Horos's declaration outliner; Phylax needs its lexical boundary, not repository mapping. Do not attempt type inference.
+
+The rule contract is:
+
+| Code | Unsafe syntax concluded in one file | Required safe neighbours |
+| --- | --- | --- |
+| `P005` | A `rehype-raw` import binding occurs in a rendered `rehypePlugins` array with no later `rehype-sanitize` binding; or a `dangerouslySetInnerHTML.__html` expression bearing an explicit raw/html/markdown/content name is not a visible sanitiser call. | `[rehypeRaw, rehypeSanitize]`; aliases imported from the same package names; Emotion `style`/`styles`; raw-looking input passed through a recognised `sanitize(...)` call. |
+| `P006` | `localStorage.setItem` or `sessionStorage.setItem` writes a key/value with an explicit `sessionToken`, `authToken`, `accessToken`, `jwt` or `bearer` marker; or a `persistReducer` persists a same-file state field with one of those markers and does not exclude it through `blacklist`/`whitelist` or a visible transform. | names, timestamps and booleans in storage; `apiTokensSlice`; persisted pending signatures; a sensitive field named in `blacklist` or absent from `whitelist`. |
+| `P007` | The first argument to global `fetch` visibly constructs an absolute URL from a runtime host, such as an interpolated authority or `new URL(path, host)`, and the same function/block has no prior membership check of that host against a named allowlist. | `/api/...`, `./...`, `window.location.origin`, a fixed `https://...` literal, and an explicit `ALLOWED_HOSTS.has(host)`/`.includes(host)` guard before the fetch. |
+
+Recognised imports should be tied to their package strings, not just local names. Thus `import raw from "rehype-raw"` and `import clean from "rehype-sanitize"` work, while unrelated functions called `rehypeRaw` or `sanitize` do not silently earn trust. Direct sanitiser calls should likewise come from a short declared set established by imports in the fixture. Any widening of that set requires a hostile specimen and a neighbour.
+
+`P007` should recognise an allowlist only when the checked hostname and the hostname reaching `fetch` are the same token binding and the check dominates the fetch within the same lexical block. A variable named `allowed` is not evidence. The prototype does not follow values into or out of helper functions; that limitation is preferable to treating every `fetch(url)` as an SSRF finding.
+
+All three rules use the established `Finding` and suppression path. Messages describe the missing control without echoing the full expression, for example `P006 session credential written to persisted client storage`. JSON output requires no new schema.
+
+## Risk register seed
+
+| Area | Boundary or failure | Control in the build | Evidence the audit loop should demand |
+| --- | --- | --- | --- |
+| Untrusted input | Arbitrary TypeScript text can contain misleading comments, strings, templates, regex literals and malformed nesting. | Reuse Horos's fail-open lexer contract without executing source; preserve lines; cap work to a linear scan; emit `P000` when a construct required for analysis is unterminated. | Port the relevant Horos lexer fixtures, add Phylax rule neighbours, and compare representative span output to Horos in this checkout. |
+| Trust boundary | Import aliases can make an unsafe plugin look unrelated or make an unrelated `sanitize` call look trusted. | Resolve only bindings imported from recognised package identifiers. | Alias-positive and name-collision-negative fixtures. |
+| Raw HTML | A sanitiser before `rehypeRaw` gives a false sense of safety; arbitrary plugins after sanitation may reintroduce unsafe nodes. | Compare order and require sanitation after the recognised raw step. Do not claim safety for unknown post-sanitise transforms. | Reversed-order fixture, safe-order fixture and explicit documentation of the unknown-plugin limit. |
+| Session custody | Broad word matching can disclose or misclassify token/signature domain state; narrow matching can miss an aliased JWT. | Report only location and identifier class, never value; require explicit session/auth markers at the persistence site; leave cross-file semantics to review. | Direct browser-storage and persisted-reducer fixtures plus `apiTokensSlice` and pending-signature neighbours. |
+| External call | A runtime host can target an internal or metadata service; a name can change after a preflight resolution. | Require syntactic membership in a named host allowlist before a visible dynamic absolute fetch. Do no DNS or network call in the lint. | Unsafe dynamic-host and guarded-host fixtures; relative and same-origin neighbours. Runtime DNS pinning remains outside the mechanical claim. |
+| Filesystem | Recursive lint could inspect generated output, enormous bundles or a changing validation checkout. | Restrict TypeScript checking to `.ts`/`.tsx`; pin and record validation HEAD; keep the app read-only. | File-type tests, app HEAD check and empty `git status --porcelain` after the demo. |
+| Arithmetic | Token offsets, nesting depth and line numbers can drift around CRLF, multiline comments and templates. | Derive lines while scanning and preserve newline bytes in skipped regions; use a stack for delimiters. | Exact line assertions for multiline specimens and nested templates. |
+| Partial run | A killed scan could leave users unsure whether “clean” was complete. | The checker writes no state and prints `clean` only after walking all requested paths; process interruption yields no success receipt. | Interrupt review and unchanged validation status; no output artefact treated as a receipt. |
+| External processes | A parser helper could execute target-controlled package hooks or source. | Chosen design uses no subprocess and no target dependency. | Audit the imports and command path; focused test can patch subprocess APIs to ensure none are used if needed. |
+| Secret material | Source under inspection may contain an actual secret. | Findings contain path, line, code and a fixed message only; never include the matched string value. | JSON/text fixture asserting no sample secret appears in output. |
+| Compatibility | A TypeScript change could disturb `P001` through `P004`, suppressions, JSON or exit codes; an absorbed lexer could drift from Horos. | Dispatch by suffix and reuse `Finding`/filtering; retain all current tests; record Horos provenance and pin representative differential fixtures. | Existing Phylax suite, explicit mixed Python/TypeScript invocation test, and span-equivalence checks against the source Horos lexer in the marketplace checkout. |
+
+There is no arithmetic over funds, blockchain external call, upgradeable storage or signer key custody in this change. “Custody” here is limited to source that may contain credentials and the rule that output must not repeat them.
+
+## Glossary seeds
+
+| Term | Meaning |
+| --- | --- |
+| allowlist | A finite set of permitted hostnames checked before a runtime-selected absolute URL reaches `fetch`. |
+| browser persistence | Client-readable storage that outlives the immediate Redux value, including Web Storage and `redux-persist` for this prototype. |
+| dominating guard | An allowlist membership check in the same lexical block that occurs before the fetch it controls. |
+| dynamic host | The authority of an absolute URL is supplied through a variable or template substitution rather than fixed in source. |
+| raw-HTML step | A renderer or transform that turns untrusted HTML text into nodes the browser may render, such as `rehype-raw`. |
+| safe neighbour | Syntax close to an unsafe specimen that must remain unreported, fixing the rule's false-positive boundary. |
+| sanitiser ordering | The requirement that a sanitising transform follows the last recognised unsafe transform in the render pipeline. |
+| session marker | An explicit identifier showing authentication-session semantics: session/auth token, access token, JWT or bearer credential. |
+| source-local conclusion | A finding justified by one file without following imports, callers or runtime values across modules. |
+| TypeScript surface | `.ts` and `.tsx` source inspected by the new mechanical rules in this frontier. |
+
+## Sources
+
+- Wildcat Skills starting ref: `b95f332379a9ed9fdacbbbd26fc194eb93ad757a`.
+- Phylax checker: `plugins/hexaemeron/skills/phylax/scripts/phylax.py` at the starting ref.
+- Phylax fixtures: `plugins/hexaemeron/tests/test_phylax_checker.py` at the starting ref.
+- Phylax policy and held frontier: `plugins/hexaemeron/skills/phylax/SKILL.md` and `plugins/hexaemeron/skills/phylax/EVOLUTION.md`.
+- Phylax introduction: Git commit `a112860`.
+- Horos TypeScript lexer: `plugins/horos/skills/horos/scripts/languages/typescript/typescript.py` at `b95f332379a9ed9fdacbbbd26fc194eb93ad757a`.
+- Horos lexer fixtures and live differential record: `plugins/horos/tests/test_ts_lexer.py` and `plugins/horos/docs/evidence/wildcat-app-v2-outline.md` at that ref.
+- Version contract: `plugins/hexaemeron/skills/VERSIONING.md`.
+- Wildcat app validation ref: `.hexaemeron/validation/wildcat-app-v2` at `9b8b6d5d6db06428c5b539f267623277b65315cd`.
+- Safe markdown pipeline: `wildcat-app-v2/src/components/Markdown/index.tsx` at that validation ref.
+- Persistence neighbours: `wildcat-app-v2/src/store/slices/apiTokensSlice/apiTokensSlice.ts`, `pendingSafeMessagesSlice/pendingSafeMessagesSlice.ts` and `lenderMlaSignaturesSlice/mlaSignaturesSlice.ts` at that validation ref.
+- Fetch neighbours: `wildcat-app-v2/src/hooks/useGetMarket.ts` and `src/lib/protocol-stats/subgraph.ts` at that validation ref.
+- Microsoft, “Using the Compiler API”: <https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API> (`SourceFile`, `createSourceFile`, `Program`).
+- `rehype-sanitize` security guidance: <https://github.com/rehypejs/rehype-sanitize#security> (“after the last unsafe thing”).
+- `redux-persist` README: <https://github.com/rt2zz/redux-persist#blacklist--whitelist> and <https://github.com/rt2zz/redux-persist#transforms>.
+- WHATWG URL Standard, URL parsing and relative resolution: <https://url.spec.whatwg.org/>.

--- a/plugins/hexaemeron/lib/__init__.py
+++ b/plugins/hexaemeron/lib/__init__.py
@@ -1,0 +1,1 @@
+"""Shared implementation utilities for the bundled Hexaemeron skills."""

--- a/plugins/hexaemeron/lib/typescript_lexer.py
+++ b/plugins/hexaemeron/lib/typescript_lexer.py
@@ -1,0 +1,316 @@
+"""Classify TypeScript source without importing or executing it.
+
+Absorbed from Horos's ``languages.typescript.typescript`` lexer at Wildcat
+Skills commit b95f332379a9ed9fdacbbbd26fc194eb93ad757a.  The copy preserves the
+``lex(source)`` span and error contract while keeping Hexaemeron independently
+installable.  Horos remains the provenance source; changes here should be
+reconciled against its tested lexer rather than redesigned in place.
+"""
+
+# Tokens after which a slash starts a regex literal rather than division.
+# After an identifier, a number, or a closing ) ] } the slash divides.
+REGEX_ALLOWED_AFTER = frozenset(
+    {
+        "",
+        "(",
+        "[",
+        "{",
+        "}",
+        ",",
+        ";",
+        ":",
+        "=",
+        "=>",
+        "==",
+        "===",
+        "!",
+        "!=",
+        "!==",
+        "&",
+        "&&",
+        "|",
+        "||",
+        "?",
+        "??",
+        "+",
+        "-",
+        "*",
+        "/",
+        "%",
+        "<",
+        ">",
+        "<=",
+        ">=",
+        "~",
+        "^",
+        "return",
+        "case",
+        "typeof",
+        "instanceof",
+        "in",
+        "of",
+        "new",
+        "delete",
+        "void",
+        "do",
+        "else",
+        "yield",
+        "await",
+        "throw",
+    }
+)
+
+WORD_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_$"
+)
+
+
+def lex(source):
+    """Classify the whole source into spans; fail-open on what it cannot end.
+
+    Returns ``(spans, errors)``. Each span is ``(kind, start, end)`` with kind
+    one of code, line_comment, block_comment, string, template, regex; spans
+    cover the source in order. Each error is ``(offset, reason)`` for a
+    construct that never terminated; the span still covers the remainder so
+    the caller can confess it.
+    """
+    spans = []
+    errors = []
+    n = len(source)
+    i = 0
+    code_start = 0
+    prev = ""  # last significant code token, for the regex decision
+
+    def flush_code(end):
+        if end > code_start:
+            spans.append(("code", code_start, end))
+
+    while i < n:
+        c = source[i]
+
+        if c == "/" and i + 1 < n and source[i + 1] == "/":
+            flush_code(i)
+            end = source.find("\n", i)
+            end = n if end == -1 else end
+            spans.append(("line_comment", i, end))
+            i = end
+            code_start = i
+            continue
+
+        if c == "/" and i + 1 < n and source[i + 1] == "*":
+            flush_code(i)
+            end = source.find("*/", i + 2)
+            if end == -1:
+                errors.append((i, "unterminated block comment"))
+                spans.append(("block_comment", i, n))
+                return spans, errors
+            spans.append(("block_comment", i, end + 2))
+            i = end + 2
+            code_start = i
+            continue
+
+        if c in "'\"":
+            flush_code(i)
+            end = _scan_string(source, i)
+            # Horos's original scanner treats a raw newline as proof that a
+            # JavaScript string is unterminated. TSX quoted attribute values
+            # are the one source form that permits that newline, so retain the
+            # normal rule and widen only after the attribute boundary is
+            # established from the surrounding tag.
+            if end is None and _is_jsx_attribute_string(source, i):
+                end = _scan_jsx_attribute_string(source, i)
+            if end is None:
+                errors.append((i, "unterminated string"))
+                spans.append(("string", i, n))
+                return spans, errors
+            spans.append(("string", i, end))
+            i = end
+            code_start = i
+            prev = "string"
+            continue
+
+        if c == "`":
+            flush_code(i)
+            end = _scan_template(source, i)
+            if end is None:
+                errors.append((i, "unterminated template literal"))
+                spans.append(("template", i, n))
+                return spans, errors
+            spans.append(("template", i, end))
+            i = end
+            code_start = i
+            prev = "template"
+            continue
+
+        if c == "/" and prev in REGEX_ALLOWED_AFTER:
+            end = _scan_regex(source, i)
+            if end is not None:
+                flush_code(i)
+                spans.append(("regex", i, end))
+                i = end
+                code_start = i
+                prev = "regex"
+                continue
+            # A regex cannot hold an unescaped newline; the scan failing
+            # means this slash divides after all, so fall through as code.
+
+        if c in WORD_CHARS:
+            j = i
+            while j < n and source[j] in WORD_CHARS:
+                j += 1
+            prev = source[i:j]
+            i = j
+            continue
+
+        if not c.isspace():
+            # Fold repeated operator characters so `=>` and `===` count as
+            # one significant token for the regex decision.
+            if prev and prev[-1] == c and (prev + c) in REGEX_ALLOWED_AFTER:
+                prev += c
+            elif c == ">" and prev == "=":
+                prev = "=>"
+            else:
+                prev = c
+        i += 1
+
+    flush_code(n)
+    return spans, errors
+
+
+def _scan_string(source, start):
+    """From the opening quote past the closing one; None if it never closes."""
+    quote = source[start]
+    n = len(source)
+    i = start + 1
+    while i < n:
+        c = source[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == quote:
+            return i + 1
+        if c == "\n":
+            return None
+        i += 1
+    return None
+
+
+def _is_jsx_attribute_string(source, start):
+    """Whether a quote follows an attribute assignment inside an open tag."""
+    cursor = start - 1
+    while cursor >= 0 and source[cursor].isspace():
+        cursor -= 1
+    if cursor < 0 or source[cursor] != "=":
+        return False
+    cursor -= 1
+    while cursor >= 0 and (source[cursor].isalnum() or source[cursor] in "_:$-"):
+        cursor -= 1
+    if cursor >= 0 and not source[cursor].isspace():
+        return False
+
+    opening = source.rfind("<", 0, start)
+    closing = source.rfind(">", 0, start)
+    if opening <= closing:
+        return False
+    tag = opening + 1
+    if tag < len(source) and source[tag] == "/":
+        tag += 1
+    while tag < len(source) and source[tag].isspace():
+        tag += 1
+    return tag < len(source) and (source[tag].isalpha() or source[tag] in "_$")
+
+
+def _scan_jsx_attribute_string(source, start):
+    """Scan a TSX quoted attribute, whose value may contain raw newlines."""
+    quote = source[start]
+    i = start + 1
+    while i < len(source):
+        if source[i] == quote:
+            return i + 1
+        i += 1
+    return None
+
+
+def _scan_template(source, start):
+    """Scan a template and its nested substitutions through the closing tick."""
+    n = len(source)
+    i = start + 1
+    while i < n:
+        c = source[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == "`":
+            return i + 1
+        if c == "$" and i + 1 < n and source[i + 1] == "{":
+            i = _scan_template_expression(source, i + 2)
+            if i is None:
+                return None
+            continue
+        i += 1
+    return None
+
+
+def _scan_template_expression(source, start):
+    """From just after ``${`` past the balancing brace; None if unbalanced."""
+    n = len(source)
+    depth = 1
+    i = start
+    while i < n:
+        c = source[i]
+        if c in "'\"":
+            i = _scan_string(source, i)
+            if i is None:
+                return None
+            continue
+        if c == "`":
+            i = _scan_template(source, i)
+            if i is None:
+                return None
+            continue
+        if c == "/" and i + 1 < n and source[i + 1] == "/":
+            end = source.find("\n", i)
+            if end == -1:
+                return None
+            i = end
+            continue
+        if c == "/" and i + 1 < n and source[i + 1] == "*":
+            end = source.find("*/", i + 2)
+            if end == -1:
+                return None
+            i = end + 2
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return None
+
+
+def _scan_regex(source, start):
+    """From the opening slash past the closing one and its flags; None when
+    a newline arrives first, which proves this slash was division."""
+    n = len(source)
+    i = start + 1
+    in_class = False
+    while i < n:
+        c = source[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == "\n":
+            return None
+        if c == "[":
+            in_class = True
+        elif c == "]":
+            in_class = False
+        elif c == "/" and not in_class:
+            i += 1
+            while i < n and source[i] in "dgimsuvy":
+                i += 1
+            return i
+        i += 1
+    return None

--- a/plugins/hexaemeron/skills/phylax/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/phylax/EVOLUTION.md
@@ -2,14 +2,15 @@
 
 Policy: [../VERSIONING.md](../VERSIONING.md)
 
-- Current version: `phylax-v0.1.0`
-- Frontier status: `open`
+- Current version: `phylax-v1.1.0`
+- Frontier status: `mature`
 - Frontier revision: `off-chain-boundary-controls`
-- Current frontier: Phylax names the off-chain boundaries and the control each one needs, but every check it demands is read by a person rather than executed.
-- Next Fiat job: Extend the lint to the TypeScript surface, covering raw HTML rendered without a sanitiser after it, a session token written to persisted client storage, and a fetch against a host with no allowlist. Accepted when each is caught in a fixture, the lint runs clean over wildcat-app-v2, and both suites pass.
+- Current frontier: Phylax mechanically checks its established Python boundaries and source-local TypeScript controls for raw HTML ordering, persisted session credentials and runtime-selected absolute fetch hosts.
+- Next Fiat job: None -- mature
 
 ## History
 
 | Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
 | --- | --- | --- | --- | --- | --- |
 | `phylax-v0.1.0` | baseline | `off-chain-boundary-controls` | `ce1e5ed764d74b77b7a8608305353de47ebd0b1ef6fb0091bd7590140e188fb6` | [ariadne untrusted-input tests](../../../ariadne/tests/test_untrusted_input.py) | Phylax starts here, holding the off-chain surface that the Solidity audit skills do not cover. |
+| `phylax-v1.1.0` | evolution | `off-chain-boundary-controls` | `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604` | [TypeScript boundary fixtures](../../tests/test_phylax_checker.py), [shared lexer fixtures](../../tests/test_typescript_lexer.py), [study](../../../../docs/phylax-typescript-boundaries/study.md) | The lint absorbs Horos's lexer contract inside Hexaemeron and adds `P005` through `P007`; the held job is complete and no evidenced next frontier remains. |

--- a/plugins/hexaemeron/skills/phylax/SKILL.md
+++ b/plugins/hexaemeron/skills/phylax/SKILL.md
@@ -291,7 +291,9 @@ fixed-host and source-opaque `fetch(url)` calls stay outside that claim.
 The TypeScript recognisers use an attributed copy of Horos's lexer inside
 Hexaemeron. They never import a separately installed Horos plugin, invoke Node,
 load the target's dependencies or execute inspected source. A lexical construct
-that cannot be terminated reports `P000`.
+that cannot be terminated reports `P000`. The lint reads at most 1 MiB from
+each TypeScript file and reports `P000` when that limit is exceeded, bounding
+the lexer work before it accepts untrusted source.
 
 Deliberate exceptions state a reason: `# phylax: allow <why>` in Python or
 `// phylax: allow <why>` in TypeScript, on the line or the one above it. A bare

--- a/plugins/hexaemeron/skills/phylax/SKILL.md
+++ b/plugins/hexaemeron/skills/phylax/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   it to diagnose a failure that has already happened, which belongs to
   elenchus.
 metadata:
-  version: "0.1.0"
+  version: "1.1.0"
 ---
 
 # Phylax
@@ -266,25 +266,41 @@ what could not be established.
 
 ## The mechanical subset
 
-Four of these rules are settled by a parser rather than by reading. Run the
+Seven of these rules are settled by a parser rather than by reading. Run the
 lint over the paths a step touched, and require exit 0.
 
 ```bash
 python3 "$PLUGIN_ROOT/skills/phylax/scripts/phylax.py" src tests
 ```
 
-It reports a shell invocation, a subprocess command passed as a string rather
-than an argument list, a requirement with no exact pin, and a credential in
-source or handed to something that writes output. It covers Python and
-requirements files, and says nothing about the TypeScript surface.
+For Python and requirements files it reports a shell invocation, a subprocess
+command passed as a string rather than an argument list, a requirement with no
+exact pin, and a credential in source or handed to something that writes
+output.
 
-Deliberate exceptions state a reason: `# phylax: allow <why>` on the line or
-the one above it. A bare pragma with no reason does not suppress anything. Test
-material shaped like a credential is the usual honest case, and a lint with no
-pragma to answer it is a lint people learn to bypass.
+For tracked `.ts` and `.tsx` source it reports three source-local cases. A
+`rehype-raw` binding in a rendered plugin array needs a later
+`rehype-sanitize` binding, and a raw-named `dangerouslySetInnerHTML` value needs
+a sanitiser imported from `sanitize-html`, `dompurify` or
+`isomorphic-dompurify`. A `sessionToken`, `authToken`, `accessToken`, `jwt` or
+`bearer` value cannot reach Web Storage or an unfiltered `persistReducer`. A
+visibly absolute URL built from a runtime host cannot reach global `fetch`
+until a same-scope named allowlist guard dominates it. Relative, same-origin,
+fixed-host and source-opaque `fetch(url)` calls stay outside that claim.
+
+The TypeScript recognisers use an attributed copy of Horos's lexer inside
+Hexaemeron. They never import a separately installed Horos plugin, invoke Node,
+load the target's dependencies or execute inspected source. A lexical construct
+that cannot be terminated reports `P000`.
+
+Deliberate exceptions state a reason: `# phylax: allow <why>` in Python or
+`// phylax: allow <why>` in TypeScript, on the line or the one above it. A bare
+pragma with no reason does not suppress anything. Test material shaped like a
+credential is the usual honest case, and a lint with no pragma to answer it is
+a lint people learn to bypass.
 
 Everything else in this skill stays judgement, and a clean exit says only that
-these four found nothing.
+these seven found nothing.
 
 ## Rationalisations
 

--- a/plugins/hexaemeron/skills/phylax/scripts/phylax.py
+++ b/plugins/hexaemeron/skills/phylax/scripts/phylax.py
@@ -8,6 +8,9 @@ reading intent. Everything else in SKILL.md stays a judgement.
   P002  a subprocess command passed as a string rather than an argument list
   P003  a requirement with no exact pin
   P004  a credential in source, or handed to something that writes output
+  P005  raw HTML reaches a renderer without a later trusted sanitiser
+  P006  a session credential reaches persisted browser storage
+  P007  a runtime-selected absolute fetch host has no prior allowlist check
 
 Exit 0 clean, 1 findings, 2 bad invocation.
 """
@@ -20,6 +23,12 @@ import json
 import re
 import sys
 from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[3]
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))
+
+from lib.typescript_lexer import lex  # noqa: E402
 
 RUNNERS = {"run", "call", "check_call", "check_output", "Popen"}
 WRITERS = {"print", "debug", "info", "warning", "warn", "error", "critical", "exception"}
@@ -35,7 +44,17 @@ PIN = re.compile(r"(==|@(?:git\+)?[0-9a-f]{40})")
 SKIP_REQ = re.compile(r"^\s*(?:#|-r\s|--|$)")
 
 
-ALLOW = re.compile(r"#\s*phylax:\s*allow\s+(?P<reason>\S.*)$")
+ALLOW = re.compile(r"(?:#|//)\s*phylax:\s*allow\s+(?P<reason>\S.*)$")
+
+IDENTIFIER = r"[A-Za-z_$][\w$]*"
+SESSION_MARKER = re.compile(
+    rf"(?<![\w$])(?:session[_-]?token|auth[_-]?token|access[_-]?token|jwt|bearer)(?![\w$])",
+    re.IGNORECASE,
+)
+RAW_HTML_MARKER = re.compile(r"(?:raw|html|markdown|content)", re.IGNORECASE)
+TRUSTED_DIRECT_SANITISERS = frozenset(
+    {"sanitize-html", "dompurify", "isomorphic-dompurify"}
+)
 
 
 def suppressed(text: str, line: int) -> bool:
@@ -177,15 +196,425 @@ def check_requirements(path: Path, text: str) -> list[Finding]:
     return findings
 
 
+def _line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _masked(text: str, spans, *, keep_strings: bool = False) -> str:
+    """Blank lexical non-code while preserving offsets and newlines."""
+    parts = []
+    for kind, start, end in spans:
+        segment = text[start:end]
+        if kind == "code" or (keep_strings and kind == "string"):
+            parts.append(segment)
+        else:
+            parts.append("".join(ch if ch == "\n" else " " for ch in segment))
+    return "".join(parts)
+
+
+def _matching(mask: str, opening: int) -> int | None:
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    if opening >= len(mask) or mask[opening] not in pairs:
+        return None
+    stack = [pairs[mask[opening]]]
+    for index in range(opening + 1, len(mask)):
+        current = mask[index]
+        if current in pairs:
+            stack.append(pairs[current])
+        elif stack and current == stack[-1]:
+            stack.pop()
+            if not stack:
+                return index
+    return None
+
+
+def _split_ranges(mask: str, start: int, end: int) -> list[tuple[int, int]]:
+    """Split a comma list at lexical depth zero, retaining source offsets."""
+    ranges = []
+    stack = []
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    item = start
+    for index in range(start, end):
+        current = mask[index]
+        if current in pairs:
+            stack.append(pairs[current])
+        elif stack and current == stack[-1]:
+            stack.pop()
+        elif current == "," and not stack:
+            ranges.append((item, index))
+            item = index + 1
+    ranges.append((item, end))
+    return ranges
+
+
+def _local_bindings(clause: str) -> set[str]:
+    """Return local names from one TypeScript import clause."""
+    bindings = set()
+    clause = re.sub(r"\btype\s+", "", clause).strip()
+    default = re.match(rf"({IDENTIFIER})(?:\s*,|$)", clause)
+    if default:
+        bindings.add(default.group(1))
+    namespace = re.search(rf"\*\s+as\s+({IDENTIFIER})", clause)
+    if namespace:
+        bindings.add(namespace.group(1))
+    named = re.search(r"\{(?P<body>[^}]*)\}", clause, re.DOTALL)
+    if named:
+        for item in named.group("body").split(","):
+            words = re.findall(IDENTIFIER, item)
+            if words:
+                bindings.add(words[-1])
+    return bindings
+
+
+def _imports(mask_with_strings: str) -> dict[str, set[str]]:
+    packages: dict[str, set[str]] = {}
+    pattern = re.compile(
+        r"\bimport\s+(?!['\"])(?P<clause>.{1,500}?)\s+from\s+"
+        r"(?P<quote>['\"])(?P<package>[^'\"]+)(?P=quote)",
+        re.DOTALL,
+    )
+    for match in pattern.finditer(mask_with_strings):
+        clause = match.group("clause")
+        if ";" in clause or len(clause.splitlines()) > 20:
+            continue
+        packages.setdefault(match.group("package"), set()).update(
+            _local_bindings(clause)
+        )
+    return packages
+
+
+def _trusted_sanitiser(expression: str, bindings: set[str]) -> bool:
+    for binding in bindings:
+        if re.search(rf"\b{re.escape(binding)}(?:\s*\.\s*sanitize)?\s*\(", expression):
+            return True
+    return False
+
+
+def _check_raw_html(path: Path, text: str, mask: str,
+                    imports: dict[str, set[str]]) -> list[Finding]:
+    findings = []
+    raw_bindings = imports.get("rehype-raw", set())
+    clean_bindings = imports.get("rehype-sanitize", set())
+
+    plugin_pattern = re.compile(r"\brehypePlugins\s*=\s*\{\s*\[")
+    for match in plugin_pattern.finditer(mask):
+        opening = mask.find("[", match.start(), match.end())
+        closing = _matching(mask, opening)
+        if closing is None:
+            continue
+        items = []
+        for start, end in _split_ranges(mask, opening + 1, closing):
+            item = mask[start:end].strip()
+            name = re.match(IDENTIFIER, item)
+            if name:
+                items.append((name.group(0), start + mask[start:end].find(name.group(0))))
+        for position, (name, offset) in enumerate(items):
+            if name in raw_bindings and not any(
+                later in clean_bindings for later, _ in items[position + 1:]
+            ):
+                findings.append(Finding(
+                    path, _line_of(text, offset), "P005",
+                    "raw HTML renderer has no later trusted sanitiser",
+                ))
+
+    direct_bindings = set()
+    for package in TRUSTED_DIRECT_SANITISERS:
+        direct_bindings.update(imports.get(package, set()))
+    dangerous = re.compile(r"\bdangerouslySetInnerHTML\s*=\s*\{\s*\{\s*__html\s*:")
+    for match in dangerous.finditer(mask):
+        outer = mask.find("{", match.start(), match.end())
+        inner = mask.find("{", outer + 1, match.end())
+        closing = _matching(mask, inner)
+        if closing is None:
+            continue
+        colon = mask.find(":", inner, match.end())
+        expression = mask[colon + 1:closing]
+        if RAW_HTML_MARKER.search(expression) and not _trusted_sanitiser(
+            expression, direct_bindings
+        ):
+            findings.append(Finding(
+                path, _line_of(text, match.start()), "P005",
+                "raw HTML value is not passed through a trusted sanitiser",
+            ))
+    return findings
+
+
+def _call_ranges(mask: str, binding: str):
+    pattern = re.compile(rf"(?<![\w$.]){re.escape(binding)}\s*\(")
+    for match in pattern.finditer(mask):
+        opening = mask.find("(", match.start(), match.end())
+        closing = _matching(mask, opening)
+        if closing is not None:
+            yield match.start(), opening, closing, _split_ranges(mask, opening + 1, closing)
+
+
+def _assigned_object(mask: str, name: str, before: int) -> tuple[int, int] | None:
+    pattern = re.compile(
+        rf"\b(?:const|let|var)\s+{re.escape(name)}(?:\s*:[^=\n]+)?\s*=\s*\{{"
+    )
+    matches = [match for match in pattern.finditer(mask, 0, before)]
+    if not matches:
+        return None
+    opening = mask.find("{", matches[-1].start(), matches[-1].end())
+    closing = _matching(mask, opening)
+    return (opening, closing + 1) if closing is not None else None
+
+
+def _config_text(text: str, mask: str, start: int, end: int,
+                 call_offset: int) -> tuple[str, str]:
+    expression_mask = mask[start:end].strip()
+    expression_text = text[start:end].strip()
+    identifier = re.fullmatch(IDENTIFIER, expression_mask)
+    if identifier:
+        assigned = _assigned_object(mask, identifier.group(0), call_offset)
+        if assigned:
+            left, right = assigned
+            return text[left:right], mask[left:right]
+    return expression_text, expression_mask
+
+
+def _array_property(text: str, mask: str, name: str) -> str | None:
+    match = re.search(rf"\b{re.escape(name)}\s*:\s*\[", mask)
+    if not match:
+        return None
+    opening = mask.find("[", match.start(), match.end())
+    closing = _matching(mask, opening)
+    return text[opening + 1:closing] if closing is not None else None
+
+
+def _persist_excludes_sensitive(text: str, mask: str, sensitive: set[str],
+                                source_mask: str) -> bool:
+    blacklist = _array_property(text, mask, "blacklist")
+    if blacklist is not None and any(
+        re.search(rf"(?<![\w$]){re.escape(field)}(?![\w$])", blacklist, re.I)
+        for field in sensitive
+    ):
+        return True
+    whitelist = _array_property(text, mask, "whitelist")
+    if whitelist is not None and not any(
+        re.search(rf"(?<![\w$]){re.escape(field)}(?![\w$])", whitelist, re.I)
+        for field in sensitive
+    ):
+        return True
+    transforms = _array_property(text, mask, "transforms")
+    if transforms is not None:
+        for transform in re.findall(IDENTIFIER, transforms):
+            declaration = re.search(
+                rf"\b(?:const|let|var)\s+{re.escape(transform)}\s*=\s*"
+                r"createTransform\s*\(",
+                source_mask,
+            )
+            if not declaration:
+                continue
+            opening = source_mask.find("(", declaration.start(), declaration.end())
+            closing = _matching(source_mask, opening)
+            if closing is None:
+                continue
+            body = source_mask[opening + 1:closing]
+            if "..." in body or "delete" in body:
+                if any(re.search(
+                    rf"(?<![\w$]){re.escape(field)}(?![\w$])", body, re.I
+                ) for field in sensitive):
+                    return True
+    return False
+
+
+def _sensitive_state_fields(mask: str) -> set[str]:
+    fields = set()
+    marker = r"(?:session[_-]?token|auth[_-]?token|access[_-]?token|jwt|bearer)"
+    for pattern in (
+        re.compile(rf"(?<![\w$])(?P<field>{marker})(?![\w$])\s*\??\s*:", re.I),
+        re.compile(rf"\b(?:state|initialState)\s*\.\s*(?P<field>{marker})(?![\w$])", re.I),
+    ):
+        fields.update(match.group("field") for match in pattern.finditer(mask))
+    return fields
+
+
+def _check_persistence(path: Path, text: str, mask: str,
+                       imports: dict[str, set[str]]) -> list[Finding]:
+    findings = []
+    storage = re.compile(
+        r"(?<![\w$])(?:window\s*\.\s*)?(?:localStorage|sessionStorage)"
+        r"\s*\.\s*setItem\s*\("
+    )
+    for match in storage.finditer(mask):
+        opening = mask.find("(", match.start(), match.end())
+        closing = _matching(mask, opening)
+        if closing is None:
+            continue
+        arguments = _split_ranges(mask, opening + 1, closing)
+        persisted = " ".join(text[start:end] for start, end in arguments[:2])
+        if SESSION_MARKER.search(persisted):
+            findings.append(Finding(
+                path, _line_of(text, match.start()), "P006",
+                "session credential written to persisted client storage",
+            ))
+
+    sensitive = _sensitive_state_fields(mask)
+    for binding in imports.get("redux-persist", set()):
+        if binding != "persistReducer" and "persist" not in binding.lower():
+            continue
+        for offset, _opening, _closing, arguments in _call_ranges(mask, binding):
+            if not sensitive or not arguments:
+                continue
+            start, end = arguments[0]
+            config_text, config_mask = _config_text(text, mask, start, end, offset)
+            if not _persist_excludes_sensitive(
+                config_text, config_mask, sensitive, mask
+            ):
+                findings.append(Finding(
+                    path, _line_of(text, offset), "P006",
+                    "session credential included in a persisted reducer",
+                ))
+    return findings
+
+
+def _statement_expression(text: str, mask: str, start: int) -> tuple[str, str]:
+    stack = []
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    end = start
+    while end < len(mask):
+        current = mask[end]
+        if current in pairs:
+            stack.append(pairs[current])
+        elif stack and current == stack[-1]:
+            stack.pop()
+        elif not stack and current in ";\n":
+            break
+        end += 1
+    return text[start:end].strip(), mask[start:end].strip()
+
+
+def _runtime_host(expression: str, expression_mask: str, text: str,
+                  mask: str, before: int) -> str | None:
+    template = re.search(
+        rf"https?://\$\{{\s*(?P<host>{IDENTIFIER})\s*\}}", expression, re.I
+    )
+    if template:
+        return template.group("host")
+    new_url = re.search(
+        rf"\bnew\s+URL\s*\([^,]+,\s*(?P<host>{IDENTIFIER})\s*\)",
+        expression_mask,
+        re.DOTALL,
+    )
+    if new_url and "window.location.origin" not in expression_mask:
+        return new_url.group("host")
+    reference = re.fullmatch(
+        rf"(?P<name>{IDENTIFIER})(?:\s*\.\s*toString\s*\(\s*\))?",
+        expression_mask.strip(),
+    )
+    if not reference:
+        return None
+    name = reference.group("name")
+    assignment = re.compile(
+        rf"\b(?:const|let|var)\s+{re.escape(name)}(?:\s*:[^=\n]+)?\s*=\s*"
+    )
+    matches = [match for match in assignment.finditer(mask, 0, before)]
+    if not matches:
+        return None
+    value_text, value_mask = _statement_expression(text, mask, matches[-1].end())
+    return _runtime_host(value_text, value_mask, text, mask, matches[-1].start())
+
+
+def _scope_start(mask: str, offset: int) -> int:
+    stack = []
+    for index, current in enumerate(mask[:offset]):
+        if current == "{":
+            stack.append(index)
+        elif current == "}" and stack:
+            stack.pop()
+    for opening in reversed(stack):
+        header = mask[max(0, opening - 300):opening]
+        if re.search(r"(?:\bfunction\b|=>)[^{}]*$", header, re.DOTALL):
+            return opening + 1
+    return (stack[-1] + 1) if stack else 0
+
+
+def _allowlist_guard(mask: str, start: int, end: int, host: str) -> bool:
+    prefix = mask[start:end]
+    membership = (
+        rf"(?P<list>{IDENTIFIER})\s*\.\s*(?:has|includes)\s*"
+        rf"\(\s*{re.escape(host)}\s*\)"
+    )
+    fail_closed = re.compile(
+        rf"\bif\s*\(\s*!\s*{membership}\s*\)\s*"
+        r"(?:\{[^{}]*\b(?:throw|return)\b[^{}]*\}|"
+        r"(?:throw|return)\b[^;\n]*(?:;|\n))",
+        re.IGNORECASE,
+    )
+    for match in fail_closed.finditer(prefix):
+        if _allowlist_name(match.group("list")):
+            return True
+
+    # A positive membership test dominates a fetch inside its still-open
+    # consequent block. Closed conditionals do not earn trust for later code.
+    stack = []
+    for index, current in enumerate(prefix):
+        if current == "{":
+            stack.append(index)
+        elif current == "}" and stack:
+            stack.pop()
+    positive = re.compile(rf"\bif\s*\(\s*{membership}\s*\)\s*$", re.I)
+    for opening in stack:
+        header = prefix[max(0, opening - 500):opening]
+        match = positive.search(header)
+        if match and _allowlist_name(match.group("list")):
+            return True
+    return False
+
+
+def _allowlist_name(name: str) -> bool:
+    return bool(
+        re.search(r"(?:^|_)(?:allow|allowed)(?:_|$)", name, re.I)
+        or re.search(r"(?:Allowlist|AllowedHosts|AllowedOrigins)$", name)
+    )
+
+
+def _check_fetch_hosts(path: Path, text: str, mask: str) -> list[Finding]:
+    findings = []
+    for offset, _opening, _closing, arguments in _call_ranges(mask, "fetch"):
+        if not arguments:
+            continue
+        start, end = arguments[0]
+        host = _runtime_host(text[start:end].strip(), mask[start:end].strip(),
+                             text, mask, offset)
+        if host and not _allowlist_guard(mask, _scope_start(mask, offset), offset, host):
+            findings.append(Finding(
+                path, _line_of(text, offset), "P007",
+                "runtime-selected absolute fetch host has no prior allowlist check",
+            ))
+    return findings
+
+
+def check_typescript(path: Path, text: str) -> list[Finding]:
+    spans, errors = lex(text)
+    if errors:
+        return [Finding(path, _line_of(text, offset), "P000", reason)
+                for offset, reason in errors]
+    mask = _masked(text, spans)
+    imports = _imports(_masked(text, spans, keep_strings=True))
+    return (
+        _check_raw_html(path, text, mask, imports)
+        + _check_persistence(path, text, mask, imports)
+        + _check_fetch_hosts(path, text, mask)
+    )
+
+
 def check(path: Path) -> list[Finding]:
     requirements = path.name.startswith("requirements") and path.suffix == ".txt"
-    if not requirements and path.suffix != ".py":
+    typescript = path.suffix in {".ts", ".tsx"}
+    if not requirements and path.suffix != ".py" and not typescript:
         return []
     try:
         text = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as err:
         return [Finding(path, 1, "P000", f"unreadable: {err}")]
-    found = check_requirements(path, text) if requirements else check_python(path, text)
+    if requirements:
+        found = check_requirements(path, text)
+    elif typescript:
+        found = check_typescript(path, text)
+    else:
+        found = check_python(path, text)
     return [f for f in found if not suppressed(text, f.line)]
 
 

--- a/plugins/hexaemeron/skills/phylax/scripts/phylax.py
+++ b/plugins/hexaemeron/skills/phylax/scripts/phylax.py
@@ -55,6 +55,7 @@ RAW_HTML_MARKER = re.compile(r"(?:raw|html|markdown|content)", re.IGNORECASE)
 TRUSTED_DIRECT_SANITISERS = frozenset(
     {"sanitize-html", "dompurify", "isomorphic-dompurify"}
 )
+TYPESCRIPT_MAX_BYTES = 1024 * 1024
 
 
 def suppressed(text: str, line: int) -> bool:
@@ -606,7 +607,17 @@ def check(path: Path) -> list[Finding]:
     if not requirements and path.suffix != ".py" and not typescript:
         return []
     try:
-        text = path.read_text(encoding="utf-8")
+        if typescript:
+            with path.open("rb") as source:
+                raw = source.read(TYPESCRIPT_MAX_BYTES + 1)
+            if len(raw) > TYPESCRIPT_MAX_BYTES:
+                return [Finding(
+                    path, 1, "P000",
+                    f"TypeScript source exceeds {TYPESCRIPT_MAX_BYTES}-byte analysis cap",
+                )]
+            text = raw.decode("utf-8")
+        else:
+            text = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as err:
         return [Finding(path, 1, "P000", f"unreadable: {err}")]
     if requirements:

--- a/plugins/hexaemeron/tests/test_phylax_checker.py
+++ b/plugins/hexaemeron/tests/test_phylax_checker.py
@@ -303,6 +303,14 @@ class TypeScriptContract(unittest.TestCase):
         self.assertEqual(["P000"], [finding.code for finding in result])
         self.assertEqual(1, result[0].line)
 
+    def test_oversized_typescript_stops_at_the_analysis_cap(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "oversized.ts"
+            path.write_bytes(b"a" * (phylax.TYPESCRIPT_MAX_BYTES + 1))
+            result = phylax.check(path)
+        self.assertEqual(["P000"], [finding.code for finding in result])
+        self.assertIn("1048576-byte analysis cap", result[0].message)
+
     def test_findings_do_not_repeat_secret_material_in_text_or_json(self):
         sample_value = "top-secret-session-value"
         result = findings(

--- a/plugins/hexaemeron/tests/test_phylax_checker.py
+++ b/plugins/hexaemeron/tests/test_phylax_checker.py
@@ -6,7 +6,10 @@ an RPC client with a `.call`, and a lint that flags those is a lint people
 learn to bypass.
 """
 
+import contextlib
 import importlib.util
+import io
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -24,6 +27,13 @@ def codes(source, name="sample.py"):
         path = Path(directory) / name
         path.write_text(source, encoding="utf-8")
         return sorted(finding.code for finding in phylax.check(path))
+
+
+def findings(source, name="sample.ts"):
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / name
+        path.write_text(source, encoding="utf-8")
+        return phylax.check(path)
 
 
 class ShellInvocation(unittest.TestCase):
@@ -100,6 +110,223 @@ class Suppression(unittest.TestCase):
 
     def test_a_bare_pragma_without_a_reason_does_not_suppress(self):
         self.assertIn("P004", codes('SECRET = "9f4b2c8e"  # phylax: allow\n'))
+
+
+class RawHTML(unittest.TestCase):
+    def test_it_flags_raw_rehype_without_a_later_sanitiser_on_the_exact_line(self):
+        source = (
+            'import raw from "rehype-raw"\n'
+            'import clean from "rehype-sanitize"\n'
+            'const view = <Markdown rehypePlugins={[\n'
+            '  raw,\n'
+            ']} />\n'
+        )
+        result = findings(source, "sample.tsx")
+        self.assertEqual(["P005"], [finding.code for finding in result])
+        self.assertEqual(4, result[0].line)
+
+    def test_it_allows_import_aliases_in_safe_order(self):
+        source = (
+            'import unsafeTransform from "rehype-raw"\n'
+            'import scrub from "rehype-sanitize"\n'
+            'const view = <Markdown rehypePlugins={[unsafeTransform, scrub]} />\n'
+        )
+        self.assertEqual([], codes(source, "sample.tsx"))
+
+    def test_it_allows_emotion_style_injection(self):
+        source = '<style dangerouslySetInnerHTML={{ __html: styles }} />\n'
+        self.assertEqual([], codes(source, "sample.tsx"))
+
+    def test_it_flags_raw_named_html_without_a_trusted_call(self):
+        source = 'const view = <div dangerouslySetInnerHTML={{ __html: rawHtml }} />\n'
+        self.assertEqual(["P005"], codes(source, "sample.tsx"))
+
+    def test_a_side_effect_import_does_not_hide_the_raw_binding(self):
+        source = (
+            'import "./setup"\n'
+            'import raw from "rehype-raw"\n'
+            'const view = <Markdown rehypePlugins={[raw]} />\n'
+        )
+        self.assertEqual(["P005"], codes(source, "sample.tsx"))
+
+    def test_it_allows_raw_html_passed_to_an_imported_sanitiser(self):
+        source = (
+            'import clean from "sanitize-html"\n'
+            'const view = <div dangerouslySetInnerHTML={{ __html: clean(rawHtml) }} />\n'
+        )
+        self.assertEqual([], codes(source, "sample.tsx"))
+
+    def test_an_unrelated_function_named_sanitize_does_not_earn_trust(self):
+        source = (
+            'const sanitize = (value: string) => value\n'
+            'const view = <div dangerouslySetInnerHTML={{ __html: sanitize(rawHtml) }} />\n'
+        )
+        self.assertEqual(["P005"], codes(source, "sample.tsx"))
+
+
+class PersistedSessions(unittest.TestCase):
+    def test_it_flags_a_session_token_written_to_storage_on_the_exact_line(self):
+        source = (
+            'const accessToken = getToken()\n'
+            'localStorage.setItem("accessToken", accessToken)\n'
+        )
+        result = findings(source)
+        self.assertEqual(["P006"], [finding.code for finding in result])
+        self.assertEqual(2, result[0].line)
+
+    def test_it_allows_ordinary_ui_storage(self):
+        self.assertEqual([], codes(
+            'localStorage.setItem("lastSeen", String(Date.now()))\n', "sample.ts"))
+
+    def test_it_allows_api_token_domain_and_pending_signature_names(self):
+        source = (
+            'type ApiTokensState = { apiTokens: Record<string, string> }\n'
+            'type Pending = { signature?: string }\n'
+            'localStorage.setItem("apiTokens", JSON.stringify(apiTokens))\n'
+        )
+        self.assertEqual([], codes(source, "sample.ts"))
+
+    def test_it_flags_a_session_field_in_a_persisted_reducer(self):
+        source = (
+            'import { persistReducer } from "redux-persist"\n'
+            'type AuthState = { sessionToken: string }\n'
+            'const persistConfig = { key: "auth", storage }\n'
+            'export default persistReducer(persistConfig, reducer)\n'
+        )
+        result = findings(source)
+        self.assertEqual(["P006"], [finding.code for finding in result])
+        self.assertEqual(4, result[0].line)
+
+    def test_it_allows_a_sensitive_field_on_the_blacklist(self):
+        source = (
+            'import { persistReducer } from "redux-persist"\n'
+            'type AuthState = { authToken: string; theme: string }\n'
+            'const persistConfig = { key: "auth", storage, blacklist: ["authToken"] }\n'
+            'export default persistReducer(persistConfig, reducer)\n'
+        )
+        self.assertEqual([], codes(source, "sample.ts"))
+
+    def test_it_allows_a_whitelist_that_omits_the_sensitive_field(self):
+        source = (
+            'import { persistReducer } from "redux-persist"\n'
+            'type AuthState = { jwt: string; theme: string }\n'
+            'const persistConfig = { key: "auth", storage, whitelist: ["theme"] }\n'
+            'export default persistReducer(persistConfig, reducer)\n'
+        )
+        self.assertEqual([], codes(source, "sample.ts"))
+
+    def test_it_allows_a_visible_transform_that_removes_the_sensitive_field(self):
+        source = (
+            'import { createTransform, persistReducer } from "redux-persist"\n'
+            'type AuthState = { authToken: string; theme: string }\n'
+            'const stripAuth = createTransform((state: AuthState) => {\n'
+            '  const { authToken, ...safe } = state\n'
+            '  return safe\n'
+            '})\n'
+            'const config = { key: "auth", storage, transforms: [stripAuth] }\n'
+            'export default persistReducer(config, reducer)\n'
+        )
+        self.assertEqual([], codes(source, "sample.ts"))
+
+
+class FetchHosts(unittest.TestCase):
+    def test_it_flags_an_interpolated_absolute_host_on_the_exact_line(self):
+        source = (
+            'async function load(host: string) {\n'
+            '  return fetch(`https://${host}/api`)\n'
+            '}\n'
+        )
+        result = findings(source)
+        self.assertEqual(["P007"], [finding.code for finding in result])
+        self.assertEqual(2, result[0].line)
+
+    def test_it_flags_new_url_with_a_runtime_base(self):
+        source = (
+            'async function load(host: string) {\n'
+            '  const url = new URL("/api", host)\n'
+            '  return fetch(url.toString())\n'
+            '}\n'
+        )
+        self.assertEqual(["P007"], codes(source, "sample.ts"))
+
+    def test_it_allows_a_prior_named_allowlist_guard(self):
+        source = (
+            'const ALLOWED_HOSTS = new Set(["api.example"])\n'
+            'async function load(host: string) {\n'
+            '  if (!ALLOWED_HOSTS.has(host)) throw new Error("not allowed")\n'
+            '  return fetch(`https://${host}/api`)\n'
+            '}\n'
+        )
+        self.assertEqual([], codes(source, "sample.ts"))
+
+    def test_a_non_dominating_membership_check_does_not_earn_trust(self):
+        source = (
+            'const ALLOWED_HOSTS = new Set(["api.example"])\n'
+            'async function load(host: string) {\n'
+            '  if (ALLOWED_HOSTS.has(host)) recordAllowed(host)\n'
+            '  return fetch(`https://${host}/api`)\n'
+            '}\n'
+        )
+        self.assertEqual(["P007"], codes(source, "sample.ts"))
+
+    def test_it_allows_relative_same_origin_and_fixed_urls(self):
+        source = (
+            'fetch("/api/items")\n'
+            'fetch(new URL("/api/items", window.location.origin))\n'
+            'fetch("https://api.example/items")\n'
+        )
+        self.assertEqual([], codes(source, "sample.ts"))
+
+    def test_a_bare_fetch_binding_has_no_invented_host(self):
+        self.assertEqual([], codes(
+            'async function query(url: string) { return fetch(url) }\n', "sample.ts"))
+
+
+class TypeScriptContract(unittest.TestCase):
+    def test_reason_bearing_line_and_previous_line_suppressions_work(self):
+        self.assertEqual([], codes(
+            '// phylax: allow hostile fixture\n'
+            'localStorage.setItem("authToken", authToken)\n', "sample.ts"))
+        self.assertEqual([], codes(
+            'localStorage.setItem("authToken", authToken) // phylax: allow test-only token\n',
+            "sample.ts",
+        ))
+
+    def test_a_bare_typescript_pragma_does_not_suppress(self):
+        self.assertEqual(["P006"], codes(
+            'localStorage.setItem("authToken", authToken) // phylax: allow\n',
+            "sample.ts",
+        ))
+
+    def test_unterminated_typescript_is_p000(self):
+        result = findings('const value = `unterminated ${name}\n')
+        self.assertEqual(["P000"], [finding.code for finding in result])
+        self.assertEqual(1, result[0].line)
+
+    def test_findings_do_not_repeat_secret_material_in_text_or_json(self):
+        sample_value = "top-secret-session-value"
+        result = findings(
+            f'const accessToken = "{sample_value}"\n'
+            'localStorage.setItem("accessToken", accessToken)\n'
+        )
+        rendered = "\n".join(str(finding) for finding in result)
+        encoded = json.dumps([finding.as_dict() for finding in result])
+        self.assertNotIn(sample_value, rendered)
+        self.assertNotIn(sample_value, encoded)
+
+    def test_main_accepts_mixed_python_and_typescript_inputs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            python_path = Path(directory) / "unsafe.py"
+            typescript_path = Path(directory) / "unsafe.ts"
+            python_path.write_text('SECRET = "live-value"\n', encoding="utf-8")
+            typescript_path.write_text(
+                'localStorage.setItem("authToken", authToken)\n', encoding="utf-8")
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                status = phylax.main([str(python_path), str(typescript_path)])
+        self.assertEqual(1, status)
+        self.assertIn("P004", output.getvalue())
+        self.assertIn("P006", output.getvalue())
 
 
 class OverTheMarketplace(unittest.TestCase):

--- a/plugins/hexaemeron/tests/test_typescript_lexer.py
+++ b/plugins/hexaemeron/tests/test_typescript_lexer.py
@@ -1,0 +1,65 @@
+"""The shared lexer retains the Horos TypeScript lexical boundary."""
+
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from lib import typescript_lexer as ts  # noqa: E402
+
+
+def kinds(source):
+    spans, _ = ts.lex(source)
+    return [(kind, source[start:end]) for kind, start, end in spans]
+
+
+def only(source, kind):
+    return [text for current, text in kinds(source) if current == kind]
+
+
+class TypeScriptLexerTests(unittest.TestCase):
+    def test_spans_reconstruct_the_complete_source(self):
+        source = 'const a = "x"; // done\nconst b = /two/g;\n'
+        spans, errors = ts.lex(source)
+        self.assertEqual([], errors)
+        self.assertEqual(source, "".join(source[start:end] for _, start, end in spans))
+
+    def test_strings_and_both_comment_forms_are_separate_spans(self):
+        source = '// line\n/* block\nstill */ const value = "a\\\"b";\n'
+        self.assertEqual(["// line"], only(source, "line_comment"))
+        self.assertEqual(["/* block\nstill */"], only(source, "block_comment"))
+        self.assertEqual(['"a\\\"b"'], only(source, "string"))
+
+    def test_templates_nest_two_deep(self):
+        source = "const value = `a${ {b: `c${d}e`} }f`;\n"
+        self.assertEqual(["`a${ {b: `c${d}e`} }f`"], only(source, "template"))
+
+    def test_regex_is_distinguished_from_division(self):
+        source = "const match = /[a/b]+/gi; const ratio = total / 2;\n"
+        self.assertEqual(["/[a/b]+/gi"], only(source, "regex"))
+
+    def test_unterminated_construct_reports_offset_and_covers_remainder(self):
+        source = "const value = `open ${name};\n"
+        spans, errors = ts.lex(source)
+        self.assertEqual(1, len(errors))
+        self.assertEqual(source.index("`"), errors[0][0])
+        self.assertIn("unterminated template", errors[0][1])
+        self.assertEqual(("template", source.index("`"), len(source)), spans[-1])
+
+    def test_multiline_jsx_attribute_string_is_one_span(self):
+        source = (
+            '<Tooltip value="first line\n'
+            '  second line" />\n'
+        )
+        spans, errors = ts.lex(source)
+        self.assertEqual([], errors)
+        self.assertEqual(
+            ['"first line\n  second line"'],
+            [source[start:end] for kind, start, end in spans if kind == "string"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Phylax now checks tracked `.ts` and `.tsx` source for raw HTML without a later trusted sanitiser, session credentials written to persisted browser storage, and runtime-selected absolute fetch hosts without a prior allowlist guard.

The implementation uses an attributed copy of Horos's tested TypeScript lexer inside Hexaemeron. It preserves Horos's lexical contract without requiring a separately installed plugin. TypeScript reads stop at 1 MiB and fail closed with `P000` above that limit.

The fixtures cover each unsafe case and its safe neighbours. The pinned `wildcat-app-v2` scan is clean and leaves the checkout unchanged. The review record is in `audit/AUDIT.md`; its one finding was fixed before the clean second round. The completed stack edge is [PR #193](https://github.com/wildcat-finance/skills/pull/193).

Run the proof from the repository root:

```bash
python3 -m unittest plugins.hexaemeron.tests.test_typescript_lexer
python3 -m unittest plugins.hexaemeron.tests.test_phylax_checker
python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py .hexaemeron/validation/wildcat-app-v2
python3 plugins/hexaemeron/tests/run_tests.py
python3 -m unittest discover -s tests
git -C .hexaemeron/validation/wildcat-app-v2 status --porcelain
```

<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
