### PR TITLE
The mirror's cadence is observed, not declared

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,18 +269,27 @@ or internal. Hence the second repository:
 
 - `wildcat-finance/skills` is public and holds the work.
 - `wildcat-finance/skills-marketplace` is private. A scheduled job in that
-  repository force-pushes every branch and tag from the public one into it every
-  five minutes.
+  repository force-pushes every branch and tag from the public one into it. Its
+  cron asks for every five minutes; GitHub's scheduler has been delivering closer
+  to every twenty, so treat the interval as observed rather than declared.
 
 So the mirror is the publishing pipeline, and there is nothing to package or
 upload: organisation sync packages each plugin itself during distribution, which
 is why nobody installing needs access to a separate source repository. To
 release, merge to `main`, let the mirror run, and let organisation sync read it.
-Confirm the mirror caught up before expecting anything downstream:
+Compare the two heads rather than waiting a fixed time, because a merge that
+lands a minute after a mirror run waits for the next one:
 
 ```bash
 gh api repos/wildcat-finance/skills/commits/main --jq '.sha'
 gh api repos/wildcat-finance/skills-marketplace/commits/main --jq '.sha'
+```
+
+The job also takes a manual trigger, which is the way to release without waiting
+for the schedule:
+
+```bash
+gh workflow run sync-skills-marketplace.yml --repo wildcat-finance/skills-marketplace
 ```
 
 Two constraints follow from that route rather than from taste. Plugin sources in

--- a/plugins/hexaemeron/skills/fiat/references/plugin-currency.md
+++ b/plugins/hexaemeron/skills/fiat/references/plugin-currency.md
@@ -45,12 +45,15 @@ Two repositories. All work lands in the public one; the private one is a mirror:
 - **`wildcat-finance/skills`** is public and is where every pull request in this
   loop targets.
 - **`wildcat-finance/skills-marketplace`** is private. A scheduled job
-  force-pushes every branch and tag from the public repository into it every five
-  minutes.
+  force-pushes every branch and tag from the public repository into it. The cron
+  asks for five minutes and GitHub has been delivering closer to twenty, so read
+  the two heads rather than trusting an interval. `gh workflow run
+  sync-skills-marketplace.yml --repo wildcat-finance/skills-marketplace` runs it
+  now.
 
 The lag is a chain rather than a step, and each link can sit behind the one
-before it: a merge into the public repository, the mirror up to five minutes
-later, the install only when something updates it. All three were visibly
+before it: a merge into the public repository, the mirror on its own schedule
+after that, the install only when something updates it. All three were visibly
 different during one run, at `fiat-v4.5.1`, `fiat-v4.4.1` and `fiat-v3.4.1`.
 
 ### Which route this host used
@@ -100,9 +103,10 @@ Do not carry on and mention it.
    ```
 
    On Claude Code the second one is what an update can give you. If it is behind
-   the first, the mirror has not run yet: wait for it rather than reaching around
-   it. Five minutes is the whole delay, and hand-installing from the public
-   repository to save them puts an unpublished tree behind a run's receipts.
+   the first, the mirror has not run yet. Trigger it rather than reaching around
+   it, with `gh workflow run sync-skills-marketplace.yml --repo
+   wildcat-finance/skills-marketplace`; hand-installing from the public
+   repository puts an unpublished tree behind a run's receipts.
 2. Update the installed plugin through the host's own installer, from the
    marketplace that host uses. Do not hand-edit a plugin cache and do not copy
    files over an installed plugin: the next legitimate update overwrites it, and

--- a/plugins/hexaemeron/tests/test_fiat_skill.py
+++ b/plugins/hexaemeron/tests/test_fiat_skill.py
@@ -254,7 +254,11 @@ class PluginCurrencyTests(unittest.TestCase):
 
     def test_the_two_repositories_and_the_mirror_delay_are_stated(self):
         self.assertIn("wildcat-finance/skills-marketplace", self.doc)
-        self.assertIn("every five minutes", self.flat)
+        # Measured, not declared. The cron requests five minutes; the
+        # scheduler delivers closer to twenty, so the doc must send a
+        # reader to the two heads and the manual trigger instead.
+        self.assertIn("read the two heads rather than trusting an interval", self.flat)
+        self.assertIn("gh workflow run sync-skills-marketplace.yml", self.doc)
         self.assertIn("chain rather than a step", self.flat)
 
     def test_an_unfixable_gap_becomes_a_receipt(self):

--- a/tests/test_marketplace_prose.py
+++ b/tests/test_marketplace_prose.py
@@ -133,7 +133,7 @@ class MarketplaceProseTests(unittest.TestCase):
         publishing step at all, so an operator who guessed wrong either ran an
         update that does nothing or waited for a sync that was never involved.
         """
-        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        readme = s_readme = (ROOT / "README.md").read_text(encoding="utf-8")
         flat = " ".join(readme.split())
         self.assertIn("## Publish", readme)
         # Both routes, named.
@@ -142,7 +142,11 @@ class MarketplaceProseTests(unittest.TestCase):
         # The constraint that forces the second repository.
         self.assertIn("has to be private", flat)
         self.assertIn("wildcat-finance/skills-marketplace", readme)
-        self.assertIn("every five minutes", flat)
+        # Measured, not declared: the cron says five minutes and GitHub has
+        # been delivering closer to twenty, so the section must not promise
+        # an interval somebody would wait on.
+        self.assertIn("observed rather than declared", flat)
+        self.assertIn("gh workflow run sync-skills-marketplace.yml", s_readme)
         # Nothing is packaged by hand.
         self.assertIn("nothing to package or upload", flat)
         # The relative-source rule that keeps sync able to package.


### PR DESCRIPTION
The Publish section and `plugin-currency.md` both said the mirror runs every five
minutes. That is what its cron asks for, not what it does. Six consecutive runs:

```
05:15:21   04:58:41   04:40:24   04:20:39   04:01:14   03:39:50
    17m        18m        20m        19m        22m
```

A reader told five minutes waits, sees nothing, and concludes the pipeline is
broken. Which is what happened here: a merge landed 77 seconds after a mirror run
and the next was seventeen minutes out.

Both documents now say the cron asks for five and the scheduler has been
delivering closer to twenty, and send the reader to compare the two heads rather
than wait on an interval. Both also carry the manual trigger, which is the real
answer to releasing without waiting:

```bash
gh workflow run sync-skills-marketplace.yml --repo wildcat-finance/skills-marketplace
```

The two tests that pinned the old phrasing now pin the correction and the
trigger, so the number cannot quietly return.

No version moves. The contract says prose-only edits do not earn a generation.
The `fiat-v4.6.1` history row repeats the same five-minute phrasing and is left
alone, because a history row records what was done at the time rather than what
was later found to be true.

Root suite 30, plugin suite 362, imprimatur 100.0 on both documents.

<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
