### PR TITLE
Land the delivered janus spec and its run records

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4392,3 +4392,29 @@ its `P` and stayed out of selection, the pass rendered as `(rank-only)`, and
 than a failure.
 
 Leads not pursued: none.
+
+# Run: create the janus skill in the Wildcat Commons
+
+## Step 1, round 1 -- 2026-08-20
+
+Non-Solidity round; the security-suite waiver covers the Pashov pair (the step
+lands Markdown only). phylax exit 0, ephoros exit 0, hypomnema exit 0 over
+`docs/commons/janus.md`, `docs/janus-commons-spec/study.md` and
+`docs/janus-commons-spec/runbook.md`.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | none | -- |
+
+The look went at the study's risk register. Byte preservation holds:
+`sha256sum docs/commons/janus.md` prints the pinned
+`8234ee09201927aeb8df34c9068c5c68e9201539057ccffce3d2600dd724c3ed`. Sweep
+boundaries hold: the spec's marketplace-context block carries no frontier
+line, and nothing fails because `tests/test_shipped_prose_lints.py` skips
+`docs/**` while the frontier scans in `tests/test_marketplace_prose.py` walk
+only the twelve plugin subtrees; the full root suite ran against this tree,
+34 tests, all green. All five `../../plugins/` links in the committed study
+resolve from `docs/janus-commons-spec/`. Nothing landed under `plugins/` or
+`.agents/`, so the versioning and evolution contracts see no new surface.
+
+Leads not pursued: none.

--- a/docs/commons/janus.md
+++ b/docs/commons/janus.md
@@ -1,0 +1,116 @@
+# janus
+
+<!-- marketplace-context:start -->
+**Place in the marketplace.** Janus remains an unbuilt hook-conformance specification. Use the marketplace audit skills for a broader security review; Janus is the narrower before-and-after host boundary described here.
+<!-- marketplace-context:end -->
+
+Test a contract hook at the threshold it controls: what may happen before the
+host action, what may happen after it, and what the hook must never change.
+
+**Desk:** protocol engineering and security. **Status:** unbuilt spec.
+
+## Naming
+
+Janus is the Roman god of gates, passages and transitions, shown looking in
+both directions. Hooks live at exactly that boundary. They inspect or alter an
+action as it enters and leaves its host.
+
+## Why this exists
+
+Hooks make a fixed protocol extensible, but the host and the hook rarely share
+a machine-readable contract describing permitted effects. An interface says
+which function can be called. It does not say whether the hook may move value,
+write host state, consume all remaining gas, change an authorisation result or
+leave a user unable to exit.
+
+That policy remains distributed across implementation code, comments and the
+assumptions of whoever wrote the first hook. A new module can satisfy the ABI
+and violate the host's economic contract.
+
+## Why this belongs to Wildcat Labs
+
+Wildcat uses hooks for access and policy around deposits, transfers,
+withdrawals, borrowing and repayment. Those hooks receive protocol context and
+extra data while sitting beside lender funds and borrower permissions. The
+most dangerous mistakes are therefore effects the type system cannot express:
+redirected value, stale credentials, gas grief, nested entry back into a host
+action and an exit path that worked until a provider disappeared.
+
+Wildcat can write the first host adapter against known mechanics and actual
+hook templates. The useful public result is broader: a conformance format that
+lets any host state what a module may observe and change, without asserting
+that different hook architectures are interchangeable.
+
+## What it does
+
+A host adapter exposes actions, relevant state and economic roles. A hook
+manifest declares:
+
+- Entry points and the host actions around which they run.
+- Calls and callbacks the hook is permitted to make.
+- Host, hook and external storage it may change.
+- Assets and recipients it may cause to move.
+- Required behaviour on hook revert, host revert and partial batch failure.
+- Gas budget and whether failure is fail-open or fail-closed.
+- Liveness conditions for withdrawal, uninstall and emergency paths.
+
+The harness generates ordinary and hostile sequences, snapshots state before
+and after each threshold, and compares the observed delta with the manifest.
+
+## Gates
+
+1. **Permitted effects are enumerated.** An omitted storage write, call target
+   or value movement is forbidden rather than implicitly accepted.
+2. **Value conservation is independent of return values.** The harness checks
+   balances and claims even when every call reports success.
+3. **Exit gets a liveness property.** Credential expiry, provider removal,
+   sanctions changes and hook failure cannot be tested only on entry paths.
+4. **Revert behaviour is part of conformance.** State and value after nested or
+   partial failure must match the host's declared rollback rule.
+5. **Gas grief is exercised.** The suite includes hooks that consume gas,
+   expand return data and create expensive callback paths.
+6. **Re-entry crosses actions.** Tests enter a different host action from a
+   callback, not only the function that invoked the hook.
+7. **A host adapter limits every result.** Passing the Wildcat suite makes no
+   claim about an ERC-7579 account or another protocol's callback model.
+
+## What ships with it
+
+- Hook-manifest schema.
+- Host-adapter interface and state-delta recorder.
+- Stateful Foundry harness and a deterministic unit-test mode.
+- Hostile reference hooks for callback re-entry, gas grief, value redirection,
+  storage mutation and stale authorisation.
+- Wildcat host adapter and tests for its maintained hook templates.
+- One second adapter only after the generic boundary survives the Wildcat
+  implementation.
+- Human and SARIF reports linking each violation to a manifest rule and trace.
+
+## Relationship to existing work
+
+Pandects supplies economic properties the harness can run across hook-driven
+state transitions. Fizz can generate protocol-specific sequences around the
+host adapter. Ariadne can record the manifest revision and conformance result
+for a released hook.
+
+## Prior art and boundary
+
+[ERC-7579](https://eips.ethereum.org/EIPS/eip-7579) defines interoperable
+module types and optional pre- and post-execution hooks for modular smart
+accounts. That is a useful second architecture to study, but its hooks are not
+Wildcat hooks and the two must not share claims merely because they share a
+word.
+
+Static analysers and fuzzers already find general Solidity defects. Janus
+tests the semantic contract between a host and an extension: allowed effects,
+rollback and exit liveness.
+
+## Open questions
+
+- Whether storage-delta rules can remain stable across host upgrades.
+- How to describe a deliberately broad hook without reducing the manifest to
+  "may change anything".
+- Whether the first external adapter should target ERC-7579, a DEX hook model
+  or another lending protocol.
+- How to test liveness without pretending a bounded fuzz campaign proves that
+  an exit will always complete.

--- a/docs/janus-commons-spec/runbook.md
+++ b/docs/janus-commons-spec/runbook.md
@@ -1,0 +1,62 @@
+# Runbook: Create the janus skill in the Wildcat Commons
+
+Derived from the study beside this file. Two steps, in dependency order. The
+repository already carries its layout, toolchain pins, CI and licence, so step
+1 scaffolds the only thing this run adds to the record: the committed study
+and runbook, beside the delivered spec itself. Step 2 wires the Commons
+section to the spec and runs the demo path from the study's problem statement.
+
+## Step 1: Land the delivered janus spec and the run records
+
+**Goal.** The delivered spec sits in the tree byte-identical, with this run's
+study and runbook committed beside the repository's other run records.
+
+**Entry.** The run branch `claude/janus-wildcat-skill-bejdy0` at
+`496f7a102bf012195c48ed1615f8eff7fd832f7b`, a clean tree.
+
+**Exit.** `sha256sum docs/commons/janus.md` prints
+`8234ee09201927aeb8df34c9068c5c68e9201539057ccffce3d2600dd724c3ed`;
+`docs/janus-commons-spec/study.md` and `docs/janus-commons-spec/runbook.md`
+exist; `python3 -m unittest discover -s tests` passes.
+
+**Files.** `docs/commons/janus.md` (created, delivered bytes),
+`docs/janus-commons-spec/study.md` (created),
+`docs/janus-commons-spec/runbook.md` (created).
+
+**Tests.** None written: the change adds records under `docs/**`, which the
+root suite deliberately leaves out of the prose sweep. The full root suite
+runs anyway to prove the additions disturb nothing; expected count is the
+suite's current size, all green.
+
+**Disciplines.** phylax: none, the step adds Markdown and opens no input,
+subprocess, network or credential path. ephoros: none, nothing here runs
+unattended. metron: none, no performance claim. elenchus: none, no failure in
+hand; any that surfaces is worked to cause before the step continues.
+hypomnema: the placement decision is expensive to reverse and its record is
+the committed study's Design options section, which this step lands.
+
+## Step 2: Point the Commons at the spec and demonstrate
+
+**Goal.** A reader of the Commons section's `janus` bullet can reach the full
+specification, and the study's demo path passes end to end.
+
+**Entry.** Step 1's exit state, on a branch cut from step 1's branch.
+
+**Exit.** All three demo-path commands from the study pass:
+`python3 -m unittest discover -s tests` is green,
+`sha256sum docs/commons/janus.md` prints the pinned digest, and
+`grep -n "docs/commons/janus.md" README.md` finds the pointer in the Commons
+section. The imprimatur lint scores `README.md` clean, which the suite also
+enforces.
+
+**Files.** `README.md` (the `janus` bullet in "What remains" gains a pointer
+sentence; nothing else moves).
+
+**Tests.** None written: `tests/test_shipped_prose_lints.py` already holds
+`README.md` to a clean lint score, so the edit is guarded by the existing
+suite. The full root suite runs as the exit proof.
+
+**Disciplines.** phylax: none, one prose sentence in an existing document.
+ephoros: none, nothing runs unattended. metron: none, no performance claim.
+elenchus: none, no failure in hand. hypomnema: none further, the decision
+record landed with step 1; this step only makes it reachable.

--- a/docs/janus-commons-spec/study.md
+++ b/docs/janus-commons-spec/study.md
@@ -1,0 +1,198 @@
+# Study: Create the janus skill in the Wildcat Commons
+
+**Run branch:** `claude/janus-wildcat-skill-bejdy0`, cut from `main` at
+`496f7a102bf012195c48ed1615f8eff7fd832f7b`. That SHA is the run's real start.
+
+Assuming, unless corrected:
+
+1. "Create the janus skill" means publishing the delivered janus specification
+   into this repository's structure, not building the conformance harness. The
+   spec's own status line reads "unbuilt spec", its marketplace-context block
+   says Janus "remains an unbuilt hook-conformance specification", and its
+   "What ships with it" list is a future inventory. Building the harness would
+   contradict the document being landed.
+2. The delivered spec text is preserved byte for byte. Its SHA-256 is
+   `8234ee09201927aeb8df34c9068c5c68e9201539057ccffce3d2600dd724c3ed`, and the
+   landed file must carry the same digest.
+3. Janus gets no install surface: no `marketplace.json` entry, no
+   `plugins/janus/` directory, no portable entry under `.agents/skills/`. The
+   marketplace lists tools that do a job today; an unbuilt spec does not.
+4. Python 3.11 and stdlib `unittest`, matching the repository's root suite.
+5. The run branch is the session-designated `claude/janus-wildcat-skill-bejdy0`
+   rather than a topic slug, matching the precedent of the horos delivery
+   merged as PR #242 from `claude/horos-boundary-skill-scope-d1ho0d`.
+6. This runtime has no `gh` CLI; pull requests and merges run through the
+   authenticated GitHub MCP tools instead.
+
+## 1. Problem statement
+
+The root README's Wildcat Commons section names `janus` as one of two tools
+that remain unbuilt, in one sentence and with nothing behind the name. Wildcat
+Labs has now written the full specification: what Janus tests, why it belongs
+to Wildcat, its seven gates, what will ship, its prior art and its open
+questions. The work is to land that document in the repository where a
+reader of the Commons section will find it, without pretending the tool
+exists.
+
+A working prototype here is the delivered spec present in the tree at its
+delivered digest, reachable from the Commons section, with the full root test
+suite green. The demo path:
+
+```text
+python3 -m unittest discover -s tests
+sha256sum docs/commons/janus.md          # 8234ee09...24c3ed
+grep -n "docs/commons/janus.md" README.md
+```
+
+## 2. Prior art
+
+- `README.md` lines 476 to 488: the Commons section's "What remains" list,
+  holding the one-line `janus` and `berean` entries this spec expands.
+- The graduated Commons tools: `ariadne`, `tabularium`, `pandects`, `lazarus`,
+  `alexandria`, each of which entered the tree as a built plugin. None entered
+  as a spec, so there is no unbuilt-spec precedent to copy.
+- `tests/test_shipped_prose_lints.py`: its scope docstring names `docs/**` as
+  "records of what was written at the time", including "a delivered spec".
+  That is the test suite's own word for what this run lands.
+- `tests/test_marketplace_prose.py`: `marketplace.json` must name exactly the
+  twelve shipped plugins; every plugin landing README carries a frontier
+  sentence, a Next Fiat job line and a marketplace-context block. These
+  contracts are what a `plugins/janus/` placement would have to satisfy.
+- `tests/test_version_propagation.py` and `tests/test_evolution_contract.py`:
+  every `SKILL.md` under `plugins/*/skills/` is governed by the versioning
+  contract and an `EVOLUTION.md` ledger.
+- The horos delivery, PR #242, merged from a `claude/` branch: the structural
+  precedent for this run's branch shape.
+- [ERC-7579](https://eips.ethereum.org/EIPS/eip-7579), named by the spec as a
+  second hook architecture to study and explicitly not to share claims with.
+
+## 3. Constraints and non-goals
+
+Constraints: starting ref `496f7a1` on `main`; Python 3.11; no new
+dependencies; the spec lands byte-identical to delivery; every edited shipped
+document scores clean under the imprimatur lint; the run ships no Solidity.
+
+Non-goals, deferred past this delivery: the hook-manifest schema, host-adapter
+interface, state-delta recorder, Foundry harness, hostile reference hooks,
+Wildcat host adapter, SARIF reports; any `berean` document; any change to the
+marketplace manifests or install instructions.
+
+## 4. Design options
+
+1. **Full plugin at `plugins/janus/`.** Maximal visibility: janus would appear
+   beside the shipped tools. Trades away honesty and economy. The marketplace
+   test pins `marketplace.json` to exactly the shipped plugins, the landing
+   README contracts demand a frontier sentence and a rolling Fiat job, and the
+   versioning contract demands a ledger. All of that surface for a tool whose
+   own spec says it is unbuilt, in a marketplace whose role table scores
+   plugins "for doing the job". Rejected.
+2. **Delivered spec under `docs/commons/`, linked from the Commons section.**
+   The spec lands as a record at `docs/commons/janus.md`, and the `janus`
+   bullet in "What remains" gains a pointer to it. Trades away install-surface
+   visibility: a reader finds janus only through the README or the tree. This
+   matches the prose-lint scope's own description of `docs/**` and adds one
+   directory that `berean` can join later. Chosen: it is the cheapest
+   construction to comprehend that still meets the problem statement.
+3. **Root-level `commons/` directory.** A new top-level namespace for one
+   file. The prose sweep would lint it as shipped prose, so any later lexicon
+   change could force rewrites of a delivered record, and the README's
+   repository-layout section would need a new entry. Rejected.
+4. **Spec text inlined into the README.** The Commons section would grow by a
+   hundred lines of another document's content, all of it under the README's
+   lint. Rejected.
+
+## 5. Risk register seed
+
+What the audit loop should look hardest at:
+
+- The README edit. `test_marketplace_prose.py` asserts exact sentences and
+  section ordering in the README; the new pointer sentence must not disturb
+  them, and must itself score clean under imprimatur.
+- Byte preservation. The prose pass rewrites prose artefacts; the spec is a
+  delivered record and must leave the pass with its digest unchanged.
+- Sweep boundaries. The spec carries a marketplace-context block without a
+  frontier line. Today no test scans `docs/**` for those blocks; confirm that
+  remains true of the suite as landed, not assumed from memory.
+- Placement misread. If a full plugin was wanted after all, the reversal is
+  one file move plus one README sentence; the recorded assumption makes the
+  reading loud rather than silent.
+
+## 6. Glossary seeds
+
+- Wildcat Commons: the README section holding tools Wildcat publishes for
+  anyone to inspect, run and improve.
+- Hook: a module a host protocol calls before and after an action.
+- Host action: the protocol operation a hook runs around, such as a deposit
+  or withdrawal.
+- Hook manifest: the declaration of what a hook may observe and change.
+- Host adapter: the piece that exposes one protocol's actions and state to
+  the harness, and limits every claim to that protocol.
+- Delivered spec: a document landed as a record of what was written, kept
+  byte-identical rather than re-edited under later rules.
+- Landing README: a plugin's `README.md` carrying the marketplace contracts;
+  janus deliberately does not get one.
+
+## 7. Sources
+
+- Delivered spec: session upload `df2f2f4d-janus.md`, SHA-256
+  `8234ee09201927aeb8df34c9068c5c68e9201539057ccffce3d2600dd724c3ed`.
+- `README.md` (Commons section, repository layout, Publish section).
+- `tests/test_marketplace_prose.py`, `tests/test_shipped_prose_lints.py`,
+  `tests/test_portable_skills.py`, `tests/test_version_propagation.py`,
+  `tests/test_evolution_contract.py`.
+- `git log --first-parent main`, PR #242 merge commit `496f7a1`.
+- https://eips.ethereum.org/EIPS/eip-7579
+
+## 8. Signals, and the questions behind them
+
+None. Nothing in this delivery runs unattended: it lands two documents and one
+README sentence, checked by the root test suite at commit time. There is no
+process to ask about at three in the morning. [ephoros](../../plugins/hexaemeron/skills/ephoros/SKILL.md)
+owns signal content where a run has any; this one has none to carry.
+
+## 9. Boundaries, per capability
+
+None opened. The change adds Markdown and edits README prose: no input
+parsing, no subprocess, no network call, no credential, no execution path.
+[phylax](../../plugins/hexaemeron/skills/phylax/SKILL.md) owns the boundary list
+where a step opens one; the audit round still runs its lint so the claim of
+"none" is checked rather than trusted.
+
+## 10. The budget, or its absence
+
+None. No performance claim is made and nothing here is measured for speed.
+[metron](../../plugins/hexaemeron/skills/metron/SKILL.md) owns budgets where one
+exists.
+
+## 11. The fail-closed posture
+
+A red result from `python3 -m unittest discover -s tests` stops the step: no
+commit and no push while any root suite fails. A digest mismatch on
+`docs/commons/janus.md` is treated the same way. Any failure surfaced
+mid-step is worked under [elenchus](../../plugins/hexaemeron/skills/elenchus/SKILL.md)
+before the step continues, and its guard lands in the root suite where the
+regression would recur.
+
+## 12. Decisions and their homes
+
+One decision is expensive to reverse once published: where janus lives, and
+that it is a record rather than a plugin. Its record is this study's Design
+options section, committed under `docs/` in step 1. No `docs/decisions/`
+record is created: that scheme is not in the main tree today, and
+[hypomnema](../../plugins/hexaemeron/skills/hypomnema/SKILL.md) warns against a
+second scheme beside an existing one; introducing a repository-wide
+decision-record convention as a side effect of a janus delivery would itself
+be a decision taken silently. The evidence conflict, per hypomnema, said
+plainly: unmerged branches show a `docs/decisions/` scheme was tried and then
+rolled back, so this run cites the study and leaves that convention alone.
+
+## Boundaries the study must state
+
+- **Always.** The root test suite before every commit. The imprimatur lint on
+  every shipped document this run touches. The spec digest checked after any
+  pass that could rewrite it.
+- **Ask first.** Adding janus to `marketplace.json` or any install surface.
+  Creating a `docs/decisions/` scheme. Touching CI. Editing any exact sentence
+  `test_marketplace_prose.py` asserts.
+- **Never.** Reword the delivered spec. Edit a vendored directory. Delete or
+  weaken a failing test. Claim a command ran when it did not.


### PR DESCRIPTION
The Commons section of the root README names `janus` in one line and holds
nothing behind the name. Wildcat Labs has now written the full specification,
and this step lands it byte-identical at `docs/commons/janus.md`; its SHA-256
is `8234ee09201927aeb8df34c9068c5c68e9201539057ccffce3d2600dd724c3ed`. The
run's study and runbook are committed beside the repository's other run
records at `docs/janus-commons-spec/`.

The study records the placement decision: the spec lands as a record under
`docs/**` rather than as a marketplace plugin, because its own status line
says unbuilt and the marketplace lists tools that do a job today. Janus gets
no install surface until it does one.

Audit: step 1, round 1 in `audit/AUDIT.md` came back clean, with phylax,
ephoros and hypomnema all at exit 0. No fixes branch exists because there was
nothing to fix.

Proof:

```text
python3 -m unittest discover -s tests
sha256sum docs/commons/janus.md
```

This is step 1 of the run; step 2 stacks on this branch and points the
Commons section at the spec.

`wildcat-origin: shoggoth` — stated visibly because this runtime's GitHub
tooling strips HTML comments from pull-request bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzYExBFMq2oyrosJteQC5S