### PR TITLE
What a rank-only pass looks like in the record

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4302,3 +4302,29 @@ around exists. Step 2's ungoverned-report sentence is in the loop as quoted. The
 frontier digest matches the ledger, and the diff carries no credential.
 
 Leads not pursued: none.
+
+## Step 2, round 1 -- 2026-08-20
+
+phylax exit 0, ephoros exit 0, hypomnema exit 0. The finding came from walking
+the study's risk register against the code.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S2-R1-01 | low | plugins/hexaemeron/skills/kronos/scripts/kronos.py | a skill could be recorded as a scored candidate and reported ungoverned in the same pass, and `show` printed both | fixed in aaf172a |
+
+Reproduced before it was believed: a pass naming protasis as a candidate scored
+from its ledger and in `ungoverned` as having none recorded cleanly, and the
+rendered output asserted each. Ungoverned means no ledger, and the held-job hash
+on a scored candidate is computed out of one, so the two cannot both hold.
+
+The register's other entries were checked and hold. The `rank_only` and `run`
+contradiction is refused on the combination rather than on either alone, and a
+pass carrying `rank_only` beside an explicit null run is still accepted, since
+a null run is the absence the flag asserts. Both fields are read with a default
+in `show`, held by a case over a `v0.4.0`-shaped line, which is the fault this
+audit found twice in the previous run.
+
+Leads not pursued: the ungoverned list is not deduplicated, so a name repeated
+in it prints twice. Accepted: it is a report of what the walk found, repetition
+in it is the caller's own output rather than a contradiction, and refusing it
+would be a rule about tidiness rather than about meaning.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4328,3 +4328,20 @@ Leads not pursued: the ungoverned list is not deduplicated, so a name repeated
 in it prints twice. Accepted: it is a report of what the walk found, repetition
 in it is the caller's own output rather than a contradiction, and refusing it
 would be a rule about tidiness rather than about meaning.
+
+## Step 2, round 2 -- 2026-08-20
+
+Against the tree with round 1's fix applied. phylax exit 0, ephoros exit 0,
+hypomnema exit 0.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | none | -- |
+
+The look went after what the new refusal could have caught by mistake. An
+ungoverned list naming skills that are not candidates records as before, an
+empty list records, and a rank-only pass carrying an explicit null run records,
+which is the case a refusal keyed on the field's presence rather than its value
+would have broken.
+
+Leads not pursued: none.

--- a/plugins/hexaemeron/skills/kronos/SKILL.md
+++ b/plugins/hexaemeron/skills/kronos/SKILL.md
@@ -143,7 +143,10 @@ python3 "<this skill dir>/scripts/kronos.py" show \
 
 `record` reads the pass on stdin as one JSON object: `scope`, `mode` of `full`
 or `phase-only`, `selected`, an optional `run` naming the Fiat run this pass
-launched, and `candidates`. Each candidate carries `skill`, `ledger`, the four
+launched, an optional `rank_only` saying the pass stopped after selection, an
+optional `ungoverned` listing the in-scope skills found carrying no ledger, and
+`candidates`. A `rank_only` pass naming a `run` is refused: it launched none.
+Each candidate carries `skill`, `ledger`, the four
 axis scores under the names `impact`, `urgency`, `readiness` and `unblocks`, a
 one-sentence `basis`, an optional `total` for the arithmetic the ranking did in
 chat, which is refused when it disagrees with the axes, and an optional `parked`

--- a/plugins/hexaemeron/skills/kronos/scripts/kronos.py
+++ b/plugins/hexaemeron/skills/kronos/scripts/kronos.py
@@ -26,6 +26,8 @@ changed. This appends each pass to a file so that movement is visible.
   K013  an unpark with no standing park to release
   K014  a parked flag that disagrees with the standing parks
   K015  a pass in which every candidate is parked
+  K016  a rank-only pass that names a Fiat run
+  K017  an ungoverned list that is too long or holds something that is not a name
 
 Exit 0 clean, 1 a refusal, 2 bad invocation, and 3 from `parked` alone while a
 park stands. That last is not an error in the tool. It is the loop's reason not
@@ -70,7 +72,9 @@ CANDIDATE_FIELDS = frozenset(
     {"skill", "ledger", "basis", "total", "parked"} | {name for name, _ in AXES}
 )
 CANDIDATE_REQUIRED = ("skill", "ledger", "basis") + tuple(name for name, _ in AXES)
-PASS_FIELDS = frozenset({"scope", "mode", "candidates", "selected", "run"})
+PASS_FIELDS = frozenset(
+    {"scope", "mode", "candidates", "selected", "run", "rank_only", "ungoverned"}
+)
 PASS_REQUIRED = ("scope", "mode", "candidates", "selected")
 MODES = ("full", "phase-only")
 
@@ -80,6 +84,7 @@ MAX_LEDGER_BYTES = 1024 * 1024
 MAX_SCOREBOARD_BYTES = 16 * 1024 * 1024
 MAX_CANDIDATES = 200
 MAX_REASON_BYTES = 4096
+MAX_UNGOVERNED = 200
 STANDS = 3
 
 LEDGER_FIELDS = ("Frontier status", "Frontier revision", "Current frontier", "Next Fiat job")
@@ -309,6 +314,23 @@ def record(args: argparse.Namespace) -> int:
     if run is not None and not isinstance(run, str):
         raise Refusal("K002", f"run is {run!r}, which is neither a string nor absent")
 
+    rank_only = document.get("rank_only", False)
+    if not isinstance(rank_only, bool):
+        raise Refusal("K004", f"rank_only is {rank_only!r}, not a boolean")
+    # A rank-only pass stops after selection, so there is no run for it to name.
+    # Recording both would leave the file saying the ranking was and was not acted on.
+    if rank_only and run is not None:
+        raise Refusal("K016", f"a rank-only pass names run {run!r}, but it launched none")
+
+    ungoverned = document.get("ungoverned", [])
+    if not isinstance(ungoverned, list):
+        raise Refusal("K017", f"ungoverned is {ungoverned!r}, not a list")
+    if len(ungoverned) > MAX_UNGOVERNED:
+        raise Refusal("K017", f"{len(ungoverned)} ungoverned names, over the {MAX_UNGOVERNED} cap")
+    for name in ungoverned:
+        if not isinstance(name, str) or not name.strip():
+            raise Refusal("K017", f"ungoverned holds {name!r}, which is not a name")
+
     previous = existing_passes(scoreboard)
     entry = {
         "pass": len(previous) + 1,
@@ -316,12 +338,15 @@ def record(args: argparse.Namespace) -> int:
         "mode": document["mode"],
         "selected": document["selected"],
         "run": run,
+        "rank_only": rank_only,
+        "ungoverned": list(ungoverned),
         "candidates": scored,
     }
     append_line(scoreboard, entry)
     parked_note = f", {len(scored) - len(unparked)} parked" if len(unparked) != len(scored) else ""
+    kind = "rank-only pass" if rank_only else "pass"
     print(
-        f"pass {entry['pass']} recorded: {len(scored)} candidate(s){parked_note}, "
+        f"{kind} {entry['pass']} recorded: {len(scored)} candidate(s){parked_note}, "
         f"selected {entry['selected']}"
     )
     return 0
@@ -420,8 +445,8 @@ def show(args: argparse.Namespace) -> int:
     passes = existing_passes(scoreboard)
     moved = drift(passes)
     for entry in passes:
-        run = entry.get("run") or "no run recorded"
-        print(f"pass {entry['pass']}  {entry['mode']}  {entry['scope']}  ({run})")
+        note = "rank-only" if entry.get("rank_only") else (entry.get("run") or "no run recorded")
+        print(f"pass {entry['pass']}  {entry['mode']}  {entry['scope']}  ({note})")
         for candidate in sorted(entry["candidates"], key=lambda c: -c["total"]):
             # A parked candidate outscoring the selected one is the normal case
             # once anything is parked. Without the mark the output reads as
@@ -437,6 +462,8 @@ def show(args: argparse.Namespace) -> int:
             print(f"      {candidate['basis']}")
             for name, before, after in moved.get((entry["pass"], candidate["skill"]), []):
                 print(f"      drift: {name} {before} -> {after}, held job unchanged")
+        for name in entry.get("ungoverned", []):
+            print(f"    ungoverned: {name}")
     print(f"{len(passes)} pass(es), {len(moved)} with drift")
     return 0
 

--- a/plugins/hexaemeron/skills/kronos/scripts/kronos.py
+++ b/plugins/hexaemeron/skills/kronos/scripts/kronos.py
@@ -330,6 +330,10 @@ def record(args: argparse.Namespace) -> int:
     for name in ungoverned:
         if not isinstance(name, str) or not name.strip():
             raise Refusal("K017", f"ungoverned holds {name!r}, which is not a name")
+        # Ungoverned means no ledger, and a scored candidate was scored from one.
+        # A name in both leaves the record asserting each about the same skill.
+        if name in names:
+            raise Refusal("K017", f"{name} is reported ungoverned and scored in the same pass")
 
     previous = existing_passes(scoreboard)
     entry = {

--- a/plugins/hexaemeron/tests/test_kronos_scoreboard.py
+++ b/plugins/hexaemeron/tests/test_kronos_scoreboard.py
@@ -537,6 +537,10 @@ class ScoreboardTest(unittest.TestCase):
     def test_an_ungoverned_field_that_is_not_a_list_is_refused(self):
         self.assertRefused(self.document(ungoverned="gamma"), "K017")
 
+    def test_a_skill_both_scored_and_reported_ungoverned_is_refused(self):
+        """Round 1 recorded protasis as scored from a ledger and as having none."""
+        self.assertRefused(self.document(ungoverned=["alpha"]), "K017")
+
     def test_show_marks_a_rank_only_pass_and_lists_the_ungoverned(self):
         self.run_record(self.document(rank_only=True, ungoverned=["gamma"]))
         code, out = self.run_show()

--- a/plugins/hexaemeron/tests/test_kronos_scoreboard.py
+++ b/plugins/hexaemeron/tests/test_kronos_scoreboard.py
@@ -491,6 +491,78 @@ class ScoreboardTest(unittest.TestCase):
         section = skill.split("## Phase-only mode", 1)[1].split("## Loop", 1)[0]
         self.assertIn("park", section)
 
+    # -- rank-only ------------------------------------------------------
+
+    def test_a_rank_only_pass_is_recorded_with_no_run(self):
+        code, out, err = self.run_record(self.document(rank_only=True))
+        self.assertEqual(code, 0, err)
+        self.assertIn("rank-only pass 1 recorded", out)
+        entry = json.loads(self.lines()[0])
+        self.assertTrue(entry["rank_only"])
+        self.assertIsNone(entry["run"])
+
+    def test_a_rank_only_pass_naming_a_run_is_refused(self):
+        """The two contradict: a pass that stopped after selection launched nothing."""
+        self.assertRefused(
+            self.document(rank_only=True, run="https://example.invalid/1"), "K016"
+        )
+
+    def test_a_non_boolean_rank_only_is_refused(self):
+        self.assertRefused(self.document(rank_only="yes"), "K004")
+
+    def test_a_pass_with_neither_field_records_as_before(self):
+        code, out, err = self.run_record(self.document())
+        self.assertEqual(code, 0, err)
+        self.assertIn("pass 1 recorded", out)
+        self.assertNotIn("rank-only", out)
+        entry = json.loads(self.lines()[0])
+        self.assertFalse(entry["rank_only"])
+        self.assertEqual(entry["ungoverned"], [])
+
+    def test_an_ungoverned_list_is_stored(self):
+        code, _, err = self.run_record(self.document(ungoverned=["gamma", "delta"]))
+        self.assertEqual(code, 0, err)
+        self.assertEqual(json.loads(self.lines()[0])["ungoverned"], ["gamma", "delta"])
+
+    def test_an_ungoverned_list_over_the_cap_is_refused(self):
+        many = [f"skill-{n}" for n in range(kronos.MAX_UNGOVERNED + 1)]
+        self.assertRefused(self.document(ungoverned=many), "K017")
+
+    def test_an_ungoverned_element_that_is_not_a_name_is_refused(self):
+        self.assertRefused(self.document(ungoverned=["gamma", 7]), "K017")
+
+    def test_an_empty_ungoverned_name_is_refused(self):
+        self.assertRefused(self.document(ungoverned=["  "]), "K017")
+
+    def test_an_ungoverned_field_that_is_not_a_list_is_refused(self):
+        self.assertRefused(self.document(ungoverned="gamma"), "K017")
+
+    def test_show_marks_a_rank_only_pass_and_lists_the_ungoverned(self):
+        self.run_record(self.document(rank_only=True, ungoverned=["gamma"]))
+        code, out = self.run_show()
+        self.assertEqual(code, 0)
+        self.assertIn("(rank-only)", out)
+        self.assertIn("ungoverned: gamma", out)
+
+    def test_a_pass_written_before_either_field_still_reads(self):
+        """v0.4.0 lines carry neither field, and show must not need them."""
+        legacy = {
+            "pass": 1, "scope": "the checkout", "mode": "full", "selected": "alpha",
+            "run": None,
+            "candidates": [{
+                "skill": "alpha", "ledger": "alpha/EVOLUTION.md", "held_job": "0" * 64,
+                "impact": 30, "urgency": 20, "readiness": 15, "unblocks": 10,
+                "total": 75, "parked": False, "basis": "Written before rank-only existed.",
+            }],
+        }
+        self.scoreboard.parent.mkdir(parents=True)
+        self.scoreboard.write_text(json.dumps(legacy) + "\n", encoding="utf-8")
+        code, out = self.run_show()
+        self.assertEqual(code, 0)
+        self.assertIn("Written before rank-only existed.", out)
+        self.assertIn("no run recorded", out)
+        self.assertNotIn("ungoverned:", out)
+
     # -- the skill and the script agree ---------------------------------
 
     def test_every_field_the_script_accepts_is_named_in_the_skill(self):


### PR DESCRIPTION
Two fields on the recorded pass.

`rank_only` says the ranking stopped after selection. A missing `run` link
cannot say that on its own: `record` already accepted an absent run, so a
delivery whose link was never filled in looked identical to a ranking nobody
acted on. A `rank_only` pass naming a run is refused, because recording both
would leave the file saying the ranking was and was not acted on.

`ungoverned` carries step 2's report of in-scope skills with no ledger. The loop
has always owed that report and it has always lived only in the chat that
scrolled away.

## What it refuses

`K016` a rank-only pass naming a Fiat run. `K017` an ungoverned list that is not
a list, is over its cap, holds something that is not a name, or names a skill
that is also a scored candidate.

Both fields are read with a default in `show`, because every line written under
`kronos-v0.3.0` and `kronos-v0.4.0` carries neither, and a case holds that.
`SKILL.md` names both in the same commit, which the field-drift guard requires
and which the runbook planned for rather than discovering mid-step.

## Audit

Two rounds, in `audit/AUDIT.md`. Round 1 found one, from the study's risk
register rather than from a lint.

A skill could be recorded as a scored candidate and reported ungoverned in the
same pass, and `show` printed both. Ungoverned means no ledger, and a scored
candidate's held-job hash is computed out of one, so the two cannot both hold.
Reproduced before it was believed.

Round 2 checked what that refusal could have caught by mistake: an ungoverned
list naming non-candidates, an empty list, and a rank-only pass carrying an
explicit null run all still record.

The deduplication lead is in the log as accepted, with the reason.

## Proof

```bash
python3 plugins/hexaemeron/tests/run_tests.py
python3 -m unittest discover -s tests -p "test_*.py"
```

Plugin suite 437 to 449, 12 new cases. Root 34/34.

Demo, over this checkout's real ledgers: a rank-only pass records and renders as
`(rank-only)` with three ungoverned skills listed, and the rank-only-plus-run
contradiction is refused.

The invocation itself, the description and the ledger row are step 3.