### PR TITLE
Grow the contract: the five discipline cores

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -3785,3 +3785,32 @@ installed plugin is behind the checkout. The lint outcomes are therefore
 recorded in this entry rather than as structured receipt fields. Out of scope
 here: it is a Fiat concern, not a Protasis one, and this run's topic does not
 touch the controller.
+
+## Protasis discipline cores, step 2, round 1 -- 2026-08-20
+
+Reviewed: the contract growth in `plugins/hexaemeron/skills/protasis/SKILL.md`,
+which is the whole of this step's diff.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S2-R1-01 | medium | plugins/hexaemeron/skills/protasis/SKILL.md | The frontmatter description enumerates what the contract holds and still listed only the four original commitments after five study items and a step field were added. That text decides whether the skill triggers, so an understated list costs a run that should have been held to the disciplines. | fixed in 70f5b66 |
+
+The three bundled lints ran against the changed tree and each exited 0:
+`phylax`, `ephoros`, `hypomnema`. Root suite 24/24, plugin suite 303/303,
+imprimatur 100.0 clean before and after the fix.
+
+The risk register's four concerns: path handling, hostile document content and
+a miscount reported as clean all belong to the checker, which step 3 builds, and
+have no surface in a prose change. The fourth is the ledger, and the check is
+that this step leaves it alone. The diff is one file and the version in
+frontmatter is untouched, so the single ledger write stays step 4's.
+
+One judgement worth recording rather than filing. Item 9 asks for each boundary,
+what is worth taking at it, and the control that closes it, which follows the
+same three-part shape phylax uses. The line between citing and restating is
+whether the text carries the rules or the question, and this carries the
+question: no STRIDE table, no always/ask-first/never list, no control catalogue.
+Phylax remains the only place those live. Recorded because the next person to
+grow this contract will stand at the same line.
+
+Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -3814,3 +3814,20 @@ Phylax remains the only place those live. Recorded because the next person to
 grow this contract will stand at the same line.
 
 Leads not pursued: none.
+
+## Protasis discipline cores, step 2, round 2 -- 2026-08-20
+
+Reviewed: the same file with round 1's fix applied.
+
+No findings.
+
+The three bundled lints ran against the fixed tree and each exited 0: `phylax`,
+`ephoros`, `hypomnema`. Root suite 24/24, plugin suite 303/303, imprimatur
+100.0 clean.
+
+Round 1's fix was checked rather than assumed: the description now names both
+the discipline questions and the gates a step declares, the study still holds
+twelve numbered items, Disciplines is still the last field of the schema, and
+the checklist still covers both additions. A fix to trigger text is the kind
+that can quietly contradict the body it advertises, so the check compares the
+two rather than reading the diff.

--- a/plugins/hexaemeron/skills/protasis/SKILL.md
+++ b/plugins/hexaemeron/skills/protasis/SKILL.md
@@ -3,8 +3,9 @@ name: protasis
 description: >-
   Hold a Fiat study and runbook to a content contract before any code is
   written: stated assumptions, testable success criteria, a chosen design with
-  its trade named, and steps that are discrete, green at both ends and sized
-  for the audit loop. Use when a topic is about to enter the study or runbook
+  its trade named, the five discipline questions answered before any build, and
+  steps that are discrete, green at both ends, sized for the audit loop and
+  explicit about the gates they incur. Use when a topic is about to enter the study or runbook
   phase, when a requirement arrives vague or bundles several capabilities, or
   when deciding whether a runbook is ready to build from. Do not use it to run
   the controller or write a receipt, which belong to fiat, and do not use it to

--- a/plugins/hexaemeron/skills/protasis/SKILL.md
+++ b/plugins/hexaemeron/skills/protasis/SKILL.md
@@ -112,6 +112,37 @@ are happy.
    line each.
 7. **Sources.** Enough of a pointer to find each one again.
 
+The five that follow are the disciplines the build will be held to. Answering
+them here costs a sentence each; leaving them to the audit loop costs a step.
+
+8. **Signals, and the questions behind them.** Two to four questions someone
+   will ask at three in the morning once this runs unattended, and which steps
+   emit the signals that answer them.
+   [ephoros](../ephoros/SKILL.md) owns what a signal must carry.
+9. **Boundaries, per capability.** Each boundary this opens, what is worth
+   taking at it, and the control that closes it. This feeds item 5 rather than
+   replacing it. [phylax](../phylax/SKILL.md) owns the boundary list and the
+   controls.
+10. **The budget, or its absence.** Any performance budget this must hold, with
+    the exact command that measures it.
+    [metron](../metron/SKILL.md) owns what a budget carries and how it is
+    checked.
+11. **The fail-closed posture.** What stops the run, and the guard-test
+    convention a fix will follow.
+    [elenchus](../elenchus/SKILL.md) owns the triage order and the guard rule.
+12. **Decisions and their homes.** The decisions expected to be expensive to
+    reverse, and the file each record will live in.
+    [hypomnema](../hypomnema/SKILL.md) owns which decisions earn a record and
+    where each one lives.
+
+For items 8 through 12, "none, and here is why" is a complete answer. A lint
+invoked from a terminal has no on-call question; a step that reads two files
+has no budget. What is not a complete answer is silence, because silence cannot
+be told apart from not having looked.
+
+Cite those five contracts, never restate them. Each owns its own rules and each
+evolves on its own ledger, so a copy here is stale the moment it is written.
+
 A section reading "TBD" is a section to fill or cut. Where the request is
 ambiguous, record the reading you chose and the reason for it. Never resolve an
 ambiguity silently.
@@ -131,7 +162,23 @@ And it stays small enough to audit, because that phase dominates the clock.
 **Exit.** Deliverables, plus the command or test that proves them.
 **Files.** Paths created or changed.
 **Tests.** What gets written or extended, and the expected count if known.
+**Disciplines.** Which of the five apply to this step and why, or none with
+the reason.
 ```
+
+The Disciplines line carries the study's items 8 through 12 down to the step
+that actually incurs them. Name each discipline and the reason in one clause:
+
+```text
+**Disciplines.** phylax: this step opens the ingestion path. ephoros: it runs
+unattended once deployed. metron: none, no performance claim. elenchus: none,
+no failure in hand. hypomnema: the storage format is expensive to reverse.
+```
+
+A step that names a discipline without a reason has not answered; a step that
+omits one has not been asked. Mason builds against the declared gates and
+warden audits against them, so a gate named here is cheaper than the same gate
+discovered in round three.
 
 Three fixed points. Step 1 scaffolds: layout, toolchain pins, CI stub, licence,
 and committed copies of the study and runbook. The last step demonstrates, by
@@ -213,12 +260,15 @@ other shipped artefact, and both go through the prose pass first.
 Report the count, then name every failure. A set reported as passed without the
 count is not a report.
 
-- [ ] The study answers all seven items.
+- [ ] The study answers all twelve items.
+- [ ] Items 8 through 12 each carry an answer or a stated none with its reason.
+- [ ] No discipline core is restated where a citation belongs.
 - [ ] Assumptions are on the page and were confirmed or corrected.
 - [ ] Every success criterion names a command, a test or a demo path.
 - [ ] The chosen design says what it traded away.
 - [ ] Always, ask-first and never each carry concrete entries.
-- [ ] Each step carries goal, entry, exit, files and tests.
+- [ ] Each step carries goal, entry, exit, files, tests and disciplines.
+- [ ] Every discipline a step names carries the reason it applies.
 - [ ] No exit rests on anything but a command.
 - [ ] Step 1 scaffolds and the last step demonstrates.
 - [ ] Steps are in dependency order.


### PR DESCRIPTION
The study contract goes from seven items to twelve, and the runbook step schema
gains a sixth field.

The five new study items ask what the build will be held to before it exists:
the on-call questions and which steps emit the signals that answer them, the
boundaries each capability opens with the control that closes each, the budget
with the exact command that measures it, the fail-closed posture and the
guard-test convention a fix will follow, and the decisions expected to be
expensive to reverse with the file each record lands in.

Each cites its owning skill rather than restating it. Content rules live in
exactly one skill, and with all six ledgers evolving a copy here would be stale
the moment it was written. The five citations are relative paths, and the step
exit checks they resolve as files on disk rather than trusting the link text.

"None, and here is why" is a complete answer for items 8 through 12. A lint
invoked from a terminal has no on-call question; a step that reads two files has
no budget. Demanding invented content would teach people to invent it. What the
contract refuses is silence, which cannot be told apart from not having looked.

The new **Disciplines** step field carries those answers down to the step that
actually incurs them, so mason builds against declared gates and warden audits
against them instead of both rediscovering them in round three. Four checklist
rows cover the additions.

The version is untouched here. The ledger moves once, in step 4, when the
frontier closes.

Audit: `audit/AUDIT.md`, step 2, two rounds. Round 1 found one medium issue and
fixed it in 70f5b66: the frontmatter description enumerates what the contract
holds and still listed only the four original commitments, which understates the
skill in the text that decides whether it triggers. Round 2 was clean against
the fixed tree, and checked the fix against the contract body rather than
reading it, because trigger text is exactly the kind that can contradict what it
advertises. The three bundled lints exited 0 in both rounds. No Solidity ships
in this run, so the waiver recorded at init covers the Pashov trio.

Proof:

```bash
python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py \
  plugins/hexaemeron/skills/protasis/SKILL.md
python3 -m unittest discover -s tests
python3 plugins/hexaemeron/tests/run_tests.py
```

Root suite 24/24, plugin suite 303/303, imprimatur 100.0 clean.

Stacks on: step 1, `fiat/absorb-the-five-discipline-cores-into-protasis-s-step-1-commit-the-spec`.

<!-- wildcat-origin: shoggoth -->
