### PR TITLE
Classify Elenchus guards from runner reports

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1648,3 +1648,14 @@ Location: `plugins/hexaemeron/skills/elenchus/scripts/elenchus.py:214`
 Mechanism: A background writer could grow the file after its accepted size was read but before unbounded `read_bytes()` completed.
 Impact: A report could exceed the 1 MiB memory and parser-work limit.
 Fix: Read at most 1 MiB plus one byte and reject the extra byte before parsing.
+
+## Elenchus structured reports, step 1, round 2 -- 2026-08-19
+
+Suite waived (no Solidity); Phylax, Ephoros and Hypomnema lints clean.
+Hexaemeron 179/179 and root 24/24. Real unittest, Forge and Node fixtures ran without skips.
+Manual review of `5311fbaff498e1d20e256eb5d312b024d9354a2c` found no further issue.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -1634,3 +1634,17 @@ Manual review of `bff0eb6460e8f682e230ee6d982456121a33e2cc` found no further iss
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Elenchus structured reports, step 1, round 1 -- 2026-08-19
+
+[Medium] A descendant process could supply the accepted report.
+Location: `plugins/hexaemeron/skills/elenchus/scripts/elenchus.py:310`
+Mechanism: The report path was exported through `ELENCHUS_REPORT_FILE`, so every descendant inherited the same write target.
+Impact: A broken parent run was classified as guarded from a nested fixture's unrelated assertion report.
+Fix: Substitute one exact `{report}` command argument and remove the inherited report variable before launch.
+
+[Medium] The report-size check had a stat/read race.
+Location: `plugins/hexaemeron/skills/elenchus/scripts/elenchus.py:214`
+Mechanism: A background writer could grow the file after its accepted size was read but before unbounded `read_bytes()` completed.
+Impact: A report could exceed the 1 MiB memory and parser-work limit.
+Fix: Read at most 1 MiB plus one byte and reject the extra byte before parsing.

--- a/plugins/hexaemeron/docs/elenchus-structured-runner-reports/runbook.md
+++ b/plugins/hexaemeron/docs/elenchus-structured-runner-reports/runbook.md
@@ -23,7 +23,8 @@ Hexaemeron tests and 24 root tests, all green under Python 3.14.6. The runner
 fixtures will be exercised with Forge 1.7.1 and Node 26.6.0.
 
 **Exit.** `elenchus.py` accepts the explicit report-format and report-file
-contract from the study, validates report paths and sizes, parses versioned
+contract from the study, substitutes the path for one exact `{report}` command
+argument without exporting an inheritable report variable, validates paths and sizes, parses versioned
 unittest `TestResult` JSON, Forge JUnit XML and Node `TestsStream` JSON, and
 normalises each into completion, executed, assertion-failure, error and skip
 counts. The shared decision table fails closed for missing, stale, malformed,

--- a/plugins/hexaemeron/docs/elenchus-structured-runner-reports/runbook.md
+++ b/plugins/hexaemeron/docs/elenchus-structured-runner-reports/runbook.md
@@ -1,0 +1,113 @@
+# Elenchus structured runner-report runbook
+
+This run has one step. The report adapters, the shared decision table, the
+three fixture repositories, the public command contract, the skill text and
+the frontier ledger all change the same compatibility boundary. Splitting
+them would leave either an undocumented interface or a classifier with no
+cross-runner proof.
+
+## Step 1: Replace diagnostic matching with structured runner reports
+
+**Goal.** Make Elenchus decide `guarded`, `passed` or `inconclusive` from a
+fresh runner-owned report for unittest, Forge and Node `node:test`, with no
+exit-code or diagnostic-text matching in the decision.
+
+**Entry.** Controller base `main` at
+`c29159d098dd468f07ba1edde3c03614106b3694`; controller run branch
+`fiat/teach-the-check-to-read-a-runner-s-own-report-ra`. The implementation
+step branches from that run branch using the exact `branch` and `branch_from`
+in the controller's implementation directive. Elenchus is
+`elenchus-v0.1.0`; its checker still carries `BROKEN_RUN` and
+`broken_run(output)`. Baselines at this ref are 8 focused Elenchus tests, 167
+Hexaemeron tests and 24 root tests, all green under Python 3.14.6. The runner
+fixtures will be exercised with Forge 1.7.1 and Node 26.6.0.
+
+**Exit.** `elenchus.py` accepts the explicit report-format and report-file
+contract from the study, validates report paths and sizes, parses versioned
+unittest `TestResult` JSON, Forge JUnit XML and Node `TestsStream` JSON, and
+normalises each into completion, executed, assertion-failure, error and skip
+counts. The shared decision table fails closed for missing, stale, malformed,
+partial, oversized, mixed-error, zero-test, timed-out, interrupted and legacy
+no-report runs. Exit codes and stdout/stderr remain diagnostic only;
+`BROKEN_RUN`, `broken_run()` and all diagnostic-string classification are
+gone. Real git fixtures prove guarded, passed and broken outcomes for all
+three runners, including diagnostics whose words contradict the structured
+result. Existing statuses, audit-line shape, default severity, changed-test
+detection, parent overlay and source-tree cleanliness remain covered.
+
+The repository also contains prose-checked copies of this study and runbook.
+`SKILL.md` documents the new command contract and its fail-closed limits.
+Elenchus's governed version advances once from `elenchus-v0.1.0` to
+`elenchus-v1.1.0`; its evolution ledger records the completed evidence and
+either one concrete evidenced next job or a mature frontier with
+`None -- mature`, following `skills/VERSIONING.md`. The focused test, both
+repository suites and the final demo below exit zero, the audit closes clean,
+and the run completes through one merged integration pull request.
+
+**Files.** Change
+`plugins/hexaemeron/skills/elenchus/scripts/elenchus.py`,
+`plugins/hexaemeron/tests/test_elenchus_checker.py`,
+`plugins/hexaemeron/skills/elenchus/SKILL.md`, and
+`plugins/hexaemeron/skills/elenchus/EVOLUTION.md`. Create
+`plugins/hexaemeron/docs/elenchus-structured-runner-reports/study.md` and
+`plugins/hexaemeron/docs/elenchus-structured-runner-reports/runbook.md` as
+committed copies of the completed specification and plan. Keep fixture
+repository sources inside the focused test unless a separate fixture file is
+needed to make a runner-owned emitter readable; if so, place it under
+`plugins/hexaemeron/tests/fixtures/elenchus/` and list every added file in the
+step handoff. Do not change Fiat controller state, audit history outside the
+required appended step record, other skills, CI, vendored Foundry output or
+the portable Elenchus entrypoint unless a failing contract test proves it is
+required.
+
+**Tests.** Preserve the entry baselines before editing:
+
+```bash
+python3 -m unittest plugins.hexaemeron.tests.test_elenchus_checker -v
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 -m unittest discover -s tests
+python3 --version
+forge --version
+node --version
+```
+
+Extend the focused suite with three real temporary git repositories. Each
+runner must prove a parent assertion is `guarded`, an unchanged passing test is
+`passed`, and an import/load/compile failure is `inconclusive`. Add rejection
+cases for a missing report, stale report, malformed report, incomplete report,
+oversized report, contradictory counts, mixed assertion and infrastructure
+errors, zero executed tests, unsafe report paths, symlinks and legacy
+no-report commands. Add at least two poisoned-diagnostic cases: assertion
+structure accompanied by broken-run wording, and broken structure accompanied
+by assertion wording. Verify timeout and executable-not-found paths clean up
+their worktrees and reports. Do not skip Forge or Node cases and count the
+suite as acceptance.
+
+Run the final demo from the repository root:
+
+```bash
+python3 -m unittest plugins.hexaemeron.tests.test_elenchus_checker -v
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 -m unittest discover -s tests
+git diff --check
+```
+
+Then verify that the old classifier is absent and that all changed prose is
+clean:
+
+```bash
+! rg -n 'BROKEN_RUN|broken_run\(' plugins/hexaemeron/skills/elenchus plugins/hexaemeron/tests/test_elenchus_checker.py
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py plugins/hexaemeron/skills/elenchus/SKILL.md plugins/hexaemeron/skills/elenchus/EVOLUTION.md plugins/hexaemeron/docs/elenchus-structured-runner-reports/study.md plugins/hexaemeron/docs/elenchus-structured-runner-reports/runbook.md
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins/hexaemeron/skills/elenchus plugins/hexaemeron/tests/test_elenchus_checker.py
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins/hexaemeron/skills/elenchus plugins/hexaemeron/tests/test_elenchus_checker.py
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py plugins/hexaemeron/skills/elenchus plugins/hexaemeron/docs/elenchus-structured-runner-reports
+```
+
+The audit concentrates on report-path containment and symlinks, stale and
+partial files, JSON/XML size and schema validation, XML entity handling,
+boolean-as-integer and contradictory counts, subprocess interruption,
+diagnostic poisoning, secret-bearing output, Node error identity, the exact
+Forge JUnit subset, cleanup of detached worktrees, backward-command severity,
+and the evolution digest. The prose phase covers the committed study and
+runbook, changed Elenchus prose, the appended audit record, and the pull
+request title and body.

--- a/plugins/hexaemeron/docs/elenchus-structured-runner-reports/study.md
+++ b/plugins/hexaemeron/docs/elenchus-structured-runner-reports/study.md
@@ -1,0 +1,234 @@
+# Study: structured runner reports for the Elenchus guard check
+
+## Assumptions
+
+Assuming, unless corrected:
+
+1. Work starts from `c29159d098dd468f07ba1edde3c03614106b3694` in the Wildcat Skills repository.
+2. The held job remains word for word: “Teach the check to read a runner's own report rather than its exit code and output text, so an assertion failure is told from a broken run by structure instead of by matching error strings. Accepted when it classifies correctly for unittest, forge and one JavaScript runner in fixture repositories, with no string matching left in the decision, and both suites pass.”
+3. “Both suites” means `python3 plugins/hexaemeron/tests/run_tests.py` and `python3 -m unittest discover -s tests`, run from the repository root.
+4. The checker and its report parsers remain Python standard-library code. Forge and Node are test runners under inspection, not new Python dependencies.
+5. The JavaScript runner is Node's built-in `node:test`. It is chosen because its documented `TestsStream` supplies structured events and a fixture needs no package install or lockfile.
+6. The observed local toolchain is Python 3.14.6, Forge 1.7.1 and Node 26.6.0. The fixture evidence establishes these versions; broader version support is not claimed without another fixture run.
+7. A unittest fixture may carry a small runner-owned emitter because stdlib unittest has no native JSON file. The emitter serialises the `TestResult` categories; it does not infer a category from traceback text.
+8. A runner report is authoritative only if it is fresh, parseable, complete and records at least one executed test. Missing, stale, malformed, partial and zero-test reports are `inconclusive`.
+9. Output and exit status remain available as diagnostics. Neither is an input to the guarded/passed/inconclusive decision.
+
+These assumptions choose a fail-closed interface over silent compatibility. An old invocation that supplies only `--test-command` cannot prove a guard and therefore returns `inconclusive`; it never falls back to the current string heuristic.
+
+## Problem statement
+
+Elenchus tests whether a fix commit carries a real guard by copying the commit's changed test files onto its parent and running them there. It reports:
+
+- `guarded` when the overlaid test makes an assertion fail on the parent;
+- `unguarded` when the fix commit changed no test file;
+- `passed` when the test also passes on the parent; and
+- `inconclusive` when the run breaks before a useful assertion.
+
+The current implementation makes the critical distinction using the process exit code and the `BROKEN_RUN` tuple in `plugins/hexaemeron/skills/elenchus/scripts/elenchus.py`. `broken_run(output)` lowercases stdout and stderr and searches for fragments such as `importerror`, `cannot find module`, `compiler run failed` and `syntaxerror`. This can call a genuine assertion inconclusive when its diagnostic contains one of those phrases, or call a broken run guarded when a runner changes its wording.
+
+Build a structured-report boundary for maintainers who use Elenchus against Python, Solidity and JavaScript fixes. The test command must produce a declared runner report. Elenchus parses that report into one small internal outcome and decides from the report's fields, never from process text or exit status.
+
+A working prototype classifies `guarded`, `passed` and `inconclusive` correctly in three real git fixture repositories: stdlib unittest, Forge and Node `node:test`. Each fixture must contain an assertion failure on the parent, a test that passes on the parent and a run that breaks before assertion. Diagnostic poisoning must also prove that failure wording cannot change the decision.
+
+### Demo path and success criteria
+
+Run from the Wildcat Skills root:
+
+```bash
+python3 -m unittest plugins.hexaemeron.tests.test_elenchus_checker -v
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 -m unittest discover -s tests
+```
+
+The prototype is accepted only when all of these are true:
+
+1. The unittest fixture classifies a `TestResult.failure` as `guarded`, a clean result as `passed`, and a `TestResult.error` as `inconclusive`.
+2. The Forge fixture classifies a JUnit `<failure>` from a test revert/assertion as `guarded`, a report with executed passing cases as `passed`, and a compile failure that produces no valid report as `inconclusive`.
+3. The Node fixture classifies an assertion event from `TestsStream` as `guarded`, completed passing test events as `passed`, and a load/runtime error event as `inconclusive`.
+4. A missing, malformed, incomplete, stale or zero-executed-test report is `inconclusive` for every applicable adapter.
+5. A run whose diagnostic text says `ModuleNotFoundError` but whose report records an assertion stays `guarded`; a broken report whose diagnostic says `AssertionError` stays `inconclusive`.
+6. The decision function contains no substring, regular-expression or exception-message matching. `BROKEN_RUN` and `broken_run()` are absent.
+7. Exit-code changes with an unchanged complete report do not change the classification.
+8. The original fixture repository's working tree is unchanged after each check, and temporary report files and worktrees are removed.
+9. The focused test and both named suites exit zero. The current baseline is 8 focused Elenchus tests, 167 Hexaemeron tests and 24 root tests.
+
+## Prior art
+
+### In this repository
+
+- `plugins/hexaemeron/skills/elenchus/scripts/elenchus.py` already supplies the git mechanics, changed-test detection, detached parent worktree, test overlay, timeout, cleanup, result shape, audit line and `--require-guard` policy. Those remain the compatibility boundary.
+- The same file's `BROKEN_RUN` tuple and `broken_run(output)` name the defect this frontier removes. The output slice in the returned result is diagnostic evidence, not a classification API.
+- `plugins/hexaemeron/tests/test_elenchus_checker.py` builds a real temporary git repository. Its commits cover guarded, unguarded, passed and import-broken outcomes and verify that the source working tree stays untouched. The report fixtures should preserve this style rather than mock git or runners.
+- `plugins/hexaemeron/skills/elenchus/SKILL.md` says that an assertion failure is a guard and an import/build failure is inconclusive. It also treats error output as untrusted data, which rules out using text as a control signal.
+- `plugins/hexaemeron/skills/elenchus/EVOLUTION.md` holds the exact job under frontier revision `observed-failure-root-cause` at `elenchus-v0.1.0`.
+- Commit `5b1105a` introduced Elenchus, its checker, tests and ledger. There is no later checker history to reconcile.
+- `plugins/hexaemeron/tests/run_tests.py` discovers the Hexaemeron suite and prints a pass count. The root suite enforces portable skill and evolution contracts affected by a completed frontier change.
+- `plugins/ariadne/tests/fixtures/forge-project/` and `plugins/pandects/foundry.toml` show dependency-light Foundry fixtures pinned to Solidity 0.8.28. Their generated `out/` trees are reading-boundary exclusions and are not prior-art inputs.
+
+### Runner-owned structures
+
+- Python's `unittest.TestResult` has separate `failures` and `errors` collections. `addFailure` records a test's assertion failure; `addError` records an unexpected exception. `TestRunner.run()` returns the result for reporting tools. This is the structured distinction the JSON emitter preserves.
+- Local `forge test --help` at Forge 1.7.1 exposes `--junit`, described as a JUnit XML test report. A completed test failure appears as a test-case failure; compilation that prevents a run from producing a valid report leaves no accepted report.
+- Node documents built-in test reporters but warns that their rendered output is not a programmatic interface. It directs consumers to `TestsStream`, whose `test:pass`, `test:fail`, `test:complete` and `test:summary` events carry structured execution metadata and the actual thrown error as `details.error.cause`.
+- JUnit XML uses `testcase`, `failure`, `error` and `skipped` elements. It has no single formal specification across all producers, so the Forge adapter accepts only the exact subset anchored by the fixture.
+
+## Constraints and non-goals
+
+### Constraints
+
+- Preserve result statuses, the `check()` purpose, `audit_line()`, JSON/text CLI output and default `--require-guard` severity. Change only how a completed runner invocation is classified.
+- Keep `changed_tests`, parent lookup, overlay and worktree cleanup behaviour unless a report-path safety fix requires a narrow change.
+- Add explicit `--report-format` and `--report-file` inputs. The declared file is resolved inside the detached worktree, removed before the run, and exposed to fixture-owned emitters through `ELENCHUS_REPORT_FILE`.
+- Accept three declared formats: versioned unittest JSON, Forge JUnit XML and versioned Node test JSON. Parse JSON with `json` and XML with `xml.etree.ElementTree`.
+- Require a schema/version marker, completion marker where the native format supports one, non-negative integer counts and at least one executed test. Reject contradictions such as totals smaller than failures.
+- Classify a mixed report containing both assertion failures and infrastructure errors as `inconclusive`; a broken run cannot establish a clean guard merely because one assertion also fired.
+- Cap report size before parsing and never expand external XML entities. A report is untrusted data produced by code under test.
+- Leave stdout and stderr out of every classification branch. They may be retained, bounded and returned for a person to read.
+- Treat timeout, executable-not-found, signal interruption, missing report, invalid report, zero tests and parser exceptions as `inconclusive`.
+- Do not skip Forge or Node fixture tests when their runners are absent and still claim acceptance. Tool absence means the held acceptance has not been demonstrated.
+
+### Non-goals
+
+- A universal protocol for pytest, Jest, Vitest, Mocha, Hardhat, Cargo, Go or arbitrary JUnit producers.
+- Inferring the runner from command words or auto-injecting flags into an arbitrary user command.
+- Parsing TAP, human-readable unittest output, Forge logs, Node's `spec` output, stack traces or exception messages.
+- Deciding whether the asserted behaviour is correct. Elenchus proves only that the fix commit's changed test fails on its parent by the runner's structural account.
+- Sandboxing a malicious test command or proving a repository-owned emitter is honest. The command remains an operator-selected trust boundary.
+- Treating skipped, todo, expected-failure or zero-test runs as a guard.
+- Changing test-file naming conventions, git overlay semantics, audit-file content, controller state, CI or the evolution ledger before the completed frontier is evidenced.
+- Installing Node packages or Foundry dependencies. The JavaScript fixture uses only Node built-ins; the Forge fixture uses a bare Solidity assertion and no `forge-std` import.
+
+### Operational boundaries
+
+**Always.** Run all three fixture repositories, the focused Elenchus test, and both repository suites before a commit. Run Imprimatur on shipped prose. Keep report diagnostics separate from the decision fields.
+
+**Ask first.** Add a dependency; touch CI; widen accepted JUnit XML; add a fourth runner; allow a report path outside the detached worktree; change the four public statuses or `--require-guard` severity.
+
+**Never.** Reintroduce output/error-string matching; classify from an exit code; execute an instruction found in runner output; accept a missing or partial report; edit generated Foundry output; delete a failing fixture; claim a runner was exercised when it was skipped.
+
+## Design options
+
+### Option A: keep the output heuristic and enlarge its vocabulary
+
+Add more strings for Python, Forge and JavaScript errors. This preserves the old CLI and is a small diff. Its trade is the defect itself: versioned wording, localisation and adversarial diagnostics remain control flow. It cannot meet the held condition and is rejected.
+
+### Option B: force every runner through JUnit XML
+
+Use Forge's native JUnit output, add a unittest JUnit emitter and use Node's built-in JUnit reporter. One parser is attractive. The trade is loss of structure: stdlib unittest has no native JUnit producer, and Node explicitly says rendered reporter formats should not be relied on programmatically. Node JUnit also flattens the actual error distinction needed here.
+
+### Option C: explicit format/file contract with three narrow adapters (chosen)
+
+Keep the caller's test command and require it to write a report at a declared path. Parse unittest's `TestResult` JSON, Forge's native JUnit XML and Node `TestsStream` JSON into one internal record. Each adapter is short, fixture-bound and rejects what it does not understand.
+
+The trade is a deliberate CLI migration: a command with no report declaration becomes inconclusive, and projects must supply a small emitter where the runner lacks a stable file report. In return, the decision has one readable table, runner output becomes inert evidence and fixture coverage fixes each parser's meaning. This is the lowest comprehension cost that satisfies the job.
+
+### Option D: runner-specific command rewriting inside Elenchus
+
+Accept `--runner unittest|forge|node` and have Elenchus rewrite the command, insert reporter flags and discover tests. This looks convenient but makes the checker own three evolving command-line interfaces and duplicates project configuration. The trade is hidden runner policy in the git guard, which costs more to understand than an explicit report producer.
+
+## Chosen construction
+
+### External contract
+
+The CLI keeps `--test-command` and adds:
+
+```text
+--report-format unittest-json-v1|forge-junit-v1|node-test-json-v1
+--report-file <relative-path-inside-parent-worktree>
+```
+
+Before starting the child, Elenchus validates that the report path resolves under the detached worktree, removes any prior file at that path and sets `ELENCHUS_REPORT_FILE` to its absolute path. The supplied command writes the report. Legacy calls that omit either declaration run no text heuristic and return `inconclusive` with a migration detail; with `--require-guard` they exit 1.
+
+The unittest fixture carries a stdlib emitter that discovers tests, runs them, and writes a versioned JSON object from `TestResult.testsRun`, `failures`, `errors`, `skipped`, `expectedFailures` and `unexpectedSuccesses`. It records counts and completion, not traceback strings.
+
+The Forge fixture carries a small stdlib launcher that sends native `forge test --junit` XML to `ELENCHUS_REPORT_FILE`. The parser counts executed `testcase` elements and their `failure`, `error` and `skipped` children. A compiler failure produces no accepted XML and is therefore inconclusive.
+
+The Node fixture carries a custom reporter over `node:test`'s programmatic `TestsStream`. It writes versioned JSON counts, marks an assertion using the actual assertion-error type/structured cause, marks other failed events as errors, and writes `complete: true` only after the stream ends. It uses no npm dependency.
+
+### Normalised report and decision
+
+Every adapter returns this internal shape:
+
+```text
+complete: bool
+executed: non-negative integer
+assertion_failures: non-negative integer
+errors: non-negative integer
+skipped: non-negative integer
+```
+
+The decision is ordered and runner-neutral:
+
+| Condition | Status |
+| --- | --- |
+| no changed tests in the fix commit | `unguarded` |
+| no parent, timeout, child launch failure, unsafe path, missing/stale/malformed/oversized/incomplete report | `inconclusive` |
+| `executed == 0` or `errors > 0` | `inconclusive` |
+| `assertion_failures > 0` and `errors == 0` | `guarded` |
+| `executed > 0`, `assertion_failures == 0`, `errors == 0` | `passed` |
+
+Exit code and diagnostic bytes appear nowhere in this table. String equality on report schema identifiers is format dispatch, not error diagnosis; no diagnostic content is searched or compared.
+
+### Fixture repositories
+
+Each runner gets its own temporary git repository so its command and report emitter are real:
+
+- **unittest:** a buggy Python adder in the parent; a changed assertion that catches it; a harmless passing test; and a changed test importing a module added only by the fix commit.
+- **Forge:** a dependency-free Solidity adder and `foundry.toml` pinned to Solidity 0.8.28; a changed bare `assert` guard; a passing arithmetic test; and a changed test importing a contract absent from the parent.
+- **Node:** an ES module adder, built-in `node:test` plus `node:assert/strict`, and the `TestsStream` reporter in the base commit; guarded, passing and missing-module commits parallel the other fixtures.
+
+Add adversarial diagnostics to at least one guarded and one broken case. The words must disagree with the structured report, proving the old heuristic cannot influence the result. Keep the common unguarded, severity, test-file detection and clean-working-tree tests.
+
+## Risk register seed
+
+| Area | Boundary or failure | Control | Audit evidence |
+| --- | --- | --- | --- |
+| Runner report | Test code can emit arbitrary JSON/XML or forge a completion marker. | The operator declares a reviewed emitter; parsers validate exact schemas and fail closed. | Fixture emitter source and parser rejection tests. |
+| Diagnostic injection | Stdout/stderr can contain instruction-shaped or classifier-shaped text. | Diagnostics are stored only for humans; the decision accepts only normalised fields. | Poisoned-output tests with opposite structured outcomes. |
+| Subprocess | Command missing, killed, timed out or signalled. | Catch launch/timeout failures and return inconclusive; use argument lists and no shell. | Fixture or mocked launch-boundary tests plus cleanup assertions. |
+| Filesystem | A report path can escape the worktree, follow a symlink or overwrite a tracked file. | Require a relative resolved descendant, reject symlinks and pre-existing tracked targets, remove stale files before the run. | Traversal, absolute-path, symlink and stale-report tests. |
+| Partial writes | A killed emitter leaves valid-looking JSON/XML without a complete run. | Require completion marker for JSON; parse Forge XML only after process end; timeout always wins. | Truncated JSON/XML and timeout fixtures. |
+| Resource use | A crafted report can exhaust memory or XML parsing time. | Enforce a small byte cap before stdlib parsing and reject oversized files. | Boundary-size tests. |
+| Arithmetic | Negative, contradictory or boolean-as-integer counts can cross the decision table. | Validate exact integer types, non-negative values and count relationships before normalising. | Schema property tests for invalid counts. |
+| unittest | Traceback text exists inside `TestResult` entries and could tempt matching. | Emitter serialises category counts only; `failures` and `errors` come from runner callbacks. | Assertion/import fixtures whose messages contain misleading terms. |
+| Forge | JUnit is a producer convention rather than a fully stable standard; compile failures may emit surrounding logs. | Accept only fixture-proven Forge 1.7.1 XML elements; missing valid XML is inconclusive. | Captured fixture reports for pass, assertion and compile failure. |
+| Node | Rendered reporters are unstable and Error identity may vary with isolation/version. | Use documented `TestsStream`; pin fixture evidence to Node 26.6.0; classify from structured cause/type, not rendered text. | Reporter fixture and recorded Node version. |
+| Git worktree | Reports and runner artifacts can dirty the source repo or survive interruption. | Run only in the detached parent tree and keep unconditional worktree/temp cleanup. | Before/after source status and worktree-list assertions. |
+| Secret material | Test diagnostics may contain credentials. | Keep bounded diagnostics, do not echo them during classification and never include them in fixed detail strings. | Result-output test using a sentinel secret. |
+| Compatibility | Old callers expect exit/output classification. | Retain flag name and public statuses but fail legacy no-report calls closed with a clear migration detail. | Legacy invocation test, including `--require-guard`. |
+
+There is no Solidity storage change, public ABI, upgrade path, arithmetic over protocol funds or signer custody in the implementation. Forge is present only as a fixture runner.
+
+## Glossary seeds
+
+| Term | Meaning |
+| --- | --- |
+| assertion failure | A runner-owned result category showing that an executed test explicitly rejected the parent behaviour. |
+| broken run | A command that did not reach a trustworthy assertion result because loading, collection, compilation, setup or execution infrastructure failed. |
+| complete report | A fresh report whose parser sees the producer's terminal structure and consistent counts. |
+| diagnostic output | Stdout and stderr retained for a person but excluded from classification. |
+| emitter | A runner-specific fixture component that serialises the runner's structured result to the declared report file. |
+| executed test | A non-skipped test case the runner reports as having reached an outcome. |
+| fixture repository | A real temporary git history containing parent, fix, tests and runner configuration for one report format. |
+| legacy no-report run | An invocation with a test command but no declared structured report; it is inconclusive. |
+| normalised report | The five-field internal record returned by every report parser. |
+| report adapter | The narrow parser that validates one declared runner report and produces the normalised record. |
+| runner-owned structure | Categories or events supplied by the runner API, not inferred from rendered prose. |
+| stale report | A report that existed before the current child started or was not freshly completed by it. |
+
+## Sources
+
+- Starting ref: `c29159d098dd468f07ba1edde3c03614106b3694`.
+- Elenchus checker: `plugins/hexaemeron/skills/elenchus/scripts/elenchus.py` at the starting ref.
+- Elenchus fixture tests: `plugins/hexaemeron/tests/test_elenchus_checker.py` at the starting ref.
+- Elenchus policy and held frontier: `plugins/hexaemeron/skills/elenchus/SKILL.md` and `plugins/hexaemeron/skills/elenchus/EVOLUTION.md`.
+- Elenchus introduction: Git commit `5b1105a`.
+- Hexaemeron runner: `plugins/hexaemeron/tests/run_tests.py`.
+- Local runner probes: `python3 --version` = 3.14.6; `forge --version` = 1.7.1; `node --version` = 26.6.0; `forge test --help` documents `--junit`.
+- Python `unittest.TestResult`: <https://docs.python.org/3/library/unittest.html#unittest.TestResult> (`failures`, `errors`, `addFailure`, `addError`).
+- Node test reporters and `TestsStream`: <https://nodejs.org/api/test.html#test-reporters> and <https://nodejs.org/api/test.html#class-testsstream>.
+- Node `test:fail` event structure: <https://nodejs.org/api/test.html#event-testfail> (`details.error.cause`).
+- Foundry test command reference: <https://getfoundry.sh/forge/tests> and the local Forge 1.7.1 `forge test --help` output.
+- Foundry JUnit feature history: <https://github.com/foundry-rs/foundry/issues/7004>.
+- Python XML parser used for the narrow JUnit subset: <https://docs.python.org/3/library/xml.etree.elementtree.html>.

--- a/plugins/hexaemeron/docs/elenchus-structured-runner-reports/study.md
+++ b/plugins/hexaemeron/docs/elenchus-structured-runner-reports/study.md
@@ -79,7 +79,7 @@ The prototype is accepted only when all of these are true:
 
 - Preserve result statuses, the `check()` purpose, `audit_line()`, JSON/text CLI output and default `--require-guard` severity. Change only how a completed runner invocation is classified.
 - Keep `changed_tests`, parent lookup, overlay and worktree cleanup behaviour unless a report-path safety fix requires a narrow change.
-- Add explicit `--report-format` and `--report-file` inputs. The declared file is resolved inside the detached worktree, removed before the run, and exposed to fixture-owned emitters through `ELENCHUS_REPORT_FILE`.
+- Add explicit `--report-format` and `--report-file` inputs. The declared file is resolved inside the detached worktree, removed before the run, and substituted for one exact `{report}` argument in the declared command. Remove any inherited `ELENCHUS_REPORT_FILE` variable so nested commands cannot acquire the path by accident.
 - Accept three declared formats: versioned unittest JSON, Forge JUnit XML and versioned Node test JSON. Parse JSON with `json` and XML with `xml.etree.ElementTree`.
 - Require a schema/version marker, completion marker where the native format supports one, non-negative integer counts and at least one executed test. Reject contradictions such as totals smaller than failures.
 - Classify a mixed report containing both assertion failures and infrastructure errors as `inconclusive`; a broken run cannot establish a clean guard merely because one assertion also fired.
@@ -138,11 +138,11 @@ The CLI keeps `--test-command` and adds:
 --report-file <relative-path-inside-parent-worktree>
 ```
 
-Before starting the child, Elenchus validates that the report path resolves under the detached worktree, removes any prior file at that path and sets `ELENCHUS_REPORT_FILE` to its absolute path. The supplied command writes the report. Legacy calls that omit either declaration run no text heuristic and return `inconclusive` with a migration detail; with `--require-guard` they exit 1.
+Before starting the child, Elenchus validates that the report path resolves under the detached worktree, removes any prior file at that path and substitutes its absolute path for one exact `{report}` argument. It removes any inherited `ELENCHUS_REPORT_FILE` variable before launch. The supplied command writes the report to the explicit argument. Legacy calls that omit either declaration, or commands with no single placeholder, run no text heuristic and return `inconclusive` with a migration detail; with `--require-guard` they exit 1.
 
 The unittest fixture carries a stdlib emitter that discovers tests, runs them, and writes a versioned JSON object from `TestResult.testsRun`, `failures`, `errors`, `skipped`, `expectedFailures` and `unexpectedSuccesses`. It records counts and completion, not traceback strings.
 
-The Forge fixture carries a small stdlib launcher that sends native `forge test --junit` XML to `ELENCHUS_REPORT_FILE`. The parser counts executed `testcase` elements and their `failure`, `error` and `skipped` children. A compiler failure produces no accepted XML and is therefore inconclusive.
+The Forge fixture carries a small stdlib launcher that sends native `forge test --junit` XML to the report-path argument. The parser counts executed `testcase` elements and their `failure`, `error` and `skipped` children. A compiler failure produces no accepted XML and is therefore inconclusive.
 
 The Node fixture carries a custom reporter over `node:test`'s programmatic `TestsStream`. It writes versioned JSON counts, marks an assertion using the actual assertion-error type/structured cause, marks other failed events as errors, and writes `complete: true` only after the stream ends. It uses no npm dependency.
 

--- a/plugins/hexaemeron/skills/elenchus/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/elenchus/EVOLUTION.md
@@ -2,14 +2,15 @@
 
 Policy: [../VERSIONING.md](../VERSIONING.md)
 
-- Current version: `elenchus-v0.1.0`
-- Frontier status: `open`
+- Current version: `elenchus-v1.1.0`
+- Frontier status: `mature`
 - Frontier revision: `observed-failure-root-cause`
-- Current frontier: A check puts a fix's own test to the parent tree and tells a real guard from one that cannot import, while the rest of the triage order stays read by a person.
-- Next Fiat job: Teach the check to read a runner's own report rather than its exit code and output text, so an assertion failure is told from a broken run by structure instead of by matching error strings. Accepted when it classifies correctly for unittest, forge and one JavaScript runner in fixture repositories, with no string matching left in the decision, and both suites pass.
+- Current frontier: A check overlays a fix's changed tests onto the parent and classifies unittest, Forge and Node guards from fresh runner-owned reports, while diagnostics remain inert evidence.
+- Next Fiat job: None -- mature
 
 ## History
 
 | Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
 | --- | --- | --- | --- | --- | --- |
 | `elenchus-v0.1.0` | baseline | `observed-failure-root-cause` | `82ba62d430f8c7d248bcef1b2678aca9c56eefd21282a54cbce24d78e444cd8a` | [fiat audit loop reference](../fiat/references/audit-loop.md) | Elenchus starts here, holding root-cause work on failures that have already been observed. |
+| `elenchus-v1.1.0` | evolution | `observed-failure-root-cause` | `08e77bae576b3351d6f38e60ce9da88327014bcaa7459e319b8e51d79caeda8b` | [structured runner fixtures](../../tests/test_elenchus_checker.py), [study](../../docs/elenchus-structured-runner-reports/study.md) | The guard check replaces diagnostic matching with fresh unittest, Forge and Node report adapters; no evidenced next frontier remains. |

--- a/plugins/hexaemeron/skills/elenchus/SKILL.md
+++ b/plugins/hexaemeron/skills/elenchus/SKILL.md
@@ -186,16 +186,18 @@ there and reads a fresh structured report owned by the declared runner.
 ```bash
 python3 "$PLUGIN_ROOT/skills/elenchus/scripts/elenchus.py" \
   --ref HEAD \
-  --test-command "python3 tests/emit_unittest_report.py" \
+  --test-command "python3 tests/emit_unittest_report.py {report}" \
   --report-format unittest-json-v1 \
   --report-file .elenchus/unittest.json
 ```
 
-The test command is yours to supply. Elenchus sets `ELENCHUS_REPORT_FILE` to an
-absolute location inside the detached parent worktree, and the command writes
-its report there. Accepted formats are `unittest-json-v1`, `forge-junit-v1` and
-`node-test-json-v1`. Stdlib unittest and Node need small repository-owned
-emitters; Forge can send native `forge test --junit` XML to the declared file.
+The test command is yours to supply. It must contain one exact `{report}`
+argument. Elenchus replaces that argument with an absolute location inside the
+detached parent worktree and removes any inherited `ELENCHUS_REPORT_FILE`
+variable before starting the command. Accepted formats are
+`unittest-json-v1`, `forge-junit-v1` and `node-test-json-v1`. Stdlib unittest
+and Node need small repository-owned emitters; Forge can send native
+`forge test --junit` XML to the declared file.
 
 Every adapter normalises completion, executed tests, assertion failures,
 infrastructure errors and skips. An assertion with no infrastructure error is

--- a/plugins/hexaemeron/skills/elenchus/SKILL.md
+++ b/plugins/hexaemeron/skills/elenchus/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   has observed yet, which belongs to solidity-auditor and x-ray, and do not use
   it to speed up something that already works, which belongs to metron.
 metadata:
-  version: "0.1.0"
+  version: "1.1.0"
 ---
 
 # Elenchus
@@ -180,20 +180,33 @@ study, not a rescue improvised during debugging.
 ## The mechanical subset
 
 One rule here is executable: whether the fix carries a test that fails without
-it. The check applies the commit's test files to its parent and runs them
-there.
+it. The check applies the commit's changed test files to its parent, runs them
+there and reads a fresh structured report owned by the declared runner.
 
 ```bash
 python3 "$PLUGIN_ROOT/skills/elenchus/scripts/elenchus.py" \
-  --ref HEAD --test-command "python3 -m unittest discover -s tests"
+  --ref HEAD \
+  --test-command "python3 tests/emit_unittest_report.py" \
+  --report-format unittest-json-v1 \
+  --report-file .elenchus/unittest.json
 ```
 
-The test command is yours to supply, so this runs wherever git and a runner do.
-It reports one of four outcomes. A guard that failed on the parent by assertion
-is `guarded`. A commit changing no test files is `unguarded`. A test that passed
-on the parent guards nothing and reports `passed`. A run that died before it
-could assert, usually importing something the parent has not got yet, is
-`inconclusive` rather than proof either way.
+The test command is yours to supply. Elenchus sets `ELENCHUS_REPORT_FILE` to an
+absolute location inside the detached parent worktree, and the command writes
+its report there. Accepted formats are `unittest-json-v1`, `forge-junit-v1` and
+`node-test-json-v1`. Stdlib unittest and Node need small repository-owned
+emitters; Forge can send native `forge test --junit` XML to the declared file.
+
+Every adapter normalises completion, executed tests, assertion failures,
+infrastructure errors and skips. An assertion with no infrastructure error is
+`guarded`. A clean executed test is `passed`. A missing, stale, malformed,
+oversized, incomplete or zero-test report is `inconclusive`, as are mixed
+assertion/error reports, timeouts, interrupted commands and unsafe report
+paths. A commit changing no tests remains `unguarded`.
+
+Stdout, stderr and ordinary exit codes are retained as bounded diagnostics for
+a person. They never classify the result. A legacy invocation that omits
+either report flag is `inconclusive`; with `--require-guard` it exits 1.
 
 That last distinction is the point. Dropping a new test on an older tree
 usually fails to import, and counting that as a guard would wave through every

--- a/plugins/hexaemeron/skills/elenchus/scripts/elenchus.py
+++ b/plugins/hexaemeron/skills/elenchus/scripts/elenchus.py
@@ -27,6 +27,7 @@ import xml.etree.ElementTree as ET
 TEST_NAMES = ("test_", "_test.", ".test.", ".spec.", ".t.sol")
 TEST_DIRS = ("test", "tests", "spec", "__tests__")
 REPORT_FORMATS = ("unittest-json-v1", "forge-junit-v1", "node-test-json-v1")
+REPORT_PLACEHOLDER = "{report}"
 MAX_REPORT_BYTES = 1024 * 1024
 MAX_DIAGNOSTIC_CHARS = 4000
 
@@ -209,12 +210,13 @@ def read_report(
         raise ReportError("the runner report is not a regular file")
     if stat.st_mtime_ns < started_ns:
         raise ReportError("the runner report is stale")
-    if stat.st_size > MAX_REPORT_BYTES:
-        raise ReportError("the runner report exceeds the size limit")
     try:
-        raw = path.read_bytes()
+        with path.open("rb") as source:
+            raw = source.read(MAX_REPORT_BYTES + 1)
     except OSError as err:
         raise ReportError("the runner report could not be read") from err
+    if len(raw) > MAX_REPORT_BYTES:
+        raise ReportError("the runner report exceeds the size limit")
     parsers = {
         "unittest-json-v1": parse_unittest_report,
         "forge-junit-v1": parse_forge_report,
@@ -305,12 +307,23 @@ def check(
         except ReportError as err:
             return _base_result(ref, "inconclusive", tests, str(err))
 
+        if command.count(REPORT_PLACEHOLDER) != 1:
+            return _base_result(
+                ref,
+                "inconclusive",
+                tests,
+                "the test command must contain one exact {report} argument",
+            )
+        resolved_command = [
+            str(report_path) if argument == REPORT_PLACEHOLDER else argument
+            for argument in command
+        ]
         environment = os.environ.copy()
-        environment["ELENCHUS_REPORT_FILE"] = str(report_path)
+        environment.pop("ELENCHUS_REPORT_FILE", None)
         started_ns = time.time_ns()
         try:
             run = subprocess.run(
-                command, cwd=tree, capture_output=True, text=True, check=False,
+                resolved_command, cwd=tree, capture_output=True, text=True, check=False,
                 timeout=timeout, env=environment,
             )
         except subprocess.TimeoutExpired:

--- a/plugins/hexaemeron/skills/elenchus/scripts/elenchus.py
+++ b/plugins/hexaemeron/skills/elenchus/scripts/elenchus.py
@@ -1,53 +1,56 @@
 #!/usr/bin/env python3
 """Elenchus guard check.
 
-A fix is guarded when it carries a test that fails without it. This puts that
-claim to the parent tree instead of taking it on trust.
+A fix is guarded when its changed test records an assertion failure against
+the parent tree. The runner writes a declared structured report; process text
+and ordinary exit codes remain diagnostic evidence and never decide whether a
+test asserted, passed, or broke before assertion.
 
-For a commit: take the test files it changed, apply them to its parent, and run
-them there. A guard must fail on the parent by assertion. A test that passes
-there proves nothing, and one that dies importing something the parent has not
-got yet is inconclusive rather than proof.
-
-  guarded       a changed test failed on the parent by assertion
-  unguarded     the commit changed no test files
-  passed        a changed test passed on the parent, so it guards nothing
-  inconclusive  the run died before asserting, usually an import or build error
-
-Exit 0 unless --require-guard is set and the result is not `guarded`.
-
-The test command is yours to supply, so this runs anywhere git and a test
-runner do. Nothing here assumes a particular project, language or CI.
+Exit 0 unless ``--require-guard`` is set and the result is not ``guarded``.
 """
 
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import json
+import os
+import shlex
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
+import xml.etree.ElementTree as ET
 
 TEST_NAMES = ("test_", "_test.", ".test.", ".spec.", ".t.sol")
 TEST_DIRS = ("test", "tests", "spec", "__tests__")
+REPORT_FORMATS = ("unittest-json-v1", "forge-junit-v1", "node-test-json-v1")
+MAX_REPORT_BYTES = 1024 * 1024
+MAX_DIAGNOSTIC_CHARS = 4000
 
-# A run that died before it could assert anything. Distinguishing this from a
-# real failure is the whole difficulty: a new test dropped on the parent often
-# cannot import the thing it tests, and calling that a passing guard would let
-# every unguarded fix through.
-BROKEN_RUN = (
-    "importerror", "modulenotfounderror", "cannot find module",
-    "no module named", "collection error", "errors while importing",
-    "compiler run failed", "error ts", "syntaxerror", "cannot find name",
-    "unable to resolve", "failed to compile",
-)
+
+class ReportError(ValueError):
+    """A runner report failed the declared structural contract."""
+
+
+@dataclass(frozen=True)
+class RunnerReport:
+    complete: bool
+    executed: int
+    assertion_failures: int
+    errors: int
+    skipped: int
 
 
 def git(repo: Path, *args: str) -> str:
-    result = subprocess.run(["git", "-C", str(repo), *args],
-                            capture_output=True, text=True, check=False)
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or f"git {' '.join(args)} failed")
     return result.stdout
@@ -61,8 +64,16 @@ def is_test(path: str) -> bool:
 
 
 def changed_tests(repo: Path, ref: str) -> list[str]:
-    out = git(repo, "diff-tree", "--no-commit-id", "--name-only", "--diff-filter=AM", "-r", ref)
-    return sorted(p for p in out.splitlines() if p and is_test(p))
+    out = git(
+        repo,
+        "diff-tree",
+        "--no-commit-id",
+        "--name-only",
+        "--diff-filter=AM",
+        "-r",
+        ref,
+    )
+    return sorted(path for path in out.splitlines() if path and is_test(path))
 
 
 def parent_of(repo: Path, ref: str) -> str | None:
@@ -72,21 +83,213 @@ def parent_of(repo: Path, ref: str) -> str | None:
         return None
 
 
-def broken_run(output: str) -> bool:
-    lowered = output.lower()
-    return any(marker in lowered for marker in BROKEN_RUN)
+def _integer(value, name: str) -> int:
+    if type(value) is not int or value < 0:
+        raise ReportError(f"{name} must be a non-negative integer")
+    return value
 
 
-def check(repo: Path, ref: str, command: list[str], timeout: int = 900) -> dict:
+def _normalised(complete, executed, failures, errors, skipped) -> RunnerReport:
+    if complete is not True:
+        raise ReportError("the report is incomplete")
+    report = RunnerReport(
+        complete=True,
+        executed=_integer(executed, "executed"),
+        assertion_failures=_integer(failures, "assertion_failures"),
+        errors=_integer(errors, "errors"),
+        skipped=_integer(skipped, "skipped"),
+    )
+    if report.assertion_failures + report.errors > report.executed:
+        raise ReportError("outcome counts exceed executed tests")
+    return report
+
+
+def _json_object(raw: bytes) -> dict:
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as err:
+        raise ReportError("the report is not valid UTF-8 JSON") from err
+    if type(value) is not dict:
+        raise ReportError("the report root must be an object")
+    return value
+
+
+def parse_unittest_report(raw: bytes) -> RunnerReport:
+    value = _json_object(raw)
+    required = {
+        "schema", "complete", "testsRun", "failures", "errors", "skipped",
+        "expectedFailures", "unexpectedSuccesses",
+    }
+    if set(value) != required or value.get("schema") != "elenchus.unittest.v1":
+        raise ReportError("the unittest report schema is not supported")
+    tests_run = _integer(value["testsRun"], "testsRun")
+    failures = _integer(value["failures"], "failures")
+    errors = _integer(value["errors"], "errors")
+    skipped = _integer(value["skipped"], "skipped")
+    expected = _integer(value["expectedFailures"], "expectedFailures")
+    unexpected = _integer(value["unexpectedSuccesses"], "unexpectedSuccesses")
+    if failures + errors + skipped + expected + unexpected > tests_run:
+        raise ReportError("unittest categories exceed testsRun")
+    executed = tests_run - skipped - expected
+    return _normalised(
+        value["complete"], executed, failures, errors + unexpected, skipped + expected
+    )
+
+
+def parse_node_report(raw: bytes) -> RunnerReport:
+    value = _json_object(raw)
+    required = {
+        "schema", "complete", "executed", "assertionFailures", "errors", "skipped",
+    }
+    if set(value) != required or value.get("schema") != "elenchus.node-test.v1":
+        raise ReportError("the Node report schema is not supported")
+    return _normalised(
+        value["complete"], value["executed"], value["assertionFailures"],
+        value["errors"], value["skipped"],
+    )
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def parse_forge_report(raw: bytes) -> RunnerReport:
+    upper = raw.upper()
+    if b"<!DOCTYPE" in upper or b"<!ENTITY" in upper:
+        raise ReportError("XML declarations with entities are not accepted")
+    try:
+        root = ET.fromstring(raw)
+    except ET.ParseError as err:
+        raise ReportError("the report is not valid XML") from err
+    if _local_name(root.tag) != "testsuites":
+        raise ReportError("the Forge JUnit root must be testsuites")
+    cases = [node for node in root.iter() if _local_name(node.tag) == "testcase"]
+    failures = errors = skipped = 0
+    for case in cases:
+        children = {_local_name(child.tag) for child in case}
+        failures += "failure" in children
+        errors += "error" in children
+        skipped += "skipped" in children
+        if len(children & {"failure", "error", "skipped"}) > 1:
+            raise ReportError("a Forge testcase has contradictory outcomes")
+    for attribute, observed in (
+        ("tests", len(cases)), ("failures", failures), ("errors", errors)
+    ):
+        declared = root.attrib.get(attribute)
+        if declared is None or not declared.isascii() or not declared.isdecimal():
+            raise ReportError(f"the Forge report lacks a valid {attribute} total")
+        if int(declared) != observed:
+            raise ReportError(f"the Forge {attribute} total contradicts its cases")
+    return _normalised(True, len(cases) - skipped, failures, errors, skipped)
+
+
+def _verify_report_location(tree: Path, candidate: Path) -> None:
+    root = tree.resolve()
+    current = candidate
+    while current != tree:
+        if current.is_symlink():
+            raise ReportError("the report path cannot contain a symlink")
+        current = current.parent
+    try:
+        candidate.resolve(strict=False).relative_to(root)
+    except (OSError, ValueError) as err:
+        raise ReportError("the report path escapes the worktree") from err
+
+
+def read_report(
+    path: Path, report_format: str, started_ns: int, tree: Path | None = None
+) -> RunnerReport:
+    if tree is not None:
+        _verify_report_location(tree, path)
+    try:
+        stat = path.stat()
+    except OSError as err:
+        raise ReportError("the runner did not create its report") from err
+    if not path.is_file() or path.is_symlink():
+        raise ReportError("the runner report is not a regular file")
+    if stat.st_mtime_ns < started_ns:
+        raise ReportError("the runner report is stale")
+    if stat.st_size > MAX_REPORT_BYTES:
+        raise ReportError("the runner report exceeds the size limit")
+    try:
+        raw = path.read_bytes()
+    except OSError as err:
+        raise ReportError("the runner report could not be read") from err
+    parsers = {
+        "unittest-json-v1": parse_unittest_report,
+        "forge-junit-v1": parse_forge_report,
+        "node-test-json-v1": parse_node_report,
+    }
+    parser = parsers.get(report_format)
+    if parser is None:
+        raise ReportError("the declared report format is not supported")
+    return parser(raw)
+
+
+def classify(report: RunnerReport) -> tuple[str, str]:
+    if report.executed == 0:
+        return "inconclusive", "the runner report records no executed tests"
+    if report.errors > 0:
+        return "inconclusive", "the runner report records an infrastructure error"
+    if report.assertion_failures > 0:
+        return "guarded", "the runner report records a parent assertion failure"
+    return "passed", "the runner report records that the guard passed on the parent"
+
+
+def _tracked(tree: Path, relative: Path) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(tree), "ls-files", "--error-unmatch", "--", str(relative)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def prepare_report_path(tree: Path, raw_path: str) -> Path:
+    relative = Path(raw_path)
+    if not raw_path or relative.is_absolute() or ".." in relative.parts:
+        raise ReportError("the report path must be a relative worktree descendant")
+    candidate = tree / relative
+    _verify_report_location(tree, candidate)
+    if _tracked(tree, relative):
+        raise ReportError("the report path names a tracked file")
+    if candidate.exists():
+        if not candidate.is_file() or candidate.is_symlink():
+            raise ReportError("the stale report path is not a regular file")
+        candidate.unlink()
+    candidate.parent.mkdir(parents=True, exist_ok=True)
+    return candidate
+
+
+def _base_result(ref: str, status: str, tests: list[str], detail: str) -> dict:
+    return {"ref": ref, "status": status, "tests": tests, "detail": detail}
+
+
+def check(
+    repo: Path,
+    ref: str,
+    command: list[str],
+    timeout: int = 900,
+    report_format: str | None = None,
+    report_file: str | None = None,
+) -> dict:
     tests = changed_tests(repo, ref)
     if not tests:
-        return {"ref": ref, "status": "unguarded", "tests": [],
-                "detail": "the commit changed no test files"}
-
+        return _base_result(ref, "unguarded", [], "the commit changed no test files")
+    if not report_format or not report_file:
+        return _base_result(
+            ref, "inconclusive", tests, "declare both --report-format and --report-file"
+        )
+    if not command:
+        return _base_result(
+            ref, "inconclusive", tests, "the test command is empty"
+        )
     parent = parent_of(repo, ref)
     if parent is None:
-        return {"ref": ref, "status": "inconclusive", "tests": tests,
-                "detail": "the commit has no parent to compare against"}
+        return _base_result(
+            ref, "inconclusive", tests, "the commit has no parent to compare against"
+        )
 
     workdir = Path(tempfile.mkdtemp(prefix="elenchus-"))
     tree = workdir / "tree"
@@ -97,50 +300,89 @@ def check(repo: Path, ref: str, command: list[str], timeout: int = 900) -> dict:
             target = tree / relative
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(blob, encoding="utf-8")
+        try:
+            report_path = prepare_report_path(tree, report_file)
+        except ReportError as err:
+            return _base_result(ref, "inconclusive", tests, str(err))
 
-        run = subprocess.run(command, cwd=tree, capture_output=True,
-                             text=True, check=False, timeout=timeout)
-        output = run.stdout + run.stderr
+        environment = os.environ.copy()
+        environment["ELENCHUS_REPORT_FILE"] = str(report_path)
+        started_ns = time.time_ns()
+        try:
+            run = subprocess.run(
+                command, cwd=tree, capture_output=True, text=True, check=False,
+                timeout=timeout, env=environment,
+            )
+        except subprocess.TimeoutExpired:
+            return _base_result(
+                ref, "inconclusive", tests, f"the run did not finish inside {timeout}s"
+            )
+        except OSError:
+            return _base_result(
+                ref, "inconclusive", tests, "the test command could not be started"
+            )
 
-        if run.returncode == 0:
-            status, detail = "passed", "the guard passed on the parent, so it guards nothing"
-        elif broken_run(output):
-            status, detail = "inconclusive", "the run died before asserting; read the output"
+        output = (run.stdout + run.stderr)[-MAX_DIAGNOSTIC_CHARS:]
+        if run.returncode < 0:
+            result = _base_result(
+                ref, "inconclusive", tests, "the test command was interrupted"
+            )
         else:
-            status, detail = "guarded", "the guard failed on the parent, as a guard should"
-        return {"ref": ref, "status": status, "tests": tests, "detail": detail,
-                "exit_code": run.returncode, "output": output[-4000:]}
-    except subprocess.TimeoutExpired:
-        return {"ref": ref, "status": "inconclusive", "tests": tests,
-                "detail": f"the run did not finish inside {timeout}s"}
+            try:
+                report = read_report(report_path, report_format, started_ns, tree)
+                status, detail = classify(report)
+                result = _base_result(ref, status, tests, detail)
+                result["report"] = {
+                    "complete": report.complete,
+                    "executed": report.executed,
+                    "assertion_failures": report.assertion_failures,
+                    "errors": report.errors,
+                    "skipped": report.skipped,
+                }
+            except ReportError as err:
+                result = _base_result(ref, "inconclusive", tests, str(err))
+        result.update({"exit_code": run.returncode, "output": output})
+        return result
     finally:
-        subprocess.run(["git", "-C", str(repo), "worktree", "remove", "--force", str(tree)],
-                       capture_output=True, check=False)
+        subprocess.run(
+            ["git", "-C", str(repo), "worktree", "remove", "--force", str(tree)],
+            capture_output=True,
+            check=False,
+        )
         shutil.rmtree(workdir, ignore_errors=True)
 
 
 def audit_line(result: dict) -> str:
     """The line to carry into the audit file's leads-not-pursued list."""
-    return (f"Guard check on `{result['ref'][:12]}`: {result['status']} "
-            f"-- {result['detail']}")
+    return (
+        f"Guard check on `{result['ref'][:12]}`: {result['status']} "
+        f"-- {result['detail']}"
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Elenchus guard check.")
     parser.add_argument("--repo", default=".", help="repository to inspect")
     parser.add_argument("--ref", default="HEAD", help="commit carrying the fix")
-    parser.add_argument("--test-command", required=True,
-                        help="how to run the tests, e.g. 'python3 -m unittest discover -s tests'")
-    parser.add_argument("--require-guard", action="store_true",
-                        help="exit 1 unless the fix is guarded")
+    parser.add_argument(
+        "--test-command", required=True,
+        help="how to run the tests, with quoting interpreted by shlex",
+    )
+    parser.add_argument("--report-format", choices=REPORT_FORMATS)
+    parser.add_argument("--report-file")
+    parser.add_argument(
+        "--require-guard", action="store_true", help="exit 1 unless the fix is guarded"
+    )
     parser.add_argument("--timeout", type=int, default=900)
     parser.add_argument("--format", choices=("text", "json"), default="text")
     args = parser.parse_args(argv)
 
     try:
-        result = check(Path(args.repo).resolve(), args.ref,
-                       args.test_command.split(), args.timeout)
-    except RuntimeError as err:
+        result = check(
+            Path(args.repo).resolve(), args.ref, shlex.split(args.test_command),
+            args.timeout, args.report_format, args.report_file,
+        )
+    except (RuntimeError, ValueError) as err:
         print(f"could not inspect the repository: {err}", file=sys.stderr)
         return 2
 
@@ -150,7 +392,6 @@ def main(argv: list[str] | None = None) -> int:
         print(audit_line(result))
         for path in result["tests"]:
             print(f"  test: {path}")
-
     return 1 if args.require_guard and result["status"] != "guarded" else 0
 
 

--- a/plugins/hexaemeron/tests/test_elenchus_checker.py
+++ b/plugins/hexaemeron/tests/test_elenchus_checker.py
@@ -1,17 +1,15 @@
-"""The Elenchus guard check puts a fix's test to the parent tree.
-
-Built against a fixture repository rather than a mock, because the thing under
-test is git behaviour and a runner's exit code, and a mock of those proves
-nothing.
-"""
+"""Elenchus classifies guards from real runner-owned reports."""
 
 import contextlib
 import importlib.util
 import io
+import json
+import os
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -20,23 +18,103 @@ SCRIPT = ROOT / "skills" / "elenchus" / "scripts" / "elenchus.py"
 
 spec = importlib.util.spec_from_file_location("elenchus_guard", SCRIPT)
 elenchus = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = elenchus
 spec.loader.exec_module(elenchus)
 
-TEST_COMMAND = [sys.executable, "-m", "unittest", "discover", "-s", ".", "-p", "test_*.py"]
+REPORT_FILE = ".elenchus/report"
+
+UNITTEST_EMITTER = '''\
+import json
+import os
+from pathlib import Path
+import sys
+import unittest
+
+suite = unittest.defaultTestLoader.discover(".", pattern="test_*.py")
+result = unittest.TextTestRunner(verbosity=1).run(suite)
+payload = {
+    "schema": "elenchus.unittest.v1",
+    "complete": True,
+    "testsRun": result.testsRun,
+    "failures": len(result.failures),
+    "errors": len(result.errors),
+    "skipped": len(result.skipped),
+    "expectedFailures": len(result.expectedFailures),
+    "unexpectedSuccesses": len(result.unexpectedSuccesses),
+}
+target = Path(os.environ["ELENCHUS_REPORT_FILE"])
+target.parent.mkdir(parents=True, exist_ok=True)
+target.write_text(json.dumps(payload), encoding="utf-8")
+if "--exit-zero" not in sys.argv:
+    raise SystemExit(not result.wasSuccessful())
+'''
+
+FORGE_EMITTER = '''\
+import os
+from pathlib import Path
+import subprocess
+
+run = subprocess.run(["forge", "test", "--junit"], capture_output=True, check=False)
+target = Path(os.environ["ELENCHUS_REPORT_FILE"])
+if run.stdout:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(run.stdout)
+raise SystemExit(run.returncode)
+'''
+
+NODE_EMITTER = '''\
+import { run } from "node:test";
+import { writeFile } from "node:fs/promises";
+
+console.error("ModuleNotFoundError AssertionError");
+const counts = { executed: 0, assertionFailures: 0, errors: 0, skipped: 0 };
+const stream = run({ files: ["test_adder.mjs"], isolation: "none" });
+stream.on("test:pass", (data) => {
+  if (data.skip || data.todo) counts.skipped += 1;
+  else counts.executed += 1;
+});
+stream.on("test:fail", (data) => {
+  counts.executed += 1;
+  const wrapped = data.details?.error;
+  const cause = wrapped?.cause ?? wrapped;
+  if (cause?.code === "ERR_ASSERTION" || cause?.name === "AssertionError") {
+    counts.assertionFailures += 1;
+  } else {
+    counts.errors += 1;
+  }
+});
+const finished = new Promise((resolve, reject) => {
+  stream.on("end", resolve);
+  stream.on("error", reject);
+});
+stream.resume();
+await finished;
+await writeFile(process.env.ELENCHUS_REPORT_FILE, JSON.stringify({
+  schema: "elenchus.node-test.v1",
+  complete: true,
+  ...counts,
+}));
+process.exitCode = counts.assertionFailures + counts.errors > 0 ? 1 : 0;
+'''
 
 
 class Fixture:
-    """A repository with one commit per outcome the check reports."""
+    """A real temporary git history with independent children of one base."""
 
-    def __init__(self):
+    def __init__(self, base_files):
         self.path = Path(tempfile.mkdtemp(prefix="elenchus-fixture-"))
         self.run("init", "--quiet", "-b", "main")
         self.run("config", "user.email", "fixture@example.org")
         self.run("config", "user.name", "Fixture")
+        self.base = self.commit("base", base_files)
 
     def run(self, *args):
-        subprocess.run(["git", "-C", str(self.path), *args],
-                       capture_output=True, text=True, check=True)
+        return subprocess.run(
+            ["git", "-C", str(self.path), *args],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
 
     def commit(self, message, files):
         for name, body in files.items():
@@ -45,95 +123,312 @@ class Fixture:
             target.write_text(body, encoding="utf-8")
         self.run("add", "-A")
         self.run("commit", "--quiet", "-m", message)
-        return subprocess.run(["git", "-C", str(self.path), "rev-parse", "HEAD"],
-                              capture_output=True, text=True, check=True).stdout.strip()
+        return self.run("rev-parse", "HEAD").strip()
+
+    def child(self, message, files):
+        self.run("checkout", "--quiet", "--detach", self.base)
+        return self.commit(message, files)
+
+    def status(self):
+        return self.run("status", "--short")
+
+    def worktrees(self):
+        return self.run("worktree", "list", "--porcelain")
 
     def destroy(self):
         shutil.rmtree(self.path, ignore_errors=True)
 
 
-class GuardCheck(unittest.TestCase):
+class RunnerCase(unittest.TestCase):
+    fixture = None
+    command = None
+    report_format = None
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.fixture is not None:
+            cls.fixture.destroy()
+
+    def outcome(self, ref, command=None, **kwargs):
+        before = self.fixture.status()
+        result = elenchus.check(
+            self.fixture.path,
+            ref,
+            command or self.command,
+            timeout=kwargs.pop("timeout", 120),
+            report_format=kwargs.pop("report_format", self.report_format),
+            report_file=kwargs.pop("report_file", REPORT_FILE),
+            **kwargs,
+        )
+        self.assertEqual(before, self.fixture.status())
+        return result
+
+
+class UnittestReports(RunnerCase):
     @classmethod
     def setUpClass(cls):
-        cls.fixture = Fixture()
+        cls.command = [sys.executable, "emit_unittest.py"]
+        cls.report_format = "unittest-json-v1"
+        cls.fixture = Fixture({
+            "adder.py": "def add(a, b):\n    return a - b\n",
+            "emit_unittest.py": UNITTEST_EMITTER,
+        })
         f = cls.fixture
-
-        # A defect, shipped with no test.
-        f.commit("add the adder", {"adder.py": "def add(a, b):\n    return a - b\n"})
-
-        # A fix carrying a test that catches the defect.
-        cls.guarded = f.commit("fix the sign, with a guard", {
-            "adder.py": "def add(a, b):\n    return a + b\n",
+        cls.guarded = f.child("guarded", {
             "test_adder.py": (
                 "import unittest\nfrom adder import add\n\n"
                 "class T(unittest.TestCase):\n"
                 "    def test_it_adds(self):\n"
-                "        self.assertEqual(add(2, 2), 4)\n"),
+                "        self.assertEqual(add(2, 2), 4, 'ModuleNotFoundError')\n"
+            ),
         })
-
-        # A change with no test at all.
-        cls.unguarded = f.commit("tidy the adder", {
-            "adder.py": "def add(a, b):\n    \"\"\"Add two numbers.\"\"\"\n    return a + b\n"})
-
-        # A test that would have passed before the change too.
-        cls.passes = f.commit("add a test that guards nothing", {
+        cls.passed = f.child("passed", {
             "test_arithmetic.py": (
-                "import unittest\n\n"
-                "class T(unittest.TestCase):\n"
-                "    def test_arithmetic_still_works(self):\n"
-                "        self.assertEqual(1 + 1, 2)\n"),
+                "import unittest\n\nclass T(unittest.TestCase):\n"
+                "    def test_arithmetic(self):\n        self.assertEqual(1 + 1, 2)\n"
+            ),
         })
-
-        # A test importing something the parent has not got.
-        cls.inconclusive = f.commit("add a module and its test", {
-            "subtractor.py": "def subtract(a, b):\n    return a - b\n",
-            "test_subtractor.py": (
-                "import unittest\nfrom subtractor import subtract\n\n"
-                "class T(unittest.TestCase):\n"
-                "    def test_it_subtracts(self):\n"
-                "        self.assertEqual(subtract(4, 2), 2)\n"),
+        cls.broken = f.child("broken", {
+            "test_broken.py": "raise RuntimeError('AssertionError')\n",
         })
+        cls.unguarded = f.child("unguarded", {"adder.py": "def add(a, b):\n    return a + b\n"})
 
+    def test_runner_categories_distinguish_all_three_outcomes(self):
+        self.assertEqual("guarded", self.outcome(self.guarded)["status"])
+        self.assertEqual("passed", self.outcome(self.passed)["status"])
+        self.assertEqual("inconclusive", self.outcome(self.broken)["status"])
+
+    def test_diagnostic_poisoning_and_exit_code_do_not_change_the_report(self):
+        ordinary = self.outcome(self.guarded)
+        forced_zero = self.outcome(
+            self.guarded, [sys.executable, "emit_unittest.py", "--exit-zero"]
+        )
+        self.assertEqual("guarded", ordinary["status"])
+        self.assertEqual("guarded", forced_zero["status"])
+        self.assertNotEqual(ordinary["exit_code"], forced_zero["exit_code"])
+        self.assertIn("ModuleNotFoundError", ordinary["output"])
+        self.assertIn("AssertionError", self.outcome(self.broken)["output"])
+
+    def test_legacy_no_report_is_inconclusive(self):
+        result = elenchus.check(
+            self.fixture.path, self.guarded, self.command, timeout=120
+        )
+        self.assertEqual("inconclusive", result["status"])
+
+    def test_legacy_cli_is_nonfatal_by_default_and_fails_when_required(self):
+        argv = [
+            "--repo", str(self.fixture.path), "--ref", self.guarded,
+            "--test-command", f"{sys.executable} emit_unittest.py",
+        ]
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(0, elenchus.main(argv))
+            self.assertEqual(1, elenchus.main(argv + ["--require-guard"]))
+
+    def test_unsafe_and_tracked_report_paths_fail_closed(self):
+        traversal = self.outcome(self.guarded, report_file="../report")
+        tracked = self.outcome(self.guarded, report_file="adder.py")
+        self.assertEqual("inconclusive", traversal["status"])
+        self.assertEqual("inconclusive", tracked["status"])
+
+    def test_no_changed_test_is_still_unguarded(self):
+        self.assertEqual("unguarded", self.outcome(self.unguarded)["status"])
+
+
+class ForgeReports(RunnerCase):
     @classmethod
-    def tearDownClass(cls):
-        cls.fixture.destroy()
+    def setUpClass(cls):
+        cls.runner_version = subprocess.run(
+            ["forge", "--version"], capture_output=True, text=True, check=True
+        ).stdout.splitlines()[0]
+        cls.command = [sys.executable, "emit_forge.py"]
+        cls.report_format = "forge-junit-v1"
+        cls.fixture = Fixture({
+            "foundry.toml": (
+                "[profile.default]\nsrc = 'src'\ntest = 'test'\n"
+                "solc_version = '0.8.28'\n"
+            ),
+            "src/Adder.sol": (
+                "// SPDX-License-Identifier: UNLICENSED\npragma solidity 0.8.28;\n"
+                "contract Adder { function add(uint a, uint b) external pure returns (uint) "
+                "{ return a - b; } }\n"
+            ),
+            "emit_forge.py": FORGE_EMITTER,
+        })
+        f = cls.fixture
+        cls.guarded = f.child("guarded", {
+            "test/Adder.t.sol": (
+                "// SPDX-License-Identifier: UNLICENSED\npragma solidity 0.8.28;\n"
+                "import {Adder} from '../src/Adder.sol';\n"
+                "contract AdderTest { function testModuleNotFoundError() public { "
+                "assert(new Adder().add(2, 2) == 4); } }\n"
+            ),
+        })
+        cls.passed = f.child("passed", {
+            "test/Arithmetic.t.sol": (
+                "// SPDX-License-Identifier: UNLICENSED\npragma solidity 0.8.28;\n"
+                "contract ArithmeticTest { function testArithmetic() public pure { "
+                "assert(uint(1) + 1 == 2); } }\n"
+            ),
+        })
+        cls.broken = f.child("broken", {
+            "test/Broken.t.sol": (
+                "// SPDX-License-Identifier: UNLICENSED\npragma solidity 0.8.28;\n"
+                "import {Missing} from '../src/AssertionError.sol';\n"
+                "contract BrokenTest {}\n"
+            ),
+        })
 
-    def outcome(self, ref):
-        return elenchus.check(self.fixture.path, ref, TEST_COMMAND, timeout=120)
+    def test_native_junit_distinguishes_all_three_outcomes(self):
+        self.assertEqual("guarded", self.outcome(self.guarded)["status"])
+        self.assertEqual("passed", self.outcome(self.passed)["status"])
+        self.assertEqual("inconclusive", self.outcome(self.broken)["status"])
 
-    def test_a_real_guard_fails_on_the_parent(self):
-        result = self.outcome(self.guarded)
-        self.assertEqual("guarded", result["status"], result.get("output", ""))
-        self.assertIn("test_adder.py", result["tests"])
+    def test_fixture_exercised_the_declared_forge_version(self):
+        self.assertIn("1.7.1", self.runner_version)
 
-    def test_a_commit_with_no_test_is_unguarded(self):
-        result = self.outcome(self.unguarded)
-        self.assertEqual("unguarded", result["status"])
-        self.assertEqual([], result["tests"])
 
-    def test_a_test_that_passes_on_the_parent_guards_nothing(self):
-        self.assertEqual("passed", self.outcome(self.passes)["status"])
+class NodeReports(RunnerCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.runner_version = subprocess.run(
+            ["node", "--version"], capture_output=True, text=True, check=True
+        ).stdout.strip()
+        cls.command = ["node", "emit_node.mjs"]
+        cls.report_format = "node-test-json-v1"
+        cls.fixture = Fixture({
+            "adder.mjs": "export const add = (a, b) => a - b;\n",
+            "emit_node.mjs": NODE_EMITTER,
+        })
+        f = cls.fixture
+        cls.guarded = f.child("guarded", {
+            "test_adder.mjs": (
+                "import test from 'node:test';\nimport assert from 'node:assert/strict';\n"
+                "import { add } from './adder.mjs';\n"
+                "test('ModuleNotFoundError', () => assert.equal(add(2, 2), 4));\n"
+            ),
+        })
+        cls.passed = f.child("passed", {
+            "test_adder.mjs": (
+                "import test from 'node:test';\nimport assert from 'node:assert/strict';\n"
+                "test('arithmetic', () => assert.equal(1 + 1, 2));\n"
+            ),
+        })
+        cls.broken = f.child("broken", {
+            "test_adder.mjs": (
+                "import test from 'node:test';\n"
+                "import './AssertionError.mjs';\n"
+                "test('unreachable', () => {});\n"
+            ),
+        })
 
-    def test_a_test_that_cannot_import_is_inconclusive(self):
-        result = self.outcome(self.inconclusive)
-        self.assertEqual("inconclusive", result["status"], result.get("output", ""))
+    def test_testsstream_distinguishes_all_three_outcomes(self):
+        self.assertEqual("guarded", self.outcome(self.guarded)["status"])
+        self.assertEqual("passed", self.outcome(self.passed)["status"])
+        self.assertEqual("inconclusive", self.outcome(self.broken)["status"])
 
-    def test_the_working_tree_is_left_alone(self):
-        before = subprocess.run(["git", "-C", str(self.fixture.path), "status", "--short"],
-                                capture_output=True, text=True, check=True).stdout
-        self.outcome(self.guarded)
-        after = subprocess.run(["git", "-C", str(self.fixture.path), "status", "--short"],
-                               capture_output=True, text=True, check=True).stdout
-        self.assertEqual(before, after)
+    def test_fixture_exercised_the_declared_node_version(self):
+        self.assertEqual("v26.6.0", self.runner_version)
+
+
+class ReportValidation(unittest.TestCase):
+    def payload(self, **changes):
+        value = {
+            "schema": "elenchus.unittest.v1",
+            "complete": True,
+            "testsRun": 1,
+            "failures": 0,
+            "errors": 0,
+            "skipped": 0,
+            "expectedFailures": 0,
+            "unexpectedSuccesses": 0,
+        }
+        value.update(changes)
+        return json.dumps(value).encode()
+
+    def test_malformed_incomplete_zero_and_contradictory_reports_fail_closed(self):
+        with self.assertRaises(elenchus.ReportError):
+            elenchus.parse_unittest_report(b"{")
+        with self.assertRaises(elenchus.ReportError):
+            elenchus.parse_unittest_report(self.payload(complete=False))
+        with self.assertRaises(elenchus.ReportError):
+            elenchus.parse_unittest_report(self.payload(testsRun=1, failures=2))
+        with self.assertRaises(elenchus.ReportError):
+            elenchus.parse_unittest_report(self.payload(testsRun=True))
+        zero = elenchus.parse_unittest_report(self.payload(testsRun=0))
+        self.assertEqual("inconclusive", elenchus.classify(zero)[0])
+
+    def test_mixed_assertion_and_infrastructure_errors_are_inconclusive(self):
+        report = elenchus.RunnerReport(True, 2, 1, 1, 0)
+        self.assertEqual("inconclusive", elenchus.classify(report)[0])
+
+    def test_oversized_and_stale_reports_are_rejected_before_parsing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "report"
+            path.write_bytes(b"x" * (elenchus.MAX_REPORT_BYTES + 1))
+            with self.assertRaises(elenchus.ReportError):
+                elenchus.read_report(path, "unittest-json-v1", 0)
+            path.write_bytes(self.payload())
+            os.utime(path, (1, 1))
+            with self.assertRaises(elenchus.ReportError):
+                elenchus.read_report(path, "unittest-json-v1", time.time_ns())
+
+    def test_xml_entities_and_contradictory_cases_are_rejected(self):
+        with self.assertRaises(elenchus.ReportError):
+            elenchus.parse_forge_report(
+                b'<!DOCTYPE x [<!ENTITY y "z">]><testsuites />'
+            )
+        with self.assertRaises(elenchus.ReportError):
+            elenchus.parse_forge_report(
+                b'<testsuites><testcase><failure/><error/></testcase></testsuites>'
+            )
+        with self.assertRaises(elenchus.ReportError):
+            elenchus.parse_forge_report(b'<testsuites tests="1">')
+
+    def test_absolute_traversal_and_symlink_report_paths_are_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            tree = Path(directory)
+            (tree / "real").mkdir()
+            (tree / "link").symlink_to(tree / "real", target_is_directory=True)
+            for path in ("/tmp/report", "../report", "link/report"):
+                with self.subTest(path=path), self.assertRaises(elenchus.ReportError):
+                    elenchus.prepare_report_path(tree, path)
+
+
+class LaunchFailures(RunnerCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.report_format = "unittest-json-v1"
+        cls.fixture = Fixture({"value.py": "VALUE = 1\n"})
+        cls.changed = cls.fixture.child("test", {
+            "test_value.py": "import unittest\nclass T(unittest.TestCase):\n    pass\n"
+        })
+
+    def test_missing_report_timeout_and_executable_failure_are_inconclusive_and_clean(self):
+        before = self.fixture.worktrees()
+        missing = self.outcome(self.changed, [sys.executable, "-c", "pass"])
+        timeout = self.outcome(
+            self.changed,
+            [sys.executable, "-c", "import time; time.sleep(3)"],
+            timeout=1,
+        )
+        absent = self.outcome(self.changed, ["elenchus-command-does-not-exist"])
+        interrupted = self.outcome(
+            self.changed,
+            [sys.executable, "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTERM)"],
+        )
+        self.assertEqual(["inconclusive"] * 4, [
+            missing["status"], timeout["status"], absent["status"], interrupted["status"],
+        ])
+        self.assertEqual(before, self.fixture.worktrees())
 
 
 class Severity(unittest.TestCase):
     def test_unguarded_passes_by_default_and_fails_when_required(self):
-        fixture = Fixture()
+        fixture = Fixture({"thing.py": "value = 1\n"})
         try:
-            fixture.commit("first", {"thing.py": "value = 1\n"})
-            fixture.commit("second", {"thing.py": "value = 2\n"})
-            argv = ["--repo", str(fixture.path), "--test-command", "python3 -c pass"]
+            ref = fixture.child("second", {"thing.py": "value = 2\n"})
+            argv = ["--repo", str(fixture.path), "--ref", ref,
+                    "--test-command", "python3 -c pass"]
             with contextlib.redirect_stdout(io.StringIO()):
                 self.assertEqual(0, elenchus.main(argv))
                 self.assertEqual(1, elenchus.main(argv + ["--require-guard"]))
@@ -143,8 +438,10 @@ class Severity(unittest.TestCase):
 
 class TestFileDetection(unittest.TestCase):
     def test_it_recognises_the_conventions_this_marketplace_meets(self):
-        for path in ("tests/test_index.py", "src/thing_test.py", "app/Button.test.ts",
-                     "app/Button.spec.ts", "test/Market.t.sol", "__tests__/route.ts"):
+        for path in (
+            "tests/test_index.py", "src/thing_test.py", "app/Button.test.ts",
+            "app/Button.spec.ts", "test/Market.t.sol", "__tests__/route.ts",
+        ):
             self.assertTrue(elenchus.is_test(path), path)
 
     def test_it_leaves_ordinary_source_alone(self):

--- a/plugins/hexaemeron/tests/test_elenchus_checker.py
+++ b/plugins/hexaemeron/tests/test_elenchus_checker.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import time
 import unittest
+from unittest import mock
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -42,7 +43,7 @@ payload = {
     "expectedFailures": len(result.expectedFailures),
     "unexpectedSuccesses": len(result.unexpectedSuccesses),
 }
-target = Path(os.environ["ELENCHUS_REPORT_FILE"])
+target = Path(sys.argv[1])
 target.parent.mkdir(parents=True, exist_ok=True)
 target.write_text(json.dumps(payload), encoding="utf-8")
 if "--exit-zero" not in sys.argv:
@@ -50,12 +51,12 @@ if "--exit-zero" not in sys.argv:
 '''
 
 FORGE_EMITTER = '''\
-import os
 from pathlib import Path
 import subprocess
+import sys
 
 run = subprocess.run(["forge", "test", "--junit"], capture_output=True, check=False)
-target = Path(os.environ["ELENCHUS_REPORT_FILE"])
+target = Path(sys.argv[1])
 if run.stdout:
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_bytes(run.stdout)
@@ -89,7 +90,7 @@ const finished = new Promise((resolve, reject) => {
 });
 stream.resume();
 await finished;
-await writeFile(process.env.ELENCHUS_REPORT_FILE, JSON.stringify({
+await writeFile(process.argv[2], JSON.stringify({
   schema: "elenchus.node-test.v1",
   complete: true,
   ...counts,
@@ -167,7 +168,7 @@ class RunnerCase(unittest.TestCase):
 class UnittestReports(RunnerCase):
     @classmethod
     def setUpClass(cls):
-        cls.command = [sys.executable, "emit_unittest.py"]
+        cls.command = [sys.executable, "emit_unittest.py", "{report}"]
         cls.report_format = "unittest-json-v1"
         cls.fixture = Fixture({
             "adder.py": "def add(a, b):\n    return a - b\n",
@@ -201,7 +202,8 @@ class UnittestReports(RunnerCase):
     def test_diagnostic_poisoning_and_exit_code_do_not_change_the_report(self):
         ordinary = self.outcome(self.guarded)
         forced_zero = self.outcome(
-            self.guarded, [sys.executable, "emit_unittest.py", "--exit-zero"]
+            self.guarded,
+            [sys.executable, "emit_unittest.py", "{report}", "--exit-zero"],
         )
         self.assertEqual("guarded", ordinary["status"])
         self.assertEqual("guarded", forced_zero["status"])
@@ -218,7 +220,7 @@ class UnittestReports(RunnerCase):
     def test_legacy_cli_is_nonfatal_by_default_and_fails_when_required(self):
         argv = [
             "--repo", str(self.fixture.path), "--ref", self.guarded,
-            "--test-command", f"{sys.executable} emit_unittest.py",
+            "--test-command", f"{sys.executable} emit_unittest.py {{report}}",
         ]
         with contextlib.redirect_stdout(io.StringIO()):
             self.assertEqual(0, elenchus.main(argv))
@@ -230,6 +232,33 @@ class UnittestReports(RunnerCase):
         self.assertEqual("inconclusive", traversal["status"])
         self.assertEqual("inconclusive", tracked["status"])
 
+    def test_report_ownership_is_an_explicit_command_argument(self):
+        no_placeholder = self.outcome(
+            self.guarded, [sys.executable, "emit_unittest.py"]
+        )
+        payload = json.dumps({
+            "schema": "elenchus.unittest.v1",
+            "complete": True,
+            "testsRun": 1,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 0,
+            "expectedFailures": 0,
+            "unexpectedSuccesses": 0,
+        })
+        inherited_writer = (
+            "import os; from pathlib import Path; "
+            f"value={payload!r}; target=os.environ.get('ELENCHUS_REPORT_FILE'); "
+            "target and Path(target).write_text(value, encoding='utf-8')"
+        )
+        with mock.patch.dict(os.environ, {"ELENCHUS_REPORT_FILE": "inherited"}):
+            inherited = self.outcome(
+                self.guarded,
+                [sys.executable, "-c", inherited_writer, "{report}"],
+            )
+        self.assertEqual("inconclusive", no_placeholder["status"])
+        self.assertEqual("inconclusive", inherited["status"])
+
     def test_no_changed_test_is_still_unguarded(self):
         self.assertEqual("unguarded", self.outcome(self.unguarded)["status"])
 
@@ -240,7 +269,7 @@ class ForgeReports(RunnerCase):
         cls.runner_version = subprocess.run(
             ["forge", "--version"], capture_output=True, text=True, check=True
         ).stdout.splitlines()[0]
-        cls.command = [sys.executable, "emit_forge.py"]
+        cls.command = [sys.executable, "emit_forge.py", "{report}"]
         cls.report_format = "forge-junit-v1"
         cls.fixture = Fixture({
             "foundry.toml": (
@@ -293,7 +322,7 @@ class NodeReports(RunnerCase):
         cls.runner_version = subprocess.run(
             ["node", "--version"], capture_output=True, text=True, check=True
         ).stdout.strip()
-        cls.command = ["node", "emit_node.mjs"]
+        cls.command = ["node", "emit_node.mjs", "{report}"]
         cls.report_format = "node-test-json-v1"
         cls.fixture = Fixture({
             "adder.mjs": "export const add = (a, b) => a - b;\n",
@@ -405,16 +434,25 @@ class LaunchFailures(RunnerCase):
 
     def test_missing_report_timeout_and_executable_failure_are_inconclusive_and_clean(self):
         before = self.fixture.worktrees()
-        missing = self.outcome(self.changed, [sys.executable, "-c", "pass"])
+        missing = self.outcome(
+            self.changed, [sys.executable, "-c", "pass", "{report}"]
+        )
         timeout = self.outcome(
             self.changed,
-            [sys.executable, "-c", "import time; time.sleep(3)"],
+            [sys.executable, "-c", "import time; time.sleep(3)", "{report}"],
             timeout=1,
         )
-        absent = self.outcome(self.changed, ["elenchus-command-does-not-exist"])
+        absent = self.outcome(
+            self.changed, ["elenchus-command-does-not-exist", "{report}"]
+        )
         interrupted = self.outcome(
             self.changed,
-            [sys.executable, "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTERM)"],
+            [
+                sys.executable,
+                "-c",
+                "import os, signal; os.kill(os.getpid(), signal.SIGTERM)",
+                "{report}",
+            ],
         )
         self.assertEqual(["inconclusive"] * 4, [
             missing["status"], timeout["status"], absent["status"], interrupted["status"],


### PR DESCRIPTION
Elenchus now decides whether a changed test guards its parent from runner-owned structure rather than exit codes or diagnostic text. The supported reports are unittest `TestResult` JSON, Forge JUnit XML, and Node `node:test` `TestsStream` JSON.

Each adapter validates a strict schema and normalises executed tests, assertion failures, infrastructure errors, and skips. Missing, stale, malformed, oversized, incomplete, mixed-error, zero-test, interrupted, and legacy no-report runs fail closed as `inconclusive`. Diagnostics remain bounded evidence for a person and do not control the verdict.

The audit found two issues and fixed both. Report paths now replace one explicit `{report}` command argument instead of entering inherited environment state, and report reads stop at 1 MiB plus one byte. The clean second round is recorded in `audit/AUDIT.md`. The completed stack edge is [PR #195](https://github.com/wildcat-finance/skills/pull/195).

Run the proof from the repository root:

```bash
python3 -m unittest plugins.hexaemeron.tests.test_elenchus_checker -v
python3 plugins/hexaemeron/tests/run_tests.py
python3 -m unittest discover -s tests
git diff --check
```

<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
