### PR TITLE
The study named two interpreters

### DIFF
--- a/docs/protasis-discipline-cores/study.md
+++ b/docs/protasis-discipline-cores/study.md
@@ -77,8 +77,8 @@ document shape, not an implementation of a published standard.
 ## 3. Constraints and non-goals
 
 - Starting ref `main` at `2b92c6f`.
-- Python 3.11, stdlib only. Adding a dependency is an ask-first boundary and
-  this run does not need one.
+- Stdlib only, on the 3.14.6 interpreter assumption 1 states. Adding a
+  dependency is an ask-first boundary and this run does not need one.
 - The five discipline cores are cited, never restated. Content rules live in
   exactly one skill under the v3.3.1 architecture, and with phase-only Kronos
   evolving all six ledgers a restated manifest would go stale continuously.


### PR DESCRIPTION
Assumption 1 was corrected to 3.14.6 mid-run when the stated 3.11 turned out to
be wrong. The same claim sat in Constraints and was missed, so the shipped spec
asserted both versions in one document.

Constraints now defers to the assumption instead of restating the number, which
is the shape that could not have drifted to begin with.

The neighbouring "v3.3.1 architecture" reference is deliberately left alone. It
looks like a stale version and is not: `fiat-v3.3.1` is the entry that gave
Protasis the study and runbook contract alone, so it names the architecture by
the version that introduced it. Flagged it, checked the ledger, withdrew it.

Root suite 30, imprimatur 100.0, and the Protasis checker still exits 0 over the
runbook beside it.

<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
