### PR TITLE
The Kronos scoreboard writer

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4100,3 +4100,25 @@ Leads not pursued: the scoreboard read cap of 16 MiB refuses an append once a
 file passes it, which stops recording rather than losing a line. Accepted: the
 cap is stated in the source, and 16 MiB of ranking passes is far past any real
 loop.
+
+## Step 2, round 2 -- 2026-08-20
+
+Against the tree with round 1's fixes applied. phylax exit 0, ephoros exit 0,
+hypomnema exit 0.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | none | -- |
+
+The look went after what round 1's fix could have broken and what it did not
+cover. Moving the K010 check ahead of the stdin read does not weaken the
+append-nothing property, since it refuses earlier rather than later. `show` has
+no such check, which is correct: it only reads, and reading through a link the
+caller named writes nothing anywhere.
+
+One property was assumed in round 1 and checked here instead. A basis holding a
+newline could have split one record across two lines and broken the file for
+every later read. It does not: `json.dumps` escapes it, the file kept one line,
+and `show` renders the text across two lines without the record changing.
+
+Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4066,3 +4066,37 @@ recomputation the study says it is; the four axis caps match `SKILL.md` lines
 marketplace preflight forbids shipping.
 
 Leads not pursued: none.
+
+## Step 2, round 1 -- 2026-08-20
+
+phylax exit 0, ephoros exit 0, hypomnema exit 0. The lints found nothing, and
+both findings below came from walking the study's risk register against the
+code, one boundary at a time.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S2-R1-01 | medium | plugins/hexaemeron/skills/kronos/scripts/kronos.py | `.kronos/` occupied by a symlink was written through, putting the scoreboard and its `*` gitignore in a directory the caller never named | fixed in 885bcb6 |
+| S2-R1-02 | low | plugins/hexaemeron/skills/kronos/scripts/kronos.py | the `run` field was stored with no type check, so any JSON value reached the record | fixed in 885bcb6 |
+
+S2-R1-01 was reproduced before it was believed: a symlinked `.kronos` pointing
+at an empty directory, one `record` call, and both files appeared in the target.
+The study's boundary list states the control it needed, "refuse anything that is
+not a real directory", so this was a promise the code had not kept. Where the
+link points somewhere git watches, the `*` gitignore hides whatever sits beside
+it and the scoreboard dirties the tree, which is the failure option C was
+rejected for.
+
+The first fix was wrong and the guard test caught it. Checking
+`scoreboard.parent` after `Path(...).resolve()` never sees a symlink, because
+resolve follows it: the check ran against the target directory and passed. The
+mechanism was the resolve, not the check, so the guard now runs against the path
+as the caller gave it, and covers a symlinked scoreboard file as well as a
+symlinked directory.
+
+Four guard cases were run against the tree without the fix and all four failed,
+then against the fixed tree and all four passed.
+
+Leads not pursued: the scoreboard read cap of 16 MiB refuses an append once a
+file passes it, which stops recording rather than losing a line. Accepted: the
+cap is stated in the source, and 16 MiB of ranking passes is far past any real
+loop.

--- a/plugins/hexaemeron/skills/kronos/scripts/kronos.py
+++ b/plugins/hexaemeron/skills/kronos/scripts/kronos.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Kronos ranking scoreboard.
+
+Kronos scores every eligible held Fiat job out of 100, prints the result, runs
+the winner, and then reranks from scratch. Nothing carries between passes, so a
+job can score 62 in one pass and 78 three passes later with nothing about it
+changed. This appends each pass to a file so that movement is visible.
+
+  record  read a pass on stdin, validate it, append exactly one JSON line
+  show    print the recorded passes and mark every axis score that moved for a
+          candidate whose held job did not
+
+  K000  a path that cannot be read
+  K001  stdin that is not a JSON object
+  K002  a required field that is missing
+  K003  a field the record does not carry
+  K004  an axis outside its range
+  K005  a stated total that disagrees with the axes
+  K006  a selection that is not what the tie-break picks
+  K007  a candidate ledger that cannot be used
+  K008  an existing scoreboard line that cannot be read
+  K009  more candidates than the check will track
+
+Exit 0 clean, 1 a refusal, 2 bad invocation. A refusal appends nothing: a pass
+is recorded whole or not at all.
+
+The held-job identity hash is not supplied by the caller. It is computed here
+from the candidate's ledger, as the SHA-256 of the canonical frontier line that
+VERSIONING.md already defines, which is the same digest each ledger stores in
+its own history row. A line written here can therefore be checked against the
+ledger it describes.
+
+What this does not do. It records a judgement; it does not make one. An axis
+score is a number the ranking agent supplies, and a basis is prose nobody
+parses. It also cannot tell that a pass went unrecorded, because a loop that
+skips this writer leaves a shorter file and nothing else.
+
+The trust boundary is stdin and the argument list. The pass document arrives
+from a caller and is read with a byte cap, an unknown field is refused rather
+than stored, and the candidate count is capped. Each candidate names a ledger
+path the caller chose, so that path is resolved, required to be a regular file
+under the scoreboard's root, and read under a cap. An existing scoreboard is
+validated line by line before anything is appended, so a run interrupted
+mid-append is refused rather than written past. Nothing here starts a
+subprocess or opens a socket.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+# Kronos SKILL.md step 3. The caps sum to 100, which is what "out of 100" means.
+AXES = (("impact", 40), ("urgency", 25), ("readiness", 20), ("unblocks", 15))
+
+CANDIDATE_FIELDS = frozenset(
+    {"skill", "ledger", "basis", "total"} | {name for name, _ in AXES}
+)
+CANDIDATE_REQUIRED = ("skill", "ledger", "basis") + tuple(name for name, _ in AXES)
+PASS_FIELDS = frozenset({"scope", "mode", "candidates", "selected", "run"})
+PASS_REQUIRED = ("scope", "mode", "candidates", "selected")
+MODES = ("full", "phase-only")
+
+# Documents somebody handed over. Bound every axis that a caller controls.
+MAX_STDIN_BYTES = 1024 * 1024
+MAX_LEDGER_BYTES = 1024 * 1024
+MAX_SCOREBOARD_BYTES = 16 * 1024 * 1024
+MAX_CANDIDATES = 200
+
+LEDGER_FIELDS = ("Frontier status", "Frontier revision", "Current frontier", "Next Fiat job")
+
+
+class Refusal(Exception):
+    """A validation failure, carrying the code that names it."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+
+
+def ledger_field(text: str, name: str) -> str:
+    """One `- Name: value` line from a ledger, matching the contract test."""
+    match = re.search(rf"(?m)^- {re.escape(name)}: (.+)$", text)
+    if match is None:
+        raise Refusal("K007", f"ledger has no {name!r} field")
+    return match.group(1).strip().strip("`")
+
+
+def held_job_hash(ledger: Path) -> str:
+    """SHA-256 of the canonical frontier line VERSIONING.md defines."""
+    text = read_capped(ledger, MAX_LEDGER_BYTES, "K007")
+    canonical = "|".join(ledger_field(text, name) for name in LEDGER_FIELDS) + "\n"
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def read_capped(path: Path, cap: int, code: str) -> str:
+    """Read a regular file under a byte cap, or refuse with the given code."""
+    if not path.is_file():
+        raise Refusal(code, f"{path} is not a regular file")
+    size = path.stat().st_size
+    if size > cap:
+        raise Refusal(code, f"{path} is {size} bytes, over the {cap} byte cap")
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise Refusal(code, f"{path} could not be read: {exc}") from exc
+
+
+def resolved_under(root: Path, candidate: str) -> Path:
+    """Resolve a caller-supplied path and require it to sit under the root."""
+    path = (root / candidate).resolve() if not Path(candidate).is_absolute() else Path(candidate).resolve()
+    if path != root and root not in path.parents:
+        raise Refusal("K007", f"{candidate} resolves outside {root}")
+    return path
+
+
+def check_fields(obj: dict, allowed: frozenset, required: tuple, where: str) -> None:
+    if not isinstance(obj, dict):
+        raise Refusal("K001", f"{where} is not an object")
+    for name in required:
+        if name not in obj:
+            raise Refusal("K002", f"{where} has no {name!r}")
+    for name in obj:
+        if name not in allowed:
+            raise Refusal("K003", f"{where} carries {name!r}, which the record does not hold")
+
+
+def score(candidate: dict, root: Path, where: str) -> dict:
+    """Validate one candidate and return the line it contributes."""
+    check_fields(candidate, CANDIDATE_FIELDS, CANDIDATE_REQUIRED, where)
+    axes = {}
+    for name, cap in AXES:
+        value = candidate[name]
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise Refusal("K004", f"{where} {name} is {value!r}, not an integer")
+        if not 0 <= value <= cap:
+            raise Refusal("K004", f"{where} {name} is {value}, outside 0 to {cap}")
+        axes[name] = value
+    total = sum(axes.values())
+    stated = candidate.get("total")
+    if stated is not None and stated != total:
+        raise Refusal("K005", f"{where} states a total of {stated}, but the axes sum to {total}")
+    for name in ("skill", "basis"):
+        if not isinstance(candidate[name], str) or not candidate[name].strip():
+            raise Refusal("K002", f"{where} {name} is empty")
+    if not isinstance(candidate["ledger"], str) or not candidate["ledger"].strip():
+        raise Refusal("K002", f"{where} ledger is empty")
+    ledger = resolved_under(root, candidate["ledger"])
+    return {
+        "skill": candidate["skill"],
+        "ledger": str(ledger.relative_to(root)),
+        "held_job": held_job_hash(ledger),
+        **axes,
+        "total": total,
+        "basis": candidate["basis"],
+    }
+
+
+def tie_break(scored: list) -> str:
+    """Kronos SKILL.md step 4: total, then impact, then readiness, then order."""
+    ordered = sorted(
+        enumerate(scored),
+        key=lambda pair: (-pair[1]["total"], -pair[1]["impact"], -pair[1]["readiness"], pair[0]),
+    )
+    return ordered[0][1]["skill"]
+
+
+def existing_passes(scoreboard: Path) -> list:
+    """Every line already recorded, refusing a tail that cannot be read."""
+    if not scoreboard.exists():
+        return []
+    text = read_capped(scoreboard, MAX_SCOREBOARD_BYTES, "K008")
+    if text and not text.endswith("\n"):
+        raise Refusal("K008", f"{scoreboard} does not end in a newline, so its last line is partial")
+    passes = []
+    for number, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            raise Refusal("K008", f"{scoreboard} line {number} is blank")
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise Refusal("K008", f"{scoreboard} line {number} is not JSON: {exc}") from exc
+        if not isinstance(entry, dict) or "pass" not in entry:
+            raise Refusal("K008", f"{scoreboard} line {number} is not a pass record")
+        passes.append(entry)
+    return passes
+
+
+def record(args: argparse.Namespace) -> int:
+    scoreboard = Path(args.scoreboard).resolve()
+    root = Path(args.root).resolve() if args.root else scoreboard.parent.parent
+    raw = sys.stdin.buffer.read(MAX_STDIN_BYTES + 1)
+    if len(raw) > MAX_STDIN_BYTES:
+        raise Refusal("K001", f"stdin is over the {MAX_STDIN_BYTES} byte cap")
+    try:
+        document = json.loads(raw.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise Refusal("K001", f"stdin is not JSON: {exc}") from exc
+
+    check_fields(document, PASS_FIELDS, PASS_REQUIRED, "the pass")
+    if document["mode"] not in MODES:
+        raise Refusal("K002", f"mode is {document['mode']!r}, not one of {', '.join(MODES)}")
+    candidates = document["candidates"]
+    if not isinstance(candidates, list) or not candidates:
+        raise Refusal("K002", "the pass has no candidates")
+    if len(candidates) > MAX_CANDIDATES:
+        raise Refusal("K009", f"{len(candidates)} candidates, over the {MAX_CANDIDATES} cap")
+
+    scored = [score(c, root, f"candidate {n}") for n, c in enumerate(candidates, start=1)]
+    names = [c["skill"] for c in scored]
+    if len(set(names)) != len(names):
+        raise Refusal("K002", "two candidates name the same skill")
+    if document["selected"] not in names:
+        raise Refusal("K006", f"selected {document['selected']!r} is not among the candidates")
+    expected = tie_break(scored)
+    if document["selected"] != expected:
+        raise Refusal("K006", f"selected {document['selected']!r}, but the tie-break picks {expected!r}")
+
+    previous = existing_passes(scoreboard)
+    entry = {
+        "pass": len(previous) + 1,
+        "scope": document["scope"],
+        "mode": document["mode"],
+        "selected": document["selected"],
+        "run": document.get("run"),
+        "candidates": scored,
+    }
+    scoreboard.parent.mkdir(parents=True, exist_ok=True)
+    gitignore = scoreboard.parent / ".gitignore"
+    if not gitignore.exists():
+        gitignore.write_text("*\n", encoding="utf-8")
+    with scoreboard.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, sort_keys=True) + "\n")
+    print(f"pass {entry['pass']} recorded: {len(scored)} candidate(s), selected {entry['selected']}")
+    return 0
+
+
+def drift(passes: list) -> dict:
+    """Axis scores that moved for a skill whose held job did not, by pass."""
+    seen = {}
+    moved = {}
+    for entry in passes:
+        for candidate in entry["candidates"]:
+            key = (candidate["skill"], candidate["held_job"])
+            before = seen.get(key)
+            if before is not None:
+                changed = [name for name, _ in AXES if candidate[name] != before[name]]
+                if changed:
+                    moved[(entry["pass"], candidate["skill"])] = [
+                        (name, before[name], candidate[name]) for name in changed
+                    ]
+            seen[key] = candidate
+    return moved
+
+
+def show(args: argparse.Namespace) -> int:
+    scoreboard = Path(args.scoreboard).resolve()
+    if not scoreboard.exists():
+        print(f"no scoreboard at {scoreboard}")
+        return 0
+    passes = existing_passes(scoreboard)
+    moved = drift(passes)
+    for entry in passes:
+        run = entry.get("run") or "no run recorded"
+        print(f"pass {entry['pass']}  {entry['mode']}  {entry['scope']}  ({run})")
+        for candidate in sorted(entry["candidates"], key=lambda c: -c["total"]):
+            mark = "*" if candidate["skill"] == entry["selected"] else " "
+            axes = " ".join(f"{name}={candidate[name]}" for name, _ in AXES)
+            print(f"  {mark} {candidate['total']:3d}  {candidate['skill']:<24} {axes}")
+            print(f"      {candidate['basis']}")
+            for name, before, after in moved.get((entry["pass"], candidate["skill"]), []):
+                print(f"      drift: {name} {before} -> {after}, held job unchanged")
+    print(f"{len(passes)} pass(es), {len(moved)} with drift")
+    return 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    writer = sub.add_parser("record", help="append one validated pass read from stdin")
+    writer.add_argument("--scoreboard", required=True, help="path to the scoreboard file")
+    writer.add_argument("--root", help="checkout root each ledger must sit under")
+    writer.set_defaults(handler=record)
+
+    reader = sub.add_parser("show", help="print the recorded passes and any drift")
+    reader.add_argument("--scoreboard", required=True, help="path to the scoreboard file")
+    reader.set_defaults(handler=show)
+
+    args = parser.parse_args(argv)
+    try:
+        return args.handler(args)
+    except Refusal as refusal:
+        print(refusal, file=sys.stderr)
+        return 1
+    except OSError as exc:
+        print(f"K000: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/hexaemeron/skills/kronos/scripts/kronos.py
+++ b/plugins/hexaemeron/skills/kronos/scripts/kronos.py
@@ -20,6 +20,7 @@ changed. This appends each pass to a file so that movement is visible.
   K007  a candidate ledger that cannot be used
   K008  an existing scoreboard line that cannot be read
   K009  more candidates than the check will track
+  K010  a scoreboard directory that is not a real directory
 
 Exit 0 clean, 1 a refusal, 2 bad invocation. A refusal appends nothing: a pass
 is recorded whole or not at all.
@@ -191,7 +192,17 @@ def existing_passes(scoreboard: Path) -> list:
 
 
 def record(args: argparse.Namespace) -> int:
-    scoreboard = Path(args.scoreboard).resolve()
+    # Before resolving anything. A symlink at either the scoreboard or the
+    # directory holding it would put the file and its `*` gitignore somewhere
+    # the caller did not name, and resolve() erases the link on the way past.
+    given = Path(args.scoreboard)
+    holder = given.parent
+    if given.is_symlink():
+        raise Refusal("K010", f"{given} is a symlink")
+    if holder.is_symlink() or (holder.exists() and not holder.is_dir()):
+        raise Refusal("K010", f"{holder} is not a real directory")
+
+    scoreboard = given.resolve()
     root = Path(args.root).resolve() if args.root else scoreboard.parent.parent
     raw = sys.stdin.buffer.read(MAX_STDIN_BYTES + 1)
     if len(raw) > MAX_STDIN_BYTES:
@@ -220,13 +231,17 @@ def record(args: argparse.Namespace) -> int:
     if document["selected"] != expected:
         raise Refusal("K006", f"selected {document['selected']!r}, but the tie-break picks {expected!r}")
 
+    run = document.get("run")
+    if run is not None and not isinstance(run, str):
+        raise Refusal("K002", f"run is {run!r}, which is neither a string nor absent")
+
     previous = existing_passes(scoreboard)
     entry = {
         "pass": len(previous) + 1,
         "scope": document["scope"],
         "mode": document["mode"],
         "selected": document["selected"],
-        "run": document.get("run"),
+        "run": run,
         "candidates": scored,
     }
     scoreboard.parent.mkdir(parents=True, exist_ok=True)

--- a/plugins/hexaemeron/tests/test_kronos_scoreboard.py
+++ b/plugins/hexaemeron/tests/test_kronos_scoreboard.py
@@ -208,6 +208,46 @@ class ScoreboardTest(unittest.TestCase):
         self.assertIn("K008", err)
         self.assertEqual(len(self.lines()), 2, "the partial line stays, nothing is appended")
 
+    def test_a_symlinked_scoreboard_directory_is_refused(self):
+        """Round 1 wrote through a symlinked .kronos into an unnamed directory.
+
+        Both the scoreboard and its `*` gitignore landed there. Where the link
+        pointed somewhere git watches, that is the dirty tree the whole design
+        exists to avoid.
+        """
+        elsewhere = self.root / "elsewhere"
+        elsewhere.mkdir()
+        self.scoreboard.parent.symlink_to(elsewhere)
+        code, _, err = self.run_record(self.document())
+        self.assertEqual(code, 1)
+        self.assertIn("K010", err)
+        self.assertEqual(list(elsewhere.iterdir()), [], "nothing may be written through the link")
+
+    def test_a_symlinked_scoreboard_file_is_refused(self):
+        """resolve() follows the link, so the first fix never saw it."""
+        elsewhere = self.root / "elsewhere.jsonl"
+        self.scoreboard.parent.mkdir(parents=True)
+        self.scoreboard.symlink_to(elsewhere)
+        code, _, err = self.run_record(self.document())
+        self.assertEqual(code, 1)
+        self.assertIn("K010", err)
+        self.assertFalse(elsewhere.exists(), "nothing may be written through the link")
+
+    def test_a_scoreboard_directory_that_is_a_file_is_refused(self):
+        self.scoreboard.parent.write_text("not a directory", encoding="utf-8")
+        code, _, err = self.run_record(self.document())
+        self.assertEqual(code, 1)
+        self.assertIn("K010", err)
+
+    def test_a_run_field_that_is_not_a_string_is_refused(self):
+        self.assertRefused(self.document(run={"url": "https://example.invalid"}), "K002")
+
+    def test_a_run_field_that_is_a_string_survives_into_the_record(self):
+        url = "https://github.com/wildcat-finance/skills/pull/1"
+        code, _, err = self.run_record(self.document(run=url))
+        self.assertEqual(code, 0, err)
+        self.assertEqual(json.loads(self.lines()[0])["run"], url)
+
     # -- reading it back ------------------------------------------------
 
     def test_show_marks_an_axis_that_moved_under_an_unchanged_held_job(self):

--- a/plugins/hexaemeron/tests/test_kronos_scoreboard.py
+++ b/plugins/hexaemeron/tests/test_kronos_scoreboard.py
@@ -1,0 +1,254 @@
+"""The Kronos scoreboard records a ranking pass so the next one can be compared.
+
+Kronos reranks from scratch every pass, so an axis score that moves for a job
+nobody touched is invisible. These cases hold the writer to the two things that
+make the record worth keeping: it refuses a pass it cannot vouch for, and the
+held-job hash it writes is the one the ledger itself records.
+"""
+
+import hashlib
+import importlib.util
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout, redirect_stderr
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "skills" / "kronos" / "scripts" / "kronos.py"
+REPO = ROOT.parents[1]
+
+spec = importlib.util.spec_from_file_location("kronos_scoreboard", SCRIPT)
+kronos = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(kronos)
+
+
+LEDGER = """# Example evolution ledger
+
+- Current version: `example-v0.2.0`
+- Frontier status: `open`
+- Frontier revision: `some-revision`
+- Current frontier: A frontier sentence.
+- Next Fiat job: Do the thing that is held.
+"""
+
+
+def canonical_digest(status, revision, frontier, job):
+    line = "|".join((status, revision, frontier, job)) + "\n"
+    return hashlib.sha256(line.encode("utf-8")).hexdigest()
+
+
+class ScoreboardTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.scoreboard = self.root / ".kronos" / "scoreboard.jsonl"
+        (self.root / "alpha").mkdir()
+        (self.root / "alpha" / "EVOLUTION.md").write_text(LEDGER, encoding="utf-8")
+        (self.root / "beta").mkdir()
+        (self.root / "beta" / "EVOLUTION.md").write_text(
+            LEDGER.replace("some-revision", "other-revision"), encoding="utf-8"
+        )
+        self.addCleanup(self.tmp.cleanup)
+
+    def candidate(self, skill="alpha", **overrides):
+        base = {
+            "skill": skill,
+            "ledger": f"{skill}/EVOLUTION.md",
+            "impact": 30,
+            "urgency": 20,
+            "readiness": 15,
+            "unblocks": 10,
+            "basis": f"{skill} has a held job with evidence behind it.",
+        }
+        base.update(overrides)
+        return base
+
+    def document(self, candidates=None, **overrides):
+        base = {
+            "scope": "the checkout",
+            "mode": "full",
+            "candidates": candidates or [self.candidate()],
+            "selected": "alpha",
+        }
+        base.update(overrides)
+        return base
+
+    def run_record(self, document, root=None):
+        argv = ["record", "--scoreboard", str(self.scoreboard), "--root", str(root or self.root)]
+        payload = document if isinstance(document, str) else json.dumps(document)
+        out, err = io.StringIO(), io.StringIO()
+
+        class Stdin:
+            buffer = io.BytesIO(payload.encode("utf-8"))
+
+        real_stdin, kronos.sys.stdin = kronos.sys.stdin, Stdin()
+        try:
+            with redirect_stdout(out), redirect_stderr(err):
+                code = kronos.main(argv)
+        finally:
+            kronos.sys.stdin = real_stdin
+        return code, out.getvalue(), err.getvalue()
+
+    def run_show(self):
+        out = io.StringIO()
+        with redirect_stdout(out):
+            code = kronos.main(["show", "--scoreboard", str(self.scoreboard)])
+        return code, out.getvalue()
+
+    def lines(self):
+        return self.scoreboard.read_text(encoding="utf-8").splitlines()
+
+    # -- the clean path -------------------------------------------------
+
+    def test_a_valid_pass_appends_exactly_one_line(self):
+        code, out, _ = self.run_record(self.document())
+        self.assertEqual(code, 0)
+        self.assertIn("pass 1 recorded", out)
+        self.assertEqual(len(self.lines()), 1)
+
+    def test_the_written_hash_is_the_digest_the_ledger_itself_records(self):
+        self.run_record(self.document())
+        entry = json.loads(self.lines()[0])
+        self.assertEqual(
+            entry["candidates"][0]["held_job"],
+            canonical_digest(
+                "open", "some-revision", "A frontier sentence.", "Do the thing that is held."
+            ),
+        )
+
+    def test_the_scoreboard_directory_is_created_gitignored(self):
+        self.run_record(self.document())
+        self.assertEqual((self.scoreboard.parent / ".gitignore").read_text(encoding="utf-8"), "*\n")
+
+    def test_pass_numbers_increase(self):
+        self.run_record(self.document())
+        code, out, _ = self.run_record(self.document())
+        self.assertEqual(code, 0)
+        self.assertIn("pass 2 recorded", out)
+        self.assertEqual([json.loads(line)["pass"] for line in self.lines()], [1, 2])
+
+    def test_the_axis_caps_sum_to_one_hundred(self):
+        self.assertEqual(sum(cap for _, cap in kronos.AXES), 100)
+
+    # -- refusals -------------------------------------------------------
+
+    def assertRefused(self, document, code_name, root=None):
+        code, _, err = self.run_record(document, root=root)
+        self.assertEqual(code, 1)
+        self.assertIn(code_name, err)
+        self.assertFalse(self.scoreboard.exists(), "a refusal must append nothing")
+
+    def test_stdin_that_is_not_json_is_refused(self):
+        self.assertRefused("not json at all", "K001")
+
+    def test_an_axis_over_its_cap_is_refused(self):
+        self.assertRefused(self.document([self.candidate(unblocks=16)]), "K004")
+
+    def test_a_negative_axis_is_refused(self):
+        self.assertRefused(self.document([self.candidate(impact=-1)]), "K004")
+
+    def test_a_stated_total_that_disagrees_with_the_axes_is_refused(self):
+        self.assertRefused(self.document([self.candidate(total=105)]), "K005")
+
+    def test_a_stated_total_that_agrees_is_accepted(self):
+        code, _, err = self.run_record(self.document([self.candidate(total=75)]))
+        self.assertEqual(code, 0, err)
+
+    def test_an_unknown_field_is_refused_rather_than_stored(self):
+        self.assertRefused(self.document([self.candidate(note="extra")]), "K003")
+
+    def test_a_missing_field_is_refused(self):
+        candidate = self.candidate()
+        del candidate["basis"]
+        self.assertRefused(self.document([candidate]), "K002")
+
+    def test_a_selection_the_tie_break_does_not_pick_is_refused(self):
+        candidates = [self.candidate("alpha"), self.candidate("beta", impact=40)]
+        self.assertRefused(self.document(candidates, selected="alpha"), "K006")
+
+    def test_the_tie_break_prefers_impact_then_readiness(self):
+        candidates = [
+            self.candidate("alpha", impact=20, urgency=25, readiness=15, unblocks=10),
+            self.candidate("beta", impact=25, urgency=20, readiness=15, unblocks=10),
+        ]
+        code, _, err = self.run_record(self.document(candidates, selected="beta"))
+        self.assertEqual(code, 0, err)
+
+    def test_a_ledger_outside_the_root_is_refused(self):
+        outside = Path(self.tmp.name).parent / "elsewhere.md"
+        self.assertRefused(
+            self.document([self.candidate(ledger=str(outside))]), "K007"
+        )
+
+    def test_a_ledger_that_is_a_directory_is_refused(self):
+        self.assertRefused(self.document([self.candidate(ledger="alpha")]), "K007")
+
+    def test_a_ledger_missing_a_frontier_field_is_refused(self):
+        (self.root / "alpha" / "EVOLUTION.md").write_text("# nothing here\n", encoding="utf-8")
+        self.assertRefused(self.document(), "K007")
+
+    def test_more_candidates_than_the_cap_is_refused(self):
+        many = [self.candidate(f"skill-{n}") for n in range(kronos.MAX_CANDIDATES + 1)]
+        self.assertRefused(self.document(many, selected="skill-0"), "K009")
+
+    def test_two_candidates_naming_one_skill_is_refused(self):
+        self.assertRefused(self.document([self.candidate(), self.candidate()]), "K002")
+
+    def test_an_unknown_mode_is_refused(self):
+        self.assertRefused(self.document(mode="whatever"), "K002")
+
+    def test_a_truncated_final_line_is_refused_rather_than_written_past(self):
+        self.run_record(self.document())
+        with self.scoreboard.open("a", encoding="utf-8") as handle:
+            handle.write('{"pass": 2, "candi')
+        code, _, err = self.run_record(self.document())
+        self.assertEqual(code, 1)
+        self.assertIn("K008", err)
+        self.assertEqual(len(self.lines()), 2, "the partial line stays, nothing is appended")
+
+    # -- reading it back ------------------------------------------------
+
+    def test_show_marks_an_axis_that_moved_under_an_unchanged_held_job(self):
+        self.run_record(self.document())
+        self.run_record(self.document([self.candidate(impact=35)]))
+        code, out = self.run_show()
+        self.assertEqual(code, 0)
+        self.assertIn("drift: impact 30 -> 35, held job unchanged", out)
+        self.assertIn("2 pass(es), 1 with drift", out)
+
+    def test_show_reports_no_drift_when_the_held_job_changed_too(self):
+        self.run_record(self.document())
+        (self.root / "alpha" / "EVOLUTION.md").write_text(
+            LEDGER.replace("Do the thing that is held.", "Do a different held thing."),
+            encoding="utf-8",
+        )
+        self.run_record(self.document([self.candidate(impact=35)]))
+        _, out = self.run_show()
+        self.assertNotIn("drift:", out)
+        self.assertIn("2 pass(es), 0 with drift", out)
+
+    def test_show_on_an_absent_scoreboard_says_so_and_exits_clean(self):
+        code, out = self.run_show()
+        self.assertEqual(code, 0)
+        self.assertIn("no scoreboard at", out)
+
+    def test_show_marks_the_selected_candidate(self):
+        self.run_record(self.document([self.candidate("alpha"), self.candidate("beta", impact=40)],
+                                      selected="beta"))
+        _, out = self.run_show()
+        selected = [line for line in out.splitlines() if line.lstrip().startswith("*")]
+        self.assertEqual(len(selected), 1)
+        self.assertIn("beta", selected[0])
+
+    # -- against the real ledgers ---------------------------------------
+
+    def test_the_hash_matches_a_real_governed_ledger_history_row(self):
+        ledger = REPO / "plugins" / "hexaemeron" / "skills" / "kronos" / "EVOLUTION.md"
+        computed = kronos.held_job_hash(ledger)
+        self.assertIn(f"`{computed}`", ledger.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`record` reads a ranking pass on stdin, validates it, and appends exactly one
JSON line. `show` prints the passes and marks every axis score that moved for a
candidate whose held job did not, which is the movement Kronos had no way to
see before.

The held-job hash is computed here, not taken from the caller. It is the
SHA-256 of the canonical frontier line `VERSIONING.md` already defines, which
is the same digest every ledger stores in its own history row, so a scoreboard
line can be checked against the ledger it describes.

## What it refuses

A pass is recorded whole or not at all, and a refusal appends nothing. Codes
K000 to K010 cover a bad path, stdin that is not JSON, a missing or unknown
field, an axis outside its range, a stated total that disagrees with its axes,
a selection the tie-break does not pick, a ledger that cannot be used, a
scoreboard line that cannot be read, too many candidates, and a scoreboard
directory that is not a real directory.

The pass document is read under a byte cap, the candidate count is capped, and
each caller-supplied ledger path is resolved and required to sit under the
scoreboard's root as a regular file. An existing scoreboard is parsed line by
line before anything is appended, so a run interrupted mid-append is refused
rather than written past.

## Audit

Two rounds, in `audit/AUDIT.md`. Both round 1 findings came from walking the
study's boundary list against the code rather than from a lint.

A symlinked `.kronos` was written through, putting the scoreboard and its `*`
gitignore in a directory the caller never named. That was reproduced before it
was believed. The first fix was wrong and the guard test caught it: checking
the parent after `resolve()` never sees a symlink, because resolve follows it.
The check now runs against the path as the caller gave it and covers a
symlinked scoreboard file too. Four guard cases were seen failing on the
unfixed tree.

Round 2 came back clean, and checked the one property round 1 had assumed: a
basis holding a newline stays a single JSON line.

## Proof

```bash
python3 plugins/hexaemeron/tests/run_tests.py
python3 -m unittest discover -s tests -p "test_*.py"
```

Plugin suite 381 to 412, 31 new cases. Root 34/34.

Demo, against this checkout's real ledgers:

```bash
K=plugins/hexaemeron/skills/kronos/scripts/kronos.py
echo '{"scope":"the checkout","mode":"phase-only","selected":"protasis","candidates":[{"skill":"protasis","ledger":"plugins/hexaemeron/skills/protasis/EVOLUTION.md","impact":30,"urgency":15,"readiness":18,"unblocks":12,"basis":"Held job is specified."}]}' | python3 $K record --scoreboard /tmp/kronos-demo/.kronos/scoreboard.jsonl --root "$PWD"
python3 $K show --scoreboard /tmp/kronos-demo/.kronos/scoreboard.jsonl
```

Wiring this into `SKILL.md` and the ledger is step 3.