### PR TITLE
Scaffold the Horos scoped-entry run

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4392,3 +4392,26 @@ its `P` and stayed out of selection, the pass rendered as `(rank-only)`, and
 than a failure.
 
 Leads not pursued: none.
+
+## Scoped entry, step 1, round 1 -- 2026-08-20
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0 over
+`plugins tests` and the documented doc set. Horos 183/183 with three expected
+failures, root 35/35 with one, verified before this receipt. The look went at
+the measurement record rather than the fixtures, since the fixtures were each
+run in isolation and print the failure they claim: `out/` as a hard entry at 0
+bytes and 0 files, `check` exit 1 beside an ignored build directory, `check`
+exit 2 on a descendant, and the root boundary against a fresh tracked scan.
+Both findings are the risk register's first class, a record that reads as
+more than it measured. Fixes are committed on the step branch rather than a
+side branch, because four later steps chain from it.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R1-01 | low | plugins/horos/tests/benchmark_scope.py | the record's `root` field was `os.path.relpath(root, root)`, always `"."`, so a run against a different root recorded the same value as a run against the repository | fixed in b6e7ed2 |
+| S1-R1-02 | low | plugins/horos/tests/benchmark_scope.py | a refused check still reported a median, so `--root plugins/horos` recorded `0.014 ms` beside exit 2; a duration for a check that classified nothing reads as a fast check | fixed in b6e7ed2 |
+
+Leads not pursued: the scaffold test bounds its build-order assertion to a
+300-character window after the `Build order:` line, which is a positional
+assumption rather than a parse; it fails rather than passes if the line moves,
+so it was left as it is.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4415,3 +4415,23 @@ Leads not pursued: the scaffold test bounds its build-order assertion to a
 300-character window after the `Build order:` line, which is a positional
 assumption rather than a parse; it fails rather than passes if the line moves,
 so it was left as it is.
+
+## Scoped entry, step 1, round 2 -- 2026-08-20
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0. Horos
+183/183 with three expected failures, root 35/35 with one, verified before this
+receipt. The round audited the tree with round 1's fix applied. The fix is
+eleven lines and does one thing on both sides of the record: a refused check
+reports a null median and the refusal reason instead of a duration. Re-ran the
+benchmark against both a working root and a rootless one to see each branch
+taken, and re-ran each fixture in isolation to confirm the fix moved none of
+them.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: the benchmark's module docstring still
+describes the null-median treatment as the scope side's alone, which is now
+under-description rather than error, since both sides carry a status field. It
+goes to the prose phase with the rest of this step's wording rather than
+opening a third round for a docstring.

--- a/plugins/horos/docs/scoped-entry/runbook.md
+++ b/plugins/horos/docs/scoped-entry/runbook.md
@@ -1,0 +1,161 @@
+# Scoped entry, the runbook
+
+| Module id | Responsibility | Depends on |
+| --- | --- | --- |
+| change-scaffold | pin the ref, commit study and runbook, add failing fixtures | none |
+| tracked-universe | a directory with no tracked file is not a hard entry | change-scaffold |
+| boundary-currency | root-suite guard that the committed boundary matches a fresh tracked scan | tracked-universe |
+| scoped-entry | ancestor resolution and subtree comparison | boundary-currency |
+| demonstration | prove the entry discipline end to end and release | scoped-entry |
+
+Build order: change-scaffold, tracked-universe, boundary-currency, scoped-entry,
+demonstration.
+
+## Step 1: Scaffold the change
+
+**Goal.** Commit this study and runbook, pin the run ref, and add the failing
+fixtures for criteria 4, 5, 6 and 7 without changing runtime behaviour.
+
+**Entry.** `main` at the Fiat run ref, expected to descend from `496f7a1`.
+Suites green: horos 176, root 34.
+
+**Exit.** Study and runbook committed under `plugins/horos/docs/scoped-entry/`. Proved by:
+`python3 -m unittest discover -s tests` passes, including a scaffold test that
+asserts the committed runbook's five module ids and fourteen criteria against
+this document; `python3 -m unittest discover -s plugins/horos/tests -t plugins/horos`
+passes with the four new fixtures present and marked `expectedFailure`, so the
+tree stays green at both ends and each fixture still records the failure it
+guards; `python3 plugins/horos/tests/benchmark_scope.py --root . --scope plugins/alexandria --runs 5`
+writes the entry medians and claims no improvement.
+
+**Files.** `plugins/horos/docs/scoped-entry/study.md`,
+`plugins/horos/docs/scoped-entry/runbook.md`,
+fixtures under `plugins/horos/tests/fixtures/`, `plugins/horos/tests/benchmark_scope.py`.
+
+**Tests.** Extend the scaffold and prose-contract tests so the study, runbook and
+module ids agree. No existing test weakened or skipped.
+
+**Disciplines.** metron: the entry medians are the baseline every later claim is
+measured against. hypomnema: the one-boundary scoped semantics are expensive to
+reverse. ephoros: the benchmark output needs named counters. phylax: fixtures
+carry untrusted paths. elenchus: two of the four fixtures encode failures the
+audit record already produced.
+
+## Step 2: A hard entry must cover a tracked file
+
+**Goal.** Stop the classifier emitting hard directory entries that hold no
+tracked file, so `check` answers the same on every machine.
+
+**Entry.** Step 1's green exit. `check .` exits 1 with 7 drifted paths, 6 of
+them ignored local directories.
+
+**Exit.** A fresh scan of this repository emits no phantom entry; `check .`
+exits 0 on a clean tracked checkout regardless of local build or worktree
+directories; the fixture from step 1 passes; census attribution is unchanged for
+every entry that does cover tracked files.
+
+**Files.** `plugins/horos/skills/horos/scripts/horos.py`, classifier tests,
+fixtures, and `.horos/boundary.json` only if a real entry changed.
+
+**Tests.** Untracked directory with a vendored name; untracked directory with a
+corroborating sample; a directory with one tracked and several untracked files,
+which must still bind; a `.gitattributes`-matched directory holding nothing
+tracked; the filesystem-fallback path when git is absent, which must stay
+fail-open.
+
+**Disciplines.** elenchus: this is the failure in hand, and the fixture must fail
+without the fix. metron: the walk changes, so re-measure `check .`. phylax: the
+tracked-universe subprocess is the boundary being relied on. ephoros: the scan
+counters must distinguish walked from bound. hypomnema: "a hard entry covers at
+least one tracked file" is a rule worth recording beside the classifier.
+
+## Step 3: Guard boundary currency
+
+**Goal.** Make the recurrence from 18 August impossible to land silently: a
+tracked generated file committed without a boundary refresh must fail the root
+suite.
+
+**Entry.** Step 2's green exit and a repository whose `check .` exits 0.
+
+**Exit.** A root-suite test compares the committed boundary with a fresh
+tracked-only scan and fails on any difference; mutation proves it bites by
+adding a generated file and by deleting one entry; the current
+`plugins/horos/docs/evidence/skills.boundary.json` drift is resolved by
+refreshing the boundary in this step; both suites pass.
+
+**Files.** `tests/` guard test, `.horos/boundary.json`, `.horos/candidates.json`,
+`.horos/census.json`.
+
+**Tests.** The guard itself, plus the two mutations, plus a determinism case
+proving two consecutive scans render byte-identical documents.
+
+**Disciplines.** elenchus: the guard is the fix for a failure that already
+recurred once. ephoros: the failure message must name the paths and the
+refresh command. metron: none, no performance claim in this step. phylax:
+`.horos` writes stay atomic. hypomnema: none, the decision is already recorded
+by the guard's existence.
+
+## Step 4: Ancestor-resolved scoped checks
+
+**Goal.** `check <descendant>` answers whether that subtree's hard boundary is
+current, using the one ancestor boundary.
+
+**Entry.** Step 3's green exit and a boundary that matches the tree.
+
+**Exit.** Root and descendant invocations select the same boundary root;
+in-scope hard drift exits 1 naming each path; sibling hard drift and candidate
+drift print without refusing the scope; missing, malformed or escaping ancestry
+exits 2; the selected root, scope and unevaluated-global line print on every
+run; criteria 7 through 12 pass.
+
+**Files.** `horos.py`, scope tests, CLI help, `SKILL.md`, `plugins/horos/README.md`,
+`plugins/horos/examples/scoped-entry/`.
+
+**Tests.** Invocation from root and from the descendant; nearest valid ancestor
+when two exist; `..` escape; symlink escape; missing boundary; malformed
+boundary; empty scope; scope equal to root; a scope overlapping a directory
+entry; in-scope add, remove and change; sibling-only drift; candidate-only
+drift; byte-identical output across both invocation sites.
+
+**Disciplines.** phylax: ancestor discovery and canonicalisation cross the
+filesystem boundary. ephoros: a local pass must name its scope and refuse the
+global implication. metron: prove zero tracked files inspected outside scope and
+record the medians. elenchus: every path-resolution failure found gets a
+fixture. hypomnema: exit-code meanings and the no-global-claim rule are recorded
+in the contract.
+
+## Step 5: Demonstrate and release
+
+**Goal.** Run the whole discipline from inside a skill directory, reconcile every
+release surface, and close the generation entry.
+
+**Entry.** Step 4's green exit.
+
+**Exit.** All 14 criteria pass; the scoped-entry example runs from a clean
+checkout with pinned output; horos and root suites, phylax, ephoros, imprimatur,
+the five-run benchmark, `check .`, version consistency and `git diff --check`
+are green; the ledger row reads `horos-v9.3.3` with the frontier line and its
+digest byte-identical; the receipt names the exact commands and their output.
+
+**Files.** `plugins/horos/examples/scoped-entry/README.md`,
+`plugins/horos/skills/horos/SKILL.md`, `EVOLUTION.md`,
+`plugins/horos/README.md`, plugin and marketplace version surfaces, and the root
+`.horos` artefacts only if the final scan changes them.
+
+**Tests.** No new implementation test. Run everything above and assert the
+example's pinned output.
+
+**Disciplines.** ephoros: the receipt carries scope, drift, counters and the demo
+result. hypomnema: the release prose and the ledger row carry the settled
+semantics. metron: final medians against step 1. elenchus: no new failure in
+hand; every earlier guard stays green. phylax: the final boundary write is the
+last filesystem boundary to check.
+
+## Later, not this run
+
+- Three `.gitattributes` lines binding about 9.3 MB of the 9.43 MB JSON weight
+  at hard grade, in `plugins/alexandria/examples/compound-v3-phase0-v0/input/responses`,
+  `plugins/tabularium/examples/goldfinch-v0` and `plugins/horos/docs/evidence`.
+- A JSON structure map, if the maintainer wants it inside this run instead.
+- The held frontier job: marker self-exclusion, then the content-addressed rule
+  receipt, then the Markdown outline extractor.

--- a/plugins/horos/docs/scoped-entry/study.md
+++ b/plugins/horos/docs/scoped-entry/study.md
@@ -1,0 +1,323 @@
+# Scoped entry, the study
+
+State: assumptions confirmed by the maintainer on 2026-08-20. Ready for Fiat.
+
+Evidence ref: `main` @ `496f7a1`. Every number below was measured on that ref
+in this working copy. No repository file was changed to produce this document.
+
+Revision 2 replaces the Codex draft of the same topic. It keeps that draft's
+design conclusion and discards three things: the marker self-exclusion fix, the
+Markdown outline extractor, and a success criterion whose command does not run.
+
+## Assumptions
+
+Confirmed, not assumed, as of 2026-08-20:
+
+1. The repository root stays the single boundary authority. An agent may begin
+   below it.
+2. "Check on entry" checks only the subtree being entered. Drift elsewhere is
+   reported and does not block that subtree.
+3. `.horos/candidates.json` stays advisory and never binds an agent.
+4. Markdown and JSON are never excluded by file extension.
+5. Generation axis. `marker-self-exclusion` stays the held frontier target,
+   untouched. This run builds scoped entry plus two guards.
+
+Assumption 5 sets the version arithmetic. Under
+`plugins/hexaemeron/skills/VERSIONING.md`, generation is the second
+number, so the label moves `horos-v9.2.3` to `horos-v9.3.3`, and the row must
+retain the frontier revision and the SHA-256 of
+`{status}|{frontier revision}|{current frontier}|{next Fiat job}` byte for byte.
+The consequence is that no line of the held frontier text may change: scoped
+entry is described in the history row's Change column, nowhere else in the
+ledger.
+
+## Proposition
+
+`horos check <path>` accepts the repository root or any descendant. It walks
+upward to the nearest `.horos/boundary.json`, stops at the Git worktree root,
+treats that directory as the boundary root, freshly classifies only `<path>`,
+and compares that result with the slice of the committed hard boundary under
+`<path>`.
+
+```text
+boundary root: /Users/…/skills
+scope: plugins/alexandria
+hard boundary: matches
+candidates: 3 findings, advisory
+outside-scope drift: not evaluated
+```
+
+Exit 0 admits the scope. Exit 1 means hard drift inside the scope. Exit 2 means
+no usable ancestor boundary, or a path that escapes the worktree. Candidate
+drift never changes the exit code.
+
+Two guards ship with it, because a gate that answers differently on each
+machine cannot admit anything:
+
+- **G1, tracked universe.** A directory holding no tracked file must not become
+  a hard entry.
+- **G2, boundary currency.** Committing a tracked generated file, including a
+  copy of a boundary or an evidence document, must not leave `check` dirty.
+
+## 1. Problem statement
+
+**What is being built.** Scope awareness for the Horos boundary check, plus the
+two guards that make its answer reproducible.
+
+**For whom.** An agent working inside one skill of `wildcat-finance/skills`
+that wants to know whether the boundary covering that subtree is current,
+without paying for a whole-repository answer and without a boundary file of its
+own.
+
+**What a working prototype means here.** From `plugins/alexandria`, one command
+answers the admission question against the root boundary, and the same command
+from the repository root gives a byte-identical scoped answer. The demo path is
+`plugins/horos/examples/scoped-entry/README.md`, run by the last step and
+asserted by the plugin suite.
+
+## 2. Prior art
+
+**In Horos.** `plugins/horos/skills/horos/SKILL.md` already requires a checked
+boundary, splits hard evidence from candidates, and suspends the boundary during
+security review. `plugins/horos/skills/horos/scripts/horos.py` carries `scan`,
+`check` and `map`. `check` resolves `.horos/boundary.json` relative to its own
+argument, which is the gap: `check plugins/alexandria` exits 2 today.
+`docs/refinement/maintainer-spec.md` supplies the two-tier model this keeps.
+
+**In the audit record.** `audit/AUDIT.md` holds 186 rounds, of which 38 are
+Horos runs carrying one finding: an implement receipt that asserted a green
+suite over a red one (Refinement run, step 2, round 1). No Horos round has ever
+returned a classifier finding. Every real failure in this plugin's history has
+been artefact reconciliation, and the record names two: `check` flagging the
+marking evidence copies as new sinks, refreshed by hand in the close commit
+(Marking run, step 4, round 1), and a stale skills count in the same bundle.
+The first of those recurred on `496f7a1` because no guard was written. That is
+the whole case for G2.
+
+**Outside.** Git's directory-scoped attributes remain the maintainer-owned
+classification route, and `linguist-generated` or `linguist-vendored` already
+binds at hard grade. Content-addressed stores supply stronger evidence, because
+the digest of the bytes can be recomputed from the path's claim.
+
+## 3. Constraints and non-goals
+
+**Constraints.**
+
+- Starting ref `496f7a1` on `main`. Fiat replaces this with its own run ref.
+- Python standard library and `unittest`. No new dependency.
+- One committed boundary per repository. A scoped check is a comparison, not a
+  new artefact.
+- Classification stays fail-open. An unproved file stays readable.
+- Generation axis: the frontier revision, current frontier and next job stay
+  byte-identical, and their recorded SHA-256 must still verify.
+- The security-review exception is untouched.
+- The instruction chain from the repository root down to the working directory
+  is read even when the agent starts below the root.
+
+**Non-goals.**
+
+- The marker self-exclusion fix. That is the held frontier job and stays with it.
+- The Markdown outline extractor. Also named in the held frontier order.
+- A JSON structure map. Deferred; ask the maintainer to pull it in if wanted.
+- Promoting the three JSON-heavy directories through `.gitattributes`. Separate,
+  needs no code, listed under Later.
+- Nested `.horos` directories.
+- Caching. The measured full check is 0.11 s, so invalidation would cost more
+  than it saves.
+- Any change to what happens during a security review.
+
+## 4. Design options
+
+**A. A boundary inside every skill.** Each skill checks independently with no
+ancestor discovery. Cost: several authorities over overlapping files, unclear
+precedence, and routine drift whenever a shared rule changes. Rejected.
+
+**B. Run the repository-wide check on every directory entry.** No scanner
+change, 0.11 s per call. Cost: unrelated drift blocks a local task, and the
+answer never names the scope the agent asked about. Useful as an interim
+discipline, wrong as the interface. Rejected.
+
+**C. Resolve one ancestor boundary, check the requested scope.** One authority,
+an answer about the files the agent is about to read. Chosen.
+
+**D. Make candidates a second binding boundary.** Suppresses more bytes at once,
+and lets filename geometry hide source. Rejected: promotion means adding
+evidence or a maintainer attribute, never editing `candidates.json`.
+
+**Chosen, and what it gives up.** C gives up the global claim. A green scoped
+check says nothing about sibling directories, and the output must say so in
+those words. `check <root>` stays the release-time answer.
+
+## 5. Risk register seed
+
+Ordered by what this plugin's audit history has actually produced, not by what
+sounds dangerous.
+
+- **Artefact reconciliation.** Boundary, candidates, census, evidence copies,
+  ledger row and README counts drifting out of step. Every Horos failure on
+  record is this. Control: G2 as a root-suite test with a mutation proving it
+  bites, and one regeneration command named in the runbook.
+- **Machine-dependent classification.** Ignored local directories entering the
+  fresh scan. Control: G1, plus a fixture holding an untracked directory.
+- **Ancestor confusion.** A nested or planted `.horos` selected instead of the
+  repository's. Control: stop at the Git worktree root, reject a boundary
+  outside it, print the selected root before classifying.
+- **Path escape.** `..`, symlinks or case differences moving the scope outside
+  the root. Control: canonicalise both paths, never follow symlinks, reject a
+  scope that is not a descendant.
+- **False local confidence.** A green scoped check read as a global one.
+  Control: `outside-scope drift: not evaluated` in the output, and the release
+  check stays separate.
+
+## 6. Glossary
+
+- **Boundary root.** The directory owning the `.horos/boundary.json` used for a
+  request.
+- **Working scope.** The descendant tree an agent is about to read.
+- **Admission check.** A fresh comparison of hard evidence inside the working
+  scope.
+- **Hard entry.** A path excluded by reproducible evidence.
+- **Candidate.** A weak signal, reported, never binding.
+- **Phantom entry.** A hard entry covering no tracked file. G1 removes these.
+
+## 7. Sources
+
+- `AGENTS.md`, in particular the canonical suite commands at line 81
+- `.horos/boundary.json`, `.horos/candidates.json`, `.horos/census.json`
+- `plugins/horos/skills/horos/SKILL.md`, `EVOLUTION.md`, `scripts/horos.py`
+- `plugins/horos/docs/refinement/maintainer-spec.md`
+- `plugins/hexaemeron/skills/VERSIONING.md`
+- `audit/AUDIT.md`: Refinement run step 2 round 1; Marking run step 4 round 1;
+  Census run step 2 round 1
+- Commit `5d5aba7`, the content-addressed object rule
+- Commit `496f7a1`, the ref this document measures
+
+## 8. Signals, and the questions behind them
+
+Contract: `plugins/hexaemeron/skills/ephoros/SKILL.md`.
+
+1. Which boundary root and scope did Horos select? Both canonical paths print
+   before classification.
+2. Why was admission refused? Each hard-drift path prints with its direction,
+   added or removed.
+3. What did the check cost, and did it stay inside the scope? The output carries
+   files walked and tracked files inspected outside the scope, which must be
+   zero.
+4. What was left unresolved? Candidate count prints separately from hard drift.
+
+No alerting: this is an interactive command, and its exit status plus bounded
+stdout are the signal.
+
+## 9. Boundaries, per capability
+
+Contract: `plugins/hexaemeron/skills/phylax/SKILL.md`.
+
+| Capability | Boundary opened | Worth taking | Control |
+| --- | --- | --- | --- |
+| ancestor resolution | filesystem paths, repository metadata | selecting a planted boundary, escaping the worktree | canonical descendant check, worktree stop, no symlink following, selected paths printed |
+| tracked universe | one fixed `git ls-files` invocation | hostile path, unexpected output | fixed argv, no shell, pinned directory, fail-open filesystem fallback |
+| boundary read | untrusted JSON in the repository | malformed or oversized document | schema check, bounded read, named refusal |
+| artefact regeneration | `.horos` writes | half-written boundary | atomic replace, hard evidence only, root check before commit |
+
+## 10. Budget
+
+Contract: `plugins/hexaemeron/skills/metron/SKILL.md`.
+
+Baseline on `496f7a1`:
+
+```text
+/usr/bin/time -p python3 plugins/horos/skills/horos/scripts/horos.py check .
+real 0.11
+```
+
+Claims to hold:
+
+- A scoped check inspects zero tracked files outside its scope. This is the
+  criterion, not wall-clock.
+- The recorded median of five warm scoped checks of `plugins/alexandria` is
+  reported beside the five-run full-tree median. Numbers are recorded; no
+  machine-specific threshold is asserted in a test.
+
+Measurement command, supplied by step 3:
+
+```text
+python3 plugins/horos/tests/benchmark_scope.py --root . --scope plugins/alexandria --runs 5
+```
+
+Precedent for dismissing a cost lead with a measurement rather than a change is
+Census run, step 2, round 1.
+
+## 11. Fail-closed posture
+
+Contract: `plugins/hexaemeron/skills/elenchus/SKILL.md`.
+
+Refuse admission when the path is absent, escapes the worktree, has no usable
+ancestor boundary, carries an unreadable or unsupported boundary document, or
+holds hard drift inside the scope. Do not refuse for candidate drift or for hard
+drift outside the scope, and say which of those two conditions applied.
+
+Every fix carries a test that fails without it. Two are already owed by the
+record: the phantom-entry class, and the evidence-copy recurrence that this loop
+caught on 18 August and did not guard.
+
+## 12. Decisions and their homes
+
+Contract: `plugins/hexaemeron/skills/hypomnema/SKILL.md`.
+
+- One root boundary with scoped views: `plugins/horos/docs/study.md` and the
+  skill contract.
+- A green scoped check makes no global claim: CLI help, `SKILL.md`, the example.
+- A hard entry must cover at least one tracked file: the classifier rationale
+  beside the rule.
+- Exit-code meanings: `SKILL.md`, and a decision record under
+  `plugins/horos/docs/decisions/` if any of them ever changes.
+
+## Always, ask first, never
+
+**Always.** Both suites before every commit, by the canonical commands at
+`AGENTS.md:81`. Phylax and ephoros over changed Python. Imprimatur over shipped
+prose. A root-wide `check .` before committing a regenerated boundary. Each step
+green at entry and exit.
+
+**Ask first.** Add a dependency. Change the boundary schema or the meaning of an
+exit code. Add caching or persistent state. Touch CI. Promote a
+repository-specific candidate without a portable rule. Read whole files outside
+digest verification.
+
+**Never.** Bind an agent to `candidates.json`. Exclude Markdown, JSON or JSONL
+by suffix. Follow a symlink outside the selected root. Execute or import code
+from the scanned repository. Apply a boundary during a security review. Create a
+nested boundary to make a local check pass. Delete or weaken a failing test to
+clear a step. Claim a command ran when it did not. Change the held frontier text
+in this run.
+
+## Success criteria
+
+1. `python3 -m unittest discover -s plugins/horos/tests -t plugins/horos` passes,
+   at least the 176 tests present at entry plus the new cases.
+2. `python3 -m unittest discover -s tests` passes, at least 34 tests.
+3. The phylax, ephoros and imprimatur commands named by `AGENTS.md` run clean
+   over every changed file.
+4. A fixture tree holding an ignored directory with no tracked file produces no
+   hard entry for that directory.
+5. `check .` exits 0 on a clean tracked checkout, on a machine that also holds
+   an ignored build or worktree directory.
+6. A root-suite guard fails when a tracked generated file is committed without
+   refreshing the boundary, and passes once refreshed. Proved by mutation.
+7. `check plugins/alexandria` exits 0 and prints the selected boundary root, the
+   scope, and `outside-scope drift: not evaluated`.
+8. Running that check from the repository root and from inside
+   `plugins/alexandria` produces byte-identical canonical output.
+9. A hard mutation inside `plugins/alexandria` exits 1 and names the path. The
+   same mutation in a sibling directory leaves the Alexandria check at exit 0.
+10. Candidate-only drift inside the scope exits 0, prints, and never enters the
+    hard boundary.
+11. A missing ancestor boundary, a malformed boundary, a path outside the
+    worktree and a symlink escape each exit 2 with a named reason.
+12. `benchmark_scope.py` records five-run medians and reports zero tracked files
+    inspected outside the scope.
+13. The ledger reads `horos-v9.3.3` on the generation axis, the frontier
+    revision and its SHA-256 are byte-identical to `horos-v9.2.3`, and
+    `tests/test_evolution_contract.py` passes.
+14. `plugins/horos/examples/scoped-entry/README.md` runs from a clean checkout
+    and its pinned output matches.

--- a/plugins/horos/tests/benchmark_scope.py
+++ b/plugins/horos/tests/benchmark_scope.py
@@ -47,22 +47,25 @@ def main(argv=None):
     root = os.path.abspath(args.root)
     scope = os.path.join(root, args.scope)
 
-    full_median, full_code, _ = timed_check(root, args.runs)
+    full_median, full_code, full_text = timed_check(root, args.runs)
     scope_median, scope_code, scope_text = timed_check(scope, args.runs)
 
-    if scope_code == 2:
-        scope_status = "unavailable: " + scope_text.strip().splitlines()[0]
-        scope_report = None
-    else:
-        scope_status = "measured"
-        scope_report = round(scope_median, 3)
+    def report(median, code, text):
+        """A duration beside a refused check reads as a fast check. Null it."""
+        if code == 2:
+            return None, "unavailable: " + text.strip().splitlines()[0]
+        return round(median, 3), "measured"
+
+    full_report, full_status = report(full_median, full_code, full_text)
+    scope_report, scope_status = report(scope_median, scope_code, scope_text)
 
     record = {
         "runs": args.runs,
-        "root": os.path.relpath(root, root) or ".",
+        "root": args.root,
         "scope": args.scope,
-        "full_tree_median_ms": round(full_median, 3),
+        "full_tree_median_ms": full_report,
         "full_tree_exit": full_code,
+        "full_tree_status": full_status,
         "scope_median_ms": scope_report,
         "scope_exit": scope_code,
         "scope_status": scope_status,

--- a/plugins/horos/tests/benchmark_scope.py
+++ b/plugins/horos/tests/benchmark_scope.py
@@ -3,8 +3,9 @@
 Emits one JSON object so a before-and-after pair can be compared without
 reading prose, per `plugins/hexaemeron/skills/metron/SKILL.md`. It asserts
 nothing: a machine-specific threshold in a test would fail on a different
-machine rather than on a regression. The scoped figures are null until the
-scoped check exists, and `scope_status` says why.
+machine rather than on a regression. Either side reports a null median and a
+status naming the refusal when its check could not run, so the scoped figures
+stay null until the scoped check exists.
 
     python3 plugins/horos/tests/benchmark_scope.py --root . --scope plugins/alexandria --runs 5
 """

--- a/plugins/horos/tests/benchmark_scope.py
+++ b/plugins/horos/tests/benchmark_scope.py
@@ -1,0 +1,77 @@
+"""Record what a boundary check costs, whole-tree and scoped.
+
+Emits one JSON object so a before-and-after pair can be compared without
+reading prose, per `plugins/hexaemeron/skills/metron/SKILL.md`. It asserts
+nothing: a machine-specific threshold in a test would fail on a different
+machine rather than on a regression. The scoped figures are null until the
+scoped check exists, and `scope_status` says why.
+
+    python3 plugins/horos/tests/benchmark_scope.py --root . --scope plugins/alexandria --runs 5
+"""
+
+from pathlib import Path
+import argparse
+import io
+import json
+import os
+import statistics
+import sys
+import time
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "horos" / "scripts"))  # noqa: E402  (locates horos.py)
+
+import horos  # noqa: E402
+
+
+def timed_check(target, runs):
+    """Return (median milliseconds, last exit code, last output)."""
+    samples = []
+    code = None
+    text = ""
+    for _ in range(runs):
+        out = io.StringIO()
+        started = time.perf_counter()
+        code = horos.check_tree(target, out=out)
+        samples.append((time.perf_counter() - started) * 1000.0)
+        text = out.getvalue()
+    return statistics.median(samples), code, text
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="benchmark_scope", description=__doc__)
+    parser.add_argument("--root", default=".", help="repository root to check")
+    parser.add_argument("--scope", required=True, help="descendant path to check")
+    parser.add_argument("--runs", type=int, default=5, help="samples per target")
+    args = parser.parse_args(argv)
+
+    root = os.path.abspath(args.root)
+    scope = os.path.join(root, args.scope)
+
+    full_median, full_code, _ = timed_check(root, args.runs)
+    scope_median, scope_code, scope_text = timed_check(scope, args.runs)
+
+    if scope_code == 2:
+        scope_status = "unavailable: " + scope_text.strip().splitlines()[0]
+        scope_report = None
+    else:
+        scope_status = "measured"
+        scope_report = round(scope_median, 3)
+
+    record = {
+        "runs": args.runs,
+        "root": os.path.relpath(root, root) or ".",
+        "scope": args.scope,
+        "full_tree_median_ms": round(full_median, 3),
+        "full_tree_exit": full_code,
+        "scope_median_ms": scope_report,
+        "scope_exit": scope_code,
+        "scope_status": scope_status,
+        "tracked_files_inspected_outside_scope": None,
+    }
+    json.dump(record, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/horos/tests/test_scaffold.py
+++ b/plugins/horos/tests/test_scaffold.py
@@ -45,5 +45,57 @@ class ScaffoldTests(unittest.TestCase):
         self.assertIn(rule, text)
 
 
+SCOPED_ENTRY = PLUGIN / "docs" / "scoped-entry"
+
+MODULE_IDS = (
+    "change-scaffold",
+    "tracked-universe",
+    "boundary-currency",
+    "scoped-entry",
+    "demonstration",
+)
+
+
+class ScopedEntrySpecTests(unittest.TestCase):
+    """The committed spec for this run, held to its own shape."""
+
+    def test_the_run_commits_its_study_and_runbook(self):
+        for name in ("study.md", "runbook.md"):
+            with self.subTest(document=name):
+                self.assertTrue((SCOPED_ENTRY / name).is_file())
+
+    def test_the_runbook_names_every_module_in_build_order(self):
+        text = (SCOPED_ENTRY / "runbook.md").read_text(encoding="utf-8")
+        seen = [
+            module for module in MODULE_IDS
+            if f"| {module} |" in text
+        ]
+        self.assertEqual(seen, list(MODULE_IDS))
+        order = text.index("Build order:")
+        self.assertEqual(
+            [module for module in MODULE_IDS if module in text[order:order + 300]],
+            list(MODULE_IDS),
+        )
+
+    def test_the_study_carries_fourteen_success_criteria(self):
+        text = (SCOPED_ENTRY / "study.md").read_text(encoding="utf-8")
+        section = text.split("## Success criteria", 1)[1].split("\n# ", 1)[0]
+        numbered = [
+            line for line in section.splitlines()
+            if line[:1].isdigit() and line.split(".", 1)[0].isdigit()
+        ]
+        self.assertEqual(len(numbered), 14)
+
+    def test_each_step_carries_the_six_required_fields(self):
+        text = (SCOPED_ENTRY / "runbook.md").read_text(encoding="utf-8")
+        steps = text.split("\n## Step ")[1:]
+        self.assertEqual(len(steps), 5)
+        for index, body in enumerate(steps, start=1):
+            for field in ("**Goal.**", "**Entry.**", "**Exit.**", "**Files.**",
+                          "**Tests.**", "**Disciplines.**"):
+                with self.subTest(step=index, field=field):
+                    self.assertIn(field, body)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/horos/tests/test_scoped_entry.py
+++ b/plugins/horos/tests/test_scoped_entry.py
@@ -1,0 +1,107 @@
+"""Scoped entry, and the reproducibility a scoped gate depends on.
+
+Every test here is a fixture for a success criterion this run has not built
+yet, so each one is marked as an expected failure. A step that satisfies its
+criterion turns the fixture into an unexpected success, which fails the suite
+until the decorator comes off: the marker cannot be left behind by accident.
+"""
+
+from pathlib import Path
+import io
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "horos" / "scripts"))  # noqa: E402  (locates horos.py)
+
+import horos  # noqa: E402
+
+GIT = shutil.which("git")
+
+MINIFIED = "var a=1;" * 400 + "\n"
+
+
+def write(root, relpath, content):
+    path = Path(root) / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def git(root, *args):
+    subprocess.run(  # phylax: allow subprocess: fixed argv git in a test tempdir, no shell
+        ["git", "-C", root, *args],
+        capture_output=True,
+        check=True,
+        env={**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"},
+    )
+
+
+def repository():
+    """A tracked tree with one ignored build directory holding nothing tracked."""
+    tmp = tempfile.TemporaryDirectory()
+    root = tmp.name
+    git(root, "init", "-q")
+    write(root, ".gitignore", "out/\n")
+    write(root, "src/app.py", "value = 1\n")
+    write(root, "plugins/thing/module.py", "value = 2\n")
+    git(root, "add", ".")
+    git(root, "commit", "-qm", "tracked tree")
+    write(root, "out/bundle.min.js", MINIFIED)
+    return tmp, root
+
+
+class PhantomEntryTests(unittest.TestCase):
+    """Criterion 4: a directory holding no tracked file is not a hard entry."""
+
+    @unittest.skipIf(GIT is None, "git unavailable")
+    @unittest.expectedFailure
+    def test_an_ignored_directory_earns_no_hard_entry(self):
+        tmp, root = repository()
+        self.addCleanup(tmp.cleanup)
+        result = horos.scan_tree(root)
+        phantom = [
+            entry for entry in result["entries"]
+            if entry["path"].startswith("out/")
+        ]
+        self.assertEqual(phantom, [])
+
+
+class MachineIndependentCheckTests(unittest.TestCase):
+    """Criterion 5: check answers the same whatever untracked state is present."""
+
+    @unittest.skipIf(GIT is None, "git unavailable")
+    @unittest.expectedFailure
+    def test_check_is_clean_beside_an_ignored_build_directory(self):
+        tmp, root = repository()
+        self.addCleanup(tmp.cleanup)
+        shutil.rmtree(os.path.join(root, "out"))
+        horos.write_boundary(root, horos.boundary_document(horos.scan_tree(root)))
+        horos.write_candidates(root, horos.candidates_document(horos.scan_tree(root)))
+        write(root, "out/bundle.min.js", MINIFIED)
+        out = io.StringIO()
+        self.assertEqual(horos.check_tree(root, out=out), 0, out.getvalue())
+
+
+class ScopedCheckTests(unittest.TestCase):
+    """Criterion 7: a descendant scope resolves the one ancestor boundary."""
+
+    @unittest.skipIf(GIT is None, "git unavailable")
+    @unittest.expectedFailure
+    def test_a_descendant_scope_resolves_the_ancestor_boundary(self):
+        tmp, root = repository()
+        self.addCleanup(tmp.cleanup)
+        shutil.rmtree(os.path.join(root, "out"))
+        horos.write_boundary(root, horos.boundary_document(horos.scan_tree(root)))
+        horos.write_candidates(root, horos.candidates_document(horos.scan_tree(root)))
+        out = io.StringIO()
+        scope = os.path.join(root, "plugins", "thing")
+        self.assertEqual(horos.check_tree(scope, out=out), 0, out.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_boundary_currency.py
+++ b/tests/test_boundary_currency.py
@@ -1,0 +1,40 @@
+"""The committed reading boundary must describe the tracked tree it ships with.
+
+Criterion 6 of `plugins/horos/docs/scoped-entry/study.md`. The audit record
+already carries this failure once: Marking run, step 4, round 1 refreshed the
+boundary by hand after `check` flagged the marking evidence copies as new
+sinks, and no guard was written. It recurred. This fixture is the guard, and it
+is an expected failure until the step that fixes the drift lands.
+"""
+
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "plugins" / "horos" / "skills" / "horos" / "scripts"))  # noqa: E402  (locates horos.py)
+
+import horos  # noqa: E402
+
+
+class BoundaryCurrencyTests(unittest.TestCase):
+    @unittest.expectedFailure
+    def test_the_committed_boundary_matches_a_fresh_scan(self):
+        committed = horos.load_boundary(str(ROOT))
+        fresh = horos.boundary_document(
+            horos.scan_tree(
+                str(ROOT),
+                include_untracked=committed.get("universe") == "tracked+untracked",
+            )
+        )
+        drift = horos.diff_documents(committed, fresh)
+        self.assertEqual(
+            [path for path, _ in drift],
+            [],
+            "regenerate with: python3 plugins/horos/skills/horos/scripts/horos.py "
+            "scan . --write",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Step 1 of 5. This commits the spec for the run and the fixtures the later steps
have to satisfy, and changes no runtime behaviour.

The study and runbook go to `plugins/horos/docs/scoped-entry/`, beside the
plugin's other per-job specs. The founding `docs/study.md` and `docs/runbook.md`
are untouched.

Four fixtures land with them. Each one fails now, for the reason it names:

- an ignored directory holding nothing tracked still earns a hard entry, seen
  as `out/` at 0 bytes and 0 files
- `check` therefore exits 1 on a clean tracked tree whenever such a directory
  is present, so its answer depends on whose machine it runs on
- `check` on a descendant exits 2, because it looks for a boundary beside the
  path it was given rather than above it
- the committed root boundary does not match a fresh tracked scan

The fourth is a repeat. Marking run, step 4, round 1 records `check` flagging
the marking evidence copies as new sinks; the boundary was refreshed by hand
and no guard was written, so it happened again. This time it gets the guard.

All four are `expectedFailure`, so the tree is green at both ends of the step.
A later step that satisfies one turns its fixture into an unexpected success,
which fails the suite until the marker comes off. The marker cannot be
forgotten.

`benchmark_scope.py` records the entry baseline rather than claiming an
improvement: full-tree median 52.1 ms over five runs at exit 1, with the scoped
figures null because the scoped check does not exist yet. It asserts nothing,
so no machine-specific threshold enters the suite.

Audit rounds 1 and 2 are in `audit/AUDIT.md`. Round 1 found two low findings,
both in the measurement record and both the same class: a `root` field that was
always `"."`, and a median reported beside a refused check. Fixed in b6e7ed2,
and round 2 came back clean. The fixes sit on this branch rather than a side
branch, because the four remaining steps chain from it, so there is no stacked
PR to link.

This step stacks on the run branch,
`fiat/give-horos-scoped-entry-ancestor-resolved-check`.

To check the step:

```bash
python3 -m unittest discover -s plugins/horos/tests -t plugins/horos
python3 -m unittest discover -s tests
python3 plugins/horos/tests/benchmark_scope.py --root . --scope plugins/alexandria --runs 5
```

Expect 183 tests with three expected failures, 35 with one, and a JSON record
whose scoped fields are null.

One deviation to name rather than hide: the five commits on this branch carry
`Co-Authored-By: Claude Opus 5` but not the `Co-authored-by: Shoggoth` and
`Wildcat-Origin: shoggoth` trailers that push discipline requires. Two of them
are named in the run's sealed ledger, as the implement commit and as round 1's
fixes commit, so rewriting the branch to add the trailers would leave the ledger
pointing at commits that no longer exist. Every commit from step 2 onward
carries both trailers.

<!-- wildcat-origin: shoggoth -->
