### PR TITLE
Add test for release manifest binding identity verification

### DIFF
--- a/plugins/lazarus/tests/test_release.py
+++ b/plugins/lazarus/tests/test_release.py
@@ -573,6 +573,36 @@ class OneReadTests(unittest.TestCase):
                 module.bind = original
             self.assertIs(seen["manifest"], seen["report"]["manifest"])
 
+    def test_reading_a_release_binds_against_the_manifest_the_report_carried(self):
+        """The same decision as the write, at the site the write's test does not
+        reach.
+
+        Mutation found this one: replacing the read's manifest with a second
+        read of the directory left the suite green, because in a test nothing
+        changes between the two reads. What the rule is for is the case where
+        something does, and an identity check pins it without having to stage a
+        race.
+        """
+        with tempfile.TemporaryDirectory() as directory:
+            prepared = Prepared(directory)
+            prepared.release()
+            from lazarus_lib import release as module
+
+            original = module.bind
+            seen = {}
+
+            def watched(statement, manifest, report):
+                seen["manifest"] = manifest
+                seen["report"] = report
+                return original(statement, manifest, report)
+
+            module.bind = watched
+            try:
+                verify_release(prepared.out)
+            finally:
+                module.bind = original
+            self.assertIs(seen["manifest"], seen["report"]["manifest"])
+
     def test_a_release_records_the_digest_the_report_carried(self):
         with tempfile.TemporaryDirectory() as directory:
             prepared = Prepared(directory)


### PR DESCRIPTION
## Summary
Added a new test case to verify that when reading a release, the manifest used for binding is the same object instance as the manifest carried by the report.

## Key Changes
- Added `test_reading_a_release_binds_against_the_manifest_the_report_carried()` test method
- The test wraps the `module.bind` function to capture both the manifest and report arguments
- Verifies identity equality (`assertIs`) between the manifest passed to bind and the manifest contained in the report
- Includes detailed docstring explaining the mutation testing rationale: this test catches cases where a second read of the directory could be substituted without detection in tests, but would fail in production when the manifest changes between reads

## Implementation Details
- Uses a temporary directory with a prepared release
- Monkey-patches the `bind` function to observe its arguments
- Ensures proper cleanup by restoring the original function in a finally block
- The test validates that the same manifest object instance is used throughout the binding process, preventing subtle bugs where stale manifests could be used

https://claude.ai/code/session_01XHNRXeZxnfjhs1xUacsrMC

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
