### PR TITLE
berean: corpus manifests and byte-exact citations

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -135,6 +135,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Developer Tools"
+    },
+    {
+      "name": "berean",
+      "source": {
+        "source": "local",
+        "path": "./plugins/berean"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
     }
   ]
 }

--- a/.agents/skills/berean/SKILL.md
+++ b/.agents/skills/berean/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: berean
+description: Route evidence-backed protocol-agent release work to Berean. Use it to pin corpora, prove byte-exact citations and block-bound reads, and grade recorded answers; use Lemma for chunking and Lazarus for chain preservation.
+---
+
+# Berean portable entrypoint
+
+<!-- marketplace-context:start -->
+## Where this sits
+
+Berean pins the corpus, chain readings and evaluation record a protocol agent's answers rest on, so a release can be checked without the model that produced it.
+
+**Use another tool when.** Use Lemma to produce source-linked chunks, Lazarus to preserve the chain evidence itself, and Ariadne to bind a released artefact digest to its evidence.
+
+**Current frontier.** The reference release answers against a frozen demonstration corpus and preserved Goldfinch mainnet reads; no release yet cites live Wildcat documentation or a captured Wildcat market read, and no Ariadne statement binds a berean release.
+<!-- marketplace-context:end -->
+
+Read [the Berean runtime contract](../../../plugins/berean/AGENTS.md). Use
+its selection table to choose the skill, then read that canonical `SKILL.md`
+in full and follow it.
+
+Invocation prefixes are aliases:
+
+- `/berean:berean`, `$berean`, and a plain request to verify or release an
+  evidence-backed protocol agent all select `berean`.
+
+The canonical skill pins document corpora by digest, proves citations as
+exact bytes, holds chain values to a named chain and block through preserved
+read records, grades recorded answers against ordinary and adversarial
+evaluation cases, and keeps promotion and rollback as records. It runs no
+model and reaches no network.
+
+The canonical skill and runtime contract are authoritative if this
+entrypoint disagrees with them.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -265,6 +265,27 @@
         "evidence",
         "brevity"
       ]
+    },
+    {
+      "name": "berean",
+      "displayName": "Berean",
+      "source": "./plugins/berean",
+      "description": "Digest-pinned agent releases with byte-exact citations, block-bound reads and evaluated refusals.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Wildcat Labs",
+        "url": "https://wildcat.finance"
+      },
+      "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/berean",
+      "repository": "https://github.com/wildcat-finance/skills",
+      "category": "Developer Tools",
+      "tags": [
+        "agents",
+        "evidence",
+        "citations",
+        "releases",
+        "evaluation"
+      ]
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,11 +7,14 @@ the canonical `SKILL.md` it names.
 
 ## Marketplace boundaries
 
-The eleven plugins form one marketplace, not eleven competing descriptions of the
-same job. Alexandria preserves lending inputs; Tabularium interprets preserved
-venue records; Probitas assembles a counterparty dossier. Lazarus preserves the
-finite historical Ethereum state and exact RPC traffic a test needs, while
-Ariadne binds a released artefact digest to its evidence. Pandects supplies
+The thirteen plugins form one marketplace, not thirteen competing descriptions
+of the same job. Alexandria preserves lending inputs; Tabularium interprets
+preserved venue records; Probitas assembles a counterparty dossier. Lazarus
+preserves the finite historical Ethereum state and exact RPC traffic a test
+needs, while Ariadne binds a released artefact digest to its evidence. Berean
+holds a protocol agent's recorded answers to pinned corpora and preserved
+chain reads; it neither chunks documents nor preserves chain state itself.
+Pandects supplies
 reviewed credit laws, Hermes measures a single gas-optimisation class,
 Hexaemeron controls a receipted delivery loop and holds each of its phases to a
 named skill, while Lemma stops after producing
@@ -27,6 +30,8 @@ rather than broadening the selected skill.
   `plugins/alexandria/AGENTS.md` before running its skill or changing that
   plugin.
 - Ariadne is under `plugins/ariadne/`. Read `plugins/ariadne/AGENTS.md` before
+  running its skill or changing that plugin.
+- Berean is under `plugins/berean/`. Read `plugins/berean/AGENTS.md` before
   running its skill or changing that plugin.
 - Brevitas is under `plugins/brevitas/`. Read `plugins/brevitas/AGENTS.md`
   before running its skill or changing that plugin.
@@ -81,6 +86,7 @@ Run the checks that cover every changed area.
 python3 -m unittest discover -s tests
 python3 -m unittest discover -s plugins/alexandria/tests -t plugins/alexandria
 python3 -m unittest discover -s plugins/ariadne/tests -t plugins/ariadne
+python3 -m unittest discover -s plugins/berean/tests -t plugins/berean
 python3 -m unittest discover -s plugins/brevitas/tests -t plugins/brevitas
 python3 plugins/hermes/skills/hermes/scripts/test_hermes.py
 python3 plugins/hexaemeron/tests/run_tests.py

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ then derives only the credit rows a reviewed mapping can defend.
 [Ariadne](./plugins/ariadne) binds a release to the evidence behind it, in a statement another person can check.
 
 
+### Berean
+
+[Berean](./plugins/berean) releases evidence-backed protocol agents: the
+corpus pinned by digest, every citation provable as exact bytes, every live
+value bound to a chain and block, and promotion held to an evaluation record,
+all checkable without the model that produced the answers.
+
+
 ### Brevitas
 
 [Brevitas](./plugins/brevitas) is the final structural pass for audit findings,
@@ -95,14 +103,14 @@ another person can rebuild after the endpoint that served them is gone.
 
 Scored out of 10 for doing the job, not for reading the output. A marketer can quote a verified gas number without having any use for Hermes itself.
 
-| Role | Alexandria | Ariadne | Brevitas | Hermes | Hexaemeron | Horos | Lemma | Lazarus | Pandects | Probitas | Sapheneia | Tabularium |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Developers | 8 | 8 | 8 | 9 | 9 | 8 | 6 | 8 | 8 | 4 | 8 | 7 |
-| Security and audit | 8 | 9 | 10 | 7 | 8 | 2 | 4 | 8 | 9 | 5 | 7 | 7 |
-| Marketing | 1 | 1 | 1 | 3 | 6 | 1 | 1 | 1 | 1 | 1 | 3 | 1 |
-| Business development | 6 | 2 | 2 | 2 | 5 | 1 | 1 | 2 | 2 | 9 | 4 | 3 |
-| Finance | 8 | 1 | 2 | 3 | 4 | 1 | 1 | 2 | 2 | 7 | 4 | 7 |
-| Legal | 3 | 3 | 2 | 1 | 4 | 1 | 1 | 2 | 2 | 4 | 4 | 2 |
+| Role | Alexandria | Ariadne | Berean | Brevitas | Hermes | Hexaemeron | Horos | Lemma | Lazarus | Pandects | Probitas | Sapheneia | Tabularium |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Developers | 8 | 8 | 8 | 8 | 9 | 9 | 8 | 6 | 8 | 8 | 4 | 8 | 7 |
+| Security and audit | 8 | 9 | 7 | 10 | 7 | 8 | 2 | 4 | 8 | 9 | 5 | 7 | 7 |
+| Marketing | 1 | 1 | 2 | 1 | 3 | 6 | 1 | 1 | 1 | 1 | 1 | 3 | 1 |
+| Business development | 6 | 2 | 5 | 2 | 2 | 5 | 1 | 1 | 2 | 2 | 9 | 4 | 3 |
+| Finance | 8 | 1 | 3 | 2 | 3 | 4 | 1 | 1 | 2 | 2 | 7 | 4 | 7 |
+| Legal | 3 | 3 | 3 | 2 | 1 | 4 | 1 | 1 | 2 | 2 | 4 | 4 | 2 |
 
 Five is the barrier. At or above it, the plugin's entry carries a worked example of what that role would use it for. Below it there is no example, because there is no honest one to give. These are engineering tools, and a 2 means we could not find a reason for that desk to open the plugin rather than read what it produced.
 
@@ -114,6 +122,7 @@ The short map of what each plugin does and what is honestly left to build.
 | --- | --- | --- |
 | [Alexandria](./plugins/alexandria) | Preserving heterogeneous lending-source bytes, then deriving and querying reviewed credit views. | Compound v3 Phase 0 now pins the Comet registry and preserves one verified Ethereum execution witness; a resumable, reconciled Ethereum USDC interval harvester remains unimplemented. |
 | [Ariadne](./plugins/ariadne) | Binding an artefact digest to build, test, review and deployment evidence. | The grounded-agent predicate remains unimplemented; the state-fixture predicate now ships with its schema, gates, conformance fixtures and a capture path that reads a Lazarus fixture's evidence counts rather than recomputing them. |
+| [Berean](./plugins/berean) | Releasing and verifying evidence-backed protocol agents against pinned corpora, preserved chain reads and an evaluation record. | The reference release answers against a frozen demonstration corpus and preserved Goldfinch mainnet reads; no release yet cites live Wildcat documentation or a captured Wildcat market read, and no Ariadne statement binds a berean release. |
 | [Brevitas](./plugins/brevitas) | Enforcing mechanical volume and structure budgets on engineering review prose while preserving evidence. | The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked. |
 | [Hermes](./plugins/hermes) | Measuring one Solidity gas-optimisation class through fail-closed Foundry checks. | No complete, reproducible live Wildcat evidence bundle is published. |
 | [Hexaemeron](./plugins/hexaemeron) | Running an explicit, receipted delivery loop, ranking frontier work with Kronos, or using its fuzzing, audit and prose skills separately. | The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery. |
@@ -151,6 +160,7 @@ Add the same marketplace and install a plugin from inside Claude Code:
 /plugin marketplace add wildcat-finance/skills
 /plugin install alexandria@wildcat-labs
 /plugin install ariadne@wildcat-labs
+/plugin install berean@wildcat-labs
 /plugin install brevitas@wildcat-labs
 /plugin install hermes@wildcat-labs
 /plugin install hexaemeron@wildcat-labs
@@ -171,6 +181,7 @@ Claude namespaces plugin skills, so each entry skill answers as:
 ```text
 /alexandria:alexandria
 /ariadne:ariadne
+/berean:berean
 /brevitas:brevitas
 /hermes:hermes
 /hexaemeron:fiat "<topic>"
@@ -200,8 +211,8 @@ See Anthropic's [skills](https://code.claude.com/docs/en/skills) and [plugin mar
 
 ### Local agents
 
-Agents that support the open Agent Skills convention can discover the eleven
-host-neutral entries under [`.agents/skills`](./.agents/skills). Point the
+Agents that support the open Agent Skills convention can discover the
+nineteen host-neutral entries under [`.agents/skills`](./.agents/skills). Point the
 agent at this repository and include that directory in its project skill
 search path. Keep the repository layout intact: each entry routes to the
 canonical plugin instructions instead of copying them.
@@ -217,6 +228,7 @@ Plain-text activation works alongside host syntax:
 ```text
 Use Alexandria to preserve this lending-data capture and query its source-bound credit view.
 Use Ariadne to capture this release in an evidence statement, run its gates, and report its signature state without checking signatures.
+Use Berean to verify this release's citations, chain readings and promotion record against its pinned corpus.
 Use Brevitas to enforce evidence-preserving structural budgets on this engineering review.
 Use Hermes to optimise gas in this Foundry repository.
 Use Hexaemeron Fiat to take "<topic>" through the delivery loop.
@@ -335,6 +347,16 @@ Use $ariadne to capture this release in an evidence statement, run its gates, an
 
 The gates, the predicate and the refusals live in [Ariadne's `SKILL.md`](./plugins/ariadne/skills/ariadne/SKILL.md).
 
+Berean needs Python 3.9 or later and nothing else. Its checked-in reference
+release and every verification path run offline. Ask:
+
+```text
+Use $berean to verify this release's citations, chain readings and promotion record against its pinned corpus.
+```
+
+The release contract, the gates and the refusals live in
+[Berean's `SKILL.md`](./plugins/berean/skills/berean/SKILL.md).
+
 Brevitas needs Python 3 and no third-party package. Ask:
 
 ```text
@@ -437,6 +459,7 @@ Every plugin has that shape. What each adds beyond it:
 | --- | --- | --- |
 | Alexandria | `alexandria` | docs, examples, schemas, scripts |
 | Ariadne | `ariadne` | audit, docs, examples, schemas, scripts |
+| Berean | `berean` | docs, examples, schemas, scripts |
 | Brevitas | `brevitas` | evals |
 | Hermes | `hermes` | references and scripts inside the skill |
 | Hexaemeron | `fiat`, `kronos`, `imprimatur`, `vulgate`, the vendored `x-ray`, `solidity-auditor` and `fizz`, and `protasis`, `elenchus`, `phylax`, `ephoros`, `metron`, `hypomnema` | agents, audit, docs |
@@ -471,12 +494,12 @@ carries the shared credit laws. `lazarus` preserves and replays a finite slice
 of historical state. Another protocol, auditor, researcher or agent builder
 should be able to use each one without needing to use Wildcat. `alexandria`
 now keeps the heterogeneous raw record and serves a reviewed address view to
-`probitas` without making either one own the other's claims.
+`probitas` without making either one own the other's claims. Agents that can
+show their sources were the next gap, and `berean` now carries the release
+contract, verifier and evaluation corpus for them.
 
-What remains, listed alphabetically:
+What remains:
 
-- `berean`, a release manifest and evaluation corpus for agents that must
-  support answers with exact documents and chain state.
 - `janus`, a conformance suite for what contract hooks may observe and change
   before and after a host action.
 

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4442,3 +4442,18 @@ rather than passing as a superset; and citation digest and display text are
 checked separately so neither can vouch for the other.
 
 Leads not pursued: none.
+
+## Berean from its Commons specification, step 2, round 2 -- 2026-08-20
+
+Scope: the step 2 tree with `c8c72d3` applied. Both fixes re-reviewed
+against the current tree: the constant hook refuses all three JSON
+constants with a guard test per spelling, and the drift loop reports a
+swapped symlink as a named `corpus-bytes` failure with the refusal in its
+detail. Lints phylax, ephoros and hypomnema exit 0; root suite 34 and
+berean suite 61 green.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | No findings. | clean |
+
+Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4420,3 +4420,25 @@ Leads not pursued: brevitas B011 flags the runtime contract's selection and
 capability tables (1x3 and 5x2); the shipped template in every existing
 plugin carries the same shapes and the same flags, so the tables stay with
 the house form. Nothing else.
+
+## Berean from its Commons specification, step 2, round 1 -- 2026-08-20
+
+Scope: `c3bec0c..4438d2e`, the corpus and citation core. The suite waiver
+stands; the mechanical part ran phylax, ephoros and hypomnema over the
+changed trees, all exit 0, with the root suite (34) and berean suite (59 at
+review, 61 after fixes) green.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| B2-R1-01 | medium | `plugins/berean/scripts/berean_lib/jsonio.py` | NaN and Infinity reach `json.loads` through `parse_constant`, not `parse_float`, so a document carrying them passed the reader built to refuse non-finite numbers. | fixed in `c8c72d3` |
+| B2-R1-02 | low | `plugins/berean/scripts/berean_lib/corpus.py` | A pinned path swapped for a symlink between the walk and the drift read raised out of `verify` as a usage error instead of failing a named check. | fixed in `c8c72d3` |
+
+The look beyond the lints traced the risk register's concerns through the
+new code: traversal and backslash refusals sit in one place and both
+builders go through it; the staged write cannot leave a half manifest that
+later verifies, and a crashed staging file inside the corpus is itself a
+refusal; verification is set equality, so an unpinned extra file fails
+rather than passing as a superset; and citation digest and display text are
+checked separately so neither can vouch for the other.
+
+Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4392,3 +4392,31 @@ its `P` and stayed out of selection, the pass rendered as `(rank-only)`, and
 than a failure.
 
 Leads not pursued: none.
+
+## Berean from its Commons specification, step 1, round 1 -- 2026-08-20
+
+Scope: `496f7a1..fe36843`, the plugin scaffold and its marketplace landing.
+The Solidity suite is waived for this run: the delivery is Python, JSON and
+Markdown with no contracts in any step. The mechanical part ran phylax,
+ephoros and hypomnema over the changed trees, all exit 0, with the root
+suite (34, at 13 plugins) and the berean suite (5) green on the tracked
+tree, which also puts every new shipped document through the in-process
+imprimatur gate.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | No findings. | clean |
+
+The look beyond the lints checked the risk register's step 1 concerns: the
+frontier sentence is byte-identical across the eight berean surfaces and the
+root status row; the ledger digest reproduces from the header fields; the
+three manifests and the openai interface carry one description; the portable
+entry's links resolve at their depth; the Commons section moves berean from
+the remaining list without rewording the janus entry; and the preserved
+specification differs from the upload only in its header block, which
+`docs/design.md` records verbatim.
+
+Leads not pursued: brevitas B011 flags the runtime contract's selection and
+capability tables (1x3 and 5x2); the shipped template in every existing
+plugin carries the same shapes and the same flags, so the tables stay with
+the house form. Nothing else.

--- a/plugins/berean/.claude-plugin/plugin.json
+++ b/plugins/berean/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "berean",
+  "displayName": "Berean",
+  "version": "0.1.0",
+  "description": "Digest-pinned agent releases with byte-exact citations, block-bound reads and evaluated refusals.",
+  "author": {
+    "name": "Wildcat Labs",
+    "url": "https://wildcat.finance"
+  },
+  "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/berean",
+  "repository": "https://github.com/wildcat-finance/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "agents",
+    "evidence",
+    "citations",
+    "releases",
+    "evaluation"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/berean/.codex-plugin/plugin.json
+++ b/plugins/berean/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "berean",
+  "version": "0.1.0",
+  "description": "Digest-pinned agent releases with byte-exact citations, block-bound reads and evaluated refusals.",
+  "author": {
+    "name": "Wildcat Labs",
+    "url": "https://wildcat.finance"
+  },
+  "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/berean",
+  "repository": "https://github.com/wildcat-finance/skills",
+  "keywords": [
+    "agents",
+    "evidence",
+    "citations",
+    "releases",
+    "evaluation"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Berean",
+    "shortDescription": "Digest-pinned agent releases with byte-exact citations, block-bound reads and evaluated refusals.",
+    "longDescription": "Berean releases evidence-backed protocol agents. A release pins its corpus by digest, proves every citation as exact bytes, binds every live value to a chain and block, separates document claims from chain readings, states when it refuses, and records the evaluation that made it active. The verifier checks all of that offline, without the model that produced the answers.",
+    "developerName": "Wildcat Labs",
+    "category": "Developer Tools",
+    "capabilities": [],
+    "defaultPrompt": "Use $berean to verify this release's citations, chain readings and promotion record against its pinned corpus."
+  }
+}

--- a/plugins/berean/AGENTS.md
+++ b/plugins/berean/AGENTS.md
@@ -1,0 +1,72 @@
+# Berean runtime contract
+
+<!-- marketplace-context:start -->
+> **Marketplace context: Berean.** Berean pins the corpus, chain readings and evaluation record a protocol agent's answers rest on, so a release can be checked without the model that produced it. Use Lemma to produce source-linked chunks, Lazarus to preserve the chain evidence itself, and Ariadne to bind a released artefact digest to its evidence. **Current frontier:** The reference release answers against a frozen demonstration corpus and preserved Goldfinch mainnet reads; no release yet cites live Wildcat documentation or a captured Wildcat market read, and no Ariadne statement binds a berean release.
+<!-- marketplace-context:end -->
+
+Berean contains one Agent Skill. Select from this table, then read the chosen
+`SKILL.md` in full.
+
+| Skill | Canonical instructions | Select when |
+| --- | --- | --- |
+| `berean` | `skills/berean/SKILL.md` | Build, verify or evaluate an evidence-backed protocol-agent release |
+
+`skills/berean/SKILL.md` is the only canonical instruction document. Do not
+add a sibling browsing README.
+
+## Translate tool names by capability
+
+The canonical skill may name host tools. A local agent must map them to
+equivalent capabilities:
+
+| Instruction term | Required capability |
+| --- | --- |
+| `Read` | Read the named file completely or at the stated range |
+| `Write` or `Edit` | Create or patch the named file |
+| `Bash` | Execute the command in a shell and inspect its exit status |
+| `Glob`, `Grep`, or `find` | Enumerate or search files with the stated pattern |
+| `AskUserQuestion` | Ask the stated question through structured UI or concise text |
+
+Tool names describe capabilities, not mandatory API identifiers. Preserve the
+arguments, ordering, output files and exit codes when using an equivalent
+local tool. A non-zero exit means the requested operation did not succeed.
+
+## Resolve placeholders
+
+- `$SKILL_DIR` means the directory containing the active `SKILL.md`, unless
+  that file defines it differently.
+- `$PLUGIN_ROOT` means this `plugins/berean/` directory.
+- The tool's own commands are relative to `$PLUGIN_ROOT`, so
+  `scripts/berean.py` resolves here and not in the user's target repository.
+- Names such as `berean:berean` and `/berean:berean` are logical aliases.
+  Load the canonical path from the table above.
+
+## Network and side effects
+
+The plugin reaches no network. `build-corpus` reads the named tree and writes
+only the named manifest. `verify-corpus`, `check-citation`, `check-answer`,
+`verify-release`, `export-cases` and `promotion-chain` read local files and
+write nothing beyond the output path they were given. `run-evals` writes only
+its report. `promote` and `rollback` append one record to the release's
+promotion file and change nothing else. Every builder stages its output and
+lands it with one rename.
+
+## What this skill must refuse
+
+- No path escape. Absolute paths, parent traversal and symlinks are refused
+  everywhere a document names a file.
+- No verification by declared digest alone. Citations are re-sliced from
+  pinned bytes, request keys are recomputed, and digests are recompared.
+- No evidence upgrade. Source classes and read evidence classes are closed
+  vocabularies and never widen at read time.
+- No blockless live value. A current value that names no chain and no block
+  is not accepted as evidence.
+- No silent time-domain choice. A document claim and a later chain state that
+  disagree are both reported.
+- No grading against an unpinned corpus. A digest mismatch stops the
+  evaluation before the first case.
+- No model execution and no retrieval. Berean checks recorded answers; it
+  does not produce them.
+
+If a build, verification, evaluation or test did not run, say so plainly and
+do not describe it as successful.

--- a/plugins/berean/LICENSE
+++ b/plugins/berean/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Wildcat Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/berean/README.md
+++ b/plugins/berean/README.md
@@ -1,0 +1,121 @@
+# Berean
+
+<!-- marketplace-context:start -->
+## In one line
+
+Berean pins the corpus, chain readings and evaluation record a protocol agent's answers rest on, so a release can be checked without the model that produced it.
+
+**Try something else when.** Use Lemma to produce source-linked chunks, Lazarus to preserve the chain evidence itself, and Ariadne to bind a released artefact digest to its evidence.
+
+**Current frontier.** The reference release answers against a frozen demonstration corpus and preserved Goldfinch mainnet reads; no release yet cites live Wildcat documentation or a captured Wildcat market read, and no Ariadne statement binds a berean release.
+
+**Next Fiat job.** Use /hexaemeron:fiat to ship the first berean release grounded in captured Wildcat documentation and Wildcat market reads, replacing the demonstration corpus in the reference deployment. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
+<!-- marketplace-context:end -->
+
+A protocol agent can answer from documentation, contract state and its own
+synthesis in one paragraph. Unless those sources stay separate, the reader
+cannot tell which parts are historical, which are live, which came from a
+document and which the model supplied. Berean is the release contract that
+keeps them separate and checkable.
+
+A Berean release declares an immutable corpus version and digest, byte-exact
+citations, typed read records with the block behind each value, the rules
+separating document claims from chain readings from calculations from
+user-supplied facts, the question families it supports, the conditions under
+which it refuses, its evaluation cases and graders, and the promotion record
+that made it active. The verifier checks corpus identity, citation spans,
+read provenance and evaluation coverage offline, without the model that
+produced the answers.
+
+Three rules hold a release together:
+
+1. Citations identify bytes, not search results. A quote passes only when
+   re-slicing the pinned file reproduces its digest and its display text.
+2. Live values name a block. A current value with no chain and no block is
+   not evidence, and a document claim that disagrees with a later chain
+   state is reported beside it rather than silently replaced.
+3. Promotion is evidence. A release becomes active through a record naming
+   the evaluation corpus, thresholds and results that allowed it, and
+   rollback is a new record naming the restored release.
+
+## How it works
+
+`build-corpus` pins a document tree: one entry per file with its byte count
+and sha256, and a corpus digest over the sorted listing. `check-citation`
+and `check-answer` prove or refuse quotes, source classes, chain reads, time
+domains and refusals against those pins. `verify-release` runs the release
+gates by name. `run-evals` grades recorded answer documents against the
+release's ordinary and adversarial cases, refusing to start when any pinned
+digest disagrees with what is on disk. `promote` and `rollback` append
+records to the promotion chain; nothing edits a published release in place.
+
+Chain evidence arrives as preserved read records in the Lazarus record
+shape, held by recomputed request keys. The shipped reference release under
+`examples/goldfinch-demo-v0` answers, refuses and discloses a time-domain
+disagreement against a frozen demonstration corpus and preserved Goldfinch
+mainnet reads at block 13097494, entirely offline.
+
+## What it ships
+
+- Five versioned JSON schemas: corpus manifest, answer record, eval case,
+  release manifest and promotion record, each with a closed field table.
+- One stdlib CLI, `scripts/berean.py`, with build, check, verify, eval,
+  export and promotion commands.
+- An ordinary and adversarial evaluation corpus covering prompt injection,
+  poisoned documents, stale state, citation mismatch, unsupported inference
+  and expected refusals.
+- The reference release and its demonstration script.
+- Conformance fixtures, one passing and at least one breaching per verifier
+  gate, under `tests/fixtures/`.
+- Design records in [`docs/`](./docs), including the Commons specification
+  the plugin was built from.
+
+## Day to day
+
+**Developers.** Your support agent quotes the docs and reads contract state.
+Pin the docs tree with `build-corpus`, record the reads it may use, and ship
+answers as `berean-answer/v1` documents; `check-answer` then tells you which
+sentence lost its source before a user does.
+
+**Security and audit.** An agent's answer is a claim about documents and
+chain state. `verify-release` and `run-evals` re-check every span, key and
+threshold from bytes on disk, so reviewing the agent does not require
+trusting the vendor's harness, and the adversarial corpus shows what happens
+when a document tries to steer the agent.
+
+**Business development.** An integration answer that cites an agreement
+version and a block can be handed to a counterparty with its evidence
+attached. The promotion chain says which release produced it and what
+evaluation that release passed.
+
+## Run it
+
+```text
+python3 scripts/berean.py verify-release examples/goldfinch-demo-v0
+python3 scripts/berean.py run-evals examples/goldfinch-demo-v0
+python3 examples/goldfinch-demo-v0/demo.py
+```
+
+Berean needs Python 3.9 or later and nothing else. No command reaches the
+network.
+
+## Tests
+
+```bash
+python3 -m unittest discover -s plugins/berean/tests -t plugins/berean
+```
+
+## Reading further
+
+- [`skills/berean/SKILL.md`](./skills/berean/SKILL.md), the canonical
+  instructions and the release gates.
+- [`docs/spec.md`](./docs/spec.md), the Wildcat Commons specification this
+  plugin was built from.
+- [`docs/design.md`](./docs/design.md), the decisions behind the formats and
+  the deferred Ariadne binding.
+- [`docs/study.md`](./docs/study.md) and [`docs/runbook.md`](./docs/runbook.md),
+  the delivery record.
+
+## Licence
+
+Apache-2.0. See [LICENSE](LICENSE).

--- a/plugins/berean/docs/design.md
+++ b/plugins/berean/docs/design.md
@@ -1,0 +1,79 @@
+# Design decisions
+
+<!-- marketplace-context:start -->
+> **Marketplace context: Berean.** Berean pins the corpus, chain readings and evaluation record a protocol agent's answers rest on, so a release can be checked without the model that produced it. Use Lemma to produce source-linked chunks, Lazarus to preserve the chain evidence itself, and Ariadne to bind a released artefact digest to its evidence. **Current frontier:** The reference release answers against a frozen demonstration corpus and preserved Goldfinch mainnet reads; no release yet cites live Wildcat documentation or a captured Wildcat market read, and no Ariadne statement binds a berean release.
+<!-- marketplace-context:end -->
+
+Decisions expensive to reverse, each with the reason it went the way it did.
+The study behind them is [study.md](study.md); the specification is
+[spec.md](spec.md).
+
+## The Ariadne binding is deferred, not designed out
+
+The specification's first open question asks whether the release manifest
+should extend Ariadne directly or stay a separate document referenced by an
+Ariadne release statement. It stays separate, for two reasons that will not
+age away:
+
+1. Ariadne's core gate 4 refuses conclusion vocabulary anywhere in a
+   predicate, including `score`, `verdict` and `grade`. A berean release
+   carries evaluation thresholds and results as structured fields, so those
+   fields cannot live inside an Ariadne predicate at all.
+2. Ariadne's own ledger holds `grounded-agent-predicate` as its next job. An
+   ordinary berean delivery must not consume a sibling's held frontier.
+
+The precedent is Lazarus: the kit owns its artefact format and its own
+release document; Ariadne owns one predicate type describing that artefact;
+each side names the other by constant and is held to it by a drift test;
+neither imports the other. When the grounded-agent predicate exists, a berean
+release binds to a statement the same way. Until then, `release-v1` keeps
+every artefact digest such a statement would cover: the corpus digest, each
+component digest and the release digest, all lowercase sha256 hex over
+canonical JSON, so the binding needs no new fields when it arrives.
+
+## Goldfinch reads are copied bytes, not a cross-plugin reference
+
+The reference release needs real, block-bound mainnet reads that verify
+offline. The Lazarus example fixture at
+`plugins/lazarus/examples/goldfinch-v0-release/fixture/` preserves exactly
+that: recorded RPC outcomes for a Goldfinch contract at block 13097494,
+keyed by `request_key = sha256(canonical({method, params}))`.
+
+Berean's example carries its own `reads.jsonl` holding the records it uses,
+copied byte for byte, rather than reading the Lazarus fixture path at run
+time. Reasons:
+
+1. Each marketplace plugin must be usable alone. A release that only
+   verifies when a sibling plugin happens to be checked out beside it is not
+   self-contained, and an installed plugin does not see its siblings.
+2. The Lazarus fixture is a digested component of a published release;
+   nothing may depend on being able to write near it or reshape it.
+
+The copy is held honest the same way Ariadne holds its copied Lazarus
+constants: a drift test asserts each copied record is byte-identical to the
+record with the same request key in the Lazarus fixture whenever that plugin
+is present in the tree. The copied records keep their evidence class,
+`recorded-rpc`, and berean never restates them as anything stronger.
+
+## The demonstration corpus is frozen and fabricated
+
+The reference release's documents describe the demonstration subject in a
+form that lets every gate fire: a claim the chain confirms, a claim a later
+block contradicts, a poisoned document carrying instructions, and a question
+the corpus cannot answer. They are written for the release and frozen by
+digest in its corpus manifest.
+
+They are not live Wildcat documentation, and the frontier says so. Reusing
+Lemma's baseline corpus was considered and rejected: those files carry
+mutable marketplace-context blocks that frontier passes rewrite, so pinning
+their bytes would break at the next prose refresh. A corpus that exists to
+demonstrate byte-exact pinning cannot be built on bytes that move under it.
+
+## The original specification header
+
+The specification is preserved at [spec.md](spec.md) with one change: its
+marketplace block, which read "Berean remains unbuilt. Lemma can prepare
+source-linked chunks and Ariadne can bind a future agent release to its
+evidence; neither supplies the grounded answering and evaluation discipline
+specified here.", now carries the standard rolling context so the repository
+prose checks hold it to the same frontier as every other berean document.

--- a/plugins/berean/docs/runbook.md
+++ b/plugins/berean/docs/runbook.md
@@ -1,0 +1,171 @@
+# Runbook: Build the berean plugin from its Wildcat Commons specification
+
+Derived from the study preserved beside this runbook at
+[study.md](study.md). The run branch is
+`claude/berean-wildcat-skill-zx1o2g`, cut from `main` at
+`496f7a102bf012195c48ed1615f8eff7fd832f7b`, where the root suite is green
+(34 tests). Each step branches from the step below it; nothing merges until
+the integrate phase. Every step ends with both suites green: the root suite
+and, from step 1 on, `python3 -m unittest discover -s plugins/berean/tests
+-t plugins/berean`.
+
+## Step 1: Scaffold the plugin and land it in the marketplace
+
+**Goal.** Berean exists as the thirteenth plugin, with its shell, committed
+spec, study and runbook, and every root integration point updated and green.
+**Entry.** Run branch at `496f7a102bf012195c48ed1615f8eff7fd832f7b`.
+**Exit.** `python3 -m unittest discover -s tests` green with the plugin
+count assertions at 13; `python3 -m unittest discover -s
+plugins/berean/tests -t plugins/berean` green;
+`python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py` clean
+on every new shipped Markdown file; `python3
+plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md
+.agents plugins docs` exit 0.
+**Files.** `plugins/berean/.claude-plugin/plugin.json`,
+`plugins/berean/.codex-plugin/plugin.json`, `plugins/berean/AGENTS.md`,
+`plugins/berean/README.md`, `plugins/berean/LICENSE`,
+`plugins/berean/skills/berean/SKILL.md`,
+`plugins/berean/skills/berean/EVOLUTION.md`,
+`plugins/berean/skills/berean/agents/openai.yaml`,
+`plugins/berean/docs/spec.md`, `plugins/berean/docs/study.md`,
+`plugins/berean/docs/runbook.md`, `plugins/berean/docs/design.md`,
+`plugins/berean/tests/__init__.py`, `plugins/berean/tests/support.py`,
+`plugins/berean/tests/test_scaffold.py`, `.agents/skills/berean/SKILL.md`,
+`.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`,
+`README.md`, `AGENTS.md`, `tests/test_marketplace_prose.py`,
+`tests/test_portable_skills.py`.
+**Tests.** `test_scaffold.py`: the three manifests agree, the ledger digest
+reproduces, the frontier sentence matches across the plugin's own files.
+Expected count: 6 to 10.
+**Disciplines.** phylax: none, this step ships manifests, prose and tests
+only. ephoros: none, no runtime code yet. metron: none, no performance
+claim. elenchus: none, no failure in hand. hypomnema: the Ariadne deferral
+and the copied-reads decision land in `plugins/berean/docs/design.md`
+alongside the committed spec.
+
+## Step 2: Corpus manifests and byte-exact citations
+
+**Goal.** A document tree can be pinned into a corpus manifest and a
+citation can be proved or refused as exact bytes in it.
+**Entry.** Step 1's exit state.
+**Exit.** `python3 -m unittest discover -s plugins/berean/tests -t
+plugins/berean` green, including tests that a one-byte edit to a pinned
+file fails `verify-corpus` and a wrong span digest or display text fails
+`check-citation`; root suite still green.
+**Files.** `plugins/berean/scripts/berean.py`,
+`plugins/berean/scripts/berean_lib/__init__.py`, `canonical.py`,
+`digests.py`, `jsonio.py`, `corpus.py`, `citations.py` under
+`plugins/berean/scripts/berean_lib/`,
+`plugins/berean/schemas/corpus-manifest-v1.json`,
+`plugins/berean/tests/test_canonical.py`, `test_digests.py`,
+`test_corpus.py`, `test_citations.py`, fixture trees under
+`plugins/berean/tests/fixtures/corpus/`.
+**Tests.** Canonical JSON refusals (floats, duplicate keys), digest
+refusals (uppercase hex, symlinks), corpus build and verify, citation pass
+and every refusal class. Expected count: 30 to 40.
+**Disciplines.** phylax: this step opens the filesystem read boundary;
+symlinks, absolute and parent-relative paths are refused with tests.
+ephoros: the CLI prints named results, no logging. metron: none, ceilings
+are correctness limits with tests. elenchus: any red test is worked to its
+mechanism and lands a guard test. hypomnema: none, the format decisions are
+already recorded in `design.md`.
+
+## Step 3: Answer records, source classes and block-bound reads
+
+**Goal.** An answer document carries a source class on every factual
+sentence, block-named chain reads held by recomputed request keys, declared
+time domains and a clean refusal shape, and `check-answer` proves or
+refuses each.
+**Entry.** Step 2's exit state.
+**Exit.** Plugin suite green, including tests that an unclassified sentence,
+a chain value without chain and block, a request-key mismatch, and a silent
+time-domain disagreement each fail `check-answer`; root suite still green.
+**Files.** `plugins/berean/schemas/answer-v1.json`,
+`plugins/berean/scripts/berean_lib/answers.py`,
+`plugins/berean/scripts/berean_lib/reads.py`, subcommand wiring in
+`scripts/berean.py`, `plugins/berean/tests/test_answers.py`,
+`test_reads.py`, fixtures under `plugins/berean/tests/fixtures/answers/`
+and `fixtures/reads/`.
+**Tests.** Source-class enum closure, per-sentence classification checks,
+read record recomputation against Lazarus-shaped records, time-domain
+disagreement reporting, refusal shape. Expected count: 30 to 40.
+**Disciplines.** phylax: the untrusted-input boundary widens to answer and
+read documents; caps and refusals carry tests. ephoros: `check-answer`
+prints one named line per check. metron: none. elenchus: as step 2.
+hypomnema: the closed source-class and time-domain vocabulary is recorded
+in `plugins/berean/docs/answers.md`.
+
+## Step 4: Release manifests, verifier gates and promotion records
+
+**Goal.** A release binds corpus, reads, rules, question families, refusal
+conditions, eval references and retention into one digested document;
+`verify-release` reports the specification's gates by name; promotion and
+rollback are records, never edits.
+**Entry.** Step 3's exit state.
+**Exit.** Plugin suite green, including one `pass-*` and at least one
+`fail-*` conformance fixture per verifier gate, staged-write tests, and
+promotion-chain tests; root suite still green.
+**Files.** `plugins/berean/schemas/release-v1.json`,
+`plugins/berean/schemas/promotion-record-v1.json`,
+`plugins/berean/scripts/berean_lib/release.py`,
+`plugins/berean/scripts/berean_lib/promote.py`, subcommand wiring,
+`plugins/berean/docs/release-policy.md`,
+`plugins/berean/tests/test_release.py`, `test_promote.py`,
+`plugins/berean/tests/fixtures/conformance/`.
+**Tests.** Gate-by-gate pass and refusal, whole-release digest, staged
+landing, promotion evidence checks, rollback as supersession. Expected
+count: 40 to 50.
+**Disciplines.** phylax: release paths are confined to the release
+directory with tests. ephoros: `verify-release` prints every gate's named
+verdict. metron: none. elenchus: as step 2. hypomnema: immutability and
+rollback policy land in `plugins/berean/docs/release-policy.md`.
+
+## Step 5: The evaluation corpus and its graders
+
+**Goal.** Ordinary and adversarial eval cases are schema-validated, graded
+by code against recorded answer documents with digests pinned first, and
+exportable in the Agent Skills case shape.
+**Entry.** Step 4's exit state.
+**Exit.** Plugin suite green, including graders failing an answer that obeys
+an injected instruction, cites a mismatched span, presents stale state as
+current, answers past the evidence boundary, or answers where refusal is
+expected; `run-evals` refuses to grade on a digest mismatch; root suite
+still green.
+**Files.** `plugins/berean/schemas/eval-case-v1.json`,
+`plugins/berean/scripts/berean_lib/evals.py`, subcommand wiring,
+`plugins/berean/tests/test_evals.py`, case and answer fixtures under
+`plugins/berean/tests/fixtures/evals/`.
+**Tests.** Case schema closure, each grader class, each adversarial family,
+export shape, digest-mismatch refusal. Expected count: 30 to 40.
+**Disciplines.** phylax: adversarial fixtures are data to every code path;
+nothing interprets them. ephoros: the eval report opens with the digests it
+graded against. metron: none. elenchus: as step 2. hypomnema: none, the
+grading vocabulary was recorded in step 4's policy and step 3's answers
+records.
+
+## Step 6: The reference release, and the demonstration
+
+**Goal.** A complete reference release under
+`plugins/berean/examples/goldfinch-demo-v0/` answers, refuses and discloses
+a time-domain disagreement against a frozen corpus and preserved Goldfinch
+mainnet reads, and the demo proves the whole path offline.
+**Entry.** Step 5's exit state.
+**Exit.** `python3 plugins/berean/scripts/berean.py verify-release
+plugins/berean/examples/goldfinch-demo-v0` exits 0; the tamper tests prove
+a mutated corpus byte, read record and promotion record each exit 1;
+`python3 plugins/berean/examples/goldfinch-demo-v0/demo.py` exits 0 with no
+network; both suites green; the lint set from the study's Always list exits
+clean.
+**Files.** `plugins/berean/examples/goldfinch-demo-v0/` (corpus files,
+`corpus-manifest.json`, `reads.jsonl`, answer documents, eval cases and
+results, `release.json`, `promotions.jsonl`, `README.md`, `demo.py`),
+`plugins/berean/docs/influences.md`, `plugins/berean/tests/test_examples.py`,
+reconciled `plugins/berean/README.md` and
+`plugins/berean/skills/berean/SKILL.md`.
+**Tests.** Example verifies clean, tamper refusals, the drift test holding
+`reads.jsonl` byte-identical to the named Lazarus fixture records, docs
+link checks. Expected count: 15 to 25.
+**Disciplines.** phylax: the demo reads only inside the example tree.
+ephoros: `demo.py` prints each stage's named result. metron: none.
+elenchus: as step 2. hypomnema: `plugins/berean/docs/influences.md` records
+how the specification's named inputs shaped each component.

--- a/plugins/berean/docs/spec.md
+++ b/plugins/berean/docs/spec.md
@@ -1,0 +1,127 @@
+# berean
+
+<!-- marketplace-context:start -->
+> **Marketplace context: Berean.** Berean pins the corpus, chain readings and evaluation record a protocol agent's answers rest on, so a release can be checked without the model that produced it. Use Lemma to produce source-linked chunks, Lazarus to preserve the chain evidence itself, and Ariadne to bind a released artefact digest to its evidence. **Current frontier:** The reference release answers against a frozen demonstration corpus and preserved Goldfinch mainnet reads; no release yet cites live Wildcat documentation or a captured Wildcat market read, and no Ariadne statement binds a berean release.
+<!-- marketplace-context:end -->
+
+This is the Wildcat Commons specification the v0.1.0 prototype was built
+from, preserved as written apart from this header block, whose original text
+said only that Berean remained unbuilt. The status line below is the
+specification's own, kept as a record of where the work started.
+
+Release evidence-backed protocol agents with citation, time and live-data
+boundaries that can be tested independently of the model running them.
+
+**Desk:** developer relations, support and agent engineering. **Status:**
+unbuilt spec.
+
+## Naming
+
+In Acts, the Bereans receive a claim and check it against the scriptures each
+day to see whether it is so. The important part is not scepticism for its own
+sake. It is the habit of returning to the named source before accepting the
+answer.
+
+## Why this exists
+
+A protocol agent can answer from documentation, contract state, indexed data
+and prior conversation in one paragraph. Unless those sources remain
+separate, the reader cannot tell which parts are historical, which are live,
+which came from a document and which were supplied by the model.
+
+General agent evaluations can score answers and tool use. They do not define
+how a protocol agent pins a changing corpus, proves a citation span, separates
+a block reading from prose, or refuses a question whose evidence boundary it
+cannot satisfy.
+
+## Why this belongs to Wildcat Labs
+
+Project Aleph already uses a versioned corpus, typed mainnet reads, citations,
+abstention and release promotion. Project Null generates and reviews
+adversarial questions against it. Lemma preserves byte-exact document chunks
+for display and model use.
+
+Those repositories contain useful decisions, but a new team has to infer the
+system from three codebases. The public contribution is a small release
+contract, reference implementation and test corpus extracting the parts that
+deal with evidence. It should leave chat UI, model vendor and protocol-specific
+answers out.
+
+Wildcat can demonstrate the kit against a real protocol whose answers often
+depend on a particular market, agreement version and block. That prevents the
+reference case from becoming a static documentation bot with easy citations.
+
+## What it does
+
+A Berean release declares:
+
+- Immutable corpus version and digest.
+- Document identity, version, byte offsets and display text for every cited
+  span.
+- Typed live-data functions, their chain and contract allowlists, and the
+  block associated with each result.
+- Rules separating document claims, live readings, calculations and model
+  synthesis.
+- Supported question families and explicit refusal conditions.
+- Evaluation cases, assertions, graders and expected evidence shape.
+- Adversarial cases for prompt injection, poisoned documents, stale state,
+  citation mismatch and unsupported inference.
+- Promotion and rollback records for the active release.
+
+The verifier can check corpus identity, citation spans, live-read provenance
+and assertion coverage without needing the model that originally produced the
+answer.
+
+## Gates
+
+1. **Every factual sentence has a source class.** Document, chain read,
+   calculation or user-supplied fact. Unclassified assertions fail evaluation.
+2. **Citations identify bytes, not search results.** The cited text is checked
+   against the pinned corpus artefact.
+3. **Live values name a block.** A current value with no chain and block is not
+   accepted as evidence.
+4. **Time domains do not blur.** A document statement and a later chain state
+   may disagree. The answer reports both rather than choosing silently.
+5. **Unsupported questions refuse cleanly.** The evaluation set includes cases
+   where no answer is the correct result.
+6. **Retrieved text remains untrusted.** Instructions inside documents cannot
+   alter tool policy, corpus scope or citation rules.
+7. **Promotion is evidence-based.** A release records the evaluation corpus,
+   thresholds and result that allowed it to become active.
+8. **Conversation retention is declared.** Tests check that private user data
+   does not enter the public corpus or evaluation output.
+
+## What ships with it
+
+- A release-manifest schema and verifier.
+- A small model-neutral reference agent.
+- Corpus builder with byte-exact citation support.
+- Typed EVM read boundary and sample functions.
+- Adversarial and ordinary evaluation corpus.
+- Promotion and rollback CLI.
+- Reference deployment against Wildcat documentation and selected mainnet
+  reads.
+- A guide showing how Aleph, Null and Lemma informed each component.
+
+## Prior art and boundary
+
+The [Agent Skills evaluation guide](https://agentskills.io/skill-creation/evaluating-skills)
+already covers test cases, assertions, graders and comparison with and without
+a skill. Existing runners can exercise local models and tool calls. Berean
+should emit compatible cases where possible instead of supplying another
+general runner.
+
+Retrieval frameworks already split documents and return citations. The work
+here is the release boundary: immutable corpus identity, verified spans, typed
+and block-bound live reads, adversarial evidence tests and promotion records.
+
+## Open questions
+
+- Whether the manifest can extend Ariadne directly or should remain a separate
+  predicate referenced by an Ariadne release statement.
+- How to score an answer that is correct but cites a weaker source than the one
+  available.
+- Which calculations need a machine-readable derivation rather than source
+  citations alone.
+- How much of Project Null's generator/reviewer loop is reusable without
+  coupling the kit to one model provider.

--- a/plugins/berean/docs/study.md
+++ b/plugins/berean/docs/study.md
@@ -1,0 +1,313 @@
+# Study: Build the berean plugin from its Wildcat Commons specification
+
+Assuming, unless corrected:
+
+1. Python 3.9 or later, standard library only, `unittest` discovery, matching
+   every first-party plugin except Lazarus.
+2. The prototype's reference release answers against a small frozen
+   demonstration corpus shipped inside the plugin, plus preserved Goldfinch
+   mainnet reads copied byte for byte from the Lazarus example fixture. A
+   release grounded in live Wildcat documentation and captured Wildcat market
+   reads is the held frontier, not this run.
+3. The Ariadne binding is deferred. Ariadne's ledger holds
+   `grounded-agent-predicate` as its own next job, and this run does not
+   advance a sibling's frontier. Berean's release document carries the digests
+   a future statement will cover, and nothing more.
+4. Berean lands as the thirteenth marketplace plugin at version `0.1.0`, with
+   every root integration point (marketplace manifests, portable entry, root
+   README and AGENTS.md, hard-coded test lists) updated in the scaffold step.
+5. No GitHub issue and no CI workflow are created for this run.
+
+## 1. Problem statement
+
+Build `berean`, the Wildcat Commons release kit for evidence-backed protocol
+agents. A Berean release pins a corpus by digest, proves every citation as a
+byte range in that corpus, binds every live value to a chain and block,
+separates document claims from chain readings from calculations from
+user-supplied facts, states which question families it supports and when it
+refuses, and records the evaluation result that let it become active. The
+verifier checks all of that offline, without the model that produced the
+answers.
+
+It is for developer relations, support and agent engineering teams who run a
+protocol agent and need its answers testable after the fact. A working
+prototype means: `python3 plugins/berean/scripts/berean.py verify-release
+plugins/berean/examples/goldfinch-demo-v0` exits 0 against the shipped
+reference release, exits 1 when any pinned byte or gate is disturbed, and
+`python3 plugins/berean/examples/goldfinch-demo-v0/demo.py` walks the whole
+path: corpus check, citation check, block-bound read check, eval run,
+promotion record check. Both root suites and the berean suite pass, and every
+shipped document lints clean.
+
+## 2. Prior art
+
+In this repository:
+
+- Ariadne (`plugins/ariadne/`) supplies the verification grammar: in-toto
+  statements matched by digest rather than name, closed field tables with
+  `additionalProperties: false`, per-gate conformance fixtures named
+  `pass-*` and `fail-<gate>-*`, `digests.py` refusing uppercase hex and
+  symlinks, and `safejson.py` caps on size and depth. Its core gate 4 refuses
+  conclusion vocabulary (`score`, `verdict`, `grade`) anywhere in a
+  predicate, which is one reason berean's evaluation results cannot live
+  inside an Ariadne predicate.
+- Lazarus (`plugins/lazarus/`) supplies the evidence bundle berean consumes:
+  `rpc.jsonl` records keyed by `request_key =
+  sha256(canonical({method, params}))`, a manifest pinning block number and
+  hash, and the release-binds-to-statement pattern in
+  `scripts/lazarus_lib/binding.py` where two constants and a drift test
+  replace a runtime import. Its `canonical.dumps` discipline (sorted keys,
+  compact separators, floats refused) is copied, not imported.
+- Lemma (`plugins/lemma/`) proves byte-exact quoting is workable
+  (`display_text` sliced from source bytes, decoded after slicing,
+  `synthesised` flagged) and shows the gap berean exists to close: its
+  records carry no byte offsets, no span digest and no file digest, so a
+  chunk cannot be re-verified against a pinned corpus from the record alone.
+- Alexandria (`plugins/alexandria/`) names the rule berean generalises:
+  evidence classes are preserved, never upgraded, and corrections are new
+  releases with `supersedes` rather than mutations.
+- Tabularium (`plugins/tabularium/docs/release-policy.md`) supplies the
+  immutability and supersession policy for published releases.
+- Probitas (`plugins/probitas/`) supplies the answer-side discipline: a claim
+  without a source is dropped, gates rebuild the permitted fact set from
+  evidence and fail the document on anything outside it, and coverage gaps
+  are rows rather than silence.
+- Imprimatur's labelled corpus
+  (`plugins/hexaemeron/skills/imprimatur/evals/labelled-prose-v1/`) is the
+  house pattern for a frozen, sealed evaluation corpus: pinned sample
+  digests, a candidate freeze, named boolean gates, and a spent holdout.
+- Brevitas (`plugins/brevitas/skills/brevitas/evals/`) shows the small form:
+  a case file pinning its origin digest, graded by code, failing before
+  grading when the pin no longer matches.
+
+Outside: the in-toto Statement v1 shape (via Ariadne), EIP-1186 proofs (via
+Lazarus), and the Agent Skills evaluation guide at
+`https://agentskills.io/skill-creation/evaluating-skills`, whose case shape
+(`id`, `prompt`, `files`, `assertions`) berean emits as an export so existing
+runners can consume its cases.
+
+## 3. Constraints and non-goals
+
+Constraints. Starting ref `496f7a102bf012195c48ed1615f8eff7fd832f7b` on
+`main`; run branch `claude/berean-wildcat-skill-zx1o2g`. Python 3.9+,
+standard library only, `unittest`, no network anywhere in tests or examples.
+Digested documents are canonical JSON: sorted keys, compact separators,
+`ensure_ascii=False`, floats refused, duplicate keys refused. Digests are
+lowercase sha256 hex. Every shipped Markdown file outside `docs/` must lint
+clean under imprimatur; frontier prose must be byte-identical across every
+marketplace-context block; the `EVOLUTION.md` baseline row must reproduce the
+ledger digest formula in `plugins/hexaemeron/skills/VERSIONING.md`.
+
+Non-goals, deferred past the prototype:
+
+- The Ariadne grounded-agent predicate and any statement binding. Designed
+  for, not shipped; it is Ariadne's held frontier job.
+- A general evaluation runner. Berean grades recorded answer documents with
+  its own code assertions and exports cases in the Agent Skills shape;
+  it does not execute models or tools.
+- Live capture of documentation or chain state. The corpus builder reads
+  local trees; chain evidence arrives as preserved Lazarus-shaped records.
+- A release grounded in live Wildcat documentation and captured Wildcat
+  market reads. That is the held frontier after this run.
+- Chat UI, model vendor integration, retrieval, embeddings.
+
+## 4. Design options
+
+Option A: implement the release manifest as a new Ariadne predicate.
+Rejected. Gate 4 of Ariadne's core refuses `score`, `verdict` and `grade`
+keys, so evaluation thresholds and results cannot be structured fields
+there; and the predicate slot is Ariadne's own held next job, which an
+ordinary berean delivery must not consume.
+
+Option B: ship berean's formats and bind a reference release to an Ariadne
+statement in this run. Rejected. The binding needs the grounded-agent
+predicate to exist first, which is option A's problem again through a
+narrower door.
+
+Option C, chosen: berean owns five small formats (corpus manifest, answer
+record, eval case, release manifest, promotion record), each a versioned
+JSON schema with a closed field table, verified by one stdlib CLI. Chain
+evidence is consumed in the Lazarus record shape, held by recomputed
+`request_key`, with a drift test against the Lazarus fixture rather than an
+import. The release document keeps every artefact digest a future Ariadne
+statement would cover. The trade named: no in-toto interoperability ships in
+v0.1.0, and berean carries its own schema maintenance instead of inheriting
+Ariadne's. Bought with it: all eight specification gates are expressible,
+including the two Ariadne's vocabulary forbids, and no sibling plugin is
+coupled or advanced.
+
+The pick is the construction cheapest to comprehend: one plugin, five
+schemas, one verifier, no cross-plugin imports.
+
+## 5. Risk register seed
+
+The audit loop should look hardest at:
+
+- Untrusted JSON: every reader needs the size cap, depth cap and
+  duplicate-key refusal Ariadne's `safejson.py` models, or a poisoned release
+  parses the verifier into a hang.
+- Path handling: corpus and release component paths must refuse absolute
+  paths, `..`, backslashes and symlinks, or a citation can read bytes outside
+  the pinned tree.
+- Digest discipline: lowercase hex only, byte-exact slicing before decoding,
+  span digest and display text both checked, or a citation passes on one and
+  lies on the other.
+- Evidence-class inflation: a recorded read reported as proof-backed, or a
+  document claim reported as a chain reading. The classes are closed enums
+  copied from their owners and never widened at read time.
+- Partial writes: releases and corpus manifests are staged and landed with
+  one rename, so a killed run leaves no half-release that later verifies.
+- Prompt-injection fixtures: the adversarial corpus contains documents whose
+  text instructs policy changes; the graders must fail any answer that obeys
+  them, and the fixtures must not be executable by anything.
+- Marketplace prose drift: the frontier sentence replicates across roughly
+  twenty files and root tests compare it byte for byte.
+
+## 6. Glossary seeds
+
+- `corpus manifest`: the digest-pinned inventory of a document tree; one
+  entry per file with bytes and sha256, plus a corpus digest over the sorted
+  listing.
+- `citation`: document id, byte start, byte end, span sha256 and display
+  text; valid only when re-slicing the pinned file reproduces both digest
+  and text.
+- `source class`: one of `document`, `chain_read`, `calculation`,
+  `user_supplied`; every factual sentence in an answer carries exactly one.
+- `chain read`: a preserved RPC outcome named by chain id, block number and
+  recomputed request key.
+- `time domain`: the version stamp of an evidence item; a document version
+  on one side, a block number on the other. Answers report disagreement
+  between domains rather than choosing silently.
+- `refusal`: an answer whose body names the evidence boundary it could not
+  satisfy instead of an answer text.
+- `eval case`: a question, its expected evidence shape and its grader;
+  adversarial cases expect refusals or preserved policy.
+- `release manifest`: the document binding corpus, reads, rules, question
+  families, eval results and retention declaration into one digested unit.
+- `promotion record`: the record of which evaluation, thresholds and results
+  made a release active; rollback is a new record naming the restored
+  release, never an edit.
+
+## 7. Sources
+
+- The Commons specification, preserved beside this study at
+  [spec.md](spec.md).
+- `plugins/ariadne/docs/design.md`, `plugins/ariadne/docs/conformance.md`,
+  `plugins/ariadne/scripts/ariadne_lib/`.
+- `plugins/lazarus/docs/preservation-release.md`,
+  `plugins/lazarus/examples/goldfinch-v0-release/`,
+  `plugins/lazarus/scripts/lazarus_lib/{records,canonical,binding}.py`.
+- `plugins/lemma/INVARIANTS.md`, `plugins/lemma/schema.py`,
+  `plugins/lemma/chunkers/markdown.py`.
+- `plugins/alexandria/docs/study.md` (evidence-class inflation),
+  `plugins/tabularium/docs/release-policy.md` (supersession).
+- `plugins/probitas/scripts/probitas_lib/{evidence,gates}.py`.
+- `plugins/hexaemeron/skills/imprimatur/evals/labelled-prose-v1/README.md`.
+- `plugins/hexaemeron/skills/VERSIONING.md`, `tests/test_marketplace_prose.py`,
+  `tests/test_portable_skills.py`, `tests/test_version_propagation.py`,
+  `tests/test_evolution_contract.py` (the integration gates).
+- `https://agentskills.io/skill-creation/evaluating-skills` (exported case
+  shape).
+
+## 8. Signals, and the questions behind them
+
+The kit is a terminal CLI, so the on-call questions are a maintainer's, not
+an operator's:
+
+- "Why did verify refuse this release?" Every gate prints one named
+  pass/fail line and the first failing detail, the Ariadne report shape, so
+  the refusal is in the output rather than in a debugger. Steps 4 and 6 emit
+  this.
+- "Did the eval run grade the corpus it claims?" The eval report starts with
+  the corpus digest and release digest it graded against, and the runner
+  refuses to grade when recomputed digests disagree with pinned ones. Step 5
+  emits this.
+- "Which release is active and what promoted it?" The promotion chain is a
+  file the CLI prints verbatim with its digests checked. Step 4 emits this.
+
+No logging framework: the CLI prints, per the ephoros rule that command-line
+output is not telemetry.
+
+## 9. Boundaries, per capability
+
+- Corpus building opens a filesystem read boundary. Worth taking at it:
+  bytes outside the tree via symlink or traversal. Control: resolve and
+  refuse symlinks, refuse absolute and parent-relative paths, then digest
+  what was actually read. Owned by phylax's rules in the audit rounds.
+- Release verification opens an untrusted-input boundary. Worth taking:
+  parser exhaustion and duplicate-key shadowing. Control: byte cap, depth
+  cap, duplicate-key refusal before any field is trusted.
+- Chain-read checking opens a provenance boundary. Worth taking: a value
+  with no block, or a record whose key does not match its params. Control:
+  recompute `request_key`, require chain id and block, refuse records whose
+  copied bytes drift from the Lazarus fixture (drift test).
+- The adversarial corpus opens a content boundary. Worth taking: instructions
+  inside documents steering the verifier or graders. Control: fixtures are
+  data to every code path; graders assert policy survived.
+
+No network capability exists anywhere in the plugin, so no allowlist is
+needed beyond the release's own declared chain and contract lists, which the
+verifier checks answers against.
+
+## 10. The budget, or its absence
+
+None. No performance claim is made. Input ceilings (corpus bytes per file,
+release component count, JSON depth) are correctness limits with tests, not
+budgets, and are named in the schemas. If a later frontier adds a large
+corpus, metron owns the measurement then.
+
+## 11. The fail-closed posture
+
+Builders refuse to write: a corpus manifest or release that fails its own
+validation is not written at all, the Lemma `NOT WRITTEN` pattern. The
+verifier runs every gate and reports each by name, exits 1 on any failure,
+and never repairs. Readers refuse rather than coerce: wrong hex case, a
+`0x`-less hash, a float, a duplicate key are refusals, not normalisations.
+Every failure worked mid-step follows elenchus: reproduce, reduce, fix the
+mechanism, and land a guard test named after the failure class
+(`test_<what>_refuses_<how>`), so the fixture set grows one `fail-*` file per
+class the way Ariadne's conformance corpus does.
+
+## 12. Decisions and their homes
+
+- Deferring the Ariadne binding, and what a future statement covers:
+  `plugins/berean/docs/design.md`.
+- Copying Goldfinch read records instead of referencing the Lazarus fixture
+  path, with the drift test that holds the copy: `plugins/berean/docs/design.md`.
+- Release immutability, supersession and rollback-as-record:
+  `plugins/berean/docs/release-policy.md`.
+- Source-class and time-domain vocabulary, and why the enums are closed:
+  `plugins/berean/docs/answers.md`.
+- How the specification's named inputs (Project Aleph, Project Null, Lemma)
+  shaped each component, at the level the specification states:
+  `plugins/berean/docs/influences.md`.
+
+## Boundaries
+
+Always:
+
+- Both root suites and the berean suite before every commit:
+  `python3 -m unittest discover -s tests` and
+  `python3 -m unittest discover -s plugins/berean/tests -t plugins/berean`.
+- The imprimatur lint on every shipped document; hypomnema over
+  `README.md AGENTS.md .agents plugins docs`; phylax and ephoros over
+  `plugins tests`.
+- A `pass-*` and a `fail-*` fixture in the same step as every new gate.
+
+Ask first:
+
+- Adding a dependency (the plan is zero).
+- Changing a published schema `$id`, a format string, or a closed enum
+  (source classes, evidence classes, dispositions).
+- Touching another plugin's files beyond the root integration points this
+  study names.
+- Widening the copied Lazarus record set or its provenance claims.
+
+Never:
+
+- Commit key material or an RPC credential; the plugin never holds either.
+- Edit the Lazarus fixture, any vendored directory, or a frozen corpus file
+  once its digest is pinned.
+- Delete or weaken a failing test to make a suite pass.
+- Claim a command, lint or suite ran when it did not.
+- Upgrade an evidence class or source class during verification.

--- a/plugins/berean/schemas/corpus-manifest-v1.json
+++ b/plugins/berean/schemas/corpus-manifest-v1.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://berean.wildcat.finance/corpus/v1/schema.json",
+  "title": "Berean corpus manifest v1",
+  "description": "The digest-pinned inventory of a document tree for berean-corpus/v1. The verifier enforces this shape plus set equality against the tree it pins; a schema cannot express that equality, which is why both ship.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "corpus_version", "files", "corpus_digest"],
+  "properties": {
+    "format": { "const": "berean-corpus/v1" },
+    "corpus_version": { "type": "string", "pattern": "\\S" },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 10000,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "bytes", "sha256"],
+        "properties": {
+          "path": { "type": "string", "pattern": "^[^/\\\\][^\\\\]*$" },
+          "bytes": { "type": "integer", "minimum": 0, "maximum": 4194304 },
+          "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+        }
+      }
+    },
+    "corpus_digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+  }
+}

--- a/plugins/berean/scripts/berean.py
+++ b/plugins/berean/scripts/berean.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Berean: release, verify and evaluate evidence-backed protocol agents."""
+
+import argparse
+import sys
+
+from berean_lib import BereanError
+from berean_lib import corpus as corpus_lib
+from berean_lib import citations as citations_lib
+from berean_lib import jsonio
+
+
+def report(checks):
+    failed = 0
+    for check in checks:
+        print(check.line())
+        if not check.passed:
+            failed += 1
+    if failed:
+        print(f"refused: {failed} check(s) failed")
+        return 1
+    print("all checks passed")
+    return 0
+
+
+def cmd_build_corpus(args):
+    document = corpus_lib.build(args.tree, args.corpus_version)
+    corpus_lib.write(document, args.out)
+    print(f"pinned {len(document['files'])} file(s); corpus digest {document['corpus_digest']}")
+    return 0
+
+
+def cmd_verify_corpus(args):
+    document = jsonio.load(args.manifest, "corpus manifest")
+    return report(corpus_lib.verify(document, args.root))
+
+
+def cmd_check_citation(args):
+    citation = jsonio.load(args.citation, "citation")
+    manifest = jsonio.load(args.corpus, "corpus manifest")
+    corpus_lib.validate(manifest)
+    return report(citations_lib.check(citation, manifest, args.root))
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(prog="berean", description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    build = commands.add_parser("build-corpus", help="pin a document tree into a corpus manifest")
+    build.add_argument("tree", help="the document tree to pin")
+    build.add_argument("--out", required=True, help="where the manifest lands")
+    build.add_argument("--corpus-version", default="v1", help="the corpus version label")
+    build.set_defaults(handler=cmd_build_corpus)
+
+    verify = commands.add_parser("verify-corpus", help="hold a tree to its corpus manifest")
+    verify.add_argument("manifest", help="the corpus manifest")
+    verify.add_argument("--root", required=True, help="the document tree it pins")
+    verify.set_defaults(handler=cmd_verify_corpus)
+
+    check = commands.add_parser("check-citation", help="prove a citation as exact bytes")
+    check.add_argument("citation", help="the citation document")
+    check.add_argument("--corpus", required=True, help="the corpus manifest")
+    check.add_argument("--root", required=True, help="the document tree the manifest pins")
+    check.set_defaults(handler=cmd_check_citation)
+
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.handler(args)
+    except BereanError as error:
+        print(f"refused: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/berean/scripts/berean_lib/__init__.py
+++ b/plugins/berean/scripts/berean_lib/__init__.py
@@ -1,0 +1,12 @@
+"""Berean: evidence-backed protocol-agent releases.
+
+Every module here reads untrusted documents, so the shared posture is
+refusal: wrong hex case, a float, a duplicate key, a symlink or a path that
+leaves its tree are errors, never normalised. `BereanError` is the one
+domain error; the CLI turns it into exit status 2, and a named check that
+fails into exit status 1.
+"""
+
+
+class BereanError(Exception):
+    """A document or argument berean refuses to work with."""

--- a/plugins/berean/scripts/berean_lib/canonical.py
+++ b/plugins/berean/scripts/berean_lib/canonical.py
@@ -1,0 +1,40 @@
+"""Canonical JSON for digested documents.
+
+One spelling per document: sorted keys, compact separators, UTF-8 without
+escaping, no trailing newline. Floats are refused rather than serialised,
+because two runtimes disagree about their text long before they disagree
+about anything else, and a digest over disagreeing bytes pins nothing.
+"""
+
+import json
+import math
+
+from . import BereanError
+
+
+def _refuse_floats(value, path):
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            raise BereanError(f"non-finite number at {path}")
+        raise BereanError(f"float at {path}; canonical documents carry integers and strings")
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise BereanError(f"non-string key at {path}")
+            _refuse_floats(item, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _refuse_floats(item, f"{path}[{index}]")
+    elif value is not None and not isinstance(value, (str, int, bool)):
+        raise BereanError(f"unserialisable value at {path}: {type(value).__name__}")
+
+
+def dumps(value):
+    """Serialise to the one canonical spelling, refusing floats."""
+    _refuse_floats(value, "$")
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def encode(value):
+    """Canonical bytes for digesting."""
+    return dumps(value).encode("utf-8")

--- a/plugins/berean/scripts/berean_lib/citations.py
+++ b/plugins/berean/scripts/berean_lib/citations.py
@@ -1,0 +1,81 @@
+"""Citations: exact bytes in a pinned corpus, or nothing.
+
+A citation names a pinned document, a byte range, the range's digest and
+its display text. It passes only when the pinned file still matches the
+corpus manifest, the slice reproduces the digest, and the slice decodes to
+exactly the display text. Digest and text are both checked because either
+alone can lie: a digest with no text pins bytes nobody can read back, and
+text with no digest is a claim about bytes nobody sliced.
+"""
+
+from . import BereanError
+from . import digests
+from . import jsonio
+from . import paths
+from .corpus import Check
+
+FORMAT = "berean-citation/v1"
+FIELDS = ("format", "doc", "byte_start", "byte_end", "sha256", "display_text")
+
+
+def validate(citation):
+    jsonio.require(citation, FIELDS, "citation")
+    if citation["format"] != FORMAT:
+        raise BereanError(f"citation format is {citation['format']!r}, not {FORMAT!r}")
+    paths.usable(citation["doc"], "citation doc")
+    start = jsonio.whole_number(citation["byte_start"], "byte_start")
+    end = jsonio.whole_number(citation["byte_end"], "byte_end")
+    if end <= start:
+        raise BereanError(f"empty or inverted byte range: {start}..{end}")
+    digests.check_hex(citation["sha256"], "citation digest")
+    if not isinstance(citation["display_text"], str) or not citation["display_text"]:
+        raise BereanError("display_text is blank or not a string")
+    return citation
+
+
+def check(citation, manifest, root):
+    """Prove or refuse one citation against a pinned corpus; named checks out."""
+    checks = []
+    try:
+        validate(citation)
+        checks.append(Check("citation-shape", True))
+    except BereanError as error:
+        return [Check("citation-shape", False, str(error))]
+
+    pinned = {entry["path"]: entry for entry in manifest["files"]}
+    entry = pinned.get(citation["doc"])
+    if entry is None:
+        return checks + [Check("citation-doc", False, f"not in the corpus: {citation['doc']}")]
+    checks.append(Check("citation-doc", True))
+
+    try:
+        data = digests.read_file(paths.resolve(root, citation["doc"], "citation doc"))
+    except BereanError as error:
+        return checks + [Check("citation-pin", False, str(error))]
+    if len(data) != entry["bytes"] or digests.of_bytes(data) != entry["sha256"]:
+        return checks + [
+            Check("citation-pin", False, f"{citation['doc']} no longer matches the corpus manifest")
+        ]
+    checks.append(Check("citation-pin", True))
+
+    start, end = citation["byte_start"], citation["byte_end"]
+    if end > len(data):
+        return checks + [Check("citation-range", False, f"range {start}..{end} leaves the {len(data)} byte file")]
+    checks.append(Check("citation-range", True))
+
+    piece = data[start:end]
+    if digests.of_bytes(piece) != citation["sha256"]:
+        checks.append(Check("citation-bytes", False, "the slice does not reproduce the cited digest"))
+        return checks
+    checks.append(Check("citation-bytes", True))
+
+    try:
+        text = piece.decode("utf-8")
+    except UnicodeDecodeError:
+        checks.append(Check("citation-text", False, "the slice is not whole UTF-8; the range splits a character"))
+        return checks
+    if text != citation["display_text"]:
+        checks.append(Check("citation-text", False, "display_text is not the decoded slice"))
+    else:
+        checks.append(Check("citation-text", True))
+    return checks

--- a/plugins/berean/scripts/berean_lib/corpus.py
+++ b/plugins/berean/scripts/berean_lib/corpus.py
@@ -135,7 +135,11 @@ def verify(document, root):
     drifted = []
     for relative in sorted(set(pinned) & on_disk):
         entry = pinned[relative]
-        data = digests.read_file(paths.resolve(root, relative, "corpus path"))
+        try:
+            data = digests.read_file(paths.resolve(root, relative, "corpus path"))
+        except BereanError as error:
+            drifted.append(f"{relative} ({error})")
+            continue
         if len(data) != entry["bytes"] or digests.of_bytes(data) != entry["sha256"]:
             drifted.append(relative)
     if drifted:

--- a/plugins/berean/scripts/berean_lib/corpus.py
+++ b/plugins/berean/scripts/berean_lib/corpus.py
@@ -1,0 +1,145 @@
+"""Corpus manifests: the digest-pinned inventory of a document tree.
+
+`build` walks the tree and writes `berean-corpus/v1`; `verify` re-reads the
+tree and requires exact agreement in both directions, so a drifted byte, a
+missing file and an unpinned extra file are all refusals. A citation can
+only be as strong as this pin, which is why verification is set equality
+rather than a subset check.
+"""
+
+import os
+
+from . import BereanError
+from . import canonical
+from . import digests
+from . import jsonio
+from . import paths
+
+FORMAT = "berean-corpus/v1"
+FIELDS = ("format", "corpus_version", "files", "corpus_digest")
+FILE_FIELDS = ("path", "bytes", "sha256")
+
+
+class Check:
+    """One named verification result."""
+
+    def __init__(self, name, passed, detail=""):
+        self.name = name
+        self.passed = passed
+        self.detail = detail
+
+    def line(self):
+        state = "pass" if self.passed else "fail"
+        detail = f": {self.detail}" if self.detail else ""
+        return f"{state}  {self.name}{detail}"
+
+
+def _walk(root):
+    """Sorted relative paths of every regular file under root, refusing links."""
+    if os.path.islink(root) or not os.path.isdir(root):
+        raise BereanError(f"corpus root is not a plain directory: {root}")
+    found = []
+    for current, directories, files in os.walk(root):
+        directories.sort()
+        for name in directories:
+            if os.path.islink(os.path.join(current, name)):
+                raise BereanError(f"refusing symlink: {os.path.join(current, name)}")
+        for name in sorted(files):
+            full = os.path.join(current, name)
+            relative = os.path.relpath(full, root).replace(os.sep, "/")
+            if name.startswith(".") and name.endswith(".staging"):
+                raise BereanError(f"staging file inside the corpus: {relative}")
+            found.append(relative)
+    if len(found) > digests.MAX_FILES:
+        raise BereanError(f"corpus over the {digests.MAX_FILES} file ceiling")
+    if not found:
+        raise BereanError(f"corpus tree is empty: {root}")
+    return sorted(found)
+
+
+def build(root, corpus_version):
+    """Pin a tree into a corpus manifest document."""
+    entries = []
+    for relative in _walk(root):
+        paths.usable(relative, "corpus path")
+        full = paths.resolve(root, relative, "corpus path")
+        data = digests.read_file(full)
+        entries.append({"path": relative, "bytes": len(data), "sha256": digests.of_bytes(data)})
+    document = {
+        "format": FORMAT,
+        "corpus_version": jsonio.stated(corpus_version, "corpus_version"),
+        "files": entries,
+        "corpus_digest": digests.of_listing((e["path"], e["sha256"]) for e in entries),
+    }
+    validate(document)
+    return document
+
+
+def validate(document):
+    """Hold a corpus manifest to its closed field table."""
+    jsonio.require(document, FIELDS, "corpus manifest")
+    if document["format"] != FORMAT:
+        raise BereanError(f"corpus manifest format is {document['format']!r}, not {FORMAT!r}")
+    jsonio.stated(document["corpus_version"], "corpus_version")
+    files = document["files"]
+    if not isinstance(files, list) or not files:
+        raise BereanError("corpus manifest carries no files")
+    seen = set()
+    for entry in files:
+        jsonio.require(entry, FILE_FIELDS, "corpus file entry")
+        paths.usable(entry["path"], "corpus path")
+        jsonio.whole_number(entry["bytes"], f"bytes for {entry['path']}")
+        digests.check_hex(entry["sha256"], f"digest for {entry['path']}")
+        if entry["path"] in seen:
+            raise BereanError(f"corpus path pinned twice: {entry['path']}")
+        seen.add(entry["path"])
+    listed = [entry["path"] for entry in files]
+    if listed != sorted(listed):
+        raise BereanError("corpus files are not in sorted order")
+    expected = digests.of_listing((e["path"], e["sha256"]) for e in files)
+    if document["corpus_digest"] != expected:
+        raise BereanError("corpus_digest does not match the file listing")
+    return document
+
+
+def write(document, out):
+    validate(document)
+    jsonio.write_canonical(out, document, canonical.dumps)
+
+
+def verify(document, root):
+    """Re-read the tree and report named checks; no repair, no subsets."""
+    checks = []
+    try:
+        validate(document)
+        checks.append(Check("manifest-shape", True))
+    except BereanError as error:
+        return [Check("manifest-shape", False, str(error))]
+
+    try:
+        on_disk = set(_walk(root))
+    except BereanError as error:
+        return checks + [Check("corpus-tree", False, str(error))]
+    checks.append(Check("corpus-tree", True))
+
+    pinned = {entry["path"]: entry for entry in document["files"]}
+    missing = sorted(set(pinned) - on_disk)
+    extra = sorted(on_disk - set(pinned))
+    if missing:
+        checks.append(Check("corpus-complete", False, f"pinned but absent: {', '.join(missing)}"))
+    elif extra:
+        checks.append(Check("corpus-complete", False, f"present but unpinned: {', '.join(extra)}"))
+    else:
+        checks.append(Check("corpus-complete", True))
+
+    drifted = []
+    for relative in sorted(set(pinned) & on_disk):
+        entry = pinned[relative]
+        data = digests.read_file(paths.resolve(root, relative, "corpus path"))
+        if len(data) != entry["bytes"] or digests.of_bytes(data) != entry["sha256"]:
+            drifted.append(relative)
+    if drifted:
+        checks.append(Check("corpus-bytes", False, f"drifted: {', '.join(drifted)}"))
+    else:
+        checks.append(Check("corpus-bytes", True))
+    return checks

--- a/plugins/berean/scripts/berean_lib/digests.py
+++ b/plugins/berean/scripts/berean_lib/digests.py
@@ -1,0 +1,61 @@
+"""Digest discipline: lowercase sha256 hex, files read without following links.
+
+Uppercase hex is refused rather than folded because two spellings of one
+digest would let the same bytes carry two identities through a comparison.
+"""
+
+import hashlib
+import os
+import re
+
+from . import BereanError
+
+HEX64 = re.compile(r"^[0-9a-f]{64}$")
+
+# One pinned file is at most 4 MiB and one corpus at most 10000 files. These
+# are correctness ceilings for a documentation corpus, not tuning knobs: a
+# reader that accepts unbounded input can be parsed into a hang.
+MAX_FILE_BYTES = 4 * 1024 * 1024
+MAX_FILES = 10000
+
+
+def check_hex(value, what):
+    if not isinstance(value, str) or not HEX64.match(value):
+        raise BereanError(f"{what} is not lowercase sha256 hex: {value!r}")
+    return value
+
+
+def of_bytes(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def read_file(path):
+    """Read a regular file's bytes, refusing symlinks and oversize files."""
+    if os.path.islink(path):
+        raise BereanError(f"refusing symlink: {path}")
+    if not os.path.isfile(path):
+        raise BereanError(f"not a regular file: {path}")
+    size = os.stat(path).st_size
+    if size > MAX_FILE_BYTES:
+        raise BereanError(f"file over the {MAX_FILE_BYTES} byte ceiling: {path}")
+    with open(path, "rb") as handle:
+        return handle.read()
+
+
+def of_file(path):
+    return of_bytes(read_file(path))
+
+
+def of_listing(entries):
+    """Digest a corpus listing: sorted `path\\0digest\\n` lines.
+
+    The path is part of the digested line so a rename changes the corpus
+    identity even when every file's bytes survive.
+    """
+    lines = []
+    for path, digest in sorted(entries):
+        check_hex(digest, f"digest for {path}")
+        if "\x00" in path or "\n" in path:
+            raise BereanError(f"control character in path: {path!r}")
+        lines.append(f"{path}\x00{digest}\n")
+    return of_bytes("".join(lines).encode("utf-8"))

--- a/plugins/berean/scripts/berean_lib/jsonio.py
+++ b/plugins/berean/scripts/berean_lib/jsonio.py
@@ -39,7 +39,12 @@ def loads(text, what="document"):
     if len(text.encode("utf-8")) > MAX_JSON_BYTES:
         raise BereanError(f"{what} over the {MAX_JSON_BYTES} byte ceiling")
     try:
-        value = json.loads(text, object_pairs_hook=_no_duplicates, parse_float=_refuse_float)
+        value = json.loads(
+            text,
+            object_pairs_hook=_no_duplicates,
+            parse_float=_refuse_float,
+            parse_constant=_refuse_float,
+        )
     except BereanError:
         raise
     except ValueError as error:

--- a/plugins/berean/scripts/berean_lib/jsonio.py
+++ b/plugins/berean/scripts/berean_lib/jsonio.py
@@ -1,0 +1,104 @@
+"""Reading untrusted JSON documents.
+
+Size is checked before the read, depth during parsing, and duplicate keys
+are refused: the second spelling of a key is how a checked value and a used
+value end up being different values.
+"""
+
+import json
+import os
+
+from . import BereanError
+from . import digests
+
+MAX_JSON_BYTES = 4 * 1024 * 1024
+MAX_DEPTH = 32
+
+
+def _no_duplicates(pairs):
+    out = {}
+    for key, value in pairs:
+        if key in out:
+            raise BereanError(f"duplicate key: {key!r}")
+        out[key] = value
+    return out
+
+
+def _check_depth(value, depth, path):
+    if depth > MAX_DEPTH:
+        raise BereanError(f"document deeper than {MAX_DEPTH} at {path}")
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _check_depth(item, depth + 1, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _check_depth(item, depth + 1, f"{path}[{index}]")
+
+
+def loads(text, what="document"):
+    if len(text.encode("utf-8")) > MAX_JSON_BYTES:
+        raise BereanError(f"{what} over the {MAX_JSON_BYTES} byte ceiling")
+    try:
+        value = json.loads(text, object_pairs_hook=_no_duplicates, parse_float=_refuse_float)
+    except BereanError:
+        raise
+    except ValueError as error:
+        raise BereanError(f"{what} is not JSON: {error}") from error
+    _check_depth(value, 0, "$")
+    return value
+
+
+def _refuse_float(text):
+    raise BereanError(f"float in document: {text}")
+
+
+def load(path, what=None):
+    what = what or os.path.basename(path)
+    if os.path.islink(path):
+        raise BereanError(f"refusing symlink: {path}")
+    if not os.path.isfile(path):
+        raise BereanError(f"not a regular file: {path}")
+    if os.stat(path).st_size > MAX_JSON_BYTES:
+        raise BereanError(f"{what} over the {MAX_JSON_BYTES} byte ceiling")
+    with open(path, "rb") as handle:
+        data = handle.read()
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise BereanError(f"{what} is not UTF-8: {error}") from error
+    return loads(text, what)
+
+
+def require(document, fields, what):
+    """Hold a document to a closed field table."""
+    if not isinstance(document, dict):
+        raise BereanError(f"{what} is not an object")
+    missing = [name for name in fields if name not in document]
+    if missing:
+        raise BereanError(f"{what} is missing {', '.join(sorted(missing))}")
+    unknown = [name for name in document if name not in fields]
+    if unknown:
+        raise BereanError(f"{what} carries undeclared fields: {', '.join(sorted(unknown))}")
+    return document
+
+
+def whole_number(value, what):
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise BereanError(f"{what} is not a whole number: {value!r}")
+    return value
+
+
+def stated(value, what):
+    if not isinstance(value, str) or not value.strip():
+        raise BereanError(f"{what} is blank or not a string")
+    return value
+
+
+def write_canonical(path, document, dumps):
+    """Stage the canonical bytes beside the destination and land with one rename."""
+    text = dumps(document) + "\n"
+    directory = os.path.dirname(os.path.abspath(path)) or "."
+    staging = os.path.join(directory, f".{os.path.basename(path)}.staging")
+    with open(staging, "w", encoding="utf-8") as handle:
+        handle.write(text)
+    os.replace(staging, path)

--- a/plugins/berean/scripts/berean_lib/paths.py
+++ b/plugins/berean/scripts/berean_lib/paths.py
@@ -1,0 +1,34 @@
+"""Path discipline for documents that name files.
+
+A corpus or release path is relative, forward-slashed and stays inside its
+tree. Backslashes are refused rather than normalised, because a path that
+means different files on different systems pins neither.
+"""
+
+import os
+
+from . import BereanError
+
+
+def usable(path, what="path"):
+    if not isinstance(path, str) or not path:
+        raise BereanError(f"{what} is blank or not a string")
+    if "\\" in path:
+        raise BereanError(f"{what} carries a backslash: {path!r}")
+    if path.startswith("/") or (len(path) > 1 and path[1] == ":"):
+        raise BereanError(f"{what} is absolute: {path!r}")
+    parts = path.split("/")
+    if any(part in ("", ".", "..") for part in parts):
+        raise BereanError(f"{what} leaves or re-enters its tree: {path!r}")
+    return path
+
+
+def resolve(root, relative, what="path"):
+    """Join a checked relative path onto a root, refusing symlinked parents."""
+    usable(relative, what)
+    current = root
+    for part in relative.split("/"):
+        current = os.path.join(current, part)
+        if os.path.islink(current):
+            raise BereanError(f"{what} crosses a symlink: {relative!r}")
+    return current

--- a/plugins/berean/skills/berean/EVOLUTION.md
+++ b/plugins/berean/skills/berean/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Berean evolution ledger
+
+Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
+
+- Current version: `berean-v0.1.0`
+- Frontier status: `open`
+- Frontier revision: `wildcat-reference-release`
+- Current frontier: The reference release answers against a frozen demonstration corpus and preserved Goldfinch mainnet reads; no release yet cites live Wildcat documentation or a captured Wildcat market read, and no Ariadne statement binds a berean release.
+- Next Fiat job: Ship the first berean release grounded in captured Wildcat documentation and Wildcat market reads, replacing the demonstration corpus in the reference deployment. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `berean-v0.1.0` | baseline | `wildcat-reference-release` | `ee99e8539e4b67e18c9ec9640358cc5d9a27fe167069ce8e03a8d75d7cefe987` | [README marketplace-context](../../README.md) | Versioning starts here. The plugin is built from its Wildcat Commons specification and the held frontier is the first grounded Wildcat deployment. |

--- a/plugins/berean/skills/berean/SKILL.md
+++ b/plugins/berean/skills/berean/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: berean
+description: >
+  Build, verify and evaluate evidence-backed protocol-agent releases: pin a
+  document corpus by digest, prove citations as exact bytes, bind live values
+  to a chain and block, separate source classes, grade recorded answers
+  against an evaluation corpus and keep promotion as records. Use when the
+  user names Berean, asks to release or verify a grounded protocol agent, or
+  wants an answer's evidence checked against pinned artefacts. Do not use it
+  to run a model, retrieve documents, capture live chain state or bind a
+  release to an Ariadne statement.
+metadata:
+  version: "0.1.0"
+---
+
+# Berean
+
+In Acts, the Bereans receive a claim and check it against the scriptures each
+day to see whether it is so. The habit this skill enforces is the same one:
+return to the named source before accepting the answer.
+
+## Where this sits
+
+<!-- marketplace-context:start -->
+Berean pins the corpus, chain readings and evaluation record a protocol
+agent's answers rest on, so a release can be checked without the model that
+produced it.
+
+**Use another tool when.** Use Lemma to produce source-linked chunks, Lazarus
+to preserve the chain evidence itself, and Ariadne to bind a released
+artefact digest to its evidence.
+
+**Current frontier.** The reference release answers against a frozen demonstration corpus and preserved Goldfinch mainnet reads; no release yet cites live Wildcat documentation or a captured Wildcat market read, and no Ariadne statement binds a berean release.
+<!-- marketplace-context:end -->
+
+## Frontier
+
+Berean owns its own release frontier, not Hexaemeron's delivery frontier and
+not Ariadne's predicate frontier. Its version, held target, next job and
+maturity state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run
+another frontier pass after that ledger becomes mature.
+
+## What a release is
+
+A Berean release is a directory holding five kinds of document, each a
+versioned JSON format with a closed field table:
+
+| Document | Format | Carries |
+| --- | --- | --- |
+| corpus manifest | `berean-corpus/v1` | one entry per pinned file with bytes and sha256, and a corpus digest over the sorted listing |
+| answer record | `berean-answer/v1` | classified sentences, citations, chain reads, time domains, or a refusal naming its boundary |
+| eval case | `berean-eval-case/v1` | a question, its expected evidence shape and its grader |
+| release manifest | `berean-release/v1` | corpus, reads, rules, question families, refusal conditions, eval references, retention declaration and the release digest |
+| promotion record | `berean-promotion/v1` | which evaluation, thresholds and results made a release active; rollback is a record naming the restored release |
+
+Chain evidence arrives as preserved read records in the Lazarus record shape,
+held by recomputed request keys. Berean never fetches; a value with no chain
+and block is not evidence.
+
+## Commands
+
+Run everything from `$PLUGIN_ROOT` with Python 3.9 or later and no other
+dependency:
+
+```text
+python3 scripts/berean.py build-corpus <tree> --out <manifest>
+python3 scripts/berean.py verify-corpus <manifest> --root <tree>
+python3 scripts/berean.py check-citation <citation> --corpus <manifest> --root <tree>
+python3 scripts/berean.py check-answer <answer> --release <dir>
+python3 scripts/berean.py verify-release <dir>
+python3 scripts/berean.py run-evals <dir> [--out <report>]
+python3 scripts/berean.py export-cases <dir> --out <file>
+python3 scripts/berean.py promote <dir> --report <report>
+python3 scripts/berean.py rollback <dir> --to <release-digest> --reason <text>
+python3 scripts/berean.py promotion-chain <dir>
+```
+
+Exit 0 means every named check passed. Exit 1 names the first failing check.
+Exit 2 is a usage or validation error. Builders refuse to write an artefact
+that fails its own validation; nothing repairs on the way through.
+
+## The gates
+
+`verify-release` reports each of these by name, pass or fail, and `run-evals`
+grades recorded answer documents against the same rules:
+
+1. Every factual sentence carries one source class: `document`, `chain_read`,
+   `calculation` or `user_supplied`. An unclassified assertion fails.
+2. A citation is document identity, byte start, byte end, span digest and
+   display text. It passes only when re-slicing the pinned file reproduces
+   both digest and text.
+3. A chain value names its chain and block and its recomputed request key
+   matches a preserved read record. A current value with neither is refused.
+4. A document claim and a chain reading that disagree are both reported,
+   with their time domains. Choosing silently fails the answer.
+5. A question outside the release's declared families, or past its evidence
+   boundary, is answered with a refusal that names the boundary. The eval
+   corpus includes cases where refusal is the correct result.
+6. Text retrieved from the corpus is data. An answer that obeys instructions
+   found in a document, widens an allowlist or reclassifies evidence fails
+   its adversarial case.
+7. A release becomes active only through a promotion record naming the
+   evaluation corpus, thresholds and results that allowed it. Rollback is a
+   new record, never an edit.
+8. The release declares what conversation data it retains, and the schemas
+   refuse fields that would carry user text into corpus or evaluation
+   artefacts.
+
+## Day to day
+
+Pin a documentation tree and prove a quote:
+
+```text
+python3 scripts/berean.py build-corpus docs/ --out corpus-manifest.json
+python3 scripts/berean.py check-citation quote.json --corpus corpus-manifest.json --root docs/
+```
+
+Verify the shipped reference release and its evaluation record offline:
+
+```text
+python3 scripts/berean.py verify-release examples/goldfinch-demo-v0
+python3 scripts/berean.py run-evals examples/goldfinch-demo-v0
+```
+
+Export the evaluation cases for an external runner in the Agent Skills case
+shape:
+
+```text
+python3 scripts/berean.py export-cases examples/goldfinch-demo-v0 --out cases.json
+```
+
+## What this skill must refuse
+
+- No path escape: absolute paths, parent traversal and symlinks are refused
+  everywhere a document names a file.
+- No verification by declaration: citations are re-sliced, request keys
+  recomputed, digests recompared; a matching claim is not a passing check.
+- No evidence upgrade: a recorded read never becomes proof-backed, a document
+  claim never becomes a chain reading, and source classes never widen.
+- No blockless live value, and no silent choice between a document and a
+  later chain state.
+- No grading against an unpinned corpus: a digest mismatch stops the run
+  before the first case.
+- No model execution, retrieval or network anywhere.
+
+If a build, verification, evaluation or test did not run, say so plainly and
+do not describe it as successful.

--- a/plugins/berean/skills/berean/agents/openai.yaml
+++ b/plugins/berean/skills/berean/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Berean"
+  short_description: "Digest-pinned agent releases with byte-exact citations, block-bound reads and evaluated refusals."
+  default_prompt: "Use Berean to build, verify or evaluate an evidence-backed protocol-agent release against its pinned corpus and preserved chain reads."

--- a/plugins/berean/tests/__init__.py
+++ b/plugins/berean/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Berean tests."""

--- a/plugins/berean/tests/support.py
+++ b/plugins/berean/tests/support.py
@@ -1,0 +1,13 @@
+"""Shared paths for the berean test suite."""
+
+from pathlib import Path
+import sys
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = PLUGIN_ROOT.parents[1]
+SCRIPTS = PLUGIN_ROOT / "scripts"
+SCHEMAS = PLUGIN_ROOT / "schemas"
+FIXTURES = PLUGIN_ROOT / "tests" / "fixtures"
+
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))

--- a/plugins/berean/tests/test_canonical.py
+++ b/plugins/berean/tests/test_canonical.py
@@ -1,0 +1,47 @@
+"""Canonical JSON refusals and determinism."""
+
+import unittest
+
+from tests.support import SCRIPTS  # noqa: F401  (puts scripts on sys.path)
+
+from berean_lib import BereanError, canonical
+
+
+class CanonicalTests(unittest.TestCase):
+    def test_one_spelling_sorted_and_compact(self):
+        self.assertEqual(canonical.dumps({"b": 1, "a": [1, 2]}), '{"a":[1,2],"b":1}')
+
+    def test_utf8_is_not_escaped(self):
+        self.assertEqual(canonical.dumps({"s": "café"}), '{"s":"café"}')
+
+    def test_floats_are_refused(self):
+        with self.assertRaises(BereanError):
+            canonical.dumps({"x": 1.5})
+
+    def test_nested_floats_are_refused_with_a_path(self):
+        with self.assertRaises(BereanError) as caught:
+            canonical.dumps({"a": [{"b": 2.0}]})
+        self.assertIn("$.a[0].b", str(caught.exception))
+
+    def test_non_finite_numbers_are_refused(self):
+        with self.assertRaises(BereanError):
+            canonical.dumps({"x": float("nan")})
+
+    def test_non_string_keys_are_refused(self):
+        with self.assertRaises(BereanError):
+            canonical.dumps({1: "x"})
+
+    def test_unserialisable_values_are_refused(self):
+        with self.assertRaises(BereanError):
+            canonical.dumps({"x": object()})
+
+    def test_booleans_and_integers_stay_distinct(self):
+        self.assertEqual(canonical.dumps({"a": True, "b": 1}), '{"a":true,"b":1}')
+
+    def test_encode_is_the_dumps_bytes(self):
+        value = {"k": "v"}
+        self.assertEqual(canonical.encode(value), canonical.dumps(value).encode("utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/berean/tests/test_citations.py
+++ b/plugins/berean/tests/test_citations.py
@@ -1,0 +1,166 @@
+"""Citations pass as exact bytes or fail by name."""
+
+import os
+import tempfile
+import unittest
+
+from tests.support import SCRIPTS  # noqa: F401
+
+from berean_lib import citations, corpus, digests
+from tests.test_corpus import make_tree, failures
+
+TEXT = "# Guide\n\nThe registry refuses café entries after close.\n".encode("utf-8")
+
+
+def cite(data, start, end, doc="guide.md"):
+    piece = data[start:end]
+    return {
+        "format": citations.FORMAT,
+        "doc": doc,
+        "byte_start": start,
+        "byte_end": end,
+        "sha256": digests.of_bytes(piece),
+        "display_text": piece.decode("utf-8"),
+    }
+
+
+class CitationTests(unittest.TestCase):
+    def setUp(self):
+        self.root_holder = tempfile.TemporaryDirectory()
+        self.root = self.root_holder.name
+        make_tree(self.root, {"guide.md": TEXT})
+        self.manifest = corpus.build(self.root, "v1")
+
+    def tearDown(self):
+        self.root_holder.cleanup()
+
+    def test_an_exact_span_passes_every_check(self):
+        citation = cite(TEXT, 9, 21)
+        self.assertEqual(failures(citations.check(citation, self.manifest, self.root)), [])
+
+    def test_a_multibyte_span_passes_when_whole(self):
+        start = TEXT.index("café".encode("utf-8"))
+        citation = cite(TEXT, start, start + len("café".encode("utf-8")))
+        self.assertEqual(failures(citations.check(citation, self.manifest, self.root)), [])
+        self.assertEqual(citation["display_text"], "café")
+
+    def test_a_span_splitting_a_character_fails_citation_text(self):
+        start = TEXT.index("café".encode("utf-8"))
+        citation = {
+            "format": citations.FORMAT,
+            "doc": "guide.md",
+            "byte_start": start,
+            "byte_end": start + 4,
+            "sha256": digests.of_bytes(TEXT[start:start + 4]),
+            "display_text": "caf?",
+        }
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-text"]
+        )
+
+    def test_a_wrong_digest_fails_citation_bytes(self):
+        citation = cite(TEXT, 9, 21)
+        citation["sha256"] = "0" * 64
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-bytes"]
+        )
+
+    def test_wrong_display_text_fails_citation_text(self):
+        citation = cite(TEXT, 9, 21)
+        citation["display_text"] = "something else"
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-text"]
+        )
+
+    def test_a_range_past_the_file_fails_citation_range(self):
+        citation = cite(TEXT, 0, 8)
+        citation["byte_end"] = len(TEXT) + 1
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-range"]
+        )
+
+    def test_an_empty_range_fails_the_shape(self):
+        citation = cite(TEXT, 0, 8)
+        citation["byte_end"] = 0
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-shape"]
+        )
+
+    def test_a_boolean_offset_fails_the_shape(self):
+        citation = cite(TEXT, 0, 8)
+        citation["byte_start"] = False
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-shape"]
+        )
+
+    def test_an_unpinned_document_fails_citation_doc(self):
+        citation = cite(TEXT, 0, 8, doc="elsewhere.md")
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-doc"]
+        )
+
+    def test_a_drifted_file_fails_citation_pin(self):
+        citation = cite(TEXT, 0, 8)
+        with open(os.path.join(self.root, "guide.md"), "ab") as handle:
+            handle.write(b"\n")
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-pin"]
+        )
+
+    def test_an_undeclared_field_fails_the_shape(self):
+        citation = cite(TEXT, 0, 8)
+        citation["confidence"] = "high"
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-shape"]
+        )
+
+
+class CliTests(unittest.TestCase):
+    def test_the_cli_proves_and_refuses_end_to_end(self):
+        import importlib
+
+        berean = importlib.import_module("berean")
+        from berean_lib import canonical
+
+        with tempfile.TemporaryDirectory() as work:
+            root = os.path.join(work, "docs")
+            make_tree(root, {"guide.md": TEXT})
+            manifest_path = os.path.join(work, "corpus-manifest.json")
+            self.assertEqual(
+                berean.main(["build-corpus", root, "--out", manifest_path]), 0
+            )
+            self.assertEqual(
+                berean.main(["verify-corpus", manifest_path, "--root", root]), 0
+            )
+            citation_path = os.path.join(work, "quote.json")
+            with open(citation_path, "w", encoding="utf-8") as handle:
+                handle.write(canonical.dumps(cite(TEXT, 9, 21)) + "\n")
+            self.assertEqual(
+                berean.main(
+                    ["check-citation", citation_path, "--corpus", manifest_path, "--root", root]
+                ),
+                0,
+            )
+            with open(os.path.join(root, "guide.md"), "wb") as handle:
+                handle.write(TEXT.replace(b"refuses", b"accepts"))
+            self.assertEqual(
+                berean.main(["verify-corpus", manifest_path, "--root", root]), 1
+            )
+            self.assertEqual(
+                berean.main(
+                    ["check-citation", citation_path, "--corpus", manifest_path, "--root", root]
+                ),
+                1,
+            )
+
+    def test_usage_errors_exit_two(self):
+        import importlib
+
+        berean = importlib.import_module("berean")
+        self.assertEqual(
+            berean.main(["verify-corpus", "/no/such/manifest.json", "--root", "/tmp"]), 2
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/berean/tests/test_corpus.py
+++ b/plugins/berean/tests/test_corpus.py
@@ -1,0 +1,148 @@
+"""Corpus build and verify, and every refusal class the pin rests on."""
+
+import json
+import os
+import tempfile
+import unittest
+
+from tests.support import SCRIPTS  # noqa: F401
+
+from berean_lib import BereanError, corpus
+
+
+def make_tree(root, files):
+    for relative, data in files.items():
+        full = os.path.join(root, *relative.split("/"))
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "wb") as handle:
+            handle.write(data)
+
+
+def failures(checks):
+    return [check.name for check in checks if not check.passed]
+
+
+TREE = {"guide/a.md": "alpha café\n".encode("utf-8"), "b.md": b"bravo\n"}
+
+
+class BuildTests(unittest.TestCase):
+    def test_build_then_verify_is_clean(self):
+        with tempfile.TemporaryDirectory() as root:
+            make_tree(root, TREE)
+            document = corpus.build(root, "v1")
+            self.assertEqual(failures(corpus.verify(document, root)), [])
+
+    def test_two_builds_are_byte_identical(self):
+        from berean_lib import canonical
+
+        with tempfile.TemporaryDirectory() as root:
+            make_tree(root, TREE)
+            one = canonical.dumps(corpus.build(root, "v1"))
+            two = canonical.dumps(corpus.build(root, "v1"))
+            self.assertEqual(one, two)
+
+    def test_an_empty_tree_is_refused(self):
+        with tempfile.TemporaryDirectory() as root:
+            with self.assertRaises(BereanError):
+                corpus.build(root, "v1")
+
+    def test_a_symlink_in_the_tree_is_refused(self):
+        with tempfile.TemporaryDirectory() as root:
+            make_tree(root, TREE)
+            os.symlink(os.path.join(root, "b.md"), os.path.join(root, "c.md"))
+            with self.assertRaises(BereanError):
+                corpus.build(root, "v1")
+
+    def test_write_stages_and_lands_whole(self):
+        with tempfile.TemporaryDirectory() as root:
+            make_tree(root, TREE)
+            out = os.path.join(root, "..", "manifest.json")
+            out = os.path.abspath(out)
+            document = corpus.build(root, "v1")
+            corpus.write(document, out)
+            with open(out, "r", encoding="utf-8") as handle:
+                self.assertEqual(json.loads(handle.read()), document)
+            staging = [n for n in os.listdir(os.path.dirname(out)) if n.endswith(".staging")]
+            self.assertEqual(staging, [])
+
+    def test_write_refuses_an_invalid_document(self):
+        with tempfile.TemporaryDirectory() as root:
+            make_tree(root, TREE)
+            document = corpus.build(root, "v1")
+            document["corpus_digest"] = "0" * 64
+            out = os.path.join(root, "manifest.json")
+            with self.assertRaises(BereanError):
+                corpus.write(document, out)
+            self.assertFalse(os.path.exists(out))
+
+
+class VerifyTests(unittest.TestCase):
+    def build(self, root):
+        make_tree(root, TREE)
+        return corpus.build(root, "v1")
+
+    def test_a_one_byte_edit_fails_corpus_bytes(self):
+        with tempfile.TemporaryDirectory() as root:
+            document = self.build(root)
+            with open(os.path.join(root, "b.md"), "wb") as handle:
+                handle.write(b"Bravo\n")
+            self.assertEqual(failures(corpus.verify(document, root)), ["corpus-bytes"])
+
+    def test_a_missing_file_fails_corpus_complete(self):
+        with tempfile.TemporaryDirectory() as root:
+            document = self.build(root)
+            os.remove(os.path.join(root, "b.md"))
+            self.assertIn("corpus-complete", failures(corpus.verify(document, root)))
+
+    def test_an_unpinned_extra_file_fails_corpus_complete(self):
+        with tempfile.TemporaryDirectory() as root:
+            document = self.build(root)
+            make_tree(root, {"extra.md": b"stray\n"})
+            self.assertEqual(failures(corpus.verify(document, root)), ["corpus-complete"])
+
+    def test_a_tampered_listing_digest_fails_the_shape(self):
+        with tempfile.TemporaryDirectory() as root:
+            document = self.build(root)
+            document["corpus_digest"] = "0" * 64
+            self.assertEqual(failures(corpus.verify(document, root)), ["manifest-shape"])
+
+    def test_an_undeclared_field_fails_the_shape(self):
+        with tempfile.TemporaryDirectory() as root:
+            document = self.build(root)
+            document["verdict"] = "fine"
+            self.assertEqual(failures(corpus.verify(document, root)), ["manifest-shape"])
+
+    def test_a_duplicate_pin_fails_the_shape(self):
+        with tempfile.TemporaryDirectory() as root:
+            document = self.build(root)
+            document["files"].append(dict(document["files"][0]))
+            self.assertEqual(failures(corpus.verify(document, root)), ["manifest-shape"])
+
+    def test_an_absolute_pinned_path_fails_the_shape(self):
+        with tempfile.TemporaryDirectory() as root:
+            document = self.build(root)
+            document["files"][0]["path"] = "/etc/passwd"
+            self.assertEqual(failures(corpus.verify(document, root)), ["manifest-shape"])
+
+
+class SchemaAgreementTests(unittest.TestCase):
+    def test_the_shipped_schema_names_the_format_and_closes_the_table(self):
+        from tests.support import SCHEMAS
+
+        with open(SCHEMAS / "corpus-manifest-v1.json", "r", encoding="utf-8") as handle:
+            schema = json.load(handle)
+        self.assertEqual(schema["properties"]["format"]["const"], corpus.FORMAT)
+        self.assertFalse(schema["additionalProperties"])
+        self.assertEqual(
+            tuple(schema["required"]), corpus.FIELDS
+        )
+        entry = schema["properties"]["files"]["items"]
+        self.assertEqual(tuple(entry["required"]), corpus.FILE_FIELDS)
+        from berean_lib import digests
+
+        self.assertEqual(entry["properties"]["bytes"]["maximum"], digests.MAX_FILE_BYTES)
+        self.assertEqual(schema["properties"]["files"]["maxItems"], digests.MAX_FILES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/berean/tests/test_corpus.py
+++ b/plugins/berean/tests/test_corpus.py
@@ -100,6 +100,17 @@ class VerifyTests(unittest.TestCase):
             make_tree(root, {"extra.md": b"stray\n"})
             self.assertEqual(failures(corpus.verify(document, root)), ["corpus-complete"])
 
+    def test_a_pinned_path_swapped_for_a_symlink_fails_corpus_bytes(self):
+        with tempfile.TemporaryDirectory() as root:
+            document = self.build(root)
+            target = os.path.join(root, "b.md")
+            os.remove(target)
+            os.symlink(os.path.join(root, "guide", "a.md"), target)
+            checks = corpus.verify(document, root)
+            self.assertEqual(failures(checks), ["corpus-bytes"])
+            detail = [c.detail for c in checks if c.name == "corpus-bytes"][0]
+            self.assertIn("symlink", detail)
+
     def test_a_tampered_listing_digest_fails_the_shape(self):
         with tempfile.TemporaryDirectory() as root:
             document = self.build(root)

--- a/plugins/berean/tests/test_digests.py
+++ b/plugins/berean/tests/test_digests.py
@@ -71,6 +71,11 @@ class JsonTests(unittest.TestCase):
         with self.assertRaises(BereanError):
             jsonio.loads('{"a": 1.5}')
 
+    def test_nan_and_infinity_constants_are_refused(self):
+        for text in ('{"a": NaN}', '{"a": Infinity}', '{"a": -Infinity}'):
+            with self.assertRaises(BereanError):
+                jsonio.loads(text)
+
     def test_depth_over_the_ceiling_is_refused(self):
         text = "[" * 40 + "]" * 40
         with self.assertRaises(BereanError):

--- a/plugins/berean/tests/test_digests.py
+++ b/plugins/berean/tests/test_digests.py
@@ -1,0 +1,108 @@
+"""Digest and untrusted-reader refusals."""
+
+import os
+import tempfile
+import unittest
+
+from tests.support import SCRIPTS  # noqa: F401
+
+from berean_lib import BereanError, digests, jsonio, paths
+
+
+class HexTests(unittest.TestCase):
+    def test_lowercase_hex_passes(self):
+        digests.check_hex("a" * 64, "digest")
+
+    def test_uppercase_hex_is_refused_not_folded(self):
+        with self.assertRaises(BereanError):
+            digests.check_hex("A" * 64, "digest")
+
+    def test_wrong_length_is_refused(self):
+        with self.assertRaises(BereanError):
+            digests.check_hex("ab", "digest")
+
+
+class FileTests(unittest.TestCase):
+    def test_symlinks_are_refused(self):
+        with tempfile.TemporaryDirectory() as root:
+            target = os.path.join(root, "real.txt")
+            with open(target, "w") as handle:
+                handle.write("x")
+            link = os.path.join(root, "link.txt")
+            os.symlink(target, link)
+            with self.assertRaises(BereanError):
+                digests.read_file(link)
+
+    def test_missing_files_are_refused(self):
+        with self.assertRaises(BereanError):
+            digests.read_file("/no/such/file")
+
+    def test_oversize_files_are_refused(self):
+        with tempfile.TemporaryDirectory() as root:
+            big = os.path.join(root, "big.bin")
+            with open(big, "wb") as handle:
+                handle.truncate(digests.MAX_FILE_BYTES + 1)
+            with self.assertRaises(BereanError):
+                digests.read_file(big)
+
+
+class ListingTests(unittest.TestCase):
+    def test_a_rename_changes_the_listing_digest(self):
+        digest = digests.of_bytes(b"same bytes")
+        one = digests.of_listing([("a.md", digest)])
+        two = digests.of_listing([("b.md", digest)])
+        self.assertNotEqual(one, two)
+
+    def test_order_does_not_change_the_listing_digest(self):
+        entries = [("a.md", digests.of_bytes(b"a")), ("b.md", digests.of_bytes(b"b"))]
+        self.assertEqual(digests.of_listing(entries), digests.of_listing(reversed(entries)))
+
+    def test_control_characters_in_paths_are_refused(self):
+        with self.assertRaises(BereanError):
+            digests.of_listing([("a\nb.md", digests.of_bytes(b"a"))])
+
+
+class JsonTests(unittest.TestCase):
+    def test_duplicate_keys_are_refused(self):
+        with self.assertRaises(BereanError):
+            jsonio.loads('{"a": 1, "a": 2}')
+
+    def test_floats_are_refused(self):
+        with self.assertRaises(BereanError):
+            jsonio.loads('{"a": 1.5}')
+
+    def test_depth_over_the_ceiling_is_refused(self):
+        text = "[" * 40 + "]" * 40
+        with self.assertRaises(BereanError):
+            jsonio.loads(text)
+
+    def test_closed_field_tables_refuse_extras_and_absences(self):
+        with self.assertRaises(BereanError):
+            jsonio.require({"a": 1, "z": 2}, ("a", "b"), "thing")
+        with self.assertRaises(BereanError):
+            jsonio.require({"a": 1}, ("a", "b"), "thing")
+
+    def test_booleans_are_not_whole_numbers(self):
+        with self.assertRaises(BereanError):
+            jsonio.whole_number(True, "count")
+
+
+class PathTests(unittest.TestCase):
+    def test_absolute_paths_are_refused(self):
+        with self.assertRaises(BereanError):
+            paths.usable("/etc/passwd")
+
+    def test_parent_traversal_is_refused(self):
+        with self.assertRaises(BereanError):
+            paths.usable("a/../b.md")
+
+    def test_backslashes_are_refused_not_normalised(self):
+        with self.assertRaises(BereanError):
+            paths.usable("a\\b.md")
+
+    def test_plain_relative_paths_pass(self):
+        self.assertEqual(paths.usable("docs/a.md"), "docs/a.md")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/berean/tests/test_scaffold.py
+++ b/plugins/berean/tests/test_scaffold.py
@@ -1,0 +1,114 @@
+"""The scaffold's own honesty checks.
+
+The repository suite holds every plugin to the marketplace contract from the
+outside. These tests hold berean's shell together from the inside, so a
+drifted description, ledger digest or frontier sentence fails here, in this
+plugin's suite, before the root suite has to say so.
+"""
+
+import hashlib
+import json
+import re
+import unittest
+
+from tests.support import PLUGIN_ROOT, REPO_ROOT
+
+
+def read(path):
+    return path.read_text(encoding="utf-8")
+
+
+class ManifestTests(unittest.TestCase):
+    def test_the_three_manifests_agree(self):
+        claude = json.loads(read(PLUGIN_ROOT / ".claude-plugin" / "plugin.json"))
+        codex = json.loads(read(PLUGIN_ROOT / ".codex-plugin" / "plugin.json"))
+        marketplace = json.loads(
+            read(REPO_ROOT / ".claude-plugin" / "marketplace.json")
+        )
+        entry = {p["name"]: p for p in marketplace["plugins"]}["berean"]
+        self.assertEqual(claude["version"], "0.1.0")
+        self.assertEqual(codex["version"], claude["version"])
+        self.assertEqual(entry["version"], claude["version"])
+        self.assertEqual(codex["description"], claude["description"])
+        self.assertEqual(entry["description"], claude["description"])
+        self.assertEqual(
+            codex["interface"]["shortDescription"], claude["description"]
+        )
+
+    def test_the_openai_interface_carries_the_same_description(self):
+        claude = json.loads(read(PLUGIN_ROOT / ".claude-plugin" / "plugin.json"))
+        yaml_text = read(
+            PLUGIN_ROOT / "skills" / "berean" / "agents" / "openai.yaml"
+        )
+        match = re.search(r'(?m)^  short_description: "([^"\n]+)"$', yaml_text)
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(1), claude["description"])
+
+
+class LedgerTests(unittest.TestCase):
+    def fields(self):
+        text = read(PLUGIN_ROOT / "skills" / "berean" / "EVOLUTION.md")
+        out = {}
+        for key in (
+            "Current version",
+            "Frontier status",
+            "Frontier revision",
+            "Current frontier",
+            "Next Fiat job",
+        ):
+            match = re.search(rf"(?m)^- {re.escape(key)}: (.+)$", text)
+            self.assertIsNotNone(match, key)
+            out[key] = match.group(1).strip().strip("`")
+        return text, out
+
+    def test_the_ledger_digest_reproduces(self):
+        text, fields = self.fields()
+        expected = hashlib.sha256(
+            (
+                "|".join(
+                    (
+                        fields["Frontier status"],
+                        fields["Frontier revision"],
+                        fields["Current frontier"],
+                        fields["Next Fiat job"],
+                    )
+                )
+                + "\n"
+            ).encode("utf-8")
+        ).hexdigest()
+        rows = re.findall(r"(?m)^\| `berean-v[^`]+` \| .+ \|$", text)
+        self.assertTrue(rows)
+        self.assertIn(f"`{expected}`", rows[-1])
+
+    def test_the_skill_version_matches_the_ledger(self):
+        _, fields = self.fields()
+        skill = read(PLUGIN_ROOT / "skills" / "berean" / "SKILL.md")
+        match = re.search(r'(?m)^  version: "(\d+\.\d+\.\d+)"$', skill)
+        self.assertIsNotNone(match)
+        self.assertEqual(
+            fields["Current version"], f"berean-v{match.group(1)}"
+        )
+
+
+class FrontierTests(unittest.TestCase):
+    def test_every_marketplace_block_carries_the_same_frontier(self):
+        landing = read(PLUGIN_ROOT / "README.md")
+        expected = re.search(
+            r"\*\*Current frontier\.\*\* ([^\n]+)", landing
+        ).group(1).strip()
+        surfaces = sorted(PLUGIN_ROOT.rglob("*.md"))
+        surfaces.append(REPO_ROOT / ".agents" / "skills" / "berean" / "SKILL.md")
+        checked = 0
+        for path in surfaces:
+            text = read(path)
+            if "<!-- marketplace-context:start -->" not in text:
+                continue
+            found = re.search(r"\*\*Current frontier(?:\.|:)\*\*\s*([^\n]+)", text)
+            self.assertIsNotNone(found, path)
+            self.assertEqual(found.group(1).strip(), expected, path)
+            checked += 1
+        self.assertGreaterEqual(checked, 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_marketplace_prose.py
+++ b/tests/test_marketplace_prose.py
@@ -11,6 +11,7 @@ MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
 PLUGINS = (
     "alexandria",
     "ariadne",
+    "berean",
     "brevitas",
     "hermes",
     "hexaemeron",
@@ -25,6 +26,7 @@ PLUGINS = (
 CANONICAL_SKILLS = {
     "alexandria": ROOT / "plugins" / "alexandria" / "skills" / "alexandria" / "SKILL.md",
     "ariadne": ROOT / "plugins" / "ariadne" / "skills" / "ariadne" / "SKILL.md",
+    "berean": ROOT / "plugins" / "berean" / "skills" / "berean" / "SKILL.md",
     "brevitas": ROOT / "plugins" / "brevitas" / "skills" / "brevitas" / "SKILL.md",
     "hermes": ROOT / "plugins" / "hermes" / "skills" / "hermes" / "SKILL.md",
     "hexaemeron": ROOT / "plugins" / "hexaemeron" / "skills" / "fiat" / "SKILL.md",
@@ -165,7 +167,7 @@ class MarketplaceProseTests(unittest.TestCase):
     def test_plugin_landing_readmes_publish_unique_rolling_fiat_jobs(self):
         landings = plugin_landing_readmes()
         self.assertEqual(set(landings), set(PLUGINS))
-        self.assertEqual(len(landings), 12)
+        self.assertEqual(len(landings), 13)
 
         topics = {}
         for name, path in landings.items():

--- a/tests/test_portable_skills.py
+++ b/tests/test_portable_skills.py
@@ -32,6 +32,7 @@ class PortableSkillTests(unittest.TestCase):
         for name in (
             "alexandria",
             "ariadne",
+            "berean",
             "brevitas",
             "hermes",
             "hexaemeron",
@@ -93,6 +94,11 @@ class PortableSkillTests(unittest.TestCase):
         for relative in re.findall(r"`(skills/[^`]+/SKILL\.md)`", contract):
             self.assertTrue((ariadne / relative).is_file(), relative)
 
+        berean = ROOT / "plugins" / "berean"
+        contract = (berean / "AGENTS.md").read_text(encoding="utf-8")
+        for relative in re.findall(r"`(skills/[^`]+/SKILL\.md)`", contract):
+            self.assertTrue((berean / relative).is_file(), relative)
+
         brevitas = ROOT / "plugins" / "brevitas"
         contract = (brevitas / "AGENTS.md").read_text(encoding="utf-8")
         for relative in re.findall(r"`(skills/[^`]+/SKILL\.md)`", contract):
@@ -128,6 +134,7 @@ class PortableSkillTests(unittest.TestCase):
     def test_skill_names_match_canonical_parent_directories(self):
         skills = list((ROOT / "plugins" / "alexandria" / "skills").glob("*/SKILL.md"))
         skills += list((ROOT / "plugins" / "ariadne" / "skills").glob("*/SKILL.md"))
+        skills += list((ROOT / "plugins" / "berean" / "skills").glob("*/SKILL.md"))
         skills += list((ROOT / "plugins" / "brevitas" / "skills").glob("*/SKILL.md"))
         skills += list((ROOT / "plugins" / "hermes" / "skills").glob("*/SKILL.md"))
         skills += list((ROOT / "plugins" / "hexaemeron" / "skills").glob("*/SKILL.md"))


### PR DESCRIPTION
Step 2 of 6, stacked on the scaffold. The pin and the proof: build-corpus walks a tree, refuses symlinks, oversize files and traversal, and writes berean-corpus/v1 as canonical JSON, staged and landed with one rename. verify-corpus requires set equality in both directions, so a drifted byte, a missing file and an unpinned extra are separate named failures. check-citation re-slices the pinned bytes and requires the digest and the display text to both reproduce; a range that splits a UTF-8 character is a refusal.

The commands share canonical JSON that refuses floats, digest helpers that refuse uppercase hex, an untrusted-JSON reader with byte, depth, duplicate-key and constant refusals, and one path rule both builders share. The shipped schema names the same ceilings the code enforces and a test holds the two together.

Audit: two rounds in audit/AUDIT.md under "step 2". Round 1 found two defects (NaN and Infinity slipped past the float refusal through parse_constant; a symlink swap raised instead of failing a named check); both fixed with guard tests in round 2, which came back clean.

Proof: `python3 -m unittest discover -s plugins/berean/tests -t plugins/berean` (61 green) and the root suite (34 green).

wildcat-origin: shoggoth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQm23oFLGTtJh3wtRM1ymS

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQm23oFLGTtJh3wtRM1ymS)_