### PR TITLE
The spec for a durable Kronos ranking scoreboard

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4040,3 +4040,29 @@ step 1. The probe checks its own premise, or its verdict is worth nothing.
 Six findings across the run, one of them in the ledger and four in the checker,
 and every one was a verdict stated with more confidence than the evidence carried.
 None was a crash.
+
+# Run: record each Kronos ranking pass in a durable scoreboard
+
+## Step 1, round 1 -- 2026-08-20
+
+Two Markdown documents, no code. The three bundled lints ran against both
+files, passed as separate arguments rather than one concatenated string, which
+is the shell-quoting fault the previous run recorded in this file.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | none | -- |
+
+phylax exit 0, ephoros exit 0, hypomnema exit 0.
+
+The look the lints cannot do, against the study's risk register: the register's
+concerns are all about the writer step 2 builds, so none of them can be
+exercised by two documents. What a document can get wrong is a false claim, so
+the diff was checked against the tree instead. The frontier digest quoted in
+both files matches `plugins/hexaemeron/skills/kronos/EVOLUTION.md` byte for
+byte; the cited test at `tests/test_evolution_contract.py:111` is the digest
+recomputation the study says it is; the four axis caps match `SKILL.md` lines
+70 to 73. The diff carries no credential and no account data, which the
+marketplace preflight forbids shipping.
+
+Leads not pursued: none.

--- a/docs/kronos-ranking-scoreboard/runbook.md
+++ b/docs/kronos-ranking-scoreboard/runbook.md
@@ -1,0 +1,107 @@
+# Runbook: record each Kronos ranking pass in a durable scoreboard
+
+Derived from [study.md](study.md). Three steps, dependency ordered. Step 1
+scaffolds and commits the spec, step 2 builds the writer, step 3 wires it into
+the skill and runs the demo path.
+
+The run branch is `fiat/record-each-kronos-ranking-pass-in-a-durable-sco`, cut
+from `main` at `fec7ee5`. Both suites are green at that ref: 34/34 at the root
+and 381/381 under the plugin.
+
+## Step 1: Commit the spec
+
+**Goal.** Put the study and this runbook in the repository, where the next two
+steps and any later reader can reach them.
+
+**Entry.** The run branch at `fec7ee5`, tree clean, both suites green.
+
+**Exit.** `docs/kronos-ranking-scoreboard/study.md` and
+`docs/kronos-ranking-scoreboard/runbook.md` exist, with every relative link
+rewritten for their new depth. Proved by
+`python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py docs plugins`
+exiting 0, and by both suites still passing:
+`python3 -m unittest discover -s tests -p "test_*.py"` and
+`python3 plugins/hexaemeron/tests/run_tests.py`.
+
+**Files.** `docs/kronos-ranking-scoreboard/study.md`,
+`docs/kronos-ranking-scoreboard/runbook.md`.
+
+**Tests.** None added. The two existing suites and the hypomnema link check are
+the gate; the root suite already lints every shipped document through
+`tests/test_shipped_prose_lints.py`.
+
+**Disciplines.** phylax: none, this step adds no boundary and runs no code.
+ephoros: none, documents emit nothing. metron: none, no performance claim.
+elenchus: none, no failure in hand. hypomnema: this step is the record, and the
+link check is what proves the pointers resolve from the new depth.
+
+## Step 2: Build the scoreboard writer
+
+**Goal.** A stdlib script that appends one validated pass to a JSON Lines
+scoreboard and renders the file, with the held-job identity hash computed from
+each candidate's ledger rather than taken from the caller.
+
+**Entry.** Step 1's exit state: the spec committed, both suites green.
+
+**Exit.** `plugins/hexaemeron/skills/kronos/scripts/kronos.py` supports
+`record --scoreboard <path>` reading a pass on stdin and `show --scoreboard
+<path>`, exits 0 clean, 1 on a refusal, 2 on bad invocation, and appends
+nothing on any refusal. Proved by
+`python3 plugins/hexaemeron/tests/run_tests.py` passing with the new cases
+included, and by `python3 -m unittest discover -s tests -p "test_*.py"`.
+
+**Files.** `plugins/hexaemeron/skills/kronos/scripts/kronos.py`,
+`plugins/hexaemeron/tests/test_kronos_scoreboard.py`,
+`plugins/hexaemeron/tests/fixtures/kronos/` for ledger fixtures.
+
+**Tests.** New cases in `test_kronos_scoreboard.py`: a clean append; an axis
+over its cap; a total over 100; a selection that is not the highest score and
+states no tie-break; a candidate whose ledger path resolves outside the
+checkout root; a ledger that is a directory; a truncated final line in an
+existing scoreboard; a candidate count over the cap; stdin that is not JSON;
+an unknown field; the identity hash matching the ledger's own recorded digest;
+`show` marking a moved axis under an unchanged identity hash; `show` on an
+absent file. Expect the plugin suite above 381 by roughly fifteen cases.
+
+**Disciplines.** phylax: this step opens three boundaries the study names,
+stdin, a caller-supplied ledger path, and an append to an existing file, and
+each needs its control. ephoros: the scoreboard is the loop's own telemetry, so
+what a refusal prints and where it prints it is part of the step. metron: none,
+no performance claim and no speed-motivated change. elenchus: none, no failure
+in hand; the guard convention applies to failures this step surfaces.
+hypomnema: the interface documentation sits with the script, and the two
+expensive decisions are recorded in step 3.
+
+## Step 3: Wire the scoreboard into Kronos and demonstrate
+
+**Goal.** Make the writer part of the loop: `SKILL.md` step 3 records the pass
+and step 8 reads it back, the version moves to `0.3.0`, the ledger carries one
+generation row, and the demo path runs.
+
+**Entry.** Step 2's exit state: the writer shipped and both suites green.
+
+**Exit.** `SKILL.md` names the scoreboard in steps 3 and 8 and carries
+`version: "0.3.0"`; `EVOLUTION.md` carries one new generation row retaining
+frontier revision `terminal-goal-loop` and digest
+`ac28d95d80724aa001a92740f76416164e65d7b7b9cb5da43674d1ea73a214d1` byte for
+byte, with status still `mature` and next job still `None -- mature`. Proved by
+`python3 -m unittest discover -s tests -p "test_*.py"` passing, which is where
+`test_evolution_contract.py` and `test_version_propagation.py` live, by
+`python3 plugins/hexaemeron/tests/run_tests.py`, and by the demo path: record
+two passes over this checkout's real ledgers into a scratch scoreboard, the
+second moving one axis score for a candidate whose held-job identity hash is
+unchanged, then `show` marking that axis as drifted.
+
+**Files.** `plugins/hexaemeron/skills/kronos/SKILL.md`,
+`plugins/hexaemeron/skills/kronos/EVOLUTION.md`.
+
+**Tests.** No new test file. The root suite's evolution-contract and
+version-propagation cases are what prove the ledger row and the version bump
+agree; both already exist and both must pass over the edited ledger.
+
+**Disciplines.** phylax: none, this step adds no boundary; it edits two
+documents. ephoros: none beyond what step 2 emits. metron: none, no performance
+claim. elenchus: none, no failure in hand. hypomnema: the two decisions the
+study named as expensive to reverse, the gitignored scoreboard and the reused
+canonical hash, are recorded here in the ledger row, which is where a decision
+about a governed skill lives.

--- a/docs/kronos-ranking-scoreboard/study.md
+++ b/docs/kronos-ranking-scoreboard/study.md
@@ -53,9 +53,9 @@ A working prototype means all of this holds:
 
 **In this skill.** `plugins/hexaemeron/skills/kronos/SKILL.md` step 3 defines
 the four axes and their caps: material impact 40, evidenced urgency 25,
-readiness of inputs 20, work unblocked elsewhere 15. Step 4 defines the
-tie-break: impact, then readiness, then discovery order. Step 8 defines the
-rescan. Kronos has no `scripts/` directory today; it is prose and one
+readiness of inputs 20, work unblocked elsewhere 15. The tie-break in step 4
+runs impact, then readiness, then discovery order, and step 8 is the rescan.
+Kronos has no `scripts/` directory today. It is prose and one
 `agents/openai.yaml`.
 
 **The identity hash already exists.** `plugins/hexaemeron/skills/VERSIONING.md`
@@ -67,10 +67,10 @@ defines a canonical line per ledger:
 
 with its final newline, hashed with SHA-256, and stores that digest in every
 history row. `tests/test_evolution_contract.py:111` recomputes it and asserts
-it matches the latest row. That is the held-job identity hash this study needs,
-already specified, already tested, and already comparable against the ledger's
-own recorded digest. Defining a second hash would mean two ways of naming the
-same thing.
+it matches the latest row. That is the held-job identity hash this study needs.
+It is specified, it is tested, and a scoreboard line carrying it can be checked
+against the ledger's own recorded digest. Defining a second hash would leave
+two ways of naming one thing.
 
 **The checker pattern.** Six sibling skills ship a stdlib-only script with
 numbered diagnostic codes, exit 0 clean, 1 findings, 2 bad invocation, a stated

--- a/docs/kronos-ranking-scoreboard/study.md
+++ b/docs/kronos-ranking-scoreboard/study.md
@@ -1,0 +1,285 @@
+# Study: record each Kronos ranking pass in a durable scoreboard
+
+Assuming, unless corrected:
+
+1. Python 3.11 or later and stdlib `unittest`, matching every other checker in
+   this plugin. The machine running this has 3.14.6.
+2. The scoreboard is a per-checkout working record, not a published artefact.
+   Nobody outside the machine that ran the loop needs to read it.
+3. Kronos keeps its hard rule that Fiat owns all repository work. A scoreboard
+   writer that commits, branches or pushes would break that rule.
+4. This is generation-axis work. Kronos stays mature, the held frontier target
+   and its digest are retained byte for byte, and the run passes no
+   `--frontier` flag.
+5. The run starts from `fec7ee5` on `main`, with both suites green at 34/34
+   and 381/381.
+
+## 1. Problem statement
+
+Kronos scores every eligible held Next Fiat job out of 100 across four axes,
+prints the scores and a one-sentence basis in chat, runs the winner through
+Fiat, and then at step 8 rescans from disk and reranks from scratch. Nothing
+carries from one pass to the next. Two consequences follow.
+
+The first is that axis weighting drifts invisibly. The same held job can score
+62 in one pass and 78 three passes later with nothing changed about it, because
+the judgement is made fresh each time against a chat transcript that has since
+been compacted. Nobody can see the drift, because there is nothing to compare.
+
+The second is that the reasoning evaporates. A maintainer who wants to know why
+a frontier was picked in March has the merged pull requests and nothing about
+the field those jobs were picked out of.
+
+What is built: a scoreboard writer that appends one validated record per
+ranking pass to a durable file, and a reader that renders the file, including
+how each skill's per-axis scores moved between passes.
+
+A working prototype means all of this holds:
+
+- `python3 plugins/hexaemeron/skills/kronos/scripts/kronos.py record
+  --scoreboard <path>` reads a pass on stdin, validates it, and appends exactly
+  one JSON line.
+- The appended line carries each candidate's held-job identity hash, computed
+  from that skill's `EVOLUTION.md` on disk rather than supplied by the caller.
+- `python3 ... kronos.py show --scoreboard <path>` prints the passes, and marks
+  every axis score that moved for a skill whose held-job identity hash did not.
+- `python3 plugins/hexaemeron/tests/run_tests.py` passes, carrying new cases
+  for the writer.
+- The demo path: record two passes over this checkout's real ledgers, the
+  second changing one axis score for an unchanged held job, and `show` marks
+  it.
+
+## 2. Prior art
+
+**In this skill.** `plugins/hexaemeron/skills/kronos/SKILL.md` step 3 defines
+the four axes and their caps: material impact 40, evidenced urgency 25,
+readiness of inputs 20, work unblocked elsewhere 15. Step 4 defines the
+tie-break: impact, then readiness, then discovery order. Step 8 defines the
+rescan. Kronos has no `scripts/` directory today; it is prose and one
+`agents/openai.yaml`.
+
+**The identity hash already exists.** `plugins/hexaemeron/skills/VERSIONING.md`
+defines a canonical line per ledger:
+
+```text
+{status}|{frontier revision}|{current frontier}|{next Fiat job}
+```
+
+with its final newline, hashed with SHA-256, and stores that digest in every
+history row. `tests/test_evolution_contract.py:111` recomputes it and asserts
+it matches the latest row. That is the held-job identity hash this study needs,
+already specified, already tested, and already comparable against the ledger's
+own recorded digest. Defining a second hash would mean two ways of naming the
+same thing.
+
+**The checker pattern.** Six sibling skills ship a stdlib-only script with
+numbered diagnostic codes, exit 0 clean, 1 findings, 2 bad invocation, a stated
+trust boundary, and bounded reads:
+`plugins/hexaemeron/skills/protasis/scripts/protasis.py` is the closest in
+shape. Each has a matching `plugins/hexaemeron/tests/test_*_checker.py`.
+
+**The gitignored state directory.** Fiat keeps run state in `.hexaemeron/`,
+which ships its own `.gitignore` holding `*`, so git never sees it.
+`fiat/SKILL.md` states the pattern and `hexctl reset` archives within it.
+
+**Outside.** JSON Lines (jsonlines.org) is the append-only record format used
+here already, in `.hexaemeron/ledger.jsonl`.
+
+## 3. Constraints and non-goals
+
+**Constraints.**
+
+- Starting ref `fec7ee5` on `main`.
+- Python 3.11 or later, stdlib only. No new dependency.
+- Kronos must not write to the git index or run git. Its hard rule gives Fiat
+  every repository operation.
+- Fiat refuses to start against a dirty tree. Anything Kronos writes before
+  invoking Fiat has to be invisible to `git status --short`, or the next
+  iteration of the loop cannot start.
+- `tests/test_version_propagation.py` requires `SKILL.md` frontmatter version
+  and the ledger's current version to agree, so the bump and the ledger row
+  land in the same step.
+- The held frontier revision `terminal-goal-loop` and its digest
+  `ac28d95d80724aa001a92740f76416164e65d7b7b9cb5da43674d1ea73a214d1` are
+  retained byte for byte. Kronos stays mature.
+
+**Non-goals.**
+
+- No scoring. The writer records the judgement; it does not make or second-
+  guess it. An axis score is a number the ranking agent supplies.
+- No published scoreboard. Not committed, not exported, not signed.
+- No cross-checkout merge of scoreboards.
+- No change to the four axes, their caps, or the tie-break.
+- No enforcement that a pass was actually run. A loop that skips the writer
+  produces a shorter file, and only a reader notices.
+
+## 4. Design options
+
+**A. Prose contract only.** State the scoreboard file, its path and its fields
+in `SKILL.md`, with no machinery. Cheapest to build. Trades away every
+guarantee: the identity hash gets eyeballed or omitted, the axis caps go
+unchecked, and the file drifts into whatever each pass felt like writing. The
+wishlist entry this study answers exists because prose rules in this estate go
+unenforced.
+
+**B. A gitignored `.kronos/` directory and a stdlib writer.** A new
+`scripts/kronos.py` with `record` and `show`, appending validated JSON lines to
+`.kronos/scoreboard.jsonl` beside a `.gitignore` holding `*`, mirroring
+`.hexaemeron/`. The writer computes each identity hash from the ledger on disk
+and refuses a pass whose axes exceed their caps or whose selection contradicts
+the tie-break. Trades away visibility to anyone who did not run the loop: the
+record lives on one machine and not in the repository's history.
+
+**C. Committed records under `docs/kronos/`.** Same writer, output committed so
+the history is shared. Trades away the loop itself: an uncommitted scoreboard
+file makes the tree dirty, and Fiat stops on a dirty tree before it starts, so
+the next iteration cannot run. Committing it instead would put Kronos in the
+business of branching and committing, which its first hard rule forbids.
+
+**D. Fold the scoreboard into `hexctl`.** Reuse Fiat's hash-chained ledger and
+lock. Trades away the boundary between the two skills: `hexctl` state is
+per-run and archived at `reset`, while a scoreboard exists to span runs, and
+Kronos is not Fiat.
+
+**Chosen: B.** It is the cheapest construction that keeps the loop able to
+start. C is the one a reader wants until the dirty-tree interaction is traced,
+and that interaction is not a detail: it stops the second iteration of every
+loop. B's cost is stated plainly in the non-goals rather than hidden, and a
+maintainer who wants a shared record can copy the file by hand, which is a
+decision for a later frontier and not this one.
+
+## 5. Risk register seed
+
+This is Python reading files named on a command line and on stdin. The audit
+loop should look hardest at:
+
+- **Untrusted input.** The pass document arrives on stdin. Malformed JSON, a
+  candidate list of a hundred thousand entries, a `skill` field carrying path
+  separators, and a ledger path pointing outside the checkout are all things a
+  caller can hand over.
+- **Path handling.** Each candidate names an `EVOLUTION.md` the writer opens to
+  compute the identity hash. A path that is a symlink, a device, a directory or
+  a two-gigabyte file is the caller's choice, not the writer's.
+- **Partial writes.** An append interrupted halfway leaves a truncated final
+  line, and the next `record` has to decide what that means rather than
+  appending after it.
+- **Filesystem behaviour.** Creating `.kronos/` and its `.gitignore` has to be
+  safe to repeat, and must not follow a symlink into somewhere else.
+- **No secrets, no subprocess, no socket.** The writer starts no process and
+  opens no network connection. An audit round should confirm that rather than
+  assume it.
+
+## 6. Glossary seeds
+
+- **Pass.** One execution of Kronos steps 1 through 4: discover, filter, score
+  every eligible candidate, select one.
+- **Candidate.** One eligible governed skill and the held Next Fiat job scored
+  in that pass.
+- **Held-job identity hash.** The SHA-256 of the canonical frontier line
+  defined by `VERSIONING.md`, computed from the candidate's ledger at the time
+  of the pass.
+- **Scoreboard.** The append-only JSON Lines file, one line per pass.
+- **Drift.** An axis score that changed for a candidate whose held-job identity
+  hash did not.
+
+## 7. Sources
+
+- `plugins/hexaemeron/skills/kronos/SKILL.md`, steps 3, 4 and 8, and the hard
+  rules.
+- `plugins/hexaemeron/skills/kronos/EVOLUTION.md`, current version
+  `kronos-v0.2.0`, status `mature`.
+- `plugins/hexaemeron/skills/VERSIONING.md`, the canonical frontier line and
+  the generation-axis rule.
+- `tests/test_evolution_contract.py:111`, the digest recomputation.
+- `plugins/hexaemeron/skills/protasis/scripts/protasis.py`, the checker shape.
+- `plugins/hexaemeron/skills/fiat/SKILL.md`, the dirty-tree stop and the
+  `.hexaemeron/` gitignore pattern.
+- `plugins/hexaemeron/skills/hypomnema/SKILL.md`, where each record lives.
+- The wishlist entry `kronos-1`, artifact `wishlist-grab-bag.md`.
+
+## 8. Signals, and the questions behind them
+
+Kronos runs unattended across a long loop, so the scoreboard is itself the
+telemetry. Two questions someone asks afterwards:
+
+- *Why did this frontier get picked over that one?* Answered by the per-axis
+  scores and the basis on the pass line. Emitted by the `record` step of every
+  pass.
+- *Did the ranking change its mind about a job nobody touched?* Answered by the
+  drift marking in `show`, which compares axis scores across passes sharing an
+  identity hash. Emitted on demand rather than continuously.
+
+`record` writes to stdout only what it appended, and reports refusals on stderr
+with a code, so a loop that pipes it can tell an append from a rejection.
+[ephoros](../../plugins/hexaemeron/skills/ephoros/SKILL.md) owns what a signal
+must carry.
+
+## 9. Boundaries, per capability
+
+- **Reading a pass document from stdin.** Worth taking: a caller can send
+  anything. Control: parse with a byte cap, require the top-level shape, cap
+  the candidate count, and reject unknown fields rather than storing them.
+- **Opening a candidate's ledger by caller-supplied path.** Worth taking: a
+  path outside the checkout, a symlink, or a huge file. Control: resolve the
+  path, require a regular file, require it to sit under the scoreboard's
+  checkout root, and cap the read.
+- **Appending to the scoreboard file.** Worth taking: a truncated final line
+  from an interrupted run. Control: validate every existing line before
+  appending, refuse on a malformed tail rather than writing past it, and write
+  with a single append that ends in a newline.
+- **Creating `.kronos/` and its `.gitignore`.** Worth taking: an existing
+  symlink at that path. Control: refuse anything that is not a real directory,
+  and write the `.gitignore` only when absent.
+
+[phylax](../../plugins/hexaemeron/skills/phylax/SKILL.md) owns the boundary list
+and the controls.
+
+## 10. The budget, or its absence
+
+None. The writer appends one line per Kronos pass, and a Kronos pass is bounded
+by a Fiat delivery that takes hours. No performance claim is made and no change
+here is motivated by speed, so
+[metron](../../plugins/hexaemeron/skills/metron/SKILL.md) has nothing to measure.
+
+## 11. The fail-closed posture
+
+Every refusal exits non-zero and appends nothing. A pass is recorded whole or
+not at all. What stops the run: unreadable stdin, a pass failing validation, a
+ledger path that resolves outside the checkout, a malformed existing scoreboard
+line, or `.kronos/` occupied by something that is not a directory.
+
+Guard-test convention: a fix for a failure found here adds a case to
+`plugins/hexaemeron/tests/test_kronos_scoreboard.py` that fails on the unfixed
+tree, following
+[elenchus](../../plugins/hexaemeron/skills/elenchus/SKILL.md), which owns the
+triage order and the guard rule.
+
+## 12. Decisions and their homes
+
+Two decisions here are expensive to reverse, and both are decisions about a
+governed skill, so both belong in `plugins/hexaemeron/skills/kronos/EVOLUTION.md`
+per [hypomnema](../../plugins/hexaemeron/skills/hypomnema/SKILL.md):
+
+- The scoreboard is gitignored rather than committed. Reversing it means
+  reopening the dirty-tree interaction with Fiat.
+- The held-job identity hash is the `VERSIONING.md` canonical line rather than
+  a hash of Kronos's own choosing. Reversing it invalidates every line already
+  written.
+
+The generation row recording both lands in step 3, alongside the version bump
+that `tests/test_version_propagation.py` requires to agree with it.
+
+## Boundaries
+
+**Always.** Both suites before a commit: `python3 -m unittest discover -s tests
+-p "test_*.py"` and `python3 plugins/hexaemeron/tests/run_tests.py`. The
+imprimatur lint on every shipped document. Kronos's held frontier revision and
+digest retained byte for byte in any ledger edit.
+
+**Ask first.** Adding a dependency. Changing the four axes or their caps.
+Changing the canonical frontier line. Writing anywhere git can see. Touching
+CI.
+
+**Never.** Run git from Kronos. Commit the scoreboard. Edit a vendored skill.
+Change the held `Next Fiat job` or reopen the mature frontier. Delete a failing
+test to make a suite pass. Claim a lint or a suite ran when it did not.


### PR DESCRIPTION
Kronos scores every eligible held Fiat job out of 100 across four axes, prints
the result in chat, runs the winner through Fiat, and at step 8 reranks from
scratch. Nothing carries between passes. A job can score 62 in one pass and 78
three passes later with nothing about it changed, and nobody can see that
happen, because there is nothing to compare it against.

This step ships the study and runbook only. No code changes.

## What the study picks

A gitignored `.kronos/scoreboard.jsonl`, written by a new stdlib script under
the Kronos skill, one validated JSON line per ranking pass. The held-job
identity hash on each line is the canonical frontier line that
`VERSIONING.md` already defines and `tests/test_evolution_contract.py` already
recomputes, so a scoreboard line can be checked against the ledger's own
recorded digest instead of against a second hash invented here.

The trade is stated in the study rather than buried: the record lives on the
machine that ran the loop, not in the repository's history. Committing it is
the option a reader wants first, and it does not work. An uncommitted
scoreboard file makes the tree dirty, Fiat stops on a dirty tree before it
starts, and the loop's second iteration would never run. Having Kronos commit
the file instead breaks its first hard rule, which gives Fiat every repository
operation.

## Scope

Generation-axis work. Kronos stays mature, and the held frontier revision
`terminal-goal-loop` and its digest are retained byte for byte. The version
bump and the ledger row land together in step 3, because
`tests/test_version_propagation.py` requires them to agree.

## Proof

```bash
python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py docs plugins
python3 -m unittest discover -s tests -p "test_*.py"
python3 plugins/hexaemeron/tests/run_tests.py
```

Root 34/34, plugin 381/381, link check clean.

Audit round for this step is in `audit/AUDIT.md`: one round, zero findings,
three lints at exit 0. The look checked the documents' claims against the tree,
since the risk register describes a writer that step 2 has not built yet.