### PR TITLE
The Kronos parked lane

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4215,3 +4215,24 @@ render as whatever the terminal does with them. Accepted: stripping them on
 display would make the printed reason differ from the recorded one, which is the
 property the verbatim requirement exists to protect, and the reason arrives from
 a Fiat halt inside the same loop rather than from outside it.
+
+## Step 2, round 2 -- 2026-08-20
+
+Against the tree with round 1's fixes applied. phylax exit 0, ephoros exit 0,
+hypomnema exit 0.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | none | -- |
+
+The look went after what round 1's fix could have broken. The forged line now
+sits indented under its park and the real summary still reads 1, an ordinary
+single-line reason renders exactly as before, and a second park in the same file
+prints its own reason line rather than folding into the first.
+
+One property the fix touches without being about it: the reason on disk is
+unchanged, so the display change cannot drift from the record. The stored value
+is read back by the byte-for-byte case and the newline case, both of which read
+the file rather than the output.
+
+Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4186,3 +4186,32 @@ text appears in `SKILL.md` byte for byte. The halt-record shape cited from
 The diff carries no credential and no account data.
 
 Leads not pursued: none.
+
+## Step 2, round 1 -- 2026-08-20
+
+phylax exit 0, ephoros exit 0, hypomnema exit 0. Both findings came from walking
+the study's risk register against the code.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S2-R1-01 | low | plugins/hexaemeron/skills/kronos/scripts/kronos.py | a halt reason carrying a newline printed at the left margin, so it could forge the summary line telling a reader whether anything still stands | fixed in 00cf4d2 |
+| S2-R1-02 | low | plugins/hexaemeron/tests/test_kronos_scoreboard.py | nothing held the record format backward compatible, so a scoreboard written under v0.3.0 could stop reading without a test noticing | fixed in 00cf4d2 |
+
+S2-R1-01 was reproduced before it was believed: a park whose reason held a
+newline and the text `0 park(s) standing; the loop is not complete` printed that
+line at the margin, under the real summary saying 1. The exit code stayed 3
+throughout, so the mechanical gate never lied; the report a person reads did.
+The reason is stored byte for byte by requirement, so the display indents
+continuation lines rather than editing what was recorded.
+
+The replay was checked against the register's other cases: park after unpark, a
+second park for a parked skill, and an unpark with nothing standing all resolve
+to something defined and tested. A stale park still blocks completion, and an
+unreadable ledger reads as unknown rather than as cleared, which is the one that
+would have quietly emptied the lane.
+
+Leads not pursued: a reason may still carry terminal control characters, which
+render as whatever the terminal does with them. Accepted: stripping them on
+display would make the printed reason differ from the recorded one, which is the
+property the verbatim requirement exists to protect, and the reason arrives from
+a Fiat halt inside the same loop rather than from outside it.

--- a/docs/kronos-parked-lane/runbook.md
+++ b/docs/kronos-parked-lane/runbook.md
@@ -45,7 +45,7 @@ candidate without dropping it from the ranking.
 **Exit.** `plugins/hexaemeron/skills/kronos/scripts/kronos.py` supports
 `park --scoreboard-dir <dir> --skill <name> --ledger <path> --reason <text>`,
 `unpark --scoreboard-dir <dir> --skill <name> --reason <text>` and
-`parked --scoreboard-dir <dir>`; `parked` exits 2 while any park stands and 0
+`parked --scoreboard-dir <dir>`; `parked` exits 3 while any park stands and 0
 when none does, keeping 1 for a refusal; and `record` accepts `parked` on a
 candidate, applies the tie-break to unparked candidates only, and refuses a pass
 whose flags disagree with the standing parks. Proved by
@@ -60,7 +60,7 @@ reason byte for byte; a reason carrying a newline that leaves the file one line
 per record; an empty reason refused; an oversized reason refused; a park whose
 ledger cannot be read refused; an unpark with no standing park refused; a second
 park for an already parked skill refused; park, unpark, park again replaying to
-one standing park; `parked` exiting 2 with a park standing and 0 without; a
+one standing park; `parked` exiting 3 with a park standing and 0 without; a
 stale park reported as stale when the ledger's identity hash has moved; a
 deleted ledger reported as unknown rather than resolved; a pass selecting the
 highest unparked candidate accepted; a pass selecting a parked candidate
@@ -93,7 +93,7 @@ byte, with status still `mature` and next job still `None -- mature`. Proved by
 `test_evolution_contract.py` and `test_version_propagation.py` live, by
 `python3 plugins/hexaemeron/tests/run_tests.py`, and by the demo path: park a
 skill against this checkout's real ledger, record a pass that selects the
-next-ranked candidate, see `parked` exit 2, unpark, and see it exit 0.
+next-ranked candidate, see `parked` exit 3, unpark, and see it exit 0.
 
 **Files.** `plugins/hexaemeron/skills/kronos/SKILL.md`,
 `plugins/hexaemeron/skills/kronos/EVOLUTION.md`.
@@ -108,3 +108,27 @@ documents. ephoros: none beyond what step 2 emits. metron: none, no performance
 claim. elenchus: none, no failure in hand. hypomnema: the three decisions the
 study named as expensive to reverse are recorded here in the ledger row, which
 is where a decision about a governed skill lives.
+
+## Amendment, 2026-08-20, during step 2
+
+**What changed.** Step 2 also edits the field list in `SKILL.md`'s Scoreboard
+section, and `SKILL.md` joins its Files.
+
+**Why.** `parked` is a new candidate field, so it has to join `CANDIDATE_FIELDS`
+or `score` refuses it with K003. The field-drift guard shipped in
+`kronos-v0.3.0` then requires the Scoreboard section to name every field the
+script accepts, and it failed on the unnamed `parked` exactly as intended.
+Leaving that to step 3 would end step 2 with a red suite, and no step may hand
+the next a broken tree.
+
+**Which steps it touches.** Step 2 only. Step 3 still owns the loop wiring, the
+stop text, the version bump and the ledger row, and its entry state is unchanged:
+the lane shipped and both suites green.
+
+**Re-confirmation.** Step 3's entry and exit both still hold. Its exit rests on
+the two suites, the evolution-contract and version-propagation cases, and the
+demo path, none of which this amendment touches.
+
+**Also amended.** `parked` exits 3 rather than 2 while a park stands. Argparse
+already spends 2 on a bad invocation, so a caller could not tell a standing park
+from a mistyped command. Step 2's exit condition reads 3.

--- a/docs/kronos-parked-lane/study.md
+++ b/docs/kronos-parked-lane/study.md
@@ -44,14 +44,14 @@ A working prototype means all of this holds:
 - `kronos.py park` appends a park carrying the skill, its held-job identity
   hash computed from the ledger, and the halt reason byte for byte as given.
 - `kronos.py unpark` appends a release carrying its own reason.
-- `kronos.py parked` prints the standing parks and exits non-zero while any
+- `kronos.py parked` prints the standing parks and exits 3 while any
   stands, so a loop cannot call itself complete over one.
 - A pass whose candidates carry `parked: true` is accepted with the highest
   unparked candidate selected, and still refused when the selection is not the
   highest unparked one.
 - `python3 plugins/hexaemeron/tests/run_tests.py` passes with the new cases.
 - The demo path: park a skill, record a pass that selects the next-ranked
-  candidate, see `parked` exit non-zero, unpark, and see it exit 0.
+  candidate, see `parked` exit 3, unpark, and see it exit 0.
 
 ## 2. Prior art
 

--- a/plugins/hexaemeron/skills/kronos/SKILL.md
+++ b/plugins/hexaemeron/skills/kronos/SKILL.md
@@ -133,8 +133,9 @@ python3 "<this skill dir>/scripts/kronos.py" show \
 or `phase-only`, `selected`, an optional `run` naming the Fiat run this pass
 launched, and `candidates`. Each candidate carries `skill`, `ledger`, the four
 axis scores under the names `impact`, `urgency`, `readiness` and `unblocks`, a
-one-sentence `basis`, and an optional `total` for the arithmetic the ranking
-did in chat, which is refused when it disagrees with the axes.
+one-sentence `basis`, an optional `total` for the arithmetic the ranking did in
+chat, which is refused when it disagrees with the axes, and an optional `parked`
+naming whether that candidate has a standing park.
 
 It computes each candidate's held-job hash from that ledger on disk rather than
 taking one from the caller, so a recorded line can be checked against the digest

--- a/plugins/hexaemeron/skills/kronos/scripts/kronos.py
+++ b/plugins/hexaemeron/skills/kronos/scripts/kronos.py
@@ -385,7 +385,11 @@ def parked(args: argparse.Namespace) -> int:
             "unknown": "ledger could not be read, so the park stands",
         }[state]
         print(f"{skill}  {entry['held_job'][:12]}  {note}")
-        print(f"  reason: {entry['reason']}")
+        # Indented line by line. The reason is stored verbatim by requirement,
+        # and a newline inside one would otherwise let it forge the summary line
+        # that tells a reader whether anything still stands.
+        for number, line in enumerate(entry["reason"].splitlines() or [""]):
+            print(f"  {'reason: ' if number == 0 else '        '}{line}")
     print(f"{len(standing)} park(s) standing; the loop is not complete")
     return STANDS
 

--- a/plugins/hexaemeron/skills/kronos/scripts/kronos.py
+++ b/plugins/hexaemeron/skills/kronos/scripts/kronos.py
@@ -21,9 +21,17 @@ changed. This appends each pass to a file so that movement is visible.
   K008  an existing scoreboard line that cannot be read
   K009  more candidates than the check will track
   K010  a scoreboard directory that is not a real directory
+  K011  a halt reason that is empty or over the cap
+  K012  a park for a skill that is already parked
+  K013  an unpark with no standing park to release
+  K014  a parked flag that disagrees with the standing parks
+  K015  a pass in which every candidate is parked
 
-Exit 0 clean, 1 a refusal, 2 bad invocation. A refusal appends nothing: a pass
-is recorded whole or not at all.
+Exit 0 clean, 1 a refusal, 2 bad invocation, and 3 from `parked` alone while a
+park stands. That last is not an error in the tool. It is the loop's reason not
+to declare itself finished, which is why it needs a code of its own rather than
+the one argparse already spends on a bad invocation. A refusal appends nothing:
+a pass, a park and an unpark are each recorded whole or not at all.
 
 The held-job identity hash is not supplied by the caller. It is computed here
 from the candidate's ledger, as the SHA-256 of the canonical frontier line that
@@ -59,7 +67,7 @@ from pathlib import Path
 AXES = (("impact", 40), ("urgency", 25), ("readiness", 20), ("unblocks", 15))
 
 CANDIDATE_FIELDS = frozenset(
-    {"skill", "ledger", "basis", "total"} | {name for name, _ in AXES}
+    {"skill", "ledger", "basis", "total", "parked"} | {name for name, _ in AXES}
 )
 CANDIDATE_REQUIRED = ("skill", "ledger", "basis") + tuple(name for name, _ in AXES)
 PASS_FIELDS = frozenset({"scope", "mode", "candidates", "selected", "run"})
@@ -71,8 +79,13 @@ MAX_STDIN_BYTES = 1024 * 1024
 MAX_LEDGER_BYTES = 1024 * 1024
 MAX_SCOREBOARD_BYTES = 16 * 1024 * 1024
 MAX_CANDIDATES = 200
+MAX_REASON_BYTES = 4096
+STANDS = 3
 
 LEDGER_FIELDS = ("Frontier status", "Frontier revision", "Current frontier", "Next Fiat job")
+
+PARK_EVENTS = ("park", "unpark")
+PARKED_NAME = "parked.jsonl"
 
 
 class Refusal(Exception):
@@ -170,39 +183,81 @@ def tie_break(scored: list) -> str:
     return ordered[0][1]["skill"]
 
 
-def existing_passes(scoreboard: Path) -> list:
-    """Every line already recorded, refusing a tail that cannot be read."""
-    if not scoreboard.exists():
-        return []
-    text = read_capped(scoreboard, MAX_SCOREBOARD_BYTES, "K008")
-    if text and not text.endswith("\n"):
-        raise Refusal("K008", f"{scoreboard} does not end in a newline, so its last line is partial")
-    passes = []
-    for number, line in enumerate(text.splitlines(), start=1):
-        if not line.strip():
-            raise Refusal("K008", f"{scoreboard} line {number} is blank")
-        try:
-            entry = json.loads(line)
-        except json.JSONDecodeError as exc:
-            raise Refusal("K008", f"{scoreboard} line {number} is not JSON: {exc}") from exc
-        if not isinstance(entry, dict) or "pass" not in entry:
-            raise Refusal("K008", f"{scoreboard} line {number} is not a pass record")
-        passes.append(entry)
-    return passes
+def checked_path(given: Path) -> Path:
+    """Resolve a write target, refusing a symlink at the file or its directory.
 
-
-def record(args: argparse.Namespace) -> int:
-    # Before resolving anything. A symlink at either the scoreboard or the
-    # directory holding it would put the file and its `*` gitignore somewhere
-    # the caller did not name, and resolve() erases the link on the way past.
-    given = Path(args.scoreboard)
+    Before resolving anything: a symlink at either end would put the file and
+    the `*` gitignore beside it somewhere the caller did not name, and resolve()
+    erases the link on the way past.
+    """
     holder = given.parent
     if given.is_symlink():
         raise Refusal("K010", f"{given} is a symlink")
     if holder.is_symlink() or (holder.exists() and not holder.is_dir()):
         raise Refusal("K010", f"{holder} is not a real directory")
+    return given.resolve()
 
-    scoreboard = given.resolve()
+
+def append_line(path: Path, entry: dict) -> None:
+    """Create the gitignored directory if needed, then append one JSON line."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    gitignore = path.parent / ".gitignore"
+    if not gitignore.exists():
+        gitignore.write_text("*\n", encoding="utf-8")
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def json_lines(path: Path, marker: str) -> list:
+    """Every line already recorded, refusing a tail that cannot be read."""
+    if not path.exists():
+        return []
+    text = read_capped(path, MAX_SCOREBOARD_BYTES, "K008")
+    if text and not text.endswith("\n"):
+        raise Refusal("K008", f"{path} does not end in a newline, so its last line is partial")
+    entries = []
+    for number, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            raise Refusal("K008", f"{path} line {number} is blank")
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise Refusal("K008", f"{path} line {number} is not JSON: {exc}") from exc
+        if not isinstance(entry, dict) or marker not in entry:
+            raise Refusal("K008", f"{path} line {number} is not a {marker} record")
+        entries.append(entry)
+    return entries
+
+
+def standing_parks(parked_file: Path) -> dict:
+    """Replay park and unpark records in order into the set that still stands."""
+    standing = {}
+    for entry in json_lines(parked_file, "event"):
+        if entry["event"] not in PARK_EVENTS:
+            raise Refusal("K008", f"{parked_file} carries event {entry['event']!r}")
+        if entry["event"] == "park":
+            standing[entry["skill"]] = entry
+        else:
+            standing.pop(entry["skill"], None)
+    return standing
+
+
+def checked_reason(reason) -> str:
+    if not isinstance(reason, str) or not reason.strip():
+        raise Refusal("K011", "the reason is empty")
+    size = len(reason.encode("utf-8"))
+    if size > MAX_REASON_BYTES:
+        raise Refusal("K011", f"the reason is {size} bytes, over the {MAX_REASON_BYTES} cap")
+    return reason
+
+
+def existing_passes(scoreboard: Path) -> list:
+    """Every pass already recorded, refusing a tail that cannot be read."""
+    return json_lines(scoreboard, "pass")
+
+
+def record(args: argparse.Namespace) -> int:
+    scoreboard = checked_path(Path(args.scoreboard))
     root = Path(args.root).resolve() if args.root else scoreboard.parent.parent
     raw = sys.stdin.buffer.read(MAX_STDIN_BYTES + 1)
     if len(raw) > MAX_STDIN_BYTES:
@@ -225,9 +280,28 @@ def record(args: argparse.Namespace) -> int:
     names = [c["skill"] for c in scored]
     if len(set(names)) != len(names):
         raise Refusal("K002", "two candidates name the same skill")
+
+    # A parked candidate keeps its score and its place in the record. It is only
+    # barred from being selected, because the loop already knows why it stalled.
+    standing = standing_parks(scoreboard.parent / PARKED_NAME)
+    for candidate, given in zip(scored, candidates):
+        claimed = given.get("parked", False)
+        if not isinstance(claimed, bool):
+            raise Refusal("K004", f"{candidate['skill']} parked is {claimed!r}, not a boolean")
+        if claimed != (candidate["skill"] in standing):
+            raise Refusal(
+                "K014",
+                f"{candidate['skill']} is marked parked={claimed}, "
+                f"but the standing parks say {candidate['skill'] in standing}",
+            )
+        candidate["parked"] = claimed
+
+    unparked = [c for c in scored if not c["parked"]]
+    if not unparked:
+        raise Refusal("K015", "every candidate is parked, so the pass selects nobody")
     if document["selected"] not in names:
         raise Refusal("K006", f"selected {document['selected']!r} is not among the candidates")
-    expected = tie_break(scored)
+    expected = tie_break(unparked)
     if document["selected"] != expected:
         raise Refusal("K006", f"selected {document['selected']!r}, but the tie-break picks {expected!r}")
 
@@ -244,14 +318,76 @@ def record(args: argparse.Namespace) -> int:
         "run": run,
         "candidates": scored,
     }
-    scoreboard.parent.mkdir(parents=True, exist_ok=True)
-    gitignore = scoreboard.parent / ".gitignore"
-    if not gitignore.exists():
-        gitignore.write_text("*\n", encoding="utf-8")
-    with scoreboard.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(entry, sort_keys=True) + "\n")
-    print(f"pass {entry['pass']} recorded: {len(scored)} candidate(s), selected {entry['selected']}")
+    append_line(scoreboard, entry)
+    parked_note = f", {len(scored) - len(unparked)} parked" if len(unparked) != len(scored) else ""
+    print(
+        f"pass {entry['pass']} recorded: {len(scored)} candidate(s){parked_note}, "
+        f"selected {entry['selected']}"
+    )
     return 0
+
+
+def park(args: argparse.Namespace) -> int:
+    parked_file = checked_path(Path(args.scoreboard_dir) / PARKED_NAME)
+    root = Path(args.root).resolve() if args.root else parked_file.parent.parent
+    reason = checked_reason(args.reason)
+    ledger = resolved_under(root, args.ledger)
+    held = held_job_hash(ledger)
+    standing = standing_parks(parked_file)
+    if args.skill in standing:
+        raise Refusal("K012", f"{args.skill} is already parked; unpark it before parking it again")
+    entry = {
+        "event": "park",
+        "skill": args.skill,
+        "ledger": str(ledger.relative_to(root)),
+        "held_job": held,
+        "reason": reason,
+    }
+    append_line(parked_file, entry)
+    print(f"parked {args.skill} on its held job {held[:12]}")
+    return 0
+
+
+def unpark(args: argparse.Namespace) -> int:
+    parked_file = checked_path(Path(args.scoreboard_dir) / PARKED_NAME)
+    reason = checked_reason(args.reason)
+    standing = standing_parks(parked_file)
+    if args.skill not in standing:
+        raise Refusal("K013", f"{args.skill} is not parked, so there is nothing to release")
+    append_line(parked_file, {"event": "unpark", "skill": args.skill, "reason": reason})
+    print(f"released {args.skill}")
+    return 0
+
+
+def park_state(entry: dict, root: Path) -> str:
+    """Whether the held job a park named is still the one on disk."""
+    try:
+        ledger = resolved_under(root, entry["ledger"])
+        return "standing" if held_job_hash(ledger) == entry["held_job"] else "stale"
+    except Refusal:
+        # An unreadable ledger is not evidence that the blocker cleared.
+        return "unknown"
+
+
+def parked(args: argparse.Namespace) -> int:
+    parked_file = Path(args.scoreboard_dir) / PARKED_NAME
+    root = Path(args.root).resolve() if args.root else parked_file.resolve().parent.parent
+    standing = standing_parks(parked_file)
+    if not standing:
+        print("no parks standing")
+        return 0
+    for skill in sorted(standing):
+        entry = standing[skill]
+        state = park_state(entry, root)
+        note = {
+            "standing": "held job unchanged",
+            "stale": "held job has moved on since; a person decides whether the park still applies",
+            "unknown": "ledger could not be read, so the park stands",
+        }[state]
+        print(f"{skill}  {entry['held_job'][:12]}  {note}")
+        print(f"  reason: {entry['reason']}")
+    print(f"{len(standing)} park(s) standing; the loop is not complete")
+    return STANDS
 
 
 def drift(passes: list) -> dict:
@@ -305,6 +441,25 @@ def main(argv=None) -> int:
     reader = sub.add_parser("show", help="print the recorded passes and any drift")
     reader.add_argument("--scoreboard", required=True, help="path to the scoreboard file")
     reader.set_defaults(handler=show)
+
+    parker = sub.add_parser("park", help="record a blocked held job and why")
+    parker.add_argument("--scoreboard-dir", required=True, help="the .kronos directory")
+    parker.add_argument("--skill", required=True, help="the blocked skill")
+    parker.add_argument("--ledger", required=True, help="that skill's EVOLUTION.md")
+    parker.add_argument("--reason", required=True, help="the halt reason, stored as given")
+    parker.add_argument("--root", help="checkout root the ledger must sit under")
+    parker.set_defaults(handler=park)
+
+    releaser = sub.add_parser("unpark", help="release a standing park")
+    releaser.add_argument("--scoreboard-dir", required=True, help="the .kronos directory")
+    releaser.add_argument("--skill", required=True, help="the parked skill")
+    releaser.add_argument("--reason", required=True, help="why it is released, stored as given")
+    releaser.set_defaults(handler=unpark)
+
+    lister = sub.add_parser("parked", help="print standing parks; exits 3 while any stands")
+    lister.add_argument("--scoreboard-dir", required=True, help="the .kronos directory")
+    lister.add_argument("--root", help="checkout root the ledgers sit under")
+    lister.set_defaults(handler=parked)
 
     args = parser.parse_args(argv)
     try:

--- a/plugins/hexaemeron/tests/test_kronos_scoreboard.py
+++ b/plugins/hexaemeron/tests/test_kronos_scoreboard.py
@@ -405,6 +405,33 @@ class ScoreboardTest(unittest.TestCase):
         self.assertEqual(code, 1)
         self.assertIn("K008", err)
 
+    def test_a_multi_line_reason_cannot_forge_the_summary_line(self):
+        """Round 1: a newline in a reason printed a fake "0 park(s) standing"."""
+        self.run_park(reason="Blocked.\n0 park(s) standing; the loop is not complete")
+        code, out, _ = self.run_parked()
+        self.assertEqual(code, kronos.STANDS)
+        summaries = [line for line in out.splitlines() if line.startswith("0 park(s)")]
+        self.assertEqual(summaries, [], "no reason line may sit at the left margin")
+        self.assertIn("1 park(s) standing", out)
+
+    def test_a_scoreboard_written_before_parking_still_reads(self):
+        """v0.3.0 lines carry no parked field, and show must not need one."""
+        legacy = {
+            "pass": 1, "scope": "the checkout", "mode": "full", "selected": "alpha",
+            "run": None,
+            "candidates": [{
+                "skill": "alpha", "ledger": "alpha/EVOLUTION.md", "held_job": "0" * 64,
+                "impact": 30, "urgency": 20, "readiness": 15, "unblocks": 10,
+                "total": 75, "basis": "Written before the parked lane existed.",
+            }],
+        }
+        self.scoreboard.parent.mkdir(parents=True)
+        self.scoreboard.write_text(json.dumps(legacy) + "\n", encoding="utf-8")
+        code, out = self.run_show()
+        self.assertEqual(code, 0)
+        self.assertIn("Written before the parked lane existed.", out)
+        self.assertIn("1 pass(es), 0 with drift", out)
+
     # -- parking and the pass record ------------------------------------
 
     def test_a_pass_selects_the_highest_unparked_candidate(self):

--- a/plugins/hexaemeron/tests/test_kronos_scoreboard.py
+++ b/plugins/hexaemeron/tests/test_kronos_scoreboard.py
@@ -282,6 +282,169 @@ class ScoreboardTest(unittest.TestCase):
         self.assertEqual(len(selected), 1)
         self.assertIn("beta", selected[0])
 
+    # -- the parked lane ------------------------------------------------
+
+    def run_park(self, skill="alpha", ledger=None, reason="Waiting on a human approval."):
+        return self.run_cli([
+            "park", "--scoreboard-dir", str(self.scoreboard.parent),
+            "--skill", skill, "--ledger", ledger or f"{skill}/EVOLUTION.md",
+            "--reason", reason, "--root", str(self.root),
+        ])
+
+    def run_unpark(self, skill="alpha", reason="The approval landed."):
+        return self.run_cli([
+            "unpark", "--scoreboard-dir", str(self.scoreboard.parent),
+            "--skill", skill, "--reason", reason,
+        ])
+
+    def run_parked(self):
+        return self.run_cli([
+            "parked", "--scoreboard-dir", str(self.scoreboard.parent),
+            "--root", str(self.root),
+        ])
+
+    def run_cli(self, argv):
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            code = kronos.main(argv)
+        return code, out.getvalue(), err.getvalue()
+
+    def park_lines(self):
+        path = self.scoreboard.parent / kronos.PARKED_NAME
+        return path.read_text(encoding="utf-8").splitlines()
+
+    def test_a_park_stores_the_reason_byte_for_byte(self):
+        reason = "Halted: legal sign-off on the licence change, owner away until the 30th."
+        code, out, err = self.run_park(reason=reason)
+        self.assertEqual(code, 0, err)
+        self.assertEqual(json.loads(self.park_lines()[0])["reason"], reason)
+        self.assertIn("parked alpha", out)
+
+    def test_a_reason_carrying_a_newline_stays_one_record(self):
+        code, _, err = self.run_park(reason="First line.\nSecond line.")
+        self.assertEqual(code, 0, err)
+        self.assertEqual(len(self.park_lines()), 1)
+        self.assertEqual(
+            json.loads(self.park_lines()[0])["reason"], "First line.\nSecond line."
+        )
+
+    def test_an_empty_reason_is_refused(self):
+        code, _, err = self.run_park(reason="   ")
+        self.assertEqual(code, 1)
+        self.assertIn("K011", err)
+
+    def test_an_oversized_reason_is_refused(self):
+        code, _, err = self.run_park(reason="x" * (kronos.MAX_REASON_BYTES + 1))
+        self.assertEqual(code, 1)
+        self.assertIn("K011", err)
+
+    def test_a_park_whose_ledger_cannot_be_read_is_refused(self):
+        code, _, err = self.run_park(ledger="alpha/NOPE.md")
+        self.assertEqual(code, 1)
+        self.assertIn("K007", err)
+
+    def test_parking_an_already_parked_skill_is_refused(self):
+        self.run_park()
+        code, _, err = self.run_park()
+        self.assertEqual(code, 1)
+        self.assertIn("K012", err)
+        self.assertEqual(len(self.park_lines()), 1)
+
+    def test_unparking_something_never_parked_is_refused(self):
+        code, _, err = self.run_unpark()
+        self.assertEqual(code, 1)
+        self.assertIn("K013", err)
+
+    def test_park_unpark_park_replays_to_one_standing_park(self):
+        self.run_park()
+        self.run_unpark()
+        self.run_park(reason="Blocked again, same approval.")
+        self.assertEqual(len(self.park_lines()), 3)
+        code, out, _ = self.run_parked()
+        self.assertEqual(code, kronos.STANDS)
+        self.assertIn("1 park(s) standing", out)
+
+    def test_parked_exits_clean_when_nothing_stands(self):
+        code, out, _ = self.run_parked()
+        self.assertEqual(code, 0)
+        self.assertIn("no parks standing", out)
+        self.run_park()
+        self.run_unpark()
+        code, out, _ = self.run_parked()
+        self.assertEqual(code, 0)
+
+    def test_parked_exits_three_while_a_park_stands(self):
+        self.run_park()
+        code, out, _ = self.run_parked()
+        self.assertEqual(code, kronos.STANDS)
+        self.assertIn("the loop is not complete", out)
+        self.assertIn("Waiting on a human approval.", out)
+
+    def test_a_moved_held_job_is_reported_stale_rather_than_cleared(self):
+        self.run_park()
+        (self.root / "alpha" / "EVOLUTION.md").write_text(
+            LEDGER.replace("Do the thing that is held.", "Something else entirely."),
+            encoding="utf-8",
+        )
+        code, out, _ = self.run_parked()
+        self.assertEqual(code, kronos.STANDS, "a stale park still blocks completion")
+        self.assertIn("has moved on since", out)
+
+    def test_a_deleted_ledger_reads_as_unknown_not_resolved(self):
+        self.run_park()
+        (self.root / "alpha" / "EVOLUTION.md").unlink()
+        code, out, _ = self.run_parked()
+        self.assertEqual(code, kronos.STANDS)
+        self.assertIn("could not be read", out)
+
+    def test_a_truncated_tail_in_the_parked_file_is_refused(self):
+        self.run_park()
+        with (self.scoreboard.parent / kronos.PARKED_NAME).open("a", encoding="utf-8") as handle:
+            handle.write('{"event": "unpa')
+        code, _, err = self.run_parked()
+        self.assertEqual(code, 1)
+        self.assertIn("K008", err)
+
+    # -- parking and the pass record ------------------------------------
+
+    def test_a_pass_selects_the_highest_unparked_candidate(self):
+        self.run_park("alpha")
+        candidates = [
+            self.candidate("alpha", parked=True),
+            self.candidate("beta", impact=10, parked=False),
+        ]
+        code, out, err = self.run_record(self.document(candidates, selected="beta"))
+        self.assertEqual(code, 0, err)
+        self.assertIn("1 parked", out)
+        entry = json.loads(self.lines()[0])
+        by_name = {c["skill"]: c for c in entry["candidates"]}
+        self.assertTrue(by_name["alpha"]["parked"], "a parked candidate stays in the record")
+        self.assertEqual(entry["selected"], "beta")
+
+    def test_selecting_a_parked_candidate_is_refused(self):
+        self.run_park("alpha")
+        candidates = [
+            self.candidate("alpha", parked=True),
+            self.candidate("beta", impact=10, parked=False),
+        ]
+        self.assertRefused(self.document(candidates, selected="alpha"), "K006")
+
+    def test_a_pass_with_every_candidate_parked_is_refused(self):
+        self.run_park("alpha")
+        self.run_park("beta")
+        candidates = [self.candidate("alpha", parked=True), self.candidate("beta", parked=True)]
+        self.assertRefused(self.document(candidates, selected="alpha"), "K015")
+
+    def test_a_parked_flag_the_standing_parks_do_not_support_is_refused(self):
+        self.assertRefused(self.document([self.candidate(parked=True)]), "K014")
+
+    def test_a_standing_park_left_unflagged_is_refused(self):
+        self.run_park("alpha")
+        self.assertRefused(self.document([self.candidate(parked=False)]), "K014")
+
+    def test_a_non_boolean_parked_flag_is_refused(self):
+        self.assertRefused(self.document([self.candidate(parked="yes")]), "K004")
+
     # -- the skill and the script agree ---------------------------------
 
     def test_every_field_the_script_accepts_is_named_in_the_skill(self):


### PR DESCRIPTION
`park` records a blocked held job with the halt reason byte for byte and the
skill's held-job identity hash. `unpark` releases it with its own reason.
`parked` prints what stands and exits 3, which is the loop's reason not to
declare itself finished.

`record` now takes a `parked` flag on a candidate, checks it against the
standing parks rather than trusting it, applies the tie-break to unparked
candidates only, and refuses a pass in which everything is parked. A parked
candidate keeps its score and its place in the record. It is only barred from
selection, because the loop already knows why it stalled.

Staleness is decided by the identity hash: a park whose skill now shows a
different held job named something that has moved on. Nothing unparks itself,
and a ledger that cannot be read counts as unknown rather than as cleared, since
an unreadable file is not evidence a blocker cleared.

## Two amendments, both recorded in the runbook

`parked` exits 3, not the 2 the runbook first said. Argparse already spends 2 on
a bad invocation, so a caller could not have told a standing park from a
mistyped command.

`SKILL.md` joins this step's files for one line. `parked` is a new candidate
field, so it had to join `CANDIDATE_FIELDS` or `score` refuses it with K003, and
the field-drift guard shipped in `kronos-v0.3.0` then required the Scoreboard
section to name it. It failed until it did, which is what that guard is for.
Leaving it to step 3 would have ended this step with a red suite.

## Audit

Two rounds, in `audit/AUDIT.md`. Round 1 found two, both from the study's risk
register rather than from a lint.

A reason carrying a newline printed at the left margin, so it could add a line
reading `0 park(s) standing; the loop is not complete` to the output a person
reads to decide whether anything is still waiting. Reproduced before it was
believed. The exit code was right throughout; the report was not. Continuation
lines are now indented, because the reason is stored byte for byte by
requirement and the display has to work around that rather than edit it.

Nothing held the record format backward compatible either, so a scoreboard
written under `v0.3.0` could have stopped reading unnoticed.

Round 2 came back clean and checked what the fix could have broken.

## Proof

```bash
python3 plugins/hexaemeron/tests/run_tests.py
python3 -m unittest discover -s tests -p "test_*.py"
```

Plugin suite 414 to 435, 21 new cases. Root 34/34.

Demo, against this checkout's real ledgers: park protasis, `parked` exits 3, a
pass records with the top candidate parked and elenchus selected, unpark, and
`parked` exits 0.

The loop wiring, the stop text, the version bump and the ledger row are step 3.