### PR TITLE
Guard the reading boundary against going stale

### DIFF
--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -2,11 +2,11 @@
   "counts": {
     "bytes_binary": 17,
     "bytes_content_addressed": 7844971,
-    "bytes_generated": 121632,
+    "bytes_generated": 126422,
     "bytes_lockfile": 54,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 1135
+    "files_walked": 1149
   },
   "entries": [
     {
@@ -523,6 +523,13 @@
       "path": "plugins/hexaemeron/skills/fizz/templates/FoundryTester.sol"
     },
     {
+      "bytes": 3802,
+      "category": "generated",
+      "evidence": "marker 'do not edit' in the first 4096 bytes",
+      "grade": "hard",
+      "path": "plugins/horos/docs/evidence/skills.boundary.json"
+    },
+    {
       "bytes": 2991,
       "category": "generated",
       "evidence": "marker 'do not edit' in the first 4096 bytes",
@@ -603,7 +610,7 @@
       "path": "plugins/horos/examples/fixture/yarn.lock"
     },
     {
-      "bytes": 33328,
+      "bytes": 34316,
       "category": "generated",
       "evidence": "marker 'do not edit' in the first 4096 bytes",
       "grade": "hard",

--- a/.horos/census.json
+++ b/.horos/census.json
@@ -1,9 +1,9 @@
 {
   "rows": [
     {
-      "boundary_bytes": 70215,
-      "bytes": 9425856,
-      "files": 330,
+      "boundary_bytes": 74017,
+      "bytes": 9429658,
+      "files": 331,
       "suffix": ".json"
     },
     {
@@ -13,15 +13,15 @@
       "suffix": "(no suffix)"
     },
     {
-      "boundary_bytes": 50392,
-      "bytes": 2786663,
-      "files": 286,
+      "boundary_bytes": 51380,
+      "bytes": 2850716,
+      "files": 291,
       "suffix": ".py"
     },
     {
       "boundary_bytes": 0,
-      "bytes": 2174681,
-      "files": 286,
+      "bytes": 2290718,
+      "files": 294,
       "suffix": ".md"
     },
     {
@@ -141,6 +141,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 24022270,
-  "total_files": 1143
+  "total_bytes": 24206162,
+  "total_files": 1157
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,3 +130,11 @@ that earned its entry; leave those paths unread unless the task demands
 one. The boundary is fail-open: what it omits is merely unproven. It never
 applies during security review; during any audit, review or incident work,
 read as if no boundary exists.
+
+The root suite checks that this file's boundary still describes the tracked
+tree, so a change that adds or alters a classified file fails it until the
+boundary is regenerated:
+
+```bash
+python3 plugins/horos/skills/horos/scripts/horos.py scan . --write
+```

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4435,3 +4435,34 @@ describes the null-median treatment as the scope side's alone, which is now
 under-description rather than error, since both sides carry a status field. It
 goes to the prose phase with the rest of this step's wording rather than
 opening a third round for a docstring.
+
+## Scoped entry, step 2, round 1 -- 2026-08-20
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0. Horos
+188/188 with one expected failure, root 35/35 with one, verified before this
+receipt. Three of the five new guards were seen failing on the unfixed
+classifier and all eleven pass on the fixed one.
+
+The review went at the paths the change could break rather than the ones it
+fixes. The pruning is safe because the dropped entry covers no tracked file, so
+the walk has nothing to classify under it, and that was already the behaviour
+for a matched directory. Two edges were run rather than reasoned about. An
+empty tracked universe, a repository with nothing committed, produces an empty
+boundary and zero walked files, which is the fail-open position stated in the
+skill. The widened universe still separates the two cases correctly: with
+`--include-untracked`, an untracked-but-not-ignored `dist/` binds at one file
+while an ignored `out/` stays out, so the flag still means what it says.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: two. A directory that will be dropped is
+still walked in full before the drop, so the count that decides it is paid for
+and discarded; measured against Metron's rule the full-tree check sits at 55.5
+ms against 52.1 ms at step 1 on a tree that also grew, which is noise rather
+than a regression, and short-circuiting it would put a universe prefix scan in
+front of every directory to save that. Separately, `check .` now names this
+file's own classifier source as drifted, because the marker rule excludes it
+and its byte count moved: that is the held frontier defect showing itself
+during unrelated work, evidence for the marker self-exclusion job rather than
+for this one.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4491,3 +4491,21 @@ request body and this row. Separately, `plugins/horos/**` has no CI workflow of
 its own, so this plugin's 188 tests run locally and nowhere else; adding one is
 an ask-first change under this run's boundaries and is recorded on pull request
 256 rather than made here.
+
+## Scoped entry, step 3, round 2 -- 2026-08-20
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0. Horos
+188/188 with one expected failure, root 38/38 clean, `check .` exit 0, all
+verified before this receipt. The round audited the tree with round 1's
+correction applied and re-read every remaining quantitative claim in this
+run's two documents against the tree rather than against the earlier prose:
+the entry count, the census rows, the suite counts, the baseline median, and
+the audit references. The 87 figure now carries the checkout it was measured
+in. The three mutations that pin the guard ran again in this round as part of
+the root suite; the three ways the guard was seen failing belong to the step
+rather than to this round, and are recorded there.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4466,3 +4466,28 @@ file's own classifier source as drifted, because the marker rule excludes it
 and its byte count moved: that is the held frontier defect showing itself
 during unrelated work, evidence for the marker self-exclusion job rather than
 for this one.
+
+## Scoped entry, step 3, round 1 -- 2026-08-20
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0. Horos
+188/188 with one expected failure, root 38/38 clean, verified before this
+receipt. `check .` exits 0 for the first time in this run, 87 entries, the
+evidence copy included, none binding zero tracked files. The guard was seen
+failing three ways before it passed: as step 1's expected failure on the
+evidence copy, against a hand-removed entry, and on its own source, because a
+fixture spelling the generated-marker literal put this guard inside the
+boundary. The round then went looking for claims the earlier steps had not
+earned, which is where the finding is.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R1-01 | medium | plugins/horos/docs/scoped-entry/runbook.md | step 2's exit claimed a fresh scan takes this repository's hard entries from 93 to 87. Running the pre-fix classifier over a pristine worktree of the same commit gives 87 with no phantom entry: the 93 came from the maintainer's own checkout, which carries a stale worktree under `.claude/worktrees/` and a `plugins/pandects/out/` directory. The number described a checkout and was written as a property of the repository | fixed in 84bb99e, and pull request 256's body corrected in place |
+
+Leads not pursued: step 2's commit message carries the same wrong figure and
+keeps it. That commit is named in the run's sealed ledger as step 2's
+implementation, so rewording it would leave the ledger pointing at a commit
+that no longer exists; the corrected account lives in the runbook, the pull
+request body and this row. Separately, `plugins/horos/**` has no CI workflow of
+its own, so this plugin's 188 tests run locally and nowhere else; adding one is
+an ask-first change under this run's boundaries and is recorded on pull request
+256 rather than made here.

--- a/plugins/horos/docs/scoped-entry/runbook.md
+++ b/plugins/horos/docs/scoped-entry/runbook.md
@@ -49,10 +49,13 @@ tracked file, so `check` answers the same on every machine.
 **Entry.** Step 1's green exit. `check .` exits 1 with 7 drifted paths, 6 of
 them ignored local directories.
 
-**Exit.** A fresh scan of this repository emits no phantom entry; `check .`
-exits 0 on a clean tracked checkout regardless of local build or worktree
-directories; the fixture from step 1 passes; census attribution is unchanged for
-every entry that does cover tracked files.
+**Exit.** A fresh scan of this repository emits no phantom entry, taking its
+hard entries from 93 to 87; step 1's fixtures for criteria 4 and 5 pass with
+their markers removed, so a checkout carrying an ignored build directory exits
+0; census attribution is unchanged for every entry that does cover tracked
+files. This repository's own `check .` still exits 1 at this step, for the
+tracked evidence copy the committed boundary predates, and step 3 owns that
+refresh.
 
 **Files.** `plugins/horos/skills/horos/scripts/horos.py`, classifier tests,
 fixtures, and `.horos/boundary.json` only if a real entry changed.

--- a/plugins/horos/docs/scoped-entry/runbook.md
+++ b/plugins/horos/docs/scoped-entry/runbook.md
@@ -49,13 +49,17 @@ tracked file, so `check` answers the same on every machine.
 **Entry.** Step 1's green exit. `check .` exits 1 with 7 drifted paths, 6 of
 them ignored local directories.
 
-**Exit.** A fresh scan of this repository emits no phantom entry, taking its
-hard entries from 93 to 87; step 1's fixtures for criteria 4 and 5 pass with
-their markers removed, so a checkout carrying an ignored build directory exits
-0; census attribution is unchanged for every entry that does cover tracked
-files. This repository's own `check .` still exits 1 at this step, for the
-tracked evidence copy the committed boundary predates, and step 3 owns that
-refresh.
+**Exit.** No scan emits a phantom entry, and step 1's fixtures for criteria 4
+and 5 pass with their markers removed, so a checkout carrying an ignored build
+directory exits 0; census attribution is unchanged for every entry that does
+cover tracked files. The count depends on the checkout rather than the
+repository: a pristine clone produces 87 hard entries either side of the fix,
+because it carries no ignored build products, while the maintainer's own
+checkout produced 93 with six binding nothing, five under a stale worktree
+under `.claude/worktrees/` and one at `plugins/pandects/out/`. That difference
+is the defect, so the fixture rather than a repository count is the criterion.
+This repository's own `check .` still exits 1 at this step, for the tracked
+evidence copy the committed boundary predates, and step 3 owns that refresh.
 
 **Files.** `plugins/horos/skills/horos/scripts/horos.py`, classifier tests,
 fixtures, and `.horos/boundary.json` only if a real entry changed.

--- a/plugins/horos/skills/horos/SKILL.md
+++ b/plugins/horos/skills/horos/SKILL.md
@@ -119,7 +119,12 @@ confessions and every file oracle-parsed, recorded at
    `.horos/candidates.json` as an advisory report a maintainer can promote
    to a repository-specific rule. Scans of git repositories cover tracked
    files by default, so local build products never contaminate a committed
-   boundary; `--include-untracked` widens the universe deliberately.
+   boundary; `--include-untracked` widens the universe deliberately. A
+   directory entry has to cover at least one file in that universe: one
+   holding nothing tracked excludes no bytes a reader would have reached, and
+   emitting it would make the same check answer differently on two machines.
+   Where git cannot answer at all, the fail-open position stands and the entry
+   is kept.
 5. When writing a boundary into a repository other agents will work in, add
    the adoption stanza that `scan --write` prints to that repository's
    AGENTS.md or CLAUDE.md. Agent harnesses load those files at session

--- a/plugins/horos/skills/horos/scripts/horos.py
+++ b/plugins/horos/skills/horos/scripts/horos.py
@@ -495,6 +495,22 @@ def directory_entry(root, relpath, category, evidence, tally=None, grade="hard",
     }
 
 
+def binding_directory_entry(root, relpath, category, evidence, tally=None, universe=None):
+    """One hard directory entry, or None when it would bind no tracked file.
+
+    A directory holding nothing tracked is not a token sink: excluding it saves
+    no bytes an agent would ever read, and emitting it makes the same check
+    answer differently on two machines, since an ignored build directory or a
+    stray worktree sits in one checkout and not the other. Fail-open still
+    holds where git cannot answer: with no universe there is no tracked notion
+    to test against, so the entry stands.
+    """
+    entry = directory_entry(root, relpath, category, evidence, tally, universe=universe)
+    if universe is not None and entry["files"] == 0:
+        return None
+    return entry
+
+
 def resolve_universe(root, include_untracked=False):
     """The file set a scan covers. Git-tracked by default so local build
     products and caches never contaminate a committed boundary; the
@@ -556,16 +572,18 @@ def scan_tree(root, census=False, include_untracked=False):
             if named_category is not None:
                 corroboration = corroborate_directory(child, dirname)
                 if corroboration is not None:
-                    entries.append(
-                        directory_entry(
-                            root,
-                            relpath,
-                            named_category,
-                            f"directory name {dirname} corroborated by {corroboration}",
-                            tally,
-                            universe=universe,
-                        )
+                    entry = binding_directory_entry(
+                        root,
+                        relpath,
+                        named_category,
+                        f"directory name {dirname} corroborated by {corroboration}",
+                        tally,
+                        universe=universe,
                     )
+                    if entry is not None:
+                        entries.append(entry)
+                    # Either way the subtree is pruned: an entry covers it, or
+                    # it holds nothing tracked for the walk to classify.
                     continue
                 # Name alone is a candidate signal; the subtree is walked
                 # file by file instead of being excluded.
@@ -584,11 +602,11 @@ def scan_tree(root, census=False, include_untracked=False):
                 continue
             matched = match_attribute_scopes(scopes, relpath + "/")
             if matched is not None:
-                entries.append(
-                    directory_entry(
-                        root, relpath, matched[0], matched[1], tally, universe=universe
-                    )
+                entry = binding_directory_entry(
+                    root, relpath, matched[0], matched[1], tally, universe=universe
                 )
+                if entry is not None:
+                    entries.append(entry)
                 continue
             keep.append(dirname)
         dirnames[:] = keep

--- a/plugins/horos/tests/test_scoped_entry.py
+++ b/plugins/horos/tests/test_scoped_entry.py
@@ -59,7 +59,6 @@ class PhantomEntryTests(unittest.TestCase):
     """Criterion 4: a directory holding no tracked file is not a hard entry."""
 
     @unittest.skipIf(GIT is None, "git unavailable")
-    @unittest.expectedFailure
     def test_an_ignored_directory_earns_no_hard_entry(self):
         tmp, root = repository()
         self.addCleanup(tmp.cleanup)
@@ -75,7 +74,6 @@ class MachineIndependentCheckTests(unittest.TestCase):
     """Criterion 5: check answers the same whatever untracked state is present."""
 
     @unittest.skipIf(GIT is None, "git unavailable")
-    @unittest.expectedFailure
     def test_check_is_clean_beside_an_ignored_build_directory(self):
         tmp, root = repository()
         self.addCleanup(tmp.cleanup)

--- a/plugins/horos/tests/test_universe.py
+++ b/plugins/horos/tests/test_universe.py
@@ -104,5 +104,67 @@ class UniverseTests(unittest.TestCase):
         self.assertEqual(entry["files"], 2)
 
 
+MINIFIED = "var a=1;" * 400 + "\n"
+
+
+@unittest.skipIf(GIT is None, "git unavailable")
+class BindingDirectoryTests(unittest.TestCase):
+    """A hard directory entry must cover at least one file in the universe.
+
+    Without this, a boundary check answers differently on two machines: an
+    ignored build directory or a stray worktree is present in one checkout and
+    absent from the other, so the check drifts against local state instead of
+    against the tree.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.addCleanup(self._tmp.cleanup)
+        git(self.root, "init", "-q")
+        write(self.root, ".gitignore", "node_modules/\nout/\nvendor-only/\n")
+        write(self.root, "src/app.py", "value = 1\n")
+
+    def paths(self, result):
+        return [entry["path"] for entry in result["entries"]]
+
+    def test_a_vendored_name_holding_nothing_tracked_earns_no_entry(self):
+        write(self.root, "node_modules/dep/package.json", '{"name": "dep"}\n')
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-q", "-m", "tracked")
+        self.assertNotIn("node_modules/", self.paths(horos.scan_tree(self.root)))
+
+    def test_a_corroborated_generated_name_holding_nothing_tracked_earns_no_entry(self):
+        write(self.root, "out/bundle.min.js", MINIFIED)
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-q", "-m", "tracked")
+        self.assertNotIn("out/", self.paths(horos.scan_tree(self.root)))
+
+    def test_one_tracked_file_is_enough_to_bind_the_directory(self):
+        write(self.root, "node_modules/dep/package.json", '{"name": "dep"}\n')
+        git(self.root, "add", "-f", "node_modules/dep/package.json", "src", ".gitignore")
+        git(self.root, "commit", "-q", "-m", "one tracked")
+        write(self.root, "node_modules/dep/local-cache.js", "cache\n" * 20)
+        write(self.root, "node_modules/other/index.js", "module.exports = 2\n")
+        entries = {entry["path"]: entry for entry in horos.scan_tree(self.root)["entries"]}
+        self.assertIn("node_modules/", entries)
+        self.assertEqual(entries["node_modules/"]["files"], 1)
+
+    def test_an_attribute_matched_directory_holding_nothing_tracked_earns_no_entry(self):
+        write(self.root, ".gitattributes", "vendor-only/** linguist-vendored\n")
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-q", "-m", "attributes")
+        write(self.root, "vendor-only/lib.js", "module.exports = 3\n")
+        self.assertNotIn("vendor-only/", self.paths(horos.scan_tree(self.root)))
+
+    def test_the_filesystem_fallback_still_binds_an_untracked_directory(self):
+        outside = tempfile.TemporaryDirectory()
+        self.addCleanup(outside.cleanup)
+        write(outside.name, "node_modules/dep/package.json", '{"name": "dep"}\n')
+        result = horos.scan_tree(outside.name)
+        self.assertEqual(result["universe"], "filesystem")
+        self.assertIn("node_modules/", self.paths(result))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_boundary_currency.py
+++ b/tests/test_boundary_currency.py
@@ -1,14 +1,25 @@
 """The committed reading boundary must describe the tracked tree it ships with.
 
 Criterion 6 of `plugins/horos/docs/scoped-entry/study.md`. The audit record
-already carries this failure once: Marking run, step 4, round 1 refreshed the
+carries this failure once already: Marking run, step 4, round 1 refreshed the
 boundary by hand after `check` flagged the marking evidence copies as new
-sinks, and no guard was written. It recurred. This fixture is the guard, and it
-is an expected failure until the step that fixes the drift lands.
+sinks, and no guard was written. It recurred two days later, when a commit
+regenerated the boundary and added an evidence copy of it in the same change.
+This is the guard.
+
+A guard that cannot fail is worth nothing, so the mutations below drive the
+same comparison over a temporary repository and require it to name a path in
+both directions: an entry the tree earned and the boundary lacks, and an entry
+the boundary claims and the tree no longer earns.
 """
 
 from pathlib import Path
+import json
+import os
+import shutil
+import subprocess
 import sys
+import tempfile
 import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -16,24 +27,99 @@ sys.path.insert(0, str(ROOT / "plugins" / "horos" / "skills" / "horos" / "script
 
 import horos  # noqa: E402
 
+GIT = shutil.which("git")
+
+REFRESH = (
+    "regenerate with: python3 "
+    "plugins/horos/skills/horos/scripts/horos.py scan . --write"
+)
+
+
+def drifted_paths(root):
+    """Every path where the committed boundary and a fresh scan disagree."""
+    committed = horos.load_boundary(str(root))
+    fresh = horos.boundary_document(
+        horos.scan_tree(
+            str(root),
+            include_untracked=committed.get("universe") == "tracked+untracked",
+        )
+    )
+    return [path for path, _ in horos.diff_documents(committed, fresh)]
+
+
+def write(root, relpath, content):
+    path = Path(root) / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def git(root, *args):
+    subprocess.run(  # phylax: allow subprocess: fixed argv git in a test tempdir, no shell
+        ["git", "-C", root, *args],
+        capture_output=True,
+        check=True,
+        env={**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"},
+    )
+
 
 class BoundaryCurrencyTests(unittest.TestCase):
-    @unittest.expectedFailure
     def test_the_committed_boundary_matches_a_fresh_scan(self):
-        committed = horos.load_boundary(str(ROOT))
-        fresh = horos.boundary_document(
-            horos.scan_tree(
-                str(ROOT),
-                include_untracked=committed.get("universe") == "tracked+untracked",
-            )
+        self.assertEqual(drifted_paths(ROOT), [], REFRESH)
+
+
+@unittest.skipIf(GIT is None, "git unavailable")
+class GuardMutationTests(unittest.TestCase):
+    """The same comparison, driven against a tree that is deliberately wrong."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.addCleanup(self._tmp.cleanup)
+        git(self.root, "init", "-q")
+        write(self.root, "src/app.py", "value = 1\n")
+        write(self.root, "yarn.lock", "# lockfile\n")
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-qm", "tracked tree")
+        horos.write_boundary(
+            self.root, horos.boundary_document(horos.scan_tree(self.root))
         )
-        drift = horos.diff_documents(committed, fresh)
-        self.assertEqual(
-            [path for path, _ in drift],
-            [],
-            "regenerate with: python3 plugins/horos/skills/horos/scripts/horos.py "
-            "scan . --write",
+        self.assertEqual(drifted_paths(self.root), [])
+
+    def test_a_new_generated_file_without_a_refresh_is_named(self):
+        # Assembled rather than spelled: a file containing the marker literal
+        # classifies itself as generated, which is the held frontier defect
+        # (marker-self-exclusion). Spelling it here would put this guard's own
+        # source inside the boundary and leave it unread by every agent that
+        # honours one.
+        marker = "# Do not " + "edit: generated\n"
+        write(self.root, "src/schema.py", marker + "X = 1\n")
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-qm", "generated file")
+        self.assertEqual(drifted_paths(self.root), ["src/schema.py"])
+
+    def test_an_entry_the_tree_no_longer_earns_is_named(self):
+        path = os.path.join(self.root, horos.BOUNDARY_RELPATH)
+        document = json.loads(Path(path).read_text(encoding="utf-8"))
+        document["entries"].append(
+            {
+                "path": "src/app.py",
+                "category": "generated",
+                "bytes": 12,
+                "evidence": "invented for this test",
+                "grade": "hard",
+            }
         )
+        Path(path).write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        self.assertEqual(drifted_paths(self.root), ["src/app.py"])
+
+    def test_two_scans_render_the_same_bytes(self):
+        first = horos.render(horos.boundary_document(horos.scan_tree(self.root)))
+        second = horos.render(horos.boundary_document(horos.scan_tree(self.root)))
+        self.assertEqual(first, second)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Step 3 of 5, stacked on step 2.

`audit/AUDIT.md` records this failure once already. Marking run, step 4, round 1:
`check` flagged the marking evidence copies as new sinks, the boundary was
refreshed by hand, and no guard was written. Two days later a commit
regenerated the boundary and added an evidence copy of it in the same change,
so the boundary shipped stale again. The root suite now compares the committed
boundary with a fresh tracked scan and names every path where the two
disagree, in either direction.

The boundary is refreshed in the same step, so `check .` exits 0 here for the
first time in this run: 87 entries, the evidence copy among them, none binding
zero tracked files.

The guard was seen failing three ways before it passed:

- as step 1's expected failure, on the evidence copy the boundary predated
- against an entry removed from the committed boundary by hand, which it named
- on its own source, because the mutation test spelled the generated-marker
  literal, so the marker rule classified this guard as generated and the guard
  reported its own file as drift

The third is worth keeping in view. The marker is now assembled from two
strings, with the reason in a comment, because a guard whose source sits inside
the boundary is one that no agent honouring the boundary will read. That is the
held frontier defect, `marker-self-exclusion`, arriving uninvited in a step that
was not looking for it.

Three mutations pin the guard: a tracked generated file added without a
refresh, an entry the tree no longer earns, and two consecutive scans rendering
byte-identical documents.

Audit round 1 found one thing, and it was in step 2's prose rather than in this
code. Step 2's exit claimed a fresh scan takes this repository's hard entries
from 93 to 87. Running the pre-fix classifier over a pristine worktree of the
same commit gives 87 with no phantom entry: the 93 came from a checkout
carrying a stale worktree under `.claude/worktrees/` and a
`plugins/pandects/out/` directory. A number measured in one checkout had been
written as a property of the repository. Fixed in 84bb99e, with step 2's pull
request body corrected in place; its commit message keeps the wrong figure,
because that commit is named in the run's sealed ledger. Round 2 is clean.

`AGENTS.md` now says the root suite holds the boundary to the tracked tree and
gives the one-line refresh, since that is where a contributor meeting the
failure will look.

One consequence to expect: every later step that edits the classifier trips
this guard, because the marker rule keeps `horos.py` inside the boundary and its
byte count moves whenever it is touched. The refresh is one command, and the
friction goes away when the marker job lands.

To check the step:

```bash
python3 -m unittest discover -s tests
python3 plugins/horos/skills/horos/scripts/horos.py check .
```

Expect 38 tests green and `boundary matches the tree`.

<!-- wildcat-origin: shoggoth -->
