### PR TITLE
Shipped prose stays lint-clean

### DIFF
--- a/plugins/hexaemeron/skills/kronos/SKILL.md
+++ b/plugins/hexaemeron/skills/kronos/SKILL.md
@@ -92,13 +92,13 @@ still change any file genuinely required by that exact held job.
    the frontier becomes mature. Require it mechanically rather than by reading:
    start the run with `hexctl init --frontier <that skill's EVOLUTION.md>`, and
    `done integrate` refuses until the ledger carries exactly one new valid row.
-   A loop that ranks by held job cannot afford to take an unchanged ledger for a
-   closed one, because the next pass would rank the same job again. Then rescan
-   the entire scope from disk --
-   every plugin and every governed skill, not only those ranked in the
-   previous pass -- rerank from scratch, and repeat. A skill whose frontier
-   was replaced re-enters the ranking carrying its new held job, and a skill
-   whose ledger has appeared since the last pass enters for the first time.
+   A loop that ranks by held job cannot afford to take an unchanged ledger for
+   a closed one, because the next pass would rank the same job again. Then
+   rescan the entire scope from disk -- every plugin and every governed skill,
+   not only those ranked in the previous pass -- rerank from scratch, and
+   repeat. A skill whose frontier was replaced re-enters the ranking carrying
+   its new held job, and a skill whose ledger has appeared since the last pass
+   enters for the first time.
 
 Stop successfully when no eligible ledger remains. If Fiat halts on a genuine
 external blocker, preserve the durable goal and report that blocker; do not

--- a/tests/test_shipped_prose_lints.py
+++ b/tests/test_shipped_prose_lints.py
@@ -1,0 +1,112 @@
+"""Every document this repository ships passes its own prose lint.
+
+Imprimatur is the organisation's banned lexicon, and each plugin's prose was
+brought to a clean score one document at a time. Nothing held them there. A
+banned word could return to any shipped file and no test would notice, which is
+how `leverage` sat in Kronos's fourth scoring axis long enough for a reader to
+find it by eye rather than by suite.
+
+Scope, and why each exclusion is here rather than a matter of taste:
+
+- `audit/` and `docs/**` are records of what was written at the time. Editing a
+  logged audit round or a delivered spec to satisfy a later lexicon rewrites
+  history to look tidier than it was.
+- The vendored Pashov skills keep their upstream instructional register. Their
+  `NOTICE.md` files record the local distribution changes, and Wildcat's house
+  lint does not rewrite third-party source for style.
+- `LICENSE` and `NOTICE` files are legal text nobody may reword.
+- A frozen eval corpus is measurement input. Rewriting it changes what the
+  numbers beside it mean.
+
+Everything else is shipped prose and is held clean.
+"""
+
+from pathlib import Path
+import importlib.util
+import subprocess
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+LINT = ROOT / "plugins" / "hexaemeron" / "skills" / "imprimatur" / "scripts" / "imprimatur.py"
+
+VENDORED = ("x-ray", "solidity-auditor", "fizz", "fizz-convert", "fizz-sync")
+
+
+def imprimatur():
+    """The lint as a module.
+
+    Called in process rather than shelled out once per file: 134 subprocess
+    launches took the root suite from 0.12s to 7.1s, and a suite that slow gets
+    a test deleted rather than a document fixed. `build` is the same entry the
+    CLI uses, so the score here is the score the command reports.
+    """
+    spec = importlib.util.spec_from_file_location("imprimatur_lint", LINT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def shipped_markdown():
+    """Tracked Markdown this repository ships as its own prose."""
+    listed = subprocess.run(
+        ["git", "-C", str(ROOT), "ls-files", "*.md"],
+        capture_output=True, text=True, check=True).stdout.split("\n")
+    for name in listed:
+        if not name:
+            continue
+        parts = Path(name).parts
+        if parts[0] in ("audit", "docs"):
+            continue
+        if "docs" in parts or "evals" in parts:
+            continue
+        if any(part in VENDORED for part in parts):
+            continue
+        if Path(name).stem in ("LICENSE", "NOTICE"):
+            continue
+        yield name
+
+
+def lint(module, name):
+    report = module.build((ROOT / name).read_text(encoding="utf-8"))
+    return report["score"], report["defects"]
+
+
+class ShippedProseLintTests(unittest.TestCase):
+    def test_the_lint_is_where_this_test_expects_it(self):
+        # A moved script would otherwise make every case below fail for the
+        # wrong reason, or pass by finding nothing to check.
+        self.assertTrue(LINT.is_file(), LINT)
+
+    def test_the_scope_is_not_empty(self):
+        """A filter that excluded everything would pass in silence."""
+        found = list(shipped_markdown())
+        self.assertGreater(len(found), 50, found[:10])
+        # The documents most likely to drift are in scope.
+        for expected in ("README.md",
+                         "plugins/hexaemeron/skills/kronos/SKILL.md",
+                         "plugins/hexaemeron/skills/fiat/SKILL.md"):
+            self.assertIn(expected, found)
+
+    def test_history_and_vendored_text_stay_out_of_scope(self):
+        found = set(shipped_markdown())
+        for excluded in ("audit/AUDIT.md",
+                         "docs/protasis-discipline-cores/study.md"):
+            self.assertNotIn(excluded, found)
+        self.assertFalse([n for n in found if "x-ray" in Path(n).parts])
+
+    def test_every_shipped_document_scores_clean(self):
+        module = imprimatur()
+        dirty = []
+        for name in shipped_markdown():
+            score, defects = lint(module, name)
+            if defects:
+                dirty.append(f"{name}: {score}/100, {defects} defect(s)")
+        self.assertEqual(
+            dirty, [],
+            "shipped prose carries lint defects; run the lint on each file "
+            "named here and rewrite the sentence rather than swapping a "
+            "neighbouring word from the same family:\n  " + "\n  ".join(dirty))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Both items the peer session left behind after fixing the Kronos axis in #240,
since both sat in a hunk it did not own.

## Nothing was holding shipped prose clean

Each plugin's documents were brought to 100.0 one at a time, and then nothing
watched them. A banned word could return to any shipped file and no suite would
notice. That is how `leverage` sat in Kronos's fourth scoring axis until a reader
found it by eye rather than by test.

134 shipped documents are now held clean. The guard was seen to fail on the word
reintroduced and pass on its removal, rather than assumed to work.

Scope is argued in the module docstring rather than asserted:

- **`audit/` and `docs/**`** record what was written at the time. Editing a
  logged audit round or a delivered spec to satisfy a later lexicon rewrites
  history to look tidier than it was.
- **The vendored Pashov skills** keep their upstream instructional register by
  policy; the house lint does not rewrite third-party source for style.
- **LICENSE and NOTICE** are legal text nobody may reword.
- **A frozen eval corpus** is measurement input. Rewriting it changes what the
  numbers beside it mean.

Two further cases guard the filter itself, because a filter that excluded
everything would pass in silence.

## It runs in process, and that was measured

Shelling out once per file took the root suite from 0.12s to 7.1s. A suite that
slow gets a test deleted rather than a document fixed. Importing `build`, the
same entry the CLI uses, brings it to 2.4s. Both paths were checked against one
dirty file and agree exactly, at 95.4 and one defect.

Still twenty times the old root suite, and worth it for 134 documents held
against a lexicon that no longer relies on someone noticing.

## Step 8 reflow

My frontier-gate insertion in #239 left a line at eighty characters and a ragged
twenty-nine-character continuation, because the sentence I added ran into a line
the original had already wrapped. Mine to fix, which is why the peer left it.

```bash
python3 -m unittest discover -s tests
python3 plugins/hexaemeron/tests/run_tests.py
```

Root suite 30 to 34, plugin suite 381 unchanged, every shipped document at
100.0.

<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
