### PR TITLE
Commit the discipline-cores spec

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -3750,3 +3750,38 @@ before it counts anything, which is the habit this run bought.
 The three bundled lints ran against the changed tree and each exited 0:
 `phylax`, `ephoros`, `hypomnema`. No Solidity ships in this run, so the suite
 waiver recorded at init covers the Pashov trio.
+
+## Protasis discipline cores, step 1, round 1 -- 2026-08-20
+
+Reviewed: the two committed spec documents, `docs/protasis-discipline-cores/study.md`
+and `docs/protasis-discipline-cores/runbook.md`, as the whole of this step's diff.
+
+No findings.
+
+The three bundled lints ran against the changed tree and each exited 0:
+`phylax`, `ephoros`, `hypomnema`. No Solidity ships in this run, so the suite
+waiver recorded at init covers the Pashov trio. Root suite 24/24, plugin suite
+303/303, imprimatur clean over both documents.
+
+The risk register names four concerns. Three of them (path handling, hostile
+document content, a miscount reported as clean) belong to the checker and have
+no surface in a step that commits two documents. The fourth is the ledger, and
+the check here is that this step does not touch it: the diff is confined to
+`docs/`, and `EVOLUTION.md` is step 4's business alone.
+
+Two things the step corrected before it was receipted, both found by running the
+stated exit rather than by reading it. The runbook's exit commands named
+`python3 -m unittest discover -s plugins/hexaemeron/tests -t .`, which cannot
+load: the directory is not an importable package and `AGENTS.md` documents
+`python3 plugins/hexaemeron/tests/run_tests.py` instead. The study also assumed
+Python 3.11 where the interpreter is 3.14.6. Both were wrong on the page, which
+is the cheapest place for them to be wrong, and both are now stated as the
+commands and the version that actually hold.
+
+Leads not pursued: the installed Fiat controller's `audit-round` accepts only
+`--findings`, `--log` and `--fixes-commit`, while this repository's
+`fiat-v4.4.1` ledger records that the receipt takes the three lint exits. The
+installed plugin is behind the checkout. The lint outcomes are therefore
+recorded in this entry rather than as structured receipt fields. Out of scope
+here: it is a Fiat concern, not a Protasis one, and this run's topic does not
+touch the controller.

--- a/docs/protasis-discipline-cores/runbook.md
+++ b/docs/protasis-discipline-cores/runbook.md
@@ -1,0 +1,153 @@
+# Runbook: the discipline cores in the contract, and the checker that reads them
+
+Derived from `.hexaemeron/study.md`. Four steps, dependency ordered. Step 1
+scaffolds by committing the spec; step 4 demonstrates by running the demo path
+from the study's problem statement.
+
+Every step carries a Disciplines line. Step 2 adds that field to the contract
+and step 3 teaches the checker to require it. So this document is the first
+runbook written under the grown contract, and step 4 proves the checker
+accepts it.
+
+## Step 1: Commit the spec
+
+**Goal.** Put the study and the runbook in the repository so every later step
+builds against a committed spec rather than controller state.
+
+**Entry.** The run branch cut from `main` at `2b92c6f`, clean tree.
+
+**Exit.** Both documents committed under `docs/`, and the imprimatur lint clean
+over each.
+
+```bash
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py \
+  docs/protasis-discipline-cores/study.md \
+  docs/protasis-discipline-cores/runbook.md
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/tests/run_tests.py
+```
+
+**Files.** `docs/protasis-discipline-cores/study.md`,
+`docs/protasis-discipline-cores/runbook.md`.
+
+**Tests.** No new tests. Both existing suites run and stay green.
+
+**Disciplines.** hypomnema: two new documents need a stated home, and `docs/`
+is the convention this repository already uses for a run's spec. ephoros: none,
+nothing runs unattended. phylax: none, no new input reaches a process. metron:
+none, no performance claim. elenchus: none, no failure in hand.
+
+## Step 2: Grow the contract
+
+**Goal.** Add the five discipline answers to "What a study must answer", add
+the Disciplines field to the runbook step schema, and add the matching rows to
+"Before the runbook is receipted", citing each sibling contract by relative
+path rather than restating it.
+
+**Entry.** Step 1's exit state.
+
+**Exit.** `SKILL.md` states twelve study items, a six-field step schema, and a
+checklist covering the new field. The five citations resolve as files on disk,
+and the lint is clean.
+
+```bash
+python3 - <<'EOF'
+import pathlib, re, sys
+root = pathlib.Path("plugins/hexaemeron/skills")
+text = (root / "protasis/SKILL.md").read_text()
+missing = [s for s in ("ephoros", "phylax", "metron", "elenchus", "hypomnema")
+           if not (root / s / "SKILL.md").is_file()
+           or f"../{s}/SKILL.md" not in text]
+assert not missing, missing
+assert "**Disciplines.**" in text
+sys.exit(0)
+EOF
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py \
+  plugins/hexaemeron/skills/protasis/SKILL.md
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/tests/run_tests.py
+```
+
+**Files.** `plugins/hexaemeron/skills/protasis/SKILL.md`.
+
+**Tests.** No new tests here; the root suite already checks marketplace prose
+and portable skills, and step 3 is where the new field gains a checker.
+
+**Disciplines.** hypomnema: the contract text is itself the record, and the
+decision about a governed skill belongs in that skill's files. phylax: none, a
+prose change opens no boundary. ephoros: none, nothing runs unattended. metron:
+none, no performance claim. elenchus: none, no failure in hand.
+
+## Step 3: Ship the checker
+
+**Goal.** A checker that reads a runbook and refuses a step missing goal,
+entry, exit, files, tests or disciplines, refuses an exit that names no
+command, and refuses a document in which it finds no steps at all.
+
+**Entry.** Step 2's exit state, so the field the checker requires is already
+the stated contract.
+
+**Exit.** The checker reports a finding for each omission in the fixture
+runbooks and exits 1; it exits 0 over a complete fixture; the new test file
+passes and both suites stay green.
+
+```bash
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py \
+  plugins/hexaemeron/tests/fixtures/protasis/incomplete-runbook.md; \
+  test $? -eq 1
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py \
+  plugins/hexaemeron/tests/fixtures/protasis/complete-runbook.md
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/tests/run_tests.py
+```
+
+**Files.** `plugins/hexaemeron/skills/protasis/scripts/protasis.py`,
+`plugins/hexaemeron/tests/test_protasis_checker.py`,
+`plugins/hexaemeron/tests/fixtures/protasis/incomplete-runbook.md`,
+`plugins/hexaemeron/tests/fixtures/protasis/complete-runbook.md`.
+
+**Tests.** `plugins/hexaemeron/tests/test_protasis_checker.py`. One case per
+finding code, one per required field, one for an exit with no command, one for
+a document with no steps, one for the allow-comment suppression, and one that
+runs the checker over this run's committed runbook and asserts clean. Expect
+roughly sixteen cases.
+
+**Disciplines.** phylax: the checker takes paths on argv and reads document
+content from outside the process, so it validates its paths, bounds what it
+reads, keeps its patterns linear, and never shells out or fetches. elenchus:
+any failure found while building this step stops the line and lands with a
+test that fails without the fix. hypomnema: the finding-code vocabulary is an
+interface others will cite, so it is documented in the module docstring beside
+the codes themselves. ephoros: none, a lint invoked from a terminal has no
+unattended surface and no on-call question. metron: none, no budget.
+
+## Step 4: Demonstrate, then close the frontier
+
+**Goal.** Run the demo path from the study over the committed runbook, then
+record the completed frontier job in the ledger exactly once.
+
+**Entry.** Step 3's exit state.
+
+**Exit.** The checker exits 0 over the committed runbook. `EVOLUTION.md`
+carries exactly one new row whose frontier digest matches the line it
+describes, `SKILL.md` frontmatter matches the new label, and both suites pass.
+
+```bash
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py \
+  docs/protasis-discipline-cores/runbook.md
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/tests/run_tests.py
+```
+
+**Files.** `plugins/hexaemeron/skills/protasis/EVOLUTION.md`,
+`plugins/hexaemeron/skills/protasis/SKILL.md`.
+
+**Tests.** No new test file. `tests/test_evolution_contract.py` and
+`plugins/hexaemeron/tests/test_evolution.py` already hold the ledger shape and
+the digest rule, and they must pass over the new row.
+
+**Disciplines.** hypomnema: the ledger row is the decision record for a
+governed skill, and it is written once. elenchus: a non-zero exit from the
+checker over its own runbook stops the step rather than being explained away.
+phylax: none, no new boundary. ephoros: none, nothing runs unattended. metron:
+none, no performance claim.

--- a/docs/protasis-discipline-cores/study.md
+++ b/docs/protasis-discipline-cores/study.md
@@ -1,0 +1,217 @@
+# Study: the discipline cores in the contract, and the checker that reads them
+
+## Assumptions
+
+Assuming, unless corrected:
+
+1. Stdlib `unittest` and no new dependency, matching every other checker in
+   this plugin. The interpreter here is 3.14.6, so nothing may rely on a
+   version-specific feature newer than that or removed before it.
+2. The checker lives at `plugins/hexaemeron/skills/protasis/scripts/protasis.py`
+   and its tests at `plugins/hexaemeron/tests/test_protasis_checker.py`, which
+   is where the other five discipline checkers and their tests already sit.
+3. Both suites means the two commands `AGENTS.md` documents for this area:
+   `python3 -m unittest discover -s tests` for the root suite and
+   `python3 plugins/hexaemeron/tests/run_tests.py` for the plugin suite, which
+   has its own runner rather than a discover invocation.
+4. The frontier closes in this run, so `EVOLUTION.md` gains exactly one row and
+   `SKILL.md` frontmatter moves to the matching label.
+5. This study and its runbook are themselves written under the grown contract,
+   so the runbook carries a Disciplines line per step from the start.
+
+## 1. Problem statement
+
+Protasis states what a study and a runbook must contain, and every rule it
+states is read by a person. Two gaps follow from that.
+
+The first is coverage. The five discipline skills beside it (`ephoros`,
+`phylax`, `metron`, `elenchus`, `hypomnema`) each own a body of rules that a
+step either exercises or does not. Nothing in the study contract asks which,
+so every run rediscovers them mid-flight, in the audit loop, where a missed
+boundary costs a step rather than a sentence.
+
+The second is enforcement. A step missing its exit command is invisible until
+someone reads the runbook carefully, and the phase that reads it carefully is
+the one that has already started building.
+
+Both are settled here. The contract grows five mandated study answers and a
+per-step Disciplines line; a checker then reads a runbook and refuses one that
+omits any required field.
+
+**What a working prototype means here.** A checker that exits non-zero on a
+fixture runbook missing each field in turn, exits zero over this run's own
+runbook, and leaves both suites passing.
+
+**Demo path.**
+
+```bash
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py \
+  docs/protasis-discipline-cores/runbook.md
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/tests/run_tests.py
+```
+
+## 2. Prior art
+
+In this repository:
+
+- `plugins/hexaemeron/skills/protasis/SKILL.md`, the contract being grown.
+  "What a study must answer" holds seven items; "What a runbook step must
+  contain" holds the step schema; "Before the runbook is receipted" holds the
+  checklist those two feed.
+- `plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py`, the closest
+  model. A Markdown lint with coded findings, a `Finding` class carrying path,
+  line, code and message, `--format text|json`, and exit 0 clean, 1 findings,
+  2 bad invocation. Deliberate exceptions carry a reason in an HTML comment.
+- `plugins/hexaemeron/skills/{ephoros,phylax,metron,elenchus}/scripts/`, four
+  further checkers on the same shape, each with a test file named
+  `test_<skill>_checker.py` under `plugins/hexaemeron/tests/`.
+- `plugins/hexaemeron/skills/VERSIONING.md`, the label contract. Evolution
+  increments once per completed frontier job; the row stores the SHA-256 of
+  `{status}|{frontier revision}|{current frontier}|{next Fiat job}` including
+  its final newline.
+
+Outside: none needed. This is a convention-scanner over one repository's own
+document shape, not an implementation of a published standard.
+
+## 3. Constraints and non-goals
+
+- Starting ref `main` at `2b92c6f`.
+- Python 3.11, stdlib only. Adding a dependency is an ask-first boundary and
+  this run does not need one.
+- The five discipline cores are cited, never restated. Content rules live in
+  exactly one skill under the v3.3.1 architecture, and with phase-only Kronos
+  evolving all six ledgers a restated manifest would go stale continuously.
+  Citations are relative paths to sibling `SKILL.md` files, which resolve from
+  `PLUGIN_ROOT`.
+- Non-goal: judging the *quality* of a discipline answer. The checker reads
+  whether a required field is present and whether an exit names a command. It
+  does not decide whether the named boundaries are the right boundaries.
+- Non-goal: checking the study. The held job names the runbook, and the study
+  has seven prose sections whose presence a parser can confirm but whose
+  substance it cannot. Deferred, and recorded as the successor frontier.
+- Non-goal: wiring the checker into Fiat's audit round. That is a Fiat change,
+  not a Protasis one.
+
+## 4. Design options
+
+**A. Line scanner over the step-heading convention.** Walk the Markdown, split
+on `## Step N:` headings, and require a labelled line per field within each
+step's span. Stdlib `re`, no parser. Trade: it reads a convention, so a runbook
+written in some other shape is invisible to it rather than refused. Mitigated
+by stating the convention in the contract the checker enforces.
+
+**B. Markdown AST via a dependency.** Parse properly, walk nodes. Trade: a new
+dependency for a document shape this repository already fixes by convention,
+and every other checker here is stdlib-only. Rejected on the dependency.
+
+**C. Structured sidecar.** Require a JSON file per runbook and validate that.
+Trade: precise, but it duplicates the human-readable runbook and the two drift.
+Fiat already keeps `steps.json` for ordering; widening it into the field
+carrier would move the contract out of the document people read. Rejected.
+
+**Chosen: A.** Cheapest to comprehend, matches the five checkers already
+shipped beside it, and adds nothing to install. What it trades away is
+tolerance of an unconventional runbook shape, which is acceptable because the
+contract states the shape.
+
+## 5. Risk register seed
+
+Python, so: untrusted input, subprocess and filesystem handling, secret
+material, partial writes, and what happens when a long run is killed halfway.
+
+- **Path handling.** Paths arrive on argv. A directory walk that follows links
+  out of the repository, or a path that escapes an intended root, reads files
+  nobody asked for. No subprocess and no network are involved, so those two
+  surfaces stay closed by construction.
+- **Hostile document content.** A runbook is a text file from outside the
+  process. A regex over unbounded input is a denial surface; a document with
+  thousands of headings should bound rather than hang.
+- **Miscount as false confidence.** A checker that silently finds no steps and
+  exits zero is worse than no checker: it reports clean over a file it never
+  understood. An empty step set must be a finding, not a pass.
+- **The ledger update.** Writing `EVOLUTION.md` more than once, or with a
+  digest computed over the wrong line, corrupts the record the versioning
+  contract checks. This repository has already had to reconstruct two broken
+  evolutions.
+
+## 6. Glossary seeds
+
+- **Discipline core.** The body of rules one of the five sibling skills owns.
+- **Disciplines line.** The runbook step field naming which gates apply and
+  why, or `none` with a reason.
+- **Required field.** One of goal, entry, exit, files, tests, disciplines.
+- **Step span.** The lines that one `## Step N:` heading owns before the next.
+- **Finding.** One refusal, carrying path, line, code and message.
+
+## 7. Sources
+
+- `plugins/hexaemeron/skills/protasis/SKILL.md`, `EVOLUTION.md`
+- `plugins/hexaemeron/skills/{ephoros,phylax,metron,elenchus,hypomnema}/SKILL.md`
+- `plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py`
+- `plugins/hexaemeron/skills/VERSIONING.md`
+- `plugins/hexaemeron/skills/fiat/SKILL.md` and its `references/`
+
+## 8. Ephoros: the on-call questions
+
+No unattended surface. The checker is invoked from a terminal or from an audit
+round and reports through stdout and an exit code; nothing here runs on a timer,
+holds a queue, or wakes anyone at three in the morning. There are no on-call
+questions to write, and emitting telemetry for a lint would be volume.
+
+Stated explicitly rather than left blank, because the contract this run writes
+requires either the questions or the reason there are none.
+
+## 9. Phylax: boundaries per capability
+
+| Boundary | Worth taking | Control |
+| --- | --- | --- |
+| Path arguments on argv | Reads outside the intended tree | Resolve, then refuse a file outside the roots given; do not follow directory links out |
+| Runbook file content | Hang the run, or a wrong verdict | Treat as data, bound the read, keep patterns linear, cap the step count |
+| No subprocess | none | Closed by construction; nothing shells out |
+| No network | none | Closed by construction; nothing fetches |
+| No secrets | none | The checker reads documents and holds no credential |
+
+Feeds the risk register above, which is where the audit loop reads it.
+
+## 10. Metron: the budget
+
+No budget. The checker reads a handful of Markdown files in one pass; there is
+no performance requirement to hold and no measurement to record. Stated
+explicitly, per the contract.
+
+## 11. Elenchus: the fail-closed posture
+
+**What stops the run.** A non-zero exit from either suite. The checker
+reporting a finding over this run's own runbook. A `verify` failure on the
+controller ledger.
+
+**Guard-test convention.** Every fix lands with a test in
+`plugins/hexaemeron/tests/test_protasis_checker.py` that fails on the tree
+without the fix and passes with it. A fix arriving without one is unguarded and
+goes to the audit file's leads-not-pursued list rather than being waved
+through.
+
+## 12. Hypomnema: decisions and where each lives
+
+| Anticipated decision | Expensive to reverse because | Home |
+| --- | --- | --- |
+| The finding-code vocabulary `P001` onward | Audit rounds and any later Fiat integration cite codes; renumbering breaks every citation | `plugins/hexaemeron/skills/protasis/EVOLUTION.md` |
+| The step-heading and field-label convention | Every runbook written after this is shaped by it | `SKILL.md`, as the stated contract |
+| Closing this frontier and naming its successor | The ledger is the authority the versioning contract checks | `plugins/hexaemeron/skills/protasis/EVOLUTION.md`, one row |
+
+A decision about a governed skill belongs in that skill's ledger, not under
+`docs/decisions/`, per hypomnema's own placement rule.
+
+## Boundaries
+
+**Always.** Both suites before a commit. The imprimatur lint on every shipped
+document. Cite a sibling contract rather than restating it.
+
+**Ask first.** Adding a dependency. Changing the finding-code vocabulary once
+published. Touching CI. Widening what the checker reads beyond the paths it was
+given.
+
+**Never.** Commit key material or a credential. Delete a failing test to make a
+suite pass. Claim a lint, a suite or an audit round ran when it did not. Write
+the ledger more than once in a run.


### PR DESCRIPTION
The study and runbook for two Protasis jobs delivered together: absorbing the
five discipline cores into the study and runbook contract, then shipping the
checker that reads them.

They run as one delivery rather than two because the held job's acceptance
condition is that the checker passes over this run's own runbook. Land the
contract growth first and that runbook carries a Disciplines line, so the
checker meets the new field from birth instead of being reworked to accept it
later.

Both documents are written under the grown contract rather than the current
one. The study answers the five discipline items it introduces, including the
two that come back as an explicit none: a lint invoked from a terminal has no
unattended surface for ephoros to instrument, and reading a handful of Markdown
files carries no metron budget. Every runbook step carries its Disciplines
line.

Two spec errors were corrected before this was receipted, both found by running
the stated exit rather than reading it. The exit commands named a unittest
discover invocation against the plugin test directory, which cannot load
because the directory is not an importable package; AGENTS.md documents a
dedicated runner instead. The study also assumed Python 3.11 where the
interpreter is 3.14.6.

Audit: `audit/AUDIT.md`, step 1 round 1, clean. The three bundled lints each
exited 0. No Solidity ships in this run, so the suite waiver recorded at init
covers the Pashov trio.

Proof:

```bash
python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py \
  docs/protasis-discipline-cores/study.md \
  docs/protasis-discipline-cores/runbook.md
python3 -m unittest discover -s tests
python3 plugins/hexaemeron/tests/run_tests.py
```

Root suite 24/24, plugin suite 303/303.

Stacks on: the run branch `fiat/absorb-the-five-discipline-cores-into-protasis-s`, as step 1 of 4.

<!-- wildcat-origin: shoggoth -->
