### PR TITLE
The spec for a Kronos parked lane

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4165,3 +4165,24 @@ the section says steps 3 to 7 are unchanged and then narrows step 8's scope
 rather than replacing its instructions, so the read-back is inherited. Worth a
 sentence if a later reader trips on it, but writing one now would restate step 8
 in a second place, which is how the two drift.
+
+# Run: park a blocked Kronos job instead of stalling the loop
+
+## Step 1, round 1 -- 2026-08-20
+
+Two Markdown documents, no code. phylax exit 0, ephoros exit 0, hypomnema
+exit 0.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | none | -- |
+
+The risk register describes a lane step 2 has not built, so the look went at the
+documents' claims instead. The study leans on K006 refusing a selection the
+tie-break did not pick, and that refusal is at `kronos.py:232` reading as
+described, which matters because option A is rejected on it. The quoted stop
+text appears in `SKILL.md` byte for byte. The halt-record shape cited from
+`hexctl.py` is the one at `cmd_halt`. The frontier digest matches the ledger.
+The diff carries no credential and no account data.
+
+Leads not pursued: none.

--- a/docs/kronos-parked-lane/runbook.md
+++ b/docs/kronos-parked-lane/runbook.md
@@ -1,0 +1,110 @@
+# Runbook: park a blocked Kronos job instead of stalling the loop
+
+Derived from [study.md](study.md). Three steps, dependency ordered. Step 1
+scaffolds and commits the spec, step 2 builds the lane, step 3 wires it into the
+skill and runs the demo path.
+
+The run branch is `fiat/park-a-blocked-kronos-job-instead-of-stalling-th`, cut
+from `main` at `36f1e2e`. Both suites are green at that ref: 34/34 at the root
+and 414/414 under the plugin.
+
+## Step 1: Commit the spec
+
+**Goal.** Put the study and this runbook in the repository, where the next two
+steps and any later reader can reach them.
+
+**Entry.** The run branch at `36f1e2e`, tree clean, both suites green.
+
+**Exit.** `docs/kronos-parked-lane/study.md` and
+`docs/kronos-parked-lane/runbook.md` exist, with every relative link rewritten
+for their new depth. Proved by
+`python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py docs plugins`
+exiting 0, and by both suites still passing:
+`python3 -m unittest discover -s tests -p "test_*.py"` and
+`python3 plugins/hexaemeron/tests/run_tests.py`.
+
+**Files.** `docs/kronos-parked-lane/study.md`,
+`docs/kronos-parked-lane/runbook.md`.
+
+**Tests.** None added. The two existing suites and the hypomnema link check are
+the gate.
+
+**Disciplines.** phylax: none, this step adds no boundary and runs no code.
+ephoros: none, documents emit nothing. metron: none, no performance claim.
+elenchus: none, no failure in hand. hypomnema: this step is the record, and the
+link check is what proves the pointers resolve from the new depth.
+
+## Step 2: Build the parked lane
+
+**Goal.** Three subcommands that record a park, release it, and report the
+standing set, plus the change to `record` that lets a pass skip a parked
+candidate without dropping it from the ranking.
+
+**Entry.** Step 1's exit state: the spec committed, both suites green.
+
+**Exit.** `plugins/hexaemeron/skills/kronos/scripts/kronos.py` supports
+`park --scoreboard-dir <dir> --skill <name> --ledger <path> --reason <text>`,
+`unpark --scoreboard-dir <dir> --skill <name> --reason <text>` and
+`parked --scoreboard-dir <dir>`; `parked` exits 2 while any park stands and 0
+when none does, keeping 1 for a refusal; and `record` accepts `parked` on a
+candidate, applies the tie-break to unparked candidates only, and refuses a pass
+whose flags disagree with the standing parks. Proved by
+`python3 plugins/hexaemeron/tests/run_tests.py` passing with the new cases
+included, and by `python3 -m unittest discover -s tests -p "test_*.py"`.
+
+**Files.** `plugins/hexaemeron/skills/kronos/scripts/kronos.py`,
+`plugins/hexaemeron/tests/test_kronos_scoreboard.py`.
+
+**Tests.** New cases in `test_kronos_scoreboard.py`: a park appended with the
+reason byte for byte; a reason carrying a newline that leaves the file one line
+per record; an empty reason refused; an oversized reason refused; a park whose
+ledger cannot be read refused; an unpark with no standing park refused; a second
+park for an already parked skill refused; park, unpark, park again replaying to
+one standing park; `parked` exiting 2 with a park standing and 0 without; a
+stale park reported as stale when the ledger's identity hash has moved; a
+deleted ledger reported as unknown rather than resolved; a pass selecting the
+highest unparked candidate accepted; a pass selecting a parked candidate
+refused; a pass whose candidates are all parked refused; a pass claiming a park
+that was never recorded refused; a truncated tail in the parked file refused.
+Expect the plugin suite above 414 by roughly sixteen cases.
+
+**Disciplines.** phylax: this step takes a caller-supplied reason string stored
+verbatim and opens a second append target in the same directory, so both need
+their controls. ephoros: `parked` is what a loop and a later reader consult, so
+its exit codes and output are part of the step. metron: none, no performance
+claim. elenchus: none, no failure in hand; the guard convention applies to any
+this step surfaces. hypomnema: the interface documentation sits with the script,
+and the three expensive decisions are recorded in step 3.
+
+## Step 3: Wire the parked lane into Kronos and demonstrate
+
+**Goal.** Make the lane part of the loop: the stop text gains the third option
+it lacked, selection skips parked candidates, completion is blocked while a park
+stands, the version moves to `0.4.0`, and the ledger carries one generation row.
+
+**Entry.** Step 2's exit state: the lane shipped and both suites green.
+
+**Exit.** `SKILL.md` states the parked lane in the loop and the stop text and
+carries `version: "0.4.0"`; `EVOLUTION.md` carries one new generation row
+retaining frontier revision `terminal-goal-loop` and digest
+`ac28d95d80724aa001a92740f76416164e65d7b7b9cb5da43674d1ea73a214d1` byte for
+byte, with status still `mature` and next job still `None -- mature`. Proved by
+`python3 -m unittest discover -s tests -p "test_*.py"` passing, which is where
+`test_evolution_contract.py` and `test_version_propagation.py` live, by
+`python3 plugins/hexaemeron/tests/run_tests.py`, and by the demo path: park a
+skill against this checkout's real ledger, record a pass that selects the
+next-ranked candidate, see `parked` exit 2, unpark, and see it exit 0.
+
+**Files.** `plugins/hexaemeron/skills/kronos/SKILL.md`,
+`plugins/hexaemeron/skills/kronos/EVOLUTION.md`.
+
+**Tests.** No new test file. The root suite's evolution-contract and
+version-propagation cases prove the ledger row and the version bump agree, and
+the field-drift guard added in `kronos-v0.3.0` proves the skill text names every
+field the script accepts.
+
+**Disciplines.** phylax: none, this step adds no boundary; it edits two
+documents. ephoros: none beyond what step 2 emits. metron: none, no performance
+claim. elenchus: none, no failure in hand. hypomnema: the three decisions the
+study named as expensive to reverse are recorded here in the ledger row, which
+is where a decision about a governed skill lives.

--- a/docs/kronos-parked-lane/study.md
+++ b/docs/kronos-parked-lane/study.md
@@ -1,0 +1,274 @@
+# Study: park a blocked Kronos job instead of stalling the loop
+
+Assuming, unless corrected:
+
+1. Python 3.11 or later and stdlib `unittest`, matching every other checker in
+   this plugin.
+2. A parked job is Kronos's own working state, kept beside the scoreboard that
+   shipped in `kronos-v0.3.0`, and not published.
+3. Kronos keeps its hard rule that Fiat owns all repository work. Nothing here
+   runs git.
+4. This is generation-axis work. Kronos stays mature, the held frontier target
+   and its digest are retained byte for byte, and the run passes no
+   `--frontier` flag.
+5. The run starts from `36f1e2e` on `main`, with both suites green at 34/34
+   and 414/414.
+
+## 1. Problem statement
+
+Kronos today offers two responses to a Fiat run that halts on a blocker it
+cannot clear:
+
+> If Fiat halts on a genuine external blocker, preserve the durable goal and
+> report that blocker; do not skip to a lower-scoring job to make the loop look
+> busy.
+
+Preserve and report, or skip and be dishonest. There is no third. So a top-
+ranked job blocked on an approval nobody will grant this week stops the whole
+frontier, and every other eligible skill waits behind it. The refusal to skip is
+right; what is missing is a way to set the blocked job down without dropping it.
+
+The interaction that makes this more than a prose change: `scripts/kronos.py`
+refuses with K006 when the recorded `selected` is not what the tie-break picks.
+A loop that continues past a blocked top candidate selects the second, so the
+writer refuses the pass. Parking has to be visible to the writer or the loop
+cannot record a pass at all once anything is parked.
+
+What is built: a parked lane. A park records the halt reason verbatim against
+the blocked skill's held job, selection skips parked candidates without dropping
+them from the ranking, and the loop cannot declare itself complete while a park
+stands.
+
+A working prototype means all of this holds:
+
+- `kronos.py park` appends a park carrying the skill, its held-job identity
+  hash computed from the ledger, and the halt reason byte for byte as given.
+- `kronos.py unpark` appends a release carrying its own reason.
+- `kronos.py parked` prints the standing parks and exits non-zero while any
+  stands, so a loop cannot call itself complete over one.
+- A pass whose candidates carry `parked: true` is accepted with the highest
+  unparked candidate selected, and still refused when the selection is not the
+  highest unparked one.
+- `python3 plugins/hexaemeron/tests/run_tests.py` passes with the new cases.
+- The demo path: park a skill, record a pass that selects the next-ranked
+  candidate, see `parked` exit non-zero, unpark, and see it exit 0.
+
+## 2. Prior art
+
+**In this skill.** `SKILL.md` step 4 selects the highest score and breaks ties
+by impact, then readiness, then discovery order. Step 6 records the pass. The
+stop text above is the whole of the current blocker handling. The hard rules
+forbid altering a held Next Fiat job before its frontier job completes, which
+is what keeps a park from quietly rewriting the thing it is parking.
+
+**In the scoreboard that shipped last.** `scripts/kronos.py` holds `record` and
+`show`, the axis caps, the `tie_break` function implementing step 4, the
+`held_job_hash` computed from a ledger's canonical frontier line, and
+`existing_passes`, which validates a JSON Lines file line by line before
+appending. K006 is the check a parked lane must teach about parking.
+
+**The identity hash decides resolution.** `VERSIONING.md` gives each ledger a
+canonical frontier line whose digest changes when the held job changes. A park
+recorded against that digest can therefore be told apart from a park whose job
+has since moved on, without asking anyone.
+
+**In Fiat.** `hexctl halt --reason` writes `{"reason": ..., "ts": ...}` into run
+state and every progress command refuses until `resume`. That is the shape a
+halt reason arrives in, and the reason string is what a park has to carry
+unaltered.
+
+**Outside.** JSON Lines again, as `.hexaemeron/ledger.jsonl` and
+`.kronos/scoreboard.jsonl` already use.
+
+## 3. Constraints and non-goals
+
+**Constraints.**
+
+- Starting ref `36f1e2e` on `main`.
+- Python 3.11 or later, stdlib only. No new dependency.
+- Nothing here runs git, and nothing written may be visible to
+  `git status --short`, or Fiat's next run cannot start against a dirty tree.
+- The halt reason is recorded verbatim. Summarising it loses the thing a
+  maintainer needs to judge whether the blocker still stands.
+- `tests/test_version_propagation.py` requires the frontmatter version and the
+  ledger's current version to agree, so the bump and the row land together.
+- Frontier revision `terminal-goal-loop` and digest
+  `ac28d95d80724aa001a92740f76416164e65d7b7b9cb5da43674d1ea73a214d1` are
+  retained byte for byte. Kronos stays mature.
+
+**Non-goals.**
+
+- No judgement about whether a blocker is genuine. A park is a claim the loop
+  records, not one it evaluates.
+- No automatic unparking. A held job that moved is reported as stale, and a
+  person decides.
+- No expiry, no reminders, no scheduling.
+- No change to the four axes, their caps, or the tie-break among unparked
+  candidates.
+- No parking of a skill that was never ranked.
+
+## 4. Design options
+
+**A. Prose contract only.** State the parked lane in `SKILL.md` with no
+machinery. Cheapest to write, and it cannot work: K006 in the shipped writer
+refuses a pass whose selection is not the tie-break's pick, so a loop obeying
+the new prose could not record its passes. A rule the existing code contradicts
+is worse than no rule.
+
+**B. A separate `.kronos/parked.jsonl`, and a `parked` flag on candidates.**
+`park`, `unpark` and `parked` subcommands in the same `kronos.py`, appending to
+their own file; `record` accepts `parked` on a candidate and applies the
+tie-break to unparked candidates only. Trades away a single place to look: the
+loop's state is then two files rather than one.
+
+**C. Park records inside `scoreboard.jsonl`.** One file, one reader. Trades away
+what the scoreboard is: an append-only history of passes, where each line is
+what was true at that moment. Parking is current state that changes, so the
+standing set would have to be replayed out of a file whose other lines are
+history, and a reader could no longer take one line at face value.
+
+**D. A separate script.** `parked.py` beside `kronos.py`. Trades away the shared
+code both need, `held_job_hash` and `existing_passes` and the refusal
+vocabulary, for a boundary between two things that always run together.
+
+**Chosen: B.** The two files hold different kinds of thing, which is C's real
+cost, and they share one script and one refusal vocabulary, which is D's. The
+extra file is the honest price of keeping the scoreboard's lines readable on
+their own. A is not on the table once K006 is read.
+
+## 5. Risk register seed
+
+Python reading files named on a command line and a reason string from a caller.
+The audit loop should look hardest at:
+
+- **The reason string.** It arrives from a caller, is stored verbatim by
+  requirement, and is printed later. Embedded newlines would break the JSON
+  Lines file for every later read if the writer were careless, and an
+  unbounded reason is a caller-controlled write.
+- **Replay correctness.** The standing parked set is derived by replaying park
+  and unpark records in order. An unpark for a skill never parked, two parks
+  for one skill, and a park after an unpark all have to resolve to something
+  defined rather than to whatever the loop happens to produce.
+- **The stale test.** A park is compared against the ledger's current identity
+  hash. A ledger that has since been deleted, or that no longer parses, must
+  not read as resolved.
+- **Selection under parking.** The tie-break now runs over a subset. Every
+  candidate parked has to be refused rather than silently selecting nobody.
+- **Partial writes and paths.** The same append and path concerns the scoreboard
+  already carries, since this is a second file in the same directory.
+
+## 6. Glossary seeds
+
+- **Park.** A record that a ranked candidate's held job is blocked, carrying the
+  reason verbatim and the held-job identity hash at the time.
+- **Standing park.** A park with no later unpark for the same skill.
+- **Stale park.** A standing park whose skill's ledger now shows a different
+  held-job identity hash, so the job it named has moved on.
+- **Unparked candidate.** A candidate with no standing park, and the only kind
+  selection may pick.
+
+## 7. Sources
+
+- `plugins/hexaemeron/skills/kronos/SKILL.md`, steps 4 and 6, the stop text and
+  the hard rules.
+- `plugins/hexaemeron/skills/kronos/scripts/kronos.py`, `tie_break`,
+  `held_job_hash`, `existing_passes` and refusal K006.
+- `plugins/hexaemeron/skills/kronos/EVOLUTION.md`, `kronos-v0.3.0`, `mature`.
+- `plugins/hexaemeron/skills/VERSIONING.md`, the canonical frontier line and the
+  generation-axis rule.
+- `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`, `cmd_halt`, for the shape
+  a halt reason arrives in.
+- The wishlist entry `kronos-2`, artifact `wishlist-grab-bag.md`.
+
+## 8. Signals, and the questions behind them
+
+The parked lane is a record someone reads after a long unattended loop. Two
+questions:
+
+- *Why did the loop pass over its top-ranked job?* Answered by the standing park
+  for that skill, carrying the halt reason verbatim. Emitted when the park is
+  made, and printed by `parked`.
+- *Is anything still waiting on a person?* Answered by `parked` exiting non-zero
+  while a park stands, so the loop's own completion check carries it rather than
+  a human remembering.
+
+`parked` prints to stdout and refusals go to stderr with a code, as `record`
+already does. [ephoros](../../plugins/hexaemeron/skills/ephoros/SKILL.md) owns what
+a signal must carry.
+
+## 9. Boundaries, per capability
+
+- **The reason string from the caller.** Worth taking: an unbounded string, or
+  one carrying newlines or control characters. Control: cap its length, refuse
+  an empty one, and store it through `json.dumps`, which escapes a newline
+  rather than splitting the record.
+- **Appending to a second file in `.kronos/`.** Worth taking: a truncated tail
+  from an interrupted run, and a symlink at the path. Control: the same ones
+  `record` already applies, validating every existing line before appending and
+  refusing a symlinked path before resolving it.
+- **Reading a candidate's ledger to test staleness.** Worth taking: a ledger
+  that has been deleted or no longer parses. Control: report it as unknown
+  rather than resolved, and never let an unreadable ledger clear a park.
+- **The parked flag on a pass candidate.** Worth taking: a pass claiming
+  everything is parked, or claiming a park that was never recorded. Control:
+  refuse a pass with no unparked candidate, and check the claimed flags against
+  the standing parks rather than trusting the caller.
+
+[phylax](../../plugins/hexaemeron/skills/phylax/SKILL.md) owns the boundary list
+and the controls.
+
+## 10. The budget, or its absence
+
+None. A park happens at most once per halted Fiat run, and a Fiat run takes
+hours. No performance claim is made and nothing here is changed for speed, so
+[metron](../../plugins/hexaemeron/skills/metron/SKILL.md) has nothing to measure.
+
+## 11. The fail-closed posture
+
+Every refusal exits non-zero and appends nothing. What stops the run: an empty
+or oversized reason, a park for a skill with no readable ledger, an unpark with
+no standing park to release, a pass whose candidates are all parked, a pass
+whose parked flags disagree with the standing parks, and any of the path and
+tail failures the scoreboard already refuses.
+
+`parked` is the exception that must exit non-zero on success of a sort: a
+standing park is not an error in the tool, it is the loop's reason not to finish.
+That distinction goes in the skill text so nobody reads the exit code as a bug.
+
+Guard-test convention: a fix for a failure found here adds a case to
+`plugins/hexaemeron/tests/test_kronos_scoreboard.py` that fails on the unfixed
+tree, following
+[elenchus](../../plugins/hexaemeron/skills/elenchus/SKILL.md).
+
+## 12. Decisions and their homes
+
+Three decisions here are expensive to reverse, and all three are decisions about
+a governed skill, so all three belong in
+`plugins/hexaemeron/skills/kronos/EVOLUTION.md` per
+[hypomnema](../../plugins/hexaemeron/skills/hypomnema/SKILL.md):
+
+- Parks live in their own file rather than in the scoreboard. Reversing it means
+  rereading every scoreboard line as possibly-state.
+- The held-job identity hash decides whether a park is stale. Reversing it means
+  every recorded park loses the thing that dates it.
+- A standing park blocks the loop's completion rather than warning about it.
+  Reversing it turns the lane back into a note nobody has to act on.
+
+The generation row recording all three lands in step 3, with the version bump
+`tests/test_version_propagation.py` requires to agree with it.
+
+## Boundaries
+
+**Always.** Both suites before a commit: `python3 -m unittest discover -s tests
+-p "test_*.py"` and `python3 plugins/hexaemeron/tests/run_tests.py`. The
+imprimatur lint on every shipped document. The halt reason stored byte for byte
+as given. Kronos's frontier revision and digest retained in any ledger edit.
+
+**Ask first.** Adding a dependency. Changing the four axes, their caps or the
+tie-break among unparked candidates. Changing the scoreboard's existing record
+shape. Writing anywhere git can see. Touching CI.
+
+**Never.** Run git from Kronos. Commit the parked file. Summarise or truncate a
+halt reason. Unpark on the loop's own judgement. Select a parked candidate.
+Change the held `Next Fiat job` or reopen the mature frontier. Delete a failing
+test to make a suite pass. Claim a lint or a suite ran when it did not.


### PR DESCRIPTION
Kronos has two answers for a Fiat run that halts on a blocker it cannot clear:

> If Fiat halts on a genuine external blocker, preserve the durable goal and
> report that blocker; do not skip to a lower-scoring job to make the loop look
> busy.

Preserve and report, or skip and be dishonest. So a top-ranked job blocked on an
approval nobody will grant this week stops the whole frontier, and every other
eligible skill queues behind it. The refusal to skip is right. What is missing
is a way to set the blocked job down without dropping it.

This step ships the study and runbook only. No code changes.

## What the study picks

A park record carrying the halt reason byte for byte and the blocked skill's
held-job identity hash, in `.kronos/parked.jsonl` beside the scoreboard, with
`park`, `unpark` and `parked` added to the existing `kronos.py`. Selection skips
parked candidates without dropping them from the ranking, and `parked` exits
non-zero while any park stands, so the loop cannot declare itself complete over
one.

Staleness is decided by the identity hash rather than by a person's memory: a
park whose skill now shows a different held job named something that has since
moved on. Nothing unparks itself.

## Why the prose-only option is not on the table

`kronos.py` refuses with K006 when the recorded selection is not what the
tie-break picks. A loop obeying new prose alone would select the second
candidate and its pass would be refused, so it could not record at all once
anything was parked. The flag has to reach the writer.

Parks go in their own file rather than into `scoreboard.jsonl`, because the
scoreboard is an append-only history where each line is what was true at that
moment, and parking is current state that changes. The cost is two files instead
of one, stated in the study rather than discovered later.

## Scope

Generation-axis work. Kronos stays mature, and the held frontier revision
`terminal-goal-loop` and its digest are retained byte for byte. The version bump
and the ledger row land together in step 3.

## Proof

```bash
python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py docs plugins
python3 -m unittest discover -s tests -p "test_*.py"
python3 plugins/hexaemeron/tests/run_tests.py
```

Root 34/34, plugin 414/414, link check clean.

One audit round, zero findings, three lints at exit 0, in `audit/AUDIT.md`. The
look checked the claims the study rests on, K006 among them, since the risk
register describes a lane step 2 has not built yet.