### PR TITLE
Record how a change reaches an installed plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,72 @@ Use Tabularium to build and verify a source-bound Goldfinch, Euler v1 or Euler V
 Fiat remains explicit-only. Mentioning a similar delivery task does not start
 the controller unless the user names Hexaemeron or Fiat and asks to run it.
 
+## Publish
+
+Work lands here, in the public repository. What reaches an installed plugin
+depends on how that machine added the marketplace, and the two routes differ in
+who fetches the repository.
+
+### Git-backed, which needs no publishing step
+
+A marketplace added with `/plugin marketplace add wildcat-finance/skills`, or the
+Codex equivalent, is a clone the host pulls with the operator's own git
+credentials. Pushing to `main` is the whole of publishing. To pick up new
+commits:
+
+```bash
+claude plugin marketplace update wildcat-labs
+claude plugin update hexaemeron@wildcat-labs
+```
+
+Inside a session that is `/plugin marketplace update` and
+`/plugin update <plugin>@wildcat-labs`. In a provisioning script, pass `--yes`.
+
+### Organisation-distributed, through the private mirror
+
+A marketplace distributed through
+[Organization settings > Plugins](https://claude.ai/admin-settings/plugins) is
+read server-side by the Claude GitHub App, and that repository has to be private
+or internal. Hence the second repository:
+
+- `wildcat-finance/skills` is public and holds the work.
+- `wildcat-finance/skills-marketplace` is private. A scheduled job in that
+  repository force-pushes every branch and tag from the public one into it every
+  five minutes.
+
+So the mirror is the publishing pipeline, and there is nothing to package or
+upload: organisation sync packages each plugin itself during distribution, which
+is why nobody installing needs access to a separate source repository. To
+release, merge to `main`, let the mirror run, and let organisation sync read it.
+Confirm the mirror caught up before expecting anything downstream:
+
+```bash
+gh api repos/wildcat-finance/skills/commits/main --jq '.sha'
+gh api repos/wildcat-finance/skills-marketplace/commits/main --jq '.sha'
+```
+
+Two constraints follow from that route rather than from taste. Plugin sources in
+`.claude-plugin/marketplace.json` stay relative paths, `./plugins/<name>`, so
+sync packages each plugin out of the mirror instead of fetching it from
+somewhere it may not be able to authenticate to. And a version bump is only
+released once it has crossed all three links: merged here, mirrored there,
+distributed by sync. An installed plugin can sit a whole evolution behind while
+every one of those looks healthy.
+
+### Which route a machine is on
+
+Read it rather than assuming, because the update commands above only work on one
+of them. A git-backed install holds a git checkout; an organisation-distributed
+one holds an extracted package under an opaque identifier, with a marketplace id
+and no remote, ref or commit recorded anywhere. Hexaemeron's Fiat states the
+same distinction, and what to do about a controller behind its own repository, in
+[plugin-currency.md](./plugins/hexaemeron/skills/fiat/references/plugin-currency.md).
+
+Anthropic's [marketplace documentation](https://code.claude.com/docs/en/plugin-marketplaces)
+carries the source rules, and the
+[organisation plugin workflow](https://support.claude.com/en/articles/13837433)
+carries the admin side.
+
 ## Use
 
 Alexandria needs Python 3 and nothing else. Its checked-in demonstration and

--- a/tests/test_marketplace_prose.py
+++ b/tests/test_marketplace_prose.py
@@ -126,6 +126,38 @@ class MarketplaceProseTests(unittest.TestCase):
                 self.assertIn("[", readme)
                 self.assertIn("./plugins/%s" % name, readme)
 
+    def test_root_readme_documents_how_to_publish(self):
+        """Install was documented for three hosts and publishing for none.
+
+        The two routes take different commands, and only one of them has a
+        publishing step at all, so an operator who guessed wrong either ran an
+        update that does nothing or waited for a sync that was never involved.
+        """
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        flat = " ".join(readme.split())
+        self.assertIn("## Publish", readme)
+        # Both routes, named.
+        self.assertIn("claude plugin marketplace update wildcat-labs", readme)
+        self.assertIn("Organization settings > Plugins", readme)
+        # The constraint that forces the second repository.
+        self.assertIn("has to be private", flat)
+        self.assertIn("wildcat-finance/skills-marketplace", readme)
+        self.assertIn("every five minutes", flat)
+        # Nothing is packaged by hand.
+        self.assertIn("nothing to package or upload", flat)
+        # The relative-source rule that keeps sync able to package.
+        self.assertIn("stay relative paths", flat)
+
+    def test_the_publish_section_sits_under_its_own_heading(self):
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        install = readme.index("## Install")
+        publish = readme.index("## Publish")
+        use = readme.index("## Use")
+        self.assertLess(install, publish)
+        self.assertLess(publish, use)
+        # Local agents is an Install concern and must not have been absorbed.
+        self.assertLess(readme.index("### Local agents"), publish)
+
     def test_plugin_landing_readmes_publish_unique_rolling_fiat_jobs(self):
         landings = plugin_landing_readmes()
         self.assertEqual(set(landings), set(PLUGINS))


### PR DESCRIPTION
The README documented installing for three hosts and publishing for none, so the
answer to "how do I republish" was not in the repository that needed it.

Two routes, and only one of them has a publishing step at all:

- **Git-backed.** A marketplace added with `/plugin marketplace add` is a clone
  the host pulls with the operator's own git credentials. Pushing to `main` is
  the whole of publishing; picking it up is
  `claude plugin marketplace update wildcat-labs` then
  `claude plugin update hexaemeron@wildcat-labs`.
- **Organisation-distributed.** A marketplace distributed through Organization
  settings is read server-side by the Claude GitHub App, and that repository has
  to be private or internal. Which is why the private mirror exists: work lands
  in public `wildcat-finance/skills`, a job force-pushes it into private
  `wildcat-finance/skills-marketplace` every five minutes, and sync reads that.
  Nothing is packaged or uploaded by hand, because organisation sync packages
  each plugin itself during distribution.

Two constraints are recorded as consequences of the second route rather than as
preferences. Plugin sources in `marketplace.json` stay relative paths, so sync
packages out of the mirror instead of fetching from somewhere it may not be able
to authenticate to. And a version is released only once it has crossed all three
links, because an install can sit a whole evolution behind while every link looks
healthy, which is how one did during the run that prompted this.

It also says to read which route a machine is on rather than assume, since the
update commands only work on one of them, and points at Fiat's
`plugin-currency.md` for the same distinction seen from the controller's side.

Placement: `## Publish` sits between Install and Use, and `### Local agents`
stays an Install concern. One of the two new cases asserts exactly that, because
the first attempt at this section absorbed it under the new heading.

```bash
python3 -m unittest discover -s tests
python3 plugins/hexaemeron/tests/run_tests.py
```

Root suite 28 to 30, plugin suite 362 unchanged, imprimatur 100.0 on the README,
`hypomnema` clean over it so the new links resolve.

<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
