### PR TITLE
docs(kronos): the fourth scoring axis spoke in brochure vocabulary

### DIFF
--- a/plugins/hexaemeron/skills/kronos/SKILL.md
+++ b/plugins/hexaemeron/skills/kronos/SKILL.md
@@ -70,7 +70,7 @@ still change any file genuinely required by that exact held job.
    - material user or protocol impact: 40;
    - evidenced urgency or defect severity: 25;
    - readiness of inputs and acceptance conditions: 20;
-   - leverage for other in-scope skills: 15.
+   - work it unblocks or shapes in other in-scope skills: 15.
    Show the score and one-sentence basis for every candidate. Do not invent
    work to fill the list.
 4. Select the highest score. Break a tie by impact, then readiness, then the

--- a/plugins/hexaemeron/tests/test_evolution.py
+++ b/plugins/hexaemeron/tests/test_evolution.py
@@ -168,7 +168,7 @@ class EvolutionContractTests(unittest.TestCase):
         self.assertIn("material user or protocol impact: 40", kronos)
         self.assertIn("evidenced urgency or defect severity: 25", kronos)
         self.assertIn("readiness of inputs and acceptance conditions: 20", kronos)
-        self.assertIn("leverage for other in-scope skills: 15", kronos)
+        self.assertIn("work it unblocks or shapes in other in-scope skills: 15", kronos)
         self.assertIn("Never create one goal\n   per skill", kronos)
         self.assertIn("Invoke Fiat with the held Next Fiat job byte for byte", kronos)
         self.assertIn("Kronos itself", kronos)


### PR DESCRIPTION
Imprimatur bans `leverage` as consultant register, and Kronos's ranking step used it to name the axis that scores reach into neighbouring skills:

    H  73:6  high  consultant: 'leverage'

Every other shipped document in this repo scores 100.0/100. Kronos scored 95.2 on that one line, so the skill that ranks the frontier was the only one failing the organisation's own lint.

## The change

    -   - leverage for other in-scope skills: 15.
    +   - work it unblocks or shapes in other in-scope skills: 15.

The new wording says what the axis scores rather than gesturing at it, and stays a noun phrase parallel to the three axes above it.

`plugins/hexaemeron/tests/test_evolution.py` quotes all four axis names byte for byte, so the assertion moved with the line. That was the reason to check before editing: the axis names are Kronos's ranking contract, and a rename that left the test behind would have gone green while the contract drifted. Those two files are the only places in the repo that carry the axis name — no `EVOLUTION.md` row, README, agent manifest or portable mirror quotes it, and Kronos has no `.agents/skills` mirror to keep in step.

## Versioning

Nothing about the ranking changes: same weight of 15, same thing scored, same ordering and tie-breaks. Under [VERSIONING.md](plugins/hexaemeron/skills/VERSIONING.md) that is a prose-only edit and earns no version bump, so no generation row was added and `EVOLUTION.md` is untouched — `kronos-v0.2.0`, the `terminal-goal-loop` revision and the frontier digest all stand byte for byte. The frontier stays `mature` and no Fiat run was opened. Owing no ledger row, this branch also has nothing to declare to the `init --frontier` gate that #239 just landed.

## Rebased onto #239

#239 also edited `kronos/SKILL.md`, so this branch was rebased onto `290c277` rather than merged from behind. The two edits fall in different regions of the file — step 8's `hexctl init --frontier` citation at line ~88, this axis at line 73 — and the rebase was clean. Re-verified afterwards against the rewritten step 8 in place.

## Verification

Against the rebased tree at `290c277`:

    $ python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py plugins/hexaemeron/skills/kronos/SKILL.md
    score 100.0/100   defects 0   weighted 0   /1k words 0.0
    no defects

    $ python3 -m unittest discover -s tests
    Ran 30 tests — OK

    $ python3 plugins/hexaemeron/tests/run_tests.py
    Ran 381 tests — OK
    381/381 tests passed

381 is #239's new plugin-suite total; all 19 of its new cases landed there, and the root suite stays at 30. The two `rule_of_three` entries and the cadence notes remaining in the lint output are pre-existing signals rather than defects, and are unchanged by this edit — the new step 8 prose introduces none either.

Co-authored-by: Shoggoth <shoggoth@wildcat.finance>
Wildcat-Origin: shoggoth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
