### PR TITLE
Check one scope against the boundary above it

### DIFF
--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -2,11 +2,11 @@
   "counts": {
     "bytes_binary": 17,
     "bytes_content_addressed": 7844971,
-    "bytes_generated": 121632,
+    "bytes_generated": 126422,
     "bytes_lockfile": 54,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 1135
+    "files_walked": 1149
   },
   "entries": [
     {
@@ -523,6 +523,13 @@
       "path": "plugins/hexaemeron/skills/fizz/templates/FoundryTester.sol"
     },
     {
+      "bytes": 3802,
+      "category": "generated",
+      "evidence": "marker 'do not edit' in the first 4096 bytes",
+      "grade": "hard",
+      "path": "plugins/horos/docs/evidence/skills.boundary.json"
+    },
+    {
       "bytes": 2991,
       "category": "generated",
       "evidence": "marker 'do not edit' in the first 4096 bytes",
@@ -603,7 +610,7 @@
       "path": "plugins/horos/examples/fixture/yarn.lock"
     },
     {
-      "bytes": 33328,
+      "bytes": 34316,
       "category": "generated",
       "evidence": "marker 'do not edit' in the first 4096 bytes",
       "grade": "hard",

--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -2,7 +2,7 @@
   "counts": {
     "bytes_binary": 17,
     "bytes_content_addressed": 7844971,
-    "bytes_generated": 126422,
+    "bytes_generated": 133488,
     "bytes_lockfile": 54,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
@@ -610,7 +610,7 @@
       "path": "plugins/horos/examples/fixture/yarn.lock"
     },
     {
-      "bytes": 34316,
+      "bytes": 41382,
       "category": "generated",
       "evidence": "marker 'do not edit' in the first 4096 bytes",
       "grade": "hard",

--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -2,7 +2,7 @@
   "counts": {
     "bytes_binary": 17,
     "bytes_content_addressed": 7844971,
-    "bytes_generated": 133488,
+    "bytes_generated": 134192,
     "bytes_lockfile": 54,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
@@ -610,7 +610,7 @@
       "path": "plugins/horos/examples/fixture/yarn.lock"
     },
     {
-      "bytes": 41382,
+      "bytes": 42086,
       "category": "generated",
       "evidence": "marker 'do not edit' in the first 4096 bytes",
       "grade": "hard",

--- a/.horos/census.json
+++ b/.horos/census.json
@@ -1,9 +1,9 @@
 {
   "rows": [
     {
-      "boundary_bytes": 70215,
-      "bytes": 9425856,
-      "files": 330,
+      "boundary_bytes": 74017,
+      "bytes": 9429658,
+      "files": 331,
       "suffix": ".json"
     },
     {
@@ -13,15 +13,15 @@
       "suffix": "(no suffix)"
     },
     {
-      "boundary_bytes": 50392,
-      "bytes": 2786663,
-      "files": 286,
+      "boundary_bytes": 51380,
+      "bytes": 2850716,
+      "files": 291,
       "suffix": ".py"
     },
     {
       "boundary_bytes": 0,
-      "bytes": 2174681,
-      "files": 286,
+      "bytes": 2290718,
+      "files": 294,
       "suffix": ".md"
     },
     {
@@ -141,6 +141,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 24022270,
-  "total_files": 1143
+  "total_bytes": 24206162,
+  "total_files": 1157
 }

--- a/.horos/census.json
+++ b/.horos/census.json
@@ -13,14 +13,14 @@
       "suffix": "(no suffix)"
     },
     {
-      "boundary_bytes": 51380,
-      "bytes": 2850716,
+      "boundary_bytes": 58446,
+      "bytes": 2866968,
       "files": 291,
       "suffix": ".py"
     },
     {
       "boundary_bytes": 0,
-      "bytes": 2290718,
+      "bytes": 2294133,
       "files": 294,
       "suffix": ".md"
     },
@@ -141,6 +141,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 24206162,
+  "total_bytes": 24225829,
   "total_files": 1157
 }

--- a/.horos/census.json
+++ b/.horos/census.json
@@ -13,8 +13,8 @@
       "suffix": "(no suffix)"
     },
     {
-      "boundary_bytes": 58446,
-      "bytes": 2866968,
+      "boundary_bytes": 59150,
+      "bytes": 2868678,
       "files": 291,
       "suffix": ".py"
     },
@@ -141,6 +141,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 24225829,
+  "total_bytes": 24227539,
   "total_files": 1157
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,3 +130,11 @@ that earned its entry; leave those paths unread unless the task demands
 one. The boundary is fail-open: what it omits is merely unproven. It never
 applies during security review; during any audit, review or incident work,
 read as if no boundary exists.
+
+The root suite checks that this file's boundary still describes the tracked
+tree, so a change that adds or alters a classified file fails it until the
+boundary is regenerated:
+
+```bash
+python3 plugins/horos/skills/horos/scripts/horos.py scan . --write
+```

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4555,3 +4555,20 @@ caller that changes directory between resolving a path and checking it would be
 answered against the new one; every entry point here resolves and checks in one
 call, and threading a base directory through the command would add a parameter
 no caller has asked for.
+
+## Scoped entry, step 4, round 3 -- 2026-08-20
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0. Horos
+207/207, root 38/38, `check .` exit 0, benchmark re-run at 24.1 ms for the
+`plugins/alexandria` scope with 0 classified outside it, all verified before
+this receipt. The round audited the tree with both earlier fixes applied and
+re-checked the two things those fixes touched: the escape rule still refuses
+all four escape shapes and admits every legitimate relative path. The
+sibling case, `../two` from inside another scope, was run and then pinned as a
+test in 5deb3e3 rather than left as a reasoned assumption; and the benchmark's
+counters now come from the walk rather than from a constant.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4528,3 +4528,30 @@ Leads not pursued: `check_scope` slices the candidate document by scope
 although the scan it came from was already scope-limited, so that slice can
 never remove anything; it is a redundant call rather than a wrong one, and
 removing it would leave the two documents sliced by different code paths.
+
+## Scoped entry, step 4, round 2 -- 2026-08-20
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0. Horos
+206/206, root 38/38, `check .` exit 0, verified before this receipt. The round
+audited the tree with round 1's escape fix applied, and asked the question
+round 1 had not: whether the evidence the study demands for this step actually
+exists yet. It did not.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S4-R2-01 | medium | plugins/horos/tests/benchmark_scope.py | the benchmark still called `check_tree`, which knows nothing of ancestor resolution, so every scoped run recorded exit 2 and a null median while the check itself worked. Criterion 12's measurement did not exist, and the record said `unavailable` rather than being wrong, which is why round 1 read past it | fixed in fad07e3 |
+
+The fix also replaced the placeholder `tracked_files_inspected_outside_scope`
+null with counters taken from the same scoped walk the check performs, of which
+`classified_outside_scope` is the one that carries the claim. First measured
+numbers, five runs each: full tree 59.6 ms; `plugins/alexandria` 24.4 ms over
+210 classified files with 0 outside; `plugins/brevitas` 15.9 ms over 21
+classified files with 0 outside. The heavier scope costs more than a third of
+the whole tree because its weight is a content-addressed store, and digest
+verification reads whole files by design.
+
+Leads not pursued: the escape rule reads the process's working directory, so a
+caller that changes directory between resolving a path and checking it would be
+answered against the new one; every entry point here resolves and checks in one
+call, and threading a base directory through the command would add a parameter
+no caller has asked for.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4509,3 +4509,22 @@ rather than to this round, and are recorded there.
 | --- | --- | --- | --- | --- |
 
 Zero findings. Leads not pursued: none.
+
+## Scoped entry, step 4, round 1 -- 2026-08-20
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0. Horos
+206/206, root 38/38, verified before this receipt. Two mutations were run
+against the committed step before the suite was trusted: making the committed
+slice ignore the scope fails five of the nineteen cases, and pruning the
+ancestor chain instead of walking it fails six. The round then went at the
+control the risk register names rather than at the happy path, and found it
+half-built.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S4-R1-01 | medium | plugins/horos/skills/horos/scripts/horos.py | the escape control only inspected the given path, so a symlink as the final component was refused while a symlink in the middle was not. `git -C` resolves symlinks before answering, so `check bridge/sub` reported the far repository as its own worktree and the check would have been answered from that tree's boundary | fixed in 312bf0a, with two guards seen failing without it |
+
+Leads not pursued: `check_scope` slices the candidate document by scope
+although the scan it came from was already scope-limited, so that slice can
+never remove anything; it is a redundant call rather than a wrong one, and
+removing it would leave the two documents sliced by different code paths.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4491,3 +4491,21 @@ request body and this row. Separately, `plugins/horos/**` has no CI workflow of
 its own, so this plugin's 188 tests run locally and nowhere else; adding one is
 an ask-first change under this run's boundaries and is recorded on pull request
 256 rather than made here.
+
+## Scoped entry, step 3, round 2 -- 2026-08-20
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0. Horos
+188/188 with one expected failure, root 38/38 clean, `check .` exit 0, all
+verified before this receipt. The round audited the tree with round 1's
+correction applied and re-read every remaining quantitative claim in this
+run's two documents against the tree rather than against the earlier prose:
+the entry count, the census rows, the suite counts, the baseline median, and
+the audit references. The 87 figure now carries the checkout it was measured
+in. The three mutations that pin the guard ran again in this round as part of
+the root suite; the three ways the guard was seen failing belong to the step
+rather than to this round, and are recorded there.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4466,3 +4466,28 @@ file's own classifier source as drifted, because the marker rule excludes it
 and its byte count moved: that is the held frontier defect showing itself
 during unrelated work, evidence for the marker self-exclusion job rather than
 for this one.
+
+## Scoped entry, step 3, round 1 -- 2026-08-20
+
+Suite waived (no Solidity); lints phylax 0, ephoros 0, hypomnema 0. Horos
+188/188 with one expected failure, root 38/38 clean, verified before this
+receipt. `check .` exits 0 for the first time in this run, 87 entries, the
+evidence copy included, none binding zero tracked files. The guard was seen
+failing three ways before it passed: as step 1's expected failure on the
+evidence copy, against a hand-removed entry, and on its own source, because a
+fixture spelling the generated-marker literal put this guard inside the
+boundary. The round then went looking for claims the earlier steps had not
+earned, which is where the finding is.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R1-01 | medium | plugins/horos/docs/scoped-entry/runbook.md | step 2's exit claimed a fresh scan takes this repository's hard entries from 93 to 87. Running the pre-fix classifier over a pristine worktree of the same commit gives 87 with no phantom entry: the 93 came from the maintainer's own checkout, which carries a stale worktree under `.claude/worktrees/` and a `plugins/pandects/out/` directory. The number described a checkout and was written as a property of the repository | fixed in 84bb99e, and pull request 256's body corrected in place |
+
+Leads not pursued: step 2's commit message carries the same wrong figure and
+keeps it. That commit is named in the run's sealed ledger as step 2's
+implementation, so rewording it would leave the ledger pointing at a commit
+that no longer exists; the corrected account lives in the runbook, the pull
+request body and this row. Separately, `plugins/horos/**` has no CI workflow of
+its own, so this plugin's 188 tests run locally and nowhere else; adding one is
+an ask-first change under this run's boundaries and is recorded on pull request
+256 rather than made here.

--- a/plugins/horos/docs/scoped-entry/runbook.md
+++ b/plugins/horos/docs/scoped-entry/runbook.md
@@ -49,13 +49,17 @@ tracked file, so `check` answers the same on every machine.
 **Entry.** Step 1's green exit. `check .` exits 1 with 7 drifted paths, 6 of
 them ignored local directories.
 
-**Exit.** A fresh scan of this repository emits no phantom entry, taking its
-hard entries from 93 to 87; step 1's fixtures for criteria 4 and 5 pass with
-their markers removed, so a checkout carrying an ignored build directory exits
-0; census attribution is unchanged for every entry that does cover tracked
-files. This repository's own `check .` still exits 1 at this step, for the
-tracked evidence copy the committed boundary predates, and step 3 owns that
-refresh.
+**Exit.** No scan emits a phantom entry, and step 1's fixtures for criteria 4
+and 5 pass with their markers removed, so a checkout carrying an ignored build
+directory exits 0; census attribution is unchanged for every entry that does
+cover tracked files. The count depends on the checkout rather than the
+repository: a pristine clone produces 87 hard entries either side of the fix,
+because it carries no ignored build products, while the maintainer's own
+checkout produced 93 with six binding nothing, five under a stale worktree
+under `.claude/worktrees/` and one at `plugins/pandects/out/`. That difference
+is the defect, so the fixture rather than a repository count is the criterion.
+This repository's own `check .` still exits 1 at this step, for the tracked
+evidence copy the committed boundary predates, and step 3 owns that refresh.
 
 **Files.** `plugins/horos/skills/horos/scripts/horos.py`, classifier tests,
 fixtures, and `.horos/boundary.json` only if a real entry changed.

--- a/plugins/horos/skills/horos/SKILL.md
+++ b/plugins/horos/skills/horos/SKILL.md
@@ -40,13 +40,36 @@ boundary or the new one, never half. `--json` prints the same canonical
 bytes instead of writing them.
 
 ```bash
-python3 scripts/horos.py check <root>
+python3 scripts/horos.py check <path>
 ```
 
 re-derives the classification and compares it with the committed boundary.
 Exit 0 means the boundary matches the tree. Drift names every path, in both
 directions: a new sink the boundary lacks, and a committed entry the tree no
 longer evidences.
+
+`<path>` may be the repository root or any directory inside it. For a
+descendant, Horos walks upward to the nearest `.horos/boundary.json`, stops at
+the worktree root git reports, classifies only that subtree, and compares it
+with the matching slice of the committed boundary:
+
+```text
+boundary root: /path/to/repo
+scope: plugins/alexandria
+hard boundary: matches
+candidates: 12 findings, advisory
+outside-scope drift: not evaluated
+counters: classified 210, listed outside scope 3, attribute files above scope 0
+```
+
+Exit 1 means hard drift inside the scope, and every drifted path is named.
+Exit 2 means no usable ancestor boundary, or a path that resolves out of the
+worktree. Candidate drift never changes the exit code. A scoped pass is not a
+whole-repository pass, which is why the output says so in those words: the
+release-time answer is still `check` at the root. The walk begins at the
+boundary root even for a scope, because a `.gitattributes` above the scope
+decides how the files inside it classify; those reads are counted rather than
+hidden, and nothing outside the scope is stat'd, read or classified.
 
 ```bash
 python3 scripts/horos.py scan <root> --census [--write]
@@ -103,7 +126,11 @@ confessions and every file oracle-parsed, recorded at
 
 1. Entering a repository, look for `.horos/boundary.json`. If it exists, run
    `check` before trusting it; a stale or forged boundary fails by name. If
-   it does not exist and the repository is large, offer a scan.
+   it does not exist and the repository is large, offer a scan. Entering one
+   directory of a large repository to work in it, run `check` on that
+   directory instead: the answer covers the files about to be read, costs a
+   fraction of the whole tree, and says plainly that it evaluated nothing
+   outside the scope. Before a release, check the root.
 2. Treat every path inside a checked boundary as unread-by-default. The entry
    itself carries what a reader needs: category, size, evidence.
 3. Before opening a file over a few hundred lines in a language the

--- a/plugins/horos/skills/horos/scripts/horos.py
+++ b/plugins/horos/skills/horos/scripts/horos.py
@@ -877,11 +877,22 @@ def resolve_boundary_root(target):
     worktree is refused rather than resolved into a different tree.
     """
     given = os.path.abspath(target)
-    if os.path.islink(given):
-        parent_root = git_worktree_root(os.path.dirname(given))
-        if parent_root is not None and not _within(os.path.realpath(given), parent_root):
-            return None, f"symlink leaves the worktree at {parent_root}"
     resolved = os.path.realpath(given)
+    if not os.path.isabs(target):
+        # A relative path means "inside the repository I am working in", so
+        # anything that resolves out of it is refused rather than answered
+        # from another tree's boundary. This covers `..`, a symlinked final
+        # component and a symlinked intermediate one alike, which a check on
+        # the given path alone does not: `git -C` resolves symlinks before it
+        # answers, so a path with a symlink in the middle would otherwise
+        # report the far repository as its own worktree.
+        here = git_worktree_root(os.getcwd())
+        if here is not None and not _within(resolved, here):
+            return None, f"path leaves the worktree at {here}"
+    elif os.path.islink(given):
+        parent_root = git_worktree_root(os.path.dirname(given))
+        if parent_root is not None and not _within(resolved, parent_root):
+            return None, f"symlink leaves the worktree at {parent_root}"
     if not os.path.isdir(resolved):
         return None, f"not a directory: {target}"
     limit = git_worktree_root(resolved)

--- a/plugins/horos/skills/horos/scripts/horos.py
+++ b/plugins/horos/skills/horos/scripts/horos.py
@@ -533,12 +533,37 @@ def resolve_universe(root, include_untracked=False):
     return label, {p for p in paths if p}
 
 
-def scan_tree(root, census=False, include_untracked=False):
+def _inside_scope(relpath, scope):
+    """True when a root-relative path lies at or under the scope."""
+    if scope is None:
+        return True
+    return relpath == scope or relpath.startswith(scope + "/")
+
+
+def _leads_to_scope(relpath, scope):
+    """True when a directory is the scope, inside it, or an ancestor of it.
+
+    An ancestor is walked but never classified: its `.gitattributes` scopes the
+    files below it, so skipping it would make a scoped check disagree with a
+    whole-tree one about the same file.
+    """
+    if scope is None:
+        return True
+    return _inside_scope(relpath, scope) or scope.startswith(relpath + "/")
+
+
+def scan_tree(root, census=False, include_untracked=False, scope=None):
     """Walk the tree and return entries plus the counts a quiet run reports.
 
     With census=True the same walk also tallies every file by suffix, so the
     census can never describe a different tree than the boundary does; the
-    result gains a "census" key and nothing else changes."""
+    result gains a "census" key and nothing else changes.
+
+    With scope set to a root-relative directory, only files at or under it are
+    classified. The walk still begins at root, because the attribute files
+    above the scope decide how the files inside it classify; those are read and
+    counted separately. Whole subtrees outside the scope are pruned unvisited.
+    """
     root = os.path.abspath(root)
     universe_label, universe = resolve_universe(root, include_untracked)
     scopes = {}
@@ -547,14 +572,18 @@ def scan_tree(root, census=False, include_untracked=False):
     candidates = []
     walked = 0
     skipped_unreadable = 0
+    outside_scope_listed = 0
+    attribute_files_above_scope = 0
 
     for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
         relative_dir = os.path.relpath(dirpath, root)
+        posix_dir = "." if relative_dir == "." else relative_dir.replace(os.sep, "/")
         if ".gitattributes" in filenames:
-            scope_key = "." if relative_dir == "." else relative_dir.replace(os.sep, "/")
             rules = parse_attribute_file(os.path.join(dirpath, ".gitattributes"))
             if rules:
-                scopes[scope_key] = rules
+                scopes[posix_dir] = rules
+            if scope is not None and not _inside_scope(posix_dir, scope):
+                attribute_files_above_scope += 1
         keep = []
         for dirname in sorted(dirnames):
             if dirname in SKIPPED_DIR_NAMES:
@@ -564,6 +593,12 @@ def scan_tree(root, census=False, include_untracked=False):
                 continue
             relpath = dirname if relative_dir == "." else f"{relative_dir}/{dirname}"
             relpath = relpath.replace(os.sep, "/")
+            if not _leads_to_scope(relpath, scope):
+                continue
+            if not _inside_scope(relpath, scope):
+                # On the path down to the scope: walk it, classify nothing.
+                keep.append(dirname)
+                continue
             named_category = None
             if dirname in VENDORED_DIR_NAMES:
                 named_category = "vendored"
@@ -619,6 +654,13 @@ def scan_tree(root, census=False, include_untracked=False):
             relpath = relpath.replace(os.sep, "/")
             if universe is not None and relpath not in universe:
                 continue
+            if not _inside_scope(relpath, scope):
+                # Listed by a directory the walk had to visit, and dropped
+                # before any stat or read. Whole subtrees outside the scope are
+                # pruned unvisited, so this counts only what the ancestor chain
+                # put in front of the walk, never the tree's outside total.
+                outside_scope_listed += 1
+                continue
             walked += 1
             matched = match_attribute_scopes(scopes, relpath)
             if matched is not None:
@@ -660,6 +702,9 @@ def scan_tree(root, census=False, include_untracked=False):
     entries.sort(key=lambda entry: entry["path"])
     candidates.sort(key=lambda entry: entry["path"])
     counts = {"files_walked": walked, "files_skipped_unreadable": skipped_unreadable}
+    if scope is not None:
+        counts["files_outside_scope_listed"] = outside_scope_listed
+        counts["attribute_files_above_scope"] = attribute_files_above_scope
     for entry in entries:
         key = "bytes_" + entry["category"]
         counts[key] = counts.get(key, 0) + entry["bytes"]
@@ -669,6 +714,8 @@ def scan_tree(root, census=False, include_untracked=False):
         "counts": counts,
         "universe": universe_label,
     }
+    if scope is not None:
+        result["scope"] = scope
     if tally is not None:
         result["census"] = tally
     return result
@@ -799,6 +846,128 @@ def diff_documents(committed, fresh):
     return drifted
 
 
+def git_worktree_root(path):
+    """The worktree root git reports for a path, or None when git cannot say."""
+    try:
+        completed = subprocess.run(  # phylax: allow subprocess: fixed argv, no shell, cwd pinned by -C
+            ["git", "-C", path, "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if completed.returncode != 0:
+        return None
+    top = completed.stdout.decode("utf-8", errors="replace").strip()
+    return os.path.realpath(top) if top else None
+
+
+def _within(path, ancestor):
+    return path == ancestor or path.startswith(ancestor + os.sep)
+
+
+def resolve_boundary_root(target):
+    """Find the one boundary that governs a path.
+
+    Returns ((boundary root, scope), None) or (None, reason). The search walks
+    upward from the target to the nearest committed boundary and stops at the
+    worktree root git reports, so a boundary planted above a repository cannot
+    capture a check made inside it. The target is resolved once, up front, and
+    no symlink is followed during the search; a symlink that leaves the
+    worktree is refused rather than resolved into a different tree.
+    """
+    given = os.path.abspath(target)
+    if os.path.islink(given):
+        parent_root = git_worktree_root(os.path.dirname(given))
+        if parent_root is not None and not _within(os.path.realpath(given), parent_root):
+            return None, f"symlink leaves the worktree at {parent_root}"
+    resolved = os.path.realpath(given)
+    if not os.path.isdir(resolved):
+        return None, f"not a directory: {target}"
+    limit = git_worktree_root(resolved)
+    current = resolved
+    while True:
+        if os.path.isfile(os.path.join(current, BOUNDARY_RELPATH)):
+            scope = os.path.relpath(resolved, current).replace(os.sep, "/")
+            return (current, scope), None
+        if limit is not None and current == limit:
+            return None, f"no boundary between {resolved} and the worktree root {limit}"
+        parent = os.path.dirname(current)
+        if parent == current:
+            return None, f"no boundary at or above {resolved}"
+        current = parent
+
+
+def entries_under(document, scope, key="entries"):
+    """The slice of a boundary document that lies at or under the scope."""
+    return [
+        entry for entry in document.get(key, [])
+        if _inside_scope(entry["path"].rstrip("/"), scope)
+    ]
+
+
+def check_scope(boundary_root, scope, out=None):
+    """Admit a descendant scope against the one boundary above it.
+
+    Exit 0 admits the scope, 1 means hard drift inside it. A green scoped check
+    says nothing about the rest of the repository, and the output says so in
+    those words: a local pass read as a global one is the failure this phrasing
+    exists to prevent.
+    """
+    out = out if out is not None else sys.stdout
+    try:
+        committed = load_boundary(boundary_root)
+    except FileNotFoundError:
+        print(f"horos: no boundary at {BOUNDARY_RELPATH}; run scan --write", file=out)
+        return 2
+    except (OSError, json.JSONDecodeError) as error:
+        print(f"horos: unreadable boundary: {error}", file=out)
+        return 2
+    include_untracked = committed.get("universe") == "tracked+untracked"
+    result = scan_tree(boundary_root, include_untracked=include_untracked, scope=scope)
+    fresh = boundary_document(result)
+    drifted = diff_documents(
+        {"entries": entries_under(committed, scope)},
+        {"entries": entries_under(fresh, scope)},
+    )
+    candidate_count = len(entries_under(candidates_document(result), scope))
+    print(f"boundary root: {boundary_root}", file=out)
+    print(f"scope: {scope}", file=out)
+    for path, reason in drifted:
+        print(f"drift: {path}: {reason}", file=out)
+    print(f"hard boundary: {'drifted' if drifted else 'matches'}", file=out)
+    print(f"candidates: {candidate_count} findings, advisory", file=out)
+    print("outside-scope drift: not evaluated", file=out)
+    counts = result["counts"]
+    print(
+        "counters: classified {}, listed outside scope {}, "
+        "attribute files above scope {}".format(
+            counts["files_walked"],
+            counts["files_outside_scope_listed"],
+            counts["attribute_files_above_scope"],
+        ),
+        file=out,
+    )
+    return 1 if drifted else 0
+
+
+def check_scope_or_tree(target, out=None):
+    """Check whatever the path names: the whole tree, or one scope inside it.
+
+    This is the whole of the `check` command, so the dispatch a caller gets is
+    the dispatch the tests drive.
+    """
+    out = out if out is not None else sys.stdout
+    resolved, reason = resolve_boundary_root(target)
+    if resolved is None:
+        print(f"horos: {reason}", file=out)
+        return 2
+    boundary_root, scope = resolved
+    if scope == ".":
+        return check_tree(boundary_root, out=out)
+    return check_scope(boundary_root, scope, out=out)
+
+
 def check_tree(root, out=None):
     out = out if out is not None else sys.stdout
     try:
@@ -890,7 +1059,7 @@ def main(argv=None):
         return 2
 
     if args.command == "check":
-        return check_tree(args.root)
+        return check_scope_or_tree(args.root)
 
     result = scan_tree(
         args.root, census=args.census, include_untracked=args.include_untracked

--- a/plugins/horos/tests/benchmark_scope.py
+++ b/plugins/horos/tests/benchmark_scope.py
@@ -4,8 +4,11 @@ Emits one JSON object so a before-and-after pair can be compared without
 reading prose, per `plugins/hexaemeron/skills/metron/SKILL.md`. It asserts
 nothing: a machine-specific threshold in a test would fail on a different
 machine rather than on a regression. Either side reports a null median and a
-status naming the refusal when its check could not run, so the scoped figures
-stay null until the scoped check exists.
+status naming the refusal when its check could not run, rather than a duration
+for a check that classified nothing. The counters come from the same scoped
+walk the check performs, and `classified_outside_scope` is the one that
+matters: a scoped check that classified anything outside its scope has not
+done what it claims.
 
     python3 plugins/horos/tests/benchmark_scope.py --root . --scope plugins/alexandria --runs 5
 """
@@ -32,7 +35,7 @@ def timed_check(target, runs):
     for _ in range(runs):
         out = io.StringIO()
         started = time.perf_counter()
-        code = horos.check_tree(target, out=out)
+        code = horos.check_scope_or_tree(target, out=out)
         samples.append((time.perf_counter() - started) * 1000.0)
         text = out.getvalue()
     return statistics.median(samples), code, text
@@ -60,6 +63,13 @@ def main(argv=None):
     full_report, full_status = report(full_median, full_code, full_text)
     scope_report, scope_status = report(scope_median, scope_code, scope_text)
 
+    # What the scoped walk touched, from the same walk the check runs.
+    scoped = horos.scan_tree(root, scope=args.scope)
+    classified = {"entries": scoped["entries"] + scoped["candidates"]}
+    outside = len(classified["entries"]) - len(
+        horos.entries_under(classified, args.scope)
+    )
+
     record = {
         "runs": args.runs,
         "root": args.root,
@@ -70,7 +80,10 @@ def main(argv=None):
         "scope_median_ms": scope_report,
         "scope_exit": scope_code,
         "scope_status": scope_status,
-        "tracked_files_inspected_outside_scope": None,
+        "classified_in_scope": scoped["counts"]["files_walked"],
+        "listed_outside_scope": scoped["counts"]["files_outside_scope_listed"],
+        "attribute_files_above_scope": scoped["counts"]["attribute_files_above_scope"],
+        "classified_outside_scope": outside,
     }
     json.dump(record, sys.stdout, indent=2, sort_keys=True)
     sys.stdout.write("\n")

--- a/plugins/horos/tests/test_scoped_entry.py
+++ b/plugins/horos/tests/test_scoped_entry.py
@@ -148,6 +148,16 @@ class ScopedEntryTests(unittest.TestCase):
         self.assertIsNone(resolved)
         self.assertIn("leaves the worktree", reason)
 
+    def test_a_sibling_scope_reached_by_a_relative_path_is_admitted(self):
+        cwd = os.getcwd()
+        os.chdir(os.path.join(self.root, "plugins", "one"))
+        try:
+            code, text = self.check("../two")
+        finally:
+            os.chdir(cwd)
+        self.assertEqual(code, 0, text)
+        self.assertIn("scope: plugins/two", text)
+
     def test_a_missing_boundary_exits_two(self):
         os.remove(os.path.join(self.root, horos.BOUNDARY_RELPATH))
         resolved, reason = horos.resolve_boundary_root(

--- a/plugins/horos/tests/test_scoped_entry.py
+++ b/plugins/horos/tests/test_scoped_entry.py
@@ -123,6 +123,31 @@ class ScopedEntryTests(unittest.TestCase):
         self.assertIsNone(resolved)
         self.assertIn("leaves the worktree", reason)
 
+    def test_a_relative_path_climbing_out_of_the_worktree_is_refused(self):
+        cwd = os.getcwd()
+        os.chdir(os.path.join(self.root, "plugins", "one"))
+        try:
+            resolved, reason = horos.resolve_boundary_root("../../..")
+        finally:
+            os.chdir(cwd)
+        self.assertIsNone(resolved)
+        self.assertIn("leaves the worktree", reason)
+
+    def test_a_symlinked_intermediate_component_is_refused(self):
+        outside = tempfile.TemporaryDirectory()
+        self.addCleanup(outside.cleanup)
+        os.makedirs(os.path.join(outside.name, "sub"))
+        git(os.path.realpath(outside.name), "init", "-q")
+        os.symlink(os.path.realpath(outside.name), os.path.join(self.root, "bridge"))
+        cwd = os.getcwd()
+        os.chdir(self.root)
+        try:
+            resolved, reason = horos.resolve_boundary_root("bridge/sub")
+        finally:
+            os.chdir(cwd)
+        self.assertIsNone(resolved)
+        self.assertIn("leaves the worktree", reason)
+
     def test_a_missing_boundary_exits_two(self):
         os.remove(os.path.join(self.root, horos.BOUNDARY_RELPATH))
         resolved, reason = horos.resolve_boundary_root(

--- a/plugins/horos/tests/test_scoped_entry.py
+++ b/plugins/horos/tests/test_scoped_entry.py
@@ -1,13 +1,20 @@
-"""Scoped entry, and the reproducibility a scoped gate depends on.
+"""Scoped entry: one ancestor boundary, admitting one descendant scope.
 
-Every test here is a fixture for a success criterion this run has not built
-yet, so each one is marked as an expected failure. A step that satisfies its
-criterion turns the fixture into an unexpected success, which fails the suite
-until the decorator comes off: the marker cannot be left behind by accident.
+The tree every case here starts from:
+
+    repo/
+      .gitattributes        vendor-only/** linguist-vendored
+      src/app.py
+      plugins/one/module.py
+      plugins/one/yarn.lock      lockfile, a hard entry inside the scope
+      plugins/two/other.py
+      plugins/two/go.sum         lockfile, a hard entry in a sibling
+      vendor-only/lib.js         tracked, so the attribute rule binds the dir
 """
 
 from pathlib import Path
 import io
+import json
 import os
 import shutil
 import subprocess
@@ -22,6 +29,7 @@ import horos  # noqa: E402
 GIT = shutil.which("git")
 
 MINIFIED = "var a=1;" * 400 + "\n"
+BLOB = "[" + ",".join(['"row"'] * 4000) + "]\n"
 
 
 def write(root, relpath, content):
@@ -41,64 +49,191 @@ def git(root, *args):
     )
 
 
-def repository():
-    """A tracked tree with one ignored build directory holding nothing tracked."""
-    tmp = tempfile.TemporaryDirectory()
-    root = tmp.name
-    git(root, "init", "-q")
-    write(root, ".gitignore", "out/\n")
-    write(root, "src/app.py", "value = 1\n")
-    write(root, "plugins/thing/module.py", "value = 2\n")
-    git(root, "add", ".")
-    git(root, "commit", "-qm", "tracked tree")
-    write(root, "out/bundle.min.js", MINIFIED)
-    return tmp, root
+def commit_boundary(root):
+    result = horos.scan_tree(root)
+    horos.write_boundary(root, horos.boundary_document(result))
+    horos.write_candidates(root, horos.candidates_document(result))
 
 
-class PhantomEntryTests(unittest.TestCase):
-    """Criterion 4: a directory holding no tracked file is not a hard entry."""
+@unittest.skipIf(GIT is None, "git unavailable")
+class ScopedEntryTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = os.path.realpath(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        git(self.root, "init", "-q")
+        write(self.root, ".gitattributes", "vendor-only/** linguist-vendored\n")
+        write(self.root, "src/app.py", "value = 1\n")
+        write(self.root, "plugins/one/module.py", "value = 2\n")
+        write(self.root, "plugins/one/yarn.lock", "# lockfile\n")
+        write(self.root, "plugins/two/other.py", "value = 3\n")
+        write(self.root, "plugins/two/go.sum", "# sums\n")
+        write(self.root, "vendor-only/lib.js", "module.exports = 1\n")
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-qm", "tree")
+        commit_boundary(self.root)
 
-    @unittest.skipIf(GIT is None, "git unavailable")
-    def test_an_ignored_directory_earns_no_hard_entry(self):
-        tmp, root = repository()
-        self.addCleanup(tmp.cleanup)
-        result = horos.scan_tree(root)
-        phantom = [
-            entry for entry in result["entries"]
-            if entry["path"].startswith("out/")
-        ]
-        self.assertEqual(phantom, [])
-
-
-class MachineIndependentCheckTests(unittest.TestCase):
-    """Criterion 5: check answers the same whatever untracked state is present."""
-
-    @unittest.skipIf(GIT is None, "git unavailable")
-    def test_check_is_clean_beside_an_ignored_build_directory(self):
-        tmp, root = repository()
-        self.addCleanup(tmp.cleanup)
-        shutil.rmtree(os.path.join(root, "out"))
-        horos.write_boundary(root, horos.boundary_document(horos.scan_tree(root)))
-        horos.write_candidates(root, horos.candidates_document(horos.scan_tree(root)))
-        write(root, "out/bundle.min.js", MINIFIED)
+    def check(self, target):
         out = io.StringIO()
-        self.assertEqual(horos.check_tree(root, out=out), 0, out.getvalue())
+        code = horos.check_scope_or_tree(target, out=out)
+        return code, out.getvalue()
 
+    def scope_of(self, target):
+        resolved, reason = horos.resolve_boundary_root(target)
+        self.assertIsNotNone(resolved, reason)
+        return resolved
 
-class ScopedCheckTests(unittest.TestCase):
-    """Criterion 7: a descendant scope resolves the one ancestor boundary."""
+    # Resolution
 
-    @unittest.skipIf(GIT is None, "git unavailable")
-    @unittest.expectedFailure
-    def test_a_descendant_scope_resolves_the_ancestor_boundary(self):
-        tmp, root = repository()
-        self.addCleanup(tmp.cleanup)
-        shutil.rmtree(os.path.join(root, "out"))
-        horos.write_boundary(root, horos.boundary_document(horos.scan_tree(root)))
-        horos.write_candidates(root, horos.candidates_document(horos.scan_tree(root)))
-        out = io.StringIO()
-        scope = os.path.join(root, "plugins", "thing")
-        self.assertEqual(horos.check_tree(scope, out=out), 0, out.getvalue())
+    def test_the_root_check_keeps_its_whole_tree_wording(self):
+        code, text = self.check(self.root)
+        self.assertEqual(code, 0, text)
+        self.assertIn("boundary matches the tree", text)
+        self.assertNotIn("scope:", text)
+
+    def test_a_descendant_resolves_the_ancestor_boundary(self):
+        boundary_root, scope = self.scope_of(os.path.join(self.root, "plugins", "one"))
+        self.assertEqual(boundary_root, self.root)
+        self.assertEqual(scope, "plugins/one")
+
+    def test_the_nearest_boundary_wins(self):
+        nested = os.path.join(self.root, "plugins")
+        commit_boundary(nested)
+        boundary_root, scope = self.scope_of(os.path.join(nested, "one"))
+        self.assertEqual(boundary_root, nested)
+        self.assertEqual(scope, "one")
+
+    def test_a_scope_equal_to_the_boundary_root_is_the_whole_tree(self):
+        boundary_root, scope = self.scope_of(self.root)
+        self.assertEqual((boundary_root, scope), (self.root, "."))
+
+    def test_a_directory_outside_any_boundary_is_refused(self):
+        outside = tempfile.TemporaryDirectory()
+        self.addCleanup(outside.cleanup)
+        resolved, reason = horos.resolve_boundary_root(outside.name)
+        self.assertIsNone(resolved)
+        self.assertIn("no boundary", reason)
+
+    def test_a_symlink_leaving_the_worktree_is_refused(self):
+        outside = tempfile.TemporaryDirectory()
+        self.addCleanup(outside.cleanup)
+        link = os.path.join(self.root, "escape")
+        os.symlink(os.path.realpath(outside.name), link)
+        resolved, reason = horos.resolve_boundary_root(link)
+        self.assertIsNone(resolved)
+        self.assertIn("leaves the worktree", reason)
+
+    def test_a_missing_boundary_exits_two(self):
+        os.remove(os.path.join(self.root, horos.BOUNDARY_RELPATH))
+        resolved, reason = horos.resolve_boundary_root(
+            os.path.join(self.root, "plugins", "one")
+        )
+        self.assertIsNone(resolved)
+        self.assertIn("no boundary", reason)
+
+    def test_a_malformed_boundary_exits_two(self):
+        path = os.path.join(self.root, horos.BOUNDARY_RELPATH)
+        Path(path).write_text("{not json", encoding="utf-8")
+        code, text = self.check(os.path.join(self.root, "plugins", "one"))
+        self.assertEqual(code, 2)
+        self.assertIn("unreadable boundary", text)
+
+    # Admission
+
+    def test_a_clean_scope_is_admitted_and_says_what_it_did_not_evaluate(self):
+        code, text = self.check(os.path.join(self.root, "plugins", "one"))
+        self.assertEqual(code, 0, text)
+        self.assertIn("scope: plugins/one", text)
+        self.assertIn("hard boundary: matches", text)
+        self.assertIn("outside-scope drift: not evaluated", text)
+
+    def test_an_empty_scope_is_admitted(self):
+        empty = os.path.join(self.root, "src", "nothing")
+        os.makedirs(empty)
+        code, text = self.check(empty)
+        self.assertEqual(code, 0, text)
+        self.assertIn("hard boundary: matches", text)
+
+    def test_a_scope_that_is_itself_a_directory_entry_matches(self):
+        committed = horos.load_boundary(self.root)
+        self.assertIn("vendor-only/", [e["path"] for e in committed["entries"]])
+        code, text = self.check(os.path.join(self.root, "vendor-only"))
+        self.assertEqual(code, 0, text)
+        self.assertIn("hard boundary: matches", text)
+
+    def test_an_addition_inside_the_scope_refuses_it(self):
+        write(self.root, "plugins/one/package-lock.json", '{"lockfileVersion": 3}\n')
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-qm", "new lockfile")
+        code, text = self.check(os.path.join(self.root, "plugins", "one"))
+        self.assertEqual(code, 1, text)
+        self.assertIn("plugins/one/package-lock.json", text)
+        self.assertIn("hard boundary: drifted", text)
+
+    def test_a_removal_inside_the_scope_refuses_it(self):
+        git(self.root, "rm", "-q", "plugins/one/yarn.lock")
+        git(self.root, "commit", "-qm", "drop lockfile")
+        code, text = self.check(os.path.join(self.root, "plugins", "one"))
+        self.assertEqual(code, 1, text)
+        self.assertIn("plugins/one/yarn.lock", text)
+
+    def test_a_changed_entry_inside_the_scope_refuses_it(self):
+        write(self.root, "plugins/one/yarn.lock", "# lockfile\n" * 40)
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-qm", "grow lockfile")
+        code, text = self.check(os.path.join(self.root, "plugins", "one"))
+        self.assertEqual(code, 1, text)
+        self.assertIn("entry changed", text)
+
+    def test_drift_in_a_sibling_does_not_refuse_the_scope(self):
+        write(self.root, "plugins/two/pnpm-lock.yaml", "lockfileVersion: 9\n")
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-qm", "sibling lockfile")
+        code, text = self.check(os.path.join(self.root, "plugins", "one"))
+        self.assertEqual(code, 0, text)
+        self.assertNotIn("plugins/two", text)
+        whole, _ = self.check(self.root)
+        self.assertEqual(whole, 1)
+
+    def test_candidate_drift_inside_the_scope_does_not_refuse_it(self):
+        write(self.root, "plugins/one/rows.json", BLOB)
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-qm", "blob")
+        result = horos.scan_tree(self.root, scope="plugins/one")
+        self.assertTrue(
+            any(e["path"] == "plugins/one/rows.json" for e in result["candidates"]),
+            [e["path"] for e in result["candidates"]],
+        )
+        code, text = self.check(os.path.join(self.root, "plugins", "one"))
+        self.assertEqual(code, 0, text)
+        self.assertIn("hard boundary: matches", text)
+
+    # Cost and equivalence
+
+    def test_the_scope_classifies_nothing_outside_itself(self):
+        result = horos.scan_tree(self.root, scope="plugins/one")
+        for entry in result["entries"] + result["candidates"]:
+            self.assertTrue(
+                entry["path"].startswith("plugins/one"),
+                entry["path"],
+            )
+        self.assertEqual(result["counts"]["files_walked"], 2)
+
+    def test_an_attribute_file_above_the_scope_is_read_and_counted(self):
+        result = horos.scan_tree(self.root, scope="vendor-only")
+        self.assertEqual(result["counts"]["attribute_files_above_scope"], 1)
+        self.assertIn("vendor-only/", [e["path"] for e in result["entries"]])
+
+    def test_both_invocation_sites_print_the_same_bytes(self):
+        target = os.path.join(self.root, "plugins", "one")
+        _, from_above = self.check(target)
+        cwd = os.getcwd()
+        os.chdir(target)
+        try:
+            _, from_inside = self.check(".")
+        finally:
+            os.chdir(cwd)
+        self.assertEqual(from_above, from_inside)
 
 
 if __name__ == "__main__":

--- a/tests/test_boundary_currency.py
+++ b/tests/test_boundary_currency.py
@@ -1,14 +1,25 @@
 """The committed reading boundary must describe the tracked tree it ships with.
 
 Criterion 6 of `plugins/horos/docs/scoped-entry/study.md`. The audit record
-already carries this failure once: Marking run, step 4, round 1 refreshed the
+carries this failure once already: Marking run, step 4, round 1 refreshed the
 boundary by hand after `check` flagged the marking evidence copies as new
-sinks, and no guard was written. It recurred. This fixture is the guard, and it
-is an expected failure until the step that fixes the drift lands.
+sinks, and no guard was written. It recurred two days later, when a commit
+regenerated the boundary and added an evidence copy of it in the same change.
+This is the guard.
+
+A guard that cannot fail is worth nothing, so the mutations below drive the
+same comparison over a temporary repository and require it to name a path in
+both directions: an entry the tree earned and the boundary lacks, and an entry
+the boundary claims and the tree no longer earns.
 """
 
 from pathlib import Path
+import json
+import os
+import shutil
+import subprocess
 import sys
+import tempfile
 import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -16,24 +27,99 @@ sys.path.insert(0, str(ROOT / "plugins" / "horos" / "skills" / "horos" / "script
 
 import horos  # noqa: E402
 
+GIT = shutil.which("git")
+
+REFRESH = (
+    "regenerate with: python3 "
+    "plugins/horos/skills/horos/scripts/horos.py scan . --write"
+)
+
+
+def drifted_paths(root):
+    """Every path where the committed boundary and a fresh scan disagree."""
+    committed = horos.load_boundary(str(root))
+    fresh = horos.boundary_document(
+        horos.scan_tree(
+            str(root),
+            include_untracked=committed.get("universe") == "tracked+untracked",
+        )
+    )
+    return [path for path, _ in horos.diff_documents(committed, fresh)]
+
+
+def write(root, relpath, content):
+    path = Path(root) / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def git(root, *args):
+    subprocess.run(  # phylax: allow subprocess: fixed argv git in a test tempdir, no shell
+        ["git", "-C", root, *args],
+        capture_output=True,
+        check=True,
+        env={**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"},
+    )
+
 
 class BoundaryCurrencyTests(unittest.TestCase):
-    @unittest.expectedFailure
     def test_the_committed_boundary_matches_a_fresh_scan(self):
-        committed = horos.load_boundary(str(ROOT))
-        fresh = horos.boundary_document(
-            horos.scan_tree(
-                str(ROOT),
-                include_untracked=committed.get("universe") == "tracked+untracked",
-            )
+        self.assertEqual(drifted_paths(ROOT), [], REFRESH)
+
+
+@unittest.skipIf(GIT is None, "git unavailable")
+class GuardMutationTests(unittest.TestCase):
+    """The same comparison, driven against a tree that is deliberately wrong."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.addCleanup(self._tmp.cleanup)
+        git(self.root, "init", "-q")
+        write(self.root, "src/app.py", "value = 1\n")
+        write(self.root, "yarn.lock", "# lockfile\n")
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-qm", "tracked tree")
+        horos.write_boundary(
+            self.root, horos.boundary_document(horos.scan_tree(self.root))
         )
-        drift = horos.diff_documents(committed, fresh)
-        self.assertEqual(
-            [path for path, _ in drift],
-            [],
-            "regenerate with: python3 plugins/horos/skills/horos/scripts/horos.py "
-            "scan . --write",
+        self.assertEqual(drifted_paths(self.root), [])
+
+    def test_a_new_generated_file_without_a_refresh_is_named(self):
+        # Assembled rather than spelled: a file containing the marker literal
+        # classifies itself as generated, which is the held frontier defect
+        # (marker-self-exclusion). Spelling it here would put this guard's own
+        # source inside the boundary and leave it unread by every agent that
+        # honours one.
+        marker = "# Do not " + "edit: generated\n"
+        write(self.root, "src/schema.py", marker + "X = 1\n")
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-qm", "generated file")
+        self.assertEqual(drifted_paths(self.root), ["src/schema.py"])
+
+    def test_an_entry_the_tree_no_longer_earns_is_named(self):
+        path = os.path.join(self.root, horos.BOUNDARY_RELPATH)
+        document = json.loads(Path(path).read_text(encoding="utf-8"))
+        document["entries"].append(
+            {
+                "path": "src/app.py",
+                "category": "generated",
+                "bytes": 12,
+                "evidence": "invented for this test",
+                "grade": "hard",
+            }
         )
+        Path(path).write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        self.assertEqual(drifted_paths(self.root), ["src/app.py"])
+
+    def test_two_scans_render_the_same_bytes(self):
+        first = horos.render(horos.boundary_document(horos.scan_tree(self.root)))
+        second = horos.render(horos.boundary_document(horos.scan_tree(self.root)))
+        self.assertEqual(first, second)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Step 4 of 5, stacked on step 3. This is the feature the run exists for.

`check <path>` now takes the repository root or any directory inside it. For a
descendant, Horos walks upward to the nearest committed boundary, stops at the
worktree root git reports, classifies only that subtree, and compares it with
the matching slice of the committed hard boundary:

```text
boundary root: /path/to/repo
scope: plugins/alexandria
hard boundary: matches
candidates: 12 findings, advisory
outside-scope drift: not evaluated
counters: classified 210, listed outside scope 3, attribute files above scope 0
```

Exit 1 is hard drift inside the scope, with every path named. Exit 2 is no
usable ancestor boundary, or a path that resolves out of the worktree.
Candidate drift never changes the exit code, and `check` at the root keeps its
previous wording exactly, so a release check reads as it always did.

Three decisions carry the difference between a local answer and a misleading
one. The walk still begins at the boundary root, because a `.gitattributes`
above the scope decides how files inside it classify, and a scan that skipped
it would disagree with a whole-tree scan about the same file; those reads are
counted and reported. Whole subtrees outside the scope are pruned unvisited, so
nothing outside is stat'd, opened or classified. And a green scoped check says
`outside-scope drift: not evaluated`, because a local pass read as a global one
is the failure that phrasing exists to prevent.

Twenty-two cases cover resolution, admission, refusal and cost. Two mutations
were run against the committed step before the suite was trusted: making the
committed slice ignore the scope fails five cases, and pruning the ancestor
chain instead of walking it fails six.

Three audit rounds, two findings, both in this step rather than in an earlier
one.

The first was the escape control, built by halves. It inspected the given path,
so a symlink as the final component was refused while a symlink in the middle
was not: `git -C` resolves symlinks before it answers, so `check bridge/sub`
reported the far repository as its own worktree and would have been answered
from that tree's boundary. A relative path now means "inside the repository I am
working in" and is refused if it resolves outside that worktree, which covers
`..`, a symlinked last component and a symlinked middle one under one rule. Two
guards, both seen failing without the fix. The neighbouring legitimate case,
`../two` from inside a sibling scope, was run and then pinned as a test rather
than left as an assumption.

The second was this step's own evidence. The benchmark still called
`check_tree`, so every scoped run recorded exit 2 and a null median while the
check itself worked: criterion 12's measurement did not exist, and the record
said `unavailable` rather than wrong, which is how round 1 read past it. It now
drives the same entry point the command does and reports counters from the same
scoped walk.

First measured numbers, five runs each on this tree:

| target | median | classified | outside scope |
|---|---|---|---|
| whole tree | 59.6 ms | 1157 files | n/a |
| `plugins/alexandria` | 24.4 ms | 210 | 0 |
| `plugins/brevitas` | 15.9 ms | 21 | 0 |

Alexandria costs more than a third of the whole tree because its weight is a
content-addressed store, and digest verification reads whole files by design.

`SKILL.md` documents the scoped form, the exit codes and the no-global-claim
rule, and its entry discipline now tells an agent to check the directory it is
about to work in rather than the whole repository.

To check the step:

```bash
python3 -m unittest discover -s plugins/horos/tests -t plugins/horos
python3 plugins/horos/skills/horos/scripts/horos.py check plugins/alexandria
python3 plugins/horos/tests/benchmark_scope.py --root . --scope plugins/alexandria --runs 5
```

Expect 207 tests green, an admitted scope, and a JSON record whose
`classified_outside_scope` is 0.

<!-- wildcat-origin: shoggoth -->
