### PR TITLE
Ship the runbook schema check

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -3897,3 +3897,30 @@ always there.
 
 Leads not pursued: none new. The README test-count staleness from round 1 still
 stands and is still outside this step.
+
+## Protasis discipline cores, step 3, round 3 -- 2026-08-20
+
+Reviewed: the twice-fixed checker, probing what round 2's boundary change might
+have broken.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R3-01 | high | plugins/hexaemeron/skills/protasis/scripts/protasis.py | Round 2 let any same-level heading end the last step, and that scan does not track code fences, so a runbook quoting a step heading inside an example truncated its own last step and reported the fields below it missing. | fixed in 8cb3ef9 |
+
+The three bundled lints ran against the changed tree and each exited 0:
+`phylax`, `ephoros`, `hypomnema`. Root suite 24/24, plugin suite 334/334.
+
+Six probes this round: an h1 between steps, an h3 inside a step, a fenced step
+heading inside an exit, a last step that genuinely ends the document, a
+suppressed step at the cap boundary, and a step whose six fields are all present
+but empty. The third came apart. The sixth reports P002 and is correct: a field
+with no text names no command, and the module documents that it reads presence
+rather than quality.
+
+Unlike round 2's finding, this one is a regression from the round before it, and
+the entry says so. Round 2 widened the boundary rule without carrying over the
+fence tracking the step scan has always had. The irony is worth keeping: the
+document that broke it is this skill's own contract, which quotes a step heading
+a few lines from where it states the schema.
+
+Leads not pursued: none new.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -3831,3 +3831,41 @@ twelve numbered items, Disciplines is still the last field of the schema, and
 the checklist still covers both additions. A fix to trigger text is the kind
 that can quietly contradict the body it advertises, so the check compares the
 two rather than reading the diff.
+
+## Protasis discipline cores, step 3, round 1 -- 2026-08-20
+
+Reviewed: the checker, its tests, its four fixtures, and the README count that
+an existing test derives.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R1-01 | high | plugins/hexaemeron/skills/protasis/scripts/protasis.py | The step cap stopped scanning and discarded the fact that it had, so five hundred sound steps followed by a broken one returned clean at exit 0. The cap turned a broken runbook into a passing one. | fixed in bf4fd43 |
+
+The three bundled lints ran against the changed tree and each exited 0:
+`phylax`, `ephoros`, `hypomnema`. Root suite 24/24, plugin suite 332/332.
+
+The finding came from probing the risk register rather than reading the code.
+The register's third entry says a checker that finds nothing and exits 0 is
+worse than no checker, and names an empty step set as the way in. P003 already
+covered that door. The cap was the other one, and it was open. The fix keeps the
+bound, because a document from outside the process gets bounded, and returns the
+dropped count so P004 can report what went unchecked.
+
+Two more register entries were probed and are sound. Regex cost is not a denial
+surface: a 200,000 character step heading finishes in 0.7 ms and an unterminated
+allow comment of the same size in 2.4 ms, both linear enough at a 2 MiB read cap.
+Path handling refuses anything that is not a regular file, which covers device
+and directory arguments, and the argument list is documented as the trust
+boundary rather than pretended away.
+
+Also worth recording from this step, though it was caught by the suite rather
+than by the audit: P002 was first written to search the whole step for a command,
+which lets any field carrying backticks answer for the exit. Since
+`**Files.** `a.py`` is close to universal, the code would never have fired on a
+real runbook. It now searches the exit's own field span. Both that fix and this
+round's fix are guarded by tests seen to fail on the unfixed tree.
+
+Leads not pursued: the README states "124 controller, contract and practice-check
+tests, 55 lint tests" while the plugin suite ran 303 before this run and 332
+after. That prose was already stale by roughly 180 tests before this run touched
+it, no test derives it, and correcting it is outside what this step asks for.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -3869,3 +3869,31 @@ Leads not pursued: the README states "124 controller, contract and practice-chec
 tests, 55 lint tests" while the plugin suite ran 303 before this run and 332
 after. That prose was already stale by roughly 180 tests before this run touched
 it, no test derives it, and correcting it is outside what this step asks for.
+
+## Protasis discipline cores, step 3, round 2 -- 2026-08-20
+
+Reviewed: the checker with round 1's fix applied, probing what that fix might
+have exposed rather than re-reading it.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R2-01 | high | plugins/hexaemeron/skills/protasis/scripts/protasis.py | The last tracked step's body ran to the next non-step heading, so where the cap had dropped steps their fields sat inside that span and donated themselves upward. A broken step at the cap boundary passed while missing five of six fields. | fixed in 3f7c8d1 |
+
+The three bundled lints ran against the changed tree and each exited 0:
+`phylax`, `ephoros`, `hypomnema`. Root suite 24/24, plugin suite 333/333.
+
+How it surfaced. Round 1 removed an early break, so the question for this round
+was what that changed downstream. Four probes: eight times the cap finishes in
+16 ms and reports P004 exactly once rather than once per dropped step; a
+document exactly at the cap stays clean; one step past it reports; and a broken
+step inside the cap alongside overflow reported no P001 at all, which is where
+it came apart. Shrinking the cap to two steps isolated it in one document.
+
+The defect predates round 1. The old code broke out of the scan at the cap and
+produced the same span, so the donation happened identically; round 1 only made
+the boundary reachable by a probe. Recorded that way rather than as a regression,
+because a reader deciding whether to trust earlier releases needs to know it was
+always there.
+
+Leads not pursued: none new. The README test-count staleness from round 1 still
+stands and is still outside this step.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -3877,7 +3877,7 @@ have exposed rather than re-reading it.
 
 | id | severity | file | finding | status |
 | --- | --- | --- | --- | --- |
-| S3-R2-01 | high | plugins/hexaemeron/skills/protasis/scripts/protasis.py | The last tracked step's body ran to the next non-step heading, so where the cap had dropped steps their fields sat inside that span and donated themselves upward. A broken step at the cap boundary passed while missing five of six fields. | fixed in 3f7c8d1 |
+| S3-R2-01 | high | plugins/hexaemeron/skills/protasis/scripts/protasis.py | The last tracked step's body ran to the next non-step heading, so where the cap had dropped steps their fields sat inside that span and donated themselves upward. A broken step at the cap boundary passed while missing five of six fields. | fixed in 6a8bca8 |
 
 The three bundled lints ran against the changed tree and each exited 0:
 `phylax`, `ephoros`, `hypomnema`. Root suite 24/24, plugin suite 333/333.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -3955,3 +3955,28 @@ deliberately. Info strings, fences indented past three spaces and fences inside
 list items are all legal and all unhandled. The contract states the runbook
 shape and the study traded tolerance of an unconventional shape away on purpose.
 What was fixed here is the case a real runbook in this repository would hit.
+
+## Protasis discipline cores, step 3, round 5 -- 2026-08-20
+
+Reviewed: the checker after round 4's fix and the refactor that came with it.
+
+No findings.
+
+The three bundled lints ran against the changed tree and each exited 0:
+`phylax`, `ephoros`, `hypomnema`. Root suite 24/24, plugin suite 337/337.
+
+The refactor moved three separate fence trackers onto one generator, which is
+the kind of change that pays for a round of its own. Six probes: cost at 400 and
+3000 steps, the exit span still bounding correctly with a later field carrying
+backticks, an allow comment inside a fence, a document made only of fences, and
+the three real runbook-shaped documents this repository now holds. Cost is 3 ms
+and 7 ms, so replacing the early break with a full scan did not turn the check
+quadratic. Everything else answered as it should.
+
+Four rounds found four things and the fifth found nothing, which is where the
+loop closes. Worth naming what the four had in common: every one was the checker
+reporting a verdict it had not earned. Two said clean over a broken document, one
+truncated a document and blamed it for the missing fields, one invented findings
+against a document that used a legal fence. None was a crash, and none would have
+been caught by reading the diff. They came from asking what the code would say
+about a document built to embarrass it.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -3924,3 +3924,34 @@ document that broke it is this skill's own contract, which quotes a step heading
 a few lines from where it states the schema.
 
 Leads not pursued: none new.
+
+## Protasis discipline cores, step 3, round 4 -- 2026-08-20
+
+Reviewed: the thrice-fixed checker, probing fence and line-ending variants.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R4-01 | medium | plugins/hexaemeron/skills/protasis/scripts/protasis.py | Fences matched backticks only, so a runbook using tilde fences had its examples read as content: a quoted step heading became a step with no fields and the document collected six findings it had not earned. | fixed in 2226614 |
+
+The three bundled lints ran against the changed tree and each exited 0:
+`phylax`, `ephoros`, `hypomnema`. Root suite 24/24, plugin suite 337/337.
+
+Eight probes: tilde fences, backticks nested inside a tilde block, a four
+backtick run, an indented fence, a field label inside a fence, CRLF line
+endings, trailing spaces on a step heading, and a file with no final newline.
+Only the tilde case came apart, and it is the one that produces findings a
+document has not earned. A checker that cries wolf gets switched off, so this
+was worth a round even at medium.
+
+The fix carries a second change the previous three rounds argued for. Fence
+state was tracked separately at three sites and one of them shipped without any
+tracking, which was round 3's finding; the tilde gap then had to be fixed at all
+three. They now share one generator. The duplication was the defect rather than
+the place it happened to surface, and rounds 3 and 4 are the same underlying
+fault twice.
+
+Leads not pursued: full CommonMark fence semantics remain unimplemented, and
+deliberately. Info strings, fences indented past three spaces and fences inside
+list items are all legal and all unhandled. The contract states the runbook
+shape and the study traded tolerance of an unconventional shape away on purpose.
+What was fixed here is the case a real runbook in this repository would hit.

--- a/plugins/hexaemeron/README.md
+++ b/plugins/hexaemeron/README.md
@@ -49,7 +49,7 @@ merge per run.
 - the executable [`hexctl.py`](./skills/fiat/scripts/hexctl.py) controller with a tamper-evident ledger (`verify` proves both chain and state);
 - the [`imprimatur`](./skills/imprimatur) three-tier prose lint and the [`vulgate`](./skills/vulgate) voice mask, invokable on their own;
 - [`kronos`](./skills/kronos), which ranks eligible held frontier jobs and loops complete Fiat runs until none remain;
-- six more skills holding each phase to a standard, five of them with an executable check: [`protasis`](./skills/protasis) on what a study and runbook must answer, [`elenchus`](./skills/elenchus) on the root cause of a failure that already happened, [`phylax`](./skills/phylax) on the off-chain surface, [`ephoros`](./skills/ephoros) on what a step emits once it runs unattended, [`metron`](./skills/metron) on every measurement except gas, and [`hypomnema`](./skills/hypomnema) on what gets recorded and where;
+- six more skills holding each phase to a standard, six of them with an executable check: [`protasis`](./skills/protasis) on what a study and runbook must answer, [`elenchus`](./skills/elenchus) on the root cause of a failure that already happened, [`phylax`](./skills/phylax) on the off-chain surface, [`ephoros`](./skills/ephoros) on what a step emits once it runs unattended, [`metron`](./skills/metron) on every measurement except gas, and [`hypomnema`](./skills/hypomnema) on what gets recorded and where;
 - the Pashov Audit Group suite vendored verbatim (MIT; `LICENSE` and `NOTICE.md` in each skill directory);
 - Codex metadata for explicit or automatic invocation; and
 - 124 controller, contract and practice-check tests, 55 lint tests, and a fuzz-audit log ([`audit/AUDIT.md`](./audit/AUDIT.md)) covering the controller's own surfaces.

--- a/plugins/hexaemeron/skills/protasis/scripts/protasis.py
+++ b/plugins/hexaemeron/skills/protasis/scripts/protasis.py
@@ -42,7 +42,9 @@ from pathlib import Path
 STEP = re.compile(r"^##\s+Step\s+(?P<n>\d+)\s*:\s*(?P<title>.*?)\s*$")
 FIELD = re.compile(r"^\*\*(?P<name>[A-Za-z]+)\.\*\*")
 HEADING = re.compile(r"^#{1,2}\s+")
-FENCE = re.compile(r"^\s*```")
+# Backtick or tilde, three or more, per CommonMark. The marker is captured so a
+# fence is closed only by its own kind: ``` inside a ~~~ block is content.
+FENCE = re.compile(r"^\s*(?P<mark>`{3,}|~{3,})")
 INLINE_CODE = re.compile(r"`[^`\n]+`")
 ALLOW = re.compile(r"<!--\s*protasis:\s*allow\s+(?P<reason>\S[^>]*?)\s*-->")
 
@@ -65,6 +67,29 @@ class Finding:
 
     def __str__(self) -> str:
         return f"{self.path}:{self.line}: {self.code} {self.message}"
+
+
+def _scan(lines: list[str]):
+    """Yield (1-indexed number, line, inside_a_fence) for every line.
+
+    One tracker for all three scans. Keeping three copies is what let the tail
+    scan ship without fence tracking at all, so a runbook quoting a step heading
+    truncated itself.
+    """
+    open_mark: str | None = None
+    for number, line in enumerate(lines, start=1):
+        match = FENCE.match(line)
+        if match:
+            mark = match.group("mark")[0]
+            if open_mark is None:
+                open_mark = mark
+                yield number, line, True
+                continue
+            if mark == open_mark:
+                open_mark = None
+            yield number, line, True
+            continue
+        yield number, line, open_mark is not None
 
 
 def suppressed(lines: list[str], line: int) -> bool:
@@ -101,11 +126,7 @@ def _spans(lines: list[str]) -> tuple[list[tuple[int, str, int, int]], int]:
     """
     starts: list[tuple[int, str]] = []
     dropped = 0
-    in_fence = False
-    for index, line in enumerate(lines, start=1):
-        if FENCE.match(line):
-            in_fence = not in_fence
-            continue
+    for index, line, in_fence in _scan(lines):
         if in_fence:
             continue
         match = STEP.match(line)
@@ -121,19 +142,15 @@ def _spans(lines: list[str]) -> tuple[list[tuple[int, str, int, int]], int]:
             end = starts[position + 1][0] - 1
         else:
             end = len(lines)
-            tail_fence = False
-            for index in range(line_number + 1, len(lines) + 1):
-                line = lines[index - 1]
-                if FENCE.match(line):
-                    tail_fence = not tail_fence
+            # Any heading of this level ends the last step, a further step
+            # heading included. Excluding step headings here let a step dropped
+            # by the cap donate its fields to the last tracked step, which then
+            # passed while missing its own. Fenced lines are not headings, or a
+            # runbook quoting a step heading would truncate itself.
+            for index, line, in_fence in _scan(lines):
+                if index <= line_number or in_fence:
                     continue
-                # Any heading of this level ends the last step, a further step
-                # heading included. Excluding step headings here let a step
-                # dropped by the cap donate its fields to the last tracked
-                # step, which then passed while missing its own. Fenced lines
-                # are not headings, or a runbook quoting a step heading in an
-                # example would truncate itself.
-                if not tail_fence and HEADING.match(line):
+                if HEADING.match(line):
                     end = index - 1
                     break
         spans.append((line_number, title, line_number + 1, end))
@@ -157,12 +174,7 @@ def _field_span(body: list[str], name: str) -> list[str]:
         return []
 
     span = [body[start]]
-    in_fence = False
-    for line in body[start + 1:]:
-        if FENCE.match(line):
-            in_fence = not in_fence
-            span.append(line)
-            continue
+    for index, line, in_fence in _scan(body[start + 1:]):
         if not in_fence and FIELD.match(line):
             break
         span.append(line)

--- a/plugins/hexaemeron/skills/protasis/scripts/protasis.py
+++ b/plugins/hexaemeron/skills/protasis/scripts/protasis.py
@@ -41,6 +41,7 @@ from pathlib import Path
 # "## Steps" is prose about steps, not a step.
 STEP = re.compile(r"^##\s+Step\s+(?P<n>\d+)\s*:\s*(?P<title>.*?)\s*$")
 FIELD = re.compile(r"^\*\*(?P<name>[A-Za-z]+)\.\*\*")
+HEADING = re.compile(r"^#{1,2}\s+")
 FENCE = re.compile(r"^\s*```")
 INLINE_CODE = re.compile(r"`[^`\n]+`")
 ALLOW = re.compile(r"<!--\s*protasis:\s*allow\s+(?P<reason>\S[^>]*?)\s*-->")
@@ -121,8 +122,11 @@ def _spans(lines: list[str]) -> tuple[list[tuple[int, str, int, int]], int]:
         else:
             end = len(lines)
             for index in range(line_number + 1, len(lines) + 1):
-                stripped = lines[index - 1]
-                if re.match(r"^#{1,2}\s+", stripped) and not STEP.match(stripped):
+                # Any heading of this level ends the last step, a further step
+                # heading included. Excluding step headings here let a step
+                # dropped by the cap donate its fields to the last tracked
+                # step, which then passed while missing its own.
+                if HEADING.match(lines[index - 1]):
                     end = index - 1
                     break
         spans.append((line_number, title, line_number + 1, end))

--- a/plugins/hexaemeron/skills/protasis/scripts/protasis.py
+++ b/plugins/hexaemeron/skills/protasis/scripts/protasis.py
@@ -9,6 +9,7 @@ settles the part a parser can.
   P001  a step missing a required field
   P002  a step whose exit states no command
   P003  a document in which no step was found
+  P004  more steps than the check will track, so the tail went unchecked
 
 Exit 0 clean, 1 findings, 2 bad invocation.
 
@@ -85,14 +86,20 @@ def _read(path: Path) -> list[str] | None:
         return None
 
 
-def _spans(lines: list[str]) -> list[tuple[int, str, int, int]]:
-    """Every step as (heading line, title, body start, body end), 1-indexed.
+def _spans(lines: list[str]) -> tuple[list[tuple[int, str, int, int]], int]:
+    """Steps as (heading line, title, body start, body end), and how many were
+    left untracked by the cap.
 
     A step owns the lines after its heading up to the next step heading or the
     next heading of the same or higher level, so a trailing section does not
     get read as part of the last step.
+
+    The cap bounds the work, and the count of what it dropped is returned rather
+    than discarded: a check that stops early and still reports clean is the
+    false confidence this whole module exists to avoid.
     """
     starts: list[tuple[int, str]] = []
+    dropped = 0
     in_fence = False
     for index, line in enumerate(lines, start=1):
         if FENCE.match(line):
@@ -102,9 +109,10 @@ def _spans(lines: list[str]) -> list[tuple[int, str, int, int]]:
             continue
         match = STEP.match(line)
         if match:
-            starts.append((index, match.group("title")))
             if len(starts) >= MAX_STEPS:
-                break
+                dropped += 1
+                continue
+            starts.append((index, match.group("title")))
 
     spans = []
     for position, (line_number, title) in enumerate(starts):
@@ -118,7 +126,7 @@ def _spans(lines: list[str]) -> list[tuple[int, str, int, int]]:
                     end = index - 1
                     break
         spans.append((line_number, title, line_number + 1, end))
-    return spans
+    return spans, dropped
 
 
 def _field_span(body: list[str], name: str) -> list[str]:
@@ -164,9 +172,14 @@ def check(path: Path) -> list[Finding]:
         return [Finding(path, 1, "P000", "cannot be read as a runbook")]
 
     findings: list[Finding] = []
-    spans = _spans(lines)
+    spans, dropped = _spans(lines)
     if not spans:
         return [Finding(path, 1, "P003", "no step found; expected a '## Step N: title' heading")]
+    if dropped:
+        findings.append(Finding(
+            path, 1, "P004",
+            f"{dropped} step(s) past the {MAX_STEPS}-step cap were not checked; "
+            f"split the runbook rather than trusting this result"))
 
     for heading_line, title, body_start, body_end in spans:
         if suppressed(lines, heading_line):

--- a/plugins/hexaemeron/skills/protasis/scripts/protasis.py
+++ b/plugins/hexaemeron/skills/protasis/scripts/protasis.py
@@ -121,12 +121,19 @@ def _spans(lines: list[str]) -> tuple[list[tuple[int, str, int, int]], int]:
             end = starts[position + 1][0] - 1
         else:
             end = len(lines)
+            tail_fence = False
             for index in range(line_number + 1, len(lines) + 1):
+                line = lines[index - 1]
+                if FENCE.match(line):
+                    tail_fence = not tail_fence
+                    continue
                 # Any heading of this level ends the last step, a further step
                 # heading included. Excluding step headings here let a step
                 # dropped by the cap donate its fields to the last tracked
-                # step, which then passed while missing its own.
-                if HEADING.match(lines[index - 1]):
+                # step, which then passed while missing its own. Fenced lines
+                # are not headings, or a runbook quoting a step heading in an
+                # example would truncate itself.
+                if not tail_fence and HEADING.match(line):
                     end = index - 1
                     break
         spans.append((line_number, title, line_number + 1, end))

--- a/plugins/hexaemeron/skills/protasis/scripts/protasis.py
+++ b/plugins/hexaemeron/skills/protasis/scripts/protasis.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Protasis runbook schema check.
+
+A runbook step that omits a field is not caught by reading, because the phase
+that reads it carefully is the one that has already started building. This
+settles the part a parser can.
+
+  P000  a path that cannot be read as a runbook
+  P001  a step missing a required field
+  P002  a step whose exit states no command
+  P003  a document in which no step was found
+
+Exit 0 clean, 1 findings, 2 bad invocation.
+
+Deliberate exceptions state a reason: `<!-- protasis: allow <why> -->` on the
+step heading line or the line above it.
+
+What this does not do. It reads whether a field is present, not whether the
+answer is any good: a Disciplines line naming the wrong gates and an Exit whose
+command proves nothing both pass. Judging an answer is the reviewer's job, and
+the study's non-goals say so. P002 is the closest to a judgement, and it is
+still only presence: a step carrying no code at all cannot have named a command,
+while a step carrying one may still have named the wrong one.
+
+The trust boundary is the argument list. Paths are read as given, so the caller
+decides what is opened; the checker refuses anything that is not a regular file,
+caps what it will read, and caps how many steps it will track. It starts no
+subprocess and opens no socket.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# "## Step 3: Ship the checker". The number is required: a heading reading
+# "## Steps" is prose about steps, not a step.
+STEP = re.compile(r"^##\s+Step\s+(?P<n>\d+)\s*:\s*(?P<title>.*?)\s*$")
+FIELD = re.compile(r"^\*\*(?P<name>[A-Za-z]+)\.\*\*")
+FENCE = re.compile(r"^\s*```")
+INLINE_CODE = re.compile(r"`[^`\n]+`")
+ALLOW = re.compile(r"<!--\s*protasis:\s*allow\s+(?P<reason>\S[^>]*?)\s*-->")
+
+REQUIRED = ("Goal", "Entry", "Exit", "Files", "Tests", "Disciplines")
+
+# A runbook is a document somebody handed over. Bound both axes.
+MAX_BYTES = 2 * 1024 * 1024
+MAX_STEPS = 500
+
+
+class Finding:
+    __slots__ = ("path", "line", "code", "message")
+
+    def __init__(self, path: Path, line: int, code: str, message: str) -> None:
+        self.path, self.line, self.code, self.message = path, line, code, message
+
+    def as_dict(self) -> dict:
+        return {"path": str(self.path), "line": self.line, "code": self.code,
+                "message": self.message}
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.line}: {self.code} {self.message}"
+
+
+def suppressed(lines: list[str], line: int) -> bool:
+    """An allow comment on the heading line or the line above it."""
+    for number in (line, line - 1):
+        if 1 <= number <= len(lines) and ALLOW.search(lines[number - 1]):
+            return True
+    return False
+
+
+def _read(path: Path) -> list[str] | None:
+    """The document, or None when it is not one we will read."""
+    try:
+        if not path.is_file():
+            return None
+        if path.stat().st_size > MAX_BYTES:
+            return None
+        return path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return None
+
+
+def _spans(lines: list[str]) -> list[tuple[int, str, int, int]]:
+    """Every step as (heading line, title, body start, body end), 1-indexed.
+
+    A step owns the lines after its heading up to the next step heading or the
+    next heading of the same or higher level, so a trailing section does not
+    get read as part of the last step.
+    """
+    starts: list[tuple[int, str]] = []
+    in_fence = False
+    for index, line in enumerate(lines, start=1):
+        if FENCE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        match = STEP.match(line)
+        if match:
+            starts.append((index, match.group("title")))
+            if len(starts) >= MAX_STEPS:
+                break
+
+    spans = []
+    for position, (line_number, title) in enumerate(starts):
+        if position + 1 < len(starts):
+            end = starts[position + 1][0] - 1
+        else:
+            end = len(lines)
+            for index in range(line_number + 1, len(lines) + 1):
+                stripped = lines[index - 1]
+                if re.match(r"^#{1,2}\s+", stripped) and not STEP.match(stripped):
+                    end = index - 1
+                    break
+        spans.append((line_number, title, line_number + 1, end))
+    return spans
+
+
+def _field_span(body: list[str], name: str) -> list[str]:
+    """The lines belonging to one field: its own line up to the next field.
+
+    Scoped deliberately. Searching the whole step for a command means any other
+    field carrying backticks answers for the exit, and `**Files.** `a.py`` is
+    almost universal, so a step-wide search makes P002 unfirable in practice.
+    """
+    start = None
+    for index, line in enumerate(body):
+        match = FIELD.match(line)
+        if match and match.group("name") == name:
+            start = index
+            break
+    if start is None:
+        return []
+
+    span = [body[start]]
+    in_fence = False
+    for line in body[start + 1:]:
+        if FENCE.match(line):
+            in_fence = not in_fence
+            span.append(line)
+            continue
+        if not in_fence and FIELD.match(line):
+            break
+        span.append(line)
+    return span
+
+
+def _has_command(lines: list[str]) -> bool:
+    """A command is a fenced block or an inline code span."""
+    for line in lines:
+        if FENCE.match(line) or INLINE_CODE.search(line):
+            return True
+    return False
+
+
+def check(path: Path) -> list[Finding]:
+    lines = _read(path)
+    if lines is None:
+        return [Finding(path, 1, "P000", "cannot be read as a runbook")]
+
+    findings: list[Finding] = []
+    spans = _spans(lines)
+    if not spans:
+        return [Finding(path, 1, "P003", "no step found; expected a '## Step N: title' heading")]
+
+    for heading_line, title, body_start, body_end in spans:
+        if suppressed(lines, heading_line):
+            continue
+        body = lines[body_start - 1:body_end]
+        present = {match.group("name") for match in
+                   (FIELD.match(line) for line in body) if match}
+        for name in REQUIRED:
+            if name not in present:
+                findings.append(Finding(
+                    path, heading_line, "P001",
+                    f"step {title!r} is missing **{name}.**"))
+        if "Exit" in present and not _has_command(_field_span(body, "Exit")):
+            findings.append(Finding(
+                path, heading_line, "P002",
+                f"step {title!r} states an exit but names no command"))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Protasis runbook schema check.")
+    parser.add_argument("paths", nargs="+", help="runbook files to check")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    findings: list[Finding] = []
+    for name in args.paths:
+        findings.extend(check(Path(name)))
+
+    if args.format == "json":
+        print(json.dumps([f.as_dict() for f in findings], indent=2))
+    else:
+        for finding in findings:
+            print(finding)
+        print(f"{len(findings)} finding(s)" if findings else "clean")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/hexaemeron/tests/fixtures/protasis/complete-runbook.md
+++ b/plugins/hexaemeron/tests/fixtures/protasis/complete-runbook.md
@@ -1,0 +1,27 @@
+# Runbook: a complete fixture
+
+Two steps, both carrying every required field.
+
+## Step 1: Scaffold the thing
+
+**Goal.** Put the layout in place.
+**Entry.** The run branch at its first commit.
+**Exit.** The layout exists and the suite runs.
+
+```bash
+python3 -m unittest discover -s tests
+```
+
+**Files.** `src/thing.py`.
+**Tests.** `tests/test_thing.py`, one case.
+**Disciplines.** phylax: none, no new input. hypomnema: the layout is a
+placement decision recorded in the README.
+
+## Step 2: Demonstrate the thing
+
+**Goal.** Run the demo path.
+**Entry.** Step 1's exit state.
+**Exit.** The demo exits 0, proved by `python3 -m thing --demo`.
+**Files.** `README.md`.
+**Tests.** No new tests.
+**Disciplines.** ephoros: none, nothing runs unattended.

--- a/plugins/hexaemeron/tests/fixtures/protasis/incomplete-runbook.md
+++ b/plugins/hexaemeron/tests/fixtures/protasis/incomplete-runbook.md
@@ -1,0 +1,61 @@
+# Runbook: an incomplete fixture
+
+Each step below omits exactly one required field, and the last states an exit
+with no command anywhere in the step.
+
+## Step 1: Missing goal
+
+**Entry.** A clean tree.
+**Exit.** Proved by `pytest`.
+**Files.** `a.py`.
+**Tests.** One case.
+**Disciplines.** none, docs only.
+
+## Step 2: Missing entry
+
+**Goal.** Do the thing.
+**Exit.** Proved by `pytest`.
+**Files.** `b.py`.
+**Tests.** One case.
+**Disciplines.** none, docs only.
+
+## Step 3: Missing exit
+
+**Goal.** Do the thing.
+**Entry.** A clean tree.
+**Files.** `c.py`.
+**Tests.** One case.
+**Disciplines.** none, docs only.
+
+## Step 4: Missing files
+
+**Goal.** Do the thing.
+**Entry.** A clean tree.
+**Exit.** Proved by `pytest`.
+**Tests.** One case.
+**Disciplines.** none, docs only.
+
+## Step 5: Missing tests
+
+**Goal.** Do the thing.
+**Entry.** A clean tree.
+**Exit.** Proved by `pytest`.
+**Files.** `e.py`.
+**Disciplines.** none, docs only.
+
+## Step 6: Missing disciplines
+
+**Goal.** Do the thing.
+**Entry.** A clean tree.
+**Exit.** Proved by `pytest`.
+**Files.** `f.py`.
+**Tests.** One case.
+
+## Step 7: Exit with no command
+
+**Goal.** Do the thing.
+**Entry.** A clean tree.
+**Exit.** Reviewed and working.
+**Files.** g.py
+**Tests.** One case.
+**Disciplines.** none, docs only.

--- a/plugins/hexaemeron/tests/fixtures/protasis/no-steps.md
+++ b/plugins/hexaemeron/tests/fixtures/protasis/no-steps.md
@@ -1,0 +1,7 @@
+# Runbook: no steps at all
+
+This document talks about steps without declaring one.
+
+## Steps
+
+The steps will be decided later.

--- a/plugins/hexaemeron/tests/fixtures/protasis/suppressed.md
+++ b/plugins/hexaemeron/tests/fixtures/protasis/suppressed.md
@@ -1,0 +1,13 @@
+# Runbook: a deliberate exception
+
+## Step 1: Complete
+
+**Goal.** Do the thing.
+**Entry.** A clean tree.
+**Exit.** Proved by `pytest`.
+**Files.** `a.py`.
+**Tests.** One case.
+**Disciplines.** none, docs only.
+
+<!-- protasis: allow inherited from the upstream runbook, fields live there -->
+## Step 2: Deliberately bare

--- a/plugins/hexaemeron/tests/test_protasis_checker.py
+++ b/plugins/hexaemeron/tests/test_protasis_checker.py
@@ -155,6 +155,25 @@ class Documents(unittest.TestCase):
         found = codes(source)
         self.assertIn("P004", found)
 
+    def test_a_dropped_step_does_not_answer_for_the_last_tracked_one(self):
+        """The guard for span absorption past the cap.
+
+        The last tracked step's body ran to the next non-step heading, so a step
+        dropped by the cap donated its fields upward and the broken step above
+        it passed while missing five of six.
+        """
+        original = protasis.MAX_STEPS
+        try:
+            protasis.MAX_STEPS = 2
+            sound = COMPLETE_STEP.replace("Step 1:", "Step 1:")
+            broken = "## Step 2: Broken and last tracked\n\n**Goal.** only this.\n"
+            past = COMPLETE_STEP.replace("Step 1:", "Step 3:")
+            found = codes(sound + "\n" + broken + "\n" + past)
+        finally:
+            protasis.MAX_STEPS = original
+        self.assertEqual(found.count("P001"), 5, found)
+        self.assertIn("P004", found)
+
     def test_a_document_inside_the_cap_reports_no_truncation(self):
         capped = "\n".join(COMPLETE_STEP.replace("Step 1:", f"Step {n}:")
                            for n in range(1, protasis.MAX_STEPS + 1))

--- a/plugins/hexaemeron/tests/test_protasis_checker.py
+++ b/plugins/hexaemeron/tests/test_protasis_checker.py
@@ -142,6 +142,24 @@ class Documents(unittest.TestCase):
         source = COMPLETE_STEP + ("x" * (protasis.MAX_BYTES + 1))
         self.assertEqual(codes(source), ["P000"])
 
+    def test_steps_past_the_cap_are_reported_not_dropped(self):
+        """The guard for silent truncation.
+
+        Capping the work is right; capping it and still reporting clean is the
+        false confidence this module exists to avoid. A broken step past the cap
+        must not hide behind a clean verdict.
+        """
+        capped = "\n".join(COMPLETE_STEP.replace("Step 1:", f"Step {n}:")
+                           for n in range(1, protasis.MAX_STEPS + 1))
+        source = capped + "\n## Step 9999: Broken\n\n**Goal.** only this.\n"
+        found = codes(source)
+        self.assertIn("P004", found)
+
+    def test_a_document_inside_the_cap_reports_no_truncation(self):
+        capped = "\n".join(COMPLETE_STEP.replace("Step 1:", f"Step {n}:")
+                           for n in range(1, protasis.MAX_STEPS + 1))
+        self.assertEqual(codes(capped), [])
+
 
 class Suppression(unittest.TestCase):
     def test_an_allow_comment_above_the_heading_suppresses_the_step(self):

--- a/plugins/hexaemeron/tests/test_protasis_checker.py
+++ b/plugins/hexaemeron/tests/test_protasis_checker.py
@@ -1,0 +1,206 @@
+"""The Protasis runbook schema check catches a step that omits a field.
+
+A step missing its exit command is invisible until someone reads the runbook
+carefully, and the phase that reads it carefully has already started building.
+"""
+
+import importlib.util
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "skills" / "protasis" / "scripts" / "protasis.py"
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "protasis"
+REPO = ROOT.parents[1]
+
+spec = importlib.util.spec_from_file_location("protasis_check", SCRIPT)
+protasis = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(protasis)
+
+COMPLETE_STEP = """## Step 1: A complete step
+
+**Goal.** Do the thing.
+**Entry.** A clean tree.
+**Exit.** Proved by `pytest`.
+**Files.** `a.py`.
+**Tests.** One case.
+**Disciplines.** none, docs only.
+"""
+
+
+def findings(source):
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "runbook.md"
+        path.write_text(source, encoding="utf-8")
+        return protasis.check(path)
+
+
+def codes(source):
+    return sorted(f.code for f in findings(source))
+
+
+def without(field):
+    """The complete step with one required field removed."""
+    keep = [line for line in COMPLETE_STEP.splitlines()
+            if not line.startswith(f"**{field}.**")]
+    return "\n".join(keep) + "\n"
+
+
+class RequiredFields(unittest.TestCase):
+    def test_a_complete_step_is_clean(self):
+        self.assertEqual(codes(COMPLETE_STEP), [])
+
+    def test_each_required_field_is_required(self):
+        for field in protasis.REQUIRED:
+            with self.subTest(field=field):
+                self.assertIn("P001", codes(without(field)))
+
+    def test_the_finding_names_the_missing_field(self):
+        found = findings(without("Disciplines"))
+        self.assertEqual(len(found), 1)
+        self.assertIn("**Disciplines.**", found[0].message)
+
+    def test_the_finding_names_the_step_it_is_in(self):
+        found = findings(without("Goal"))
+        self.assertIn("A complete step", found[0].message)
+
+    def test_the_finding_points_at_the_heading_line(self):
+        found = findings("\n" + without("Goal"))
+        self.assertEqual(found[0].line, 2)
+
+
+class ExitCommands(unittest.TestCase):
+    def test_an_exit_with_no_command_is_a_finding(self):
+        source = COMPLETE_STEP.replace("**Exit.** Proved by `pytest`.",
+                                       "**Exit.** Reviewed and working.")
+        self.assertIn("P002", codes(source))
+
+    def test_a_fenced_block_counts_as_a_command(self):
+        source = COMPLETE_STEP.replace(
+            "**Exit.** Proved by `pytest`.",
+            "**Exit.** Proved by the suite.\n\n```bash\npytest\n```\n")
+        self.assertNotIn("P002", codes(source))
+
+    def test_an_inline_span_counts_as_a_command(self):
+        self.assertNotIn("P002", codes(COMPLETE_STEP))
+
+    def test_no_exit_reports_the_missing_field_not_the_missing_command(self):
+        self.assertEqual(codes(without("Exit")), ["P001"])
+
+    def test_another_field_s_code_does_not_answer_for_the_exit(self):
+        """The guard for the step-wide search.
+
+        `**Files.** `a.py`` is close to universal, so a command search over the
+        whole step lets any other field answer for the exit and P002 never
+        fires on a real runbook.
+        """
+        source = COMPLETE_STEP.replace("**Exit.** Proved by `pytest`.",
+                                       "**Exit.** Reviewed and working.")
+        self.assertIn("`a.py`", source)
+        self.assertIn("P002", codes(source))
+
+    def test_a_fenced_block_after_the_exit_still_counts(self):
+        source = COMPLETE_STEP.replace(
+            "**Exit.** Proved by `pytest`.",
+            "**Exit.** Proved by the suite.\n\n```bash\npytest\n```")
+        self.assertNotIn("P002", codes(source))
+
+    def test_a_fenced_block_under_a_later_field_does_not_count(self):
+        source = COMPLETE_STEP.replace(
+            "**Exit.** Proved by `pytest`.", "**Exit.** Reviewed.").replace(
+            "**Tests.** One case.", "**Tests.** One case.\n\n```bash\npytest\n```")
+        self.assertIn("P002", codes(source))
+
+
+class Documents(unittest.TestCase):
+    def test_a_document_with_no_step_is_a_finding(self):
+        self.assertEqual(codes("# Title\n\n## Steps\n\nDecided later.\n"),
+                         ["P003"])
+
+    def test_a_step_heading_inside_a_fence_is_not_a_step(self):
+        source = "# Title\n\n```markdown\n## Step 1: Example\n```\n"
+        self.assertEqual(codes(source), ["P003"])
+
+    def test_a_trailing_section_is_not_read_into_the_last_step(self):
+        source = COMPLETE_STEP + "\n## Notes\n\n**Goal.** Not a step field.\n"
+        self.assertEqual(codes(source), [])
+
+    def test_a_missing_path_is_reported_not_raised(self):
+        found = protasis.check(Path("does-not-exist-9d3f.md"))
+        self.assertEqual([f.code for f in found], ["P000"])
+
+    def test_a_directory_is_reported_not_raised(self):
+        with tempfile.TemporaryDirectory() as directory:
+            found = protasis.check(Path(directory))
+        self.assertEqual([f.code for f in found], ["P000"])
+
+    def test_an_oversized_document_is_refused(self):
+        source = COMPLETE_STEP + ("x" * (protasis.MAX_BYTES + 1))
+        self.assertEqual(codes(source), ["P000"])
+
+
+class Suppression(unittest.TestCase):
+    def test_an_allow_comment_above_the_heading_suppresses_the_step(self):
+        source = "<!-- protasis: allow fields live upstream -->\n" + \
+                 "## Step 1: Bare\n"
+        self.assertEqual(codes(source), [])
+
+    def test_an_allow_comment_on_the_heading_line_suppresses_the_step(self):
+        source = "## Step 1: Bare <!-- protasis: allow fields live upstream -->\n"
+        self.assertEqual(codes(source), [])
+
+    def test_an_allow_comment_needs_a_reason(self):
+        source = "<!-- protasis: allow -->\n## Step 1: Bare\n"
+        self.assertIn("P001", codes(source))
+
+
+class Invocation(unittest.TestCase):
+    def test_clean_exits_zero(self):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            code = protasis.main([str(FIXTURES / "complete-runbook.md")])
+        self.assertEqual(code, 0)
+        self.assertIn("clean", buffer.getvalue())
+
+    def test_findings_exit_one(self):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            code = protasis.main([str(FIXTURES / "incomplete-runbook.md")])
+        self.assertEqual(code, 1)
+
+    def test_json_format_is_machine_readable(self):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            protasis.main([str(FIXTURES / "incomplete-runbook.md"),
+                           "--format", "json"])
+        payload = json.loads(buffer.getvalue())
+        self.assertTrue(payload)
+        self.assertEqual(sorted(payload[0]), ["code", "line", "message", "path"])
+
+    def test_no_paths_is_a_bad_invocation(self):
+        with self.assertRaises(SystemExit) as caught:
+            with redirect_stdout(io.StringIO()):
+                protasis.main([])
+        self.assertEqual(caught.exception.code, 2)
+
+
+class Fixtures(unittest.TestCase):
+    def test_the_incomplete_fixture_catches_every_omission(self):
+        found = protasis.check(FIXTURES / "incomplete-runbook.md")
+        missing = {f.message.split("**")[1] for f in found if f.code == "P001"}
+        self.assertEqual(missing, {f"{name}." for name in protasis.REQUIRED})
+        self.assertEqual(sum(1 for f in found if f.code == "P002"), 1)
+
+    def test_this_runs_own_runbook_is_clean(self):
+        """The acceptance condition: the contract's first runbook passes."""
+        runbook = REPO / "docs" / "protasis-discipline-cores" / "runbook.md"
+        self.assertTrue(runbook.is_file(), runbook)
+        self.assertEqual(protasis.check(runbook), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/hexaemeron/tests/test_protasis_checker.py
+++ b/plugins/hexaemeron/tests/test_protasis_checker.py
@@ -125,6 +125,18 @@ class Documents(unittest.TestCase):
         source = "# Title\n\n```markdown\n## Step 1: Example\n```\n"
         self.assertEqual(codes(source), ["P003"])
 
+    def test_a_fenced_heading_does_not_truncate_the_last_step(self):
+        """The guard for fence tracking in the end scan.
+
+        A runbook that quotes a step heading inside an example, which this
+        repository's own contract does, would otherwise cut its last step short
+        at the quote and report the fields below it missing.
+        """
+        source = COMPLETE_STEP.replace(
+            "**Exit.** Proved by `pytest`.",
+            "**Exit.** Proved by:\n\n```markdown\n## Step 99: quoted, not real\n```")
+        self.assertEqual(codes(source), [])
+
     def test_a_trailing_section_is_not_read_into_the_last_step(self):
         source = COMPLETE_STEP + "\n## Notes\n\n**Goal.** Not a step field.\n"
         self.assertEqual(codes(source), [])

--- a/plugins/hexaemeron/tests/test_protasis_checker.py
+++ b/plugins/hexaemeron/tests/test_protasis_checker.py
@@ -137,6 +137,31 @@ class Documents(unittest.TestCase):
             "**Exit.** Proved by:\n\n```markdown\n## Step 99: quoted, not real\n```")
         self.assertEqual(codes(source), [])
 
+    def test_a_tilde_fence_is_a_fence(self):
+        """The guard for backtick-only fence matching.
+
+        Tildes are a CommonMark fence, so a runbook using them had its examples
+        read as real content: a quoted step heading became a step with no fields
+        and the document collected findings it had not earned. A false positive
+        costs more trust than a miss.
+        """
+        source = COMPLETE_STEP.replace(
+            "**Exit.** Proved by `pytest`.",
+            "**Exit.** see\n\n~~~\n## Step 9: quoted, not real\n~~~")
+        self.assertEqual(codes(source), [])
+
+    def test_a_fence_is_closed_only_by_its_own_marker(self):
+        source = COMPLETE_STEP.replace(
+            "**Exit.** Proved by `pytest`.",
+            "**Exit.** see\n\n~~~\n```\n## Step 9: quoted\n```\n~~~")
+        self.assertEqual(codes(source), [])
+
+    def test_a_longer_fence_run_is_a_fence(self):
+        source = COMPLETE_STEP.replace(
+            "**Exit.** Proved by `pytest`.",
+            "**Exit.** see\n\n````\n## Step 9: quoted\n````")
+        self.assertEqual(codes(source), [])
+
     def test_a_trailing_section_is_not_read_into_the_last_step(self):
         source = COMPLETE_STEP + "\n## Notes\n\n**Goal.** Not a step field.\n"
         self.assertEqual(codes(source), [])


### PR DESCRIPTION
Closes Protasis's held frontier. A runbook step that omits a field was caught
only by reading, and the phase that reads carefully is the one that has already
started building.

Five codes. P001 names the missing field and the step it is in, P002 an exit
that states no command, P003 a document with no step in it, P004 steps past the
cap that went unchecked, P000 a path that cannot be read as a runbook. Exit 0
clean, 1 findings, 2 bad invocation, with deliberate exceptions stating a reason
in an allow comment. That is the shape the five sibling checks already use.

It reads presence, not quality. A Disciplines line naming the wrong gates and an
exit whose command proves nothing both pass, and the docstring says so. The
trust boundary is the argument list: paths are read as given, anything that is
not a regular file is refused, size and step count are both capped, and nothing
shells out or opens a socket.

**The audit is the interesting part of this step.** Five rounds, four findings,
and every one was the checker returning a verdict it had not earned rather than
crashing. None would have been caught by reading the diff.

- **P002 could never fire.** It searched the whole step for a command, and
  `**Files.** `a.py`` is close to universal, so any other field answered for the
  exit. Caught by the suite before round 1.
- **A capped run reported clean.** Five hundred sound steps and a broken one
  returned exit 0, because the cap discarded the fact that it had stopped. The
  cap stays and P004 now reports what it dropped.
- **A dropped step answered for the last tracked one.** Their fields sat in the
  last step's span and donated themselves upward, so a broken step at the cap
  boundary passed while missing five of six. Predates the round before it, and
  the log says so.
- **A quoted step heading truncated its own document.** Round 3's boundary fix
  went in without the fence tracking the step scan always had, so a runbook
  quoting a step heading, which this skill's own contract does a few lines from
  where it states the schema, cut itself short.
- **Tilde fences were not fences.** A legal CommonMark fence had its contents
  read as real steps, producing findings the document had not earned.

Rounds 3 and 4 were the same fault twice: fence state tracked separately at
three sites, one of which shipped without it. They now share one generator, and
that refactor bought round 5, which came back clean.

Fixes each land with a test seen to fail on the unfixed tree. 34 cases, plugin
suite 303 to 337.

The acceptance condition is a test: the checker runs over this run's own
committed runbook and finds nothing. That is why the contract growth and the
checker ship in one run.

The README's count of phase skills with an executable check moves from five to
six, which an existing test derives rather than trusts, and which is what caught
it.

Audit: `audit/AUDIT.md`, step 3, five rounds. The three bundled lints exited 0
in every round. No Solidity ships in this run, so the waiver recorded at init
covers the Pashov trio. The file carries three imprimatur defects at lines 1176
to 1428, all in entries from earlier runs; rewriting a historical audit record
to satisfy a lint is not something this step will do. The sections added here
score 100.0 on their own.

Proof:

```bash
python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py \
  docs/protasis-discipline-cores/runbook.md
python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py \
  plugins/hexaemeron/tests/fixtures/protasis/incomplete-runbook.md   # exits 1
python3 -m unittest discover -s tests
python3 plugins/hexaemeron/tests/run_tests.py
```

Root suite 24/24, plugin suite 337/337.

Stacks on: step 2, `fiat/absorb-the-five-discipline-cores-into-protasis-s-step-2-grow-the-contract`.

<!-- wildcat-origin: shoggoth -->
