### PR TITLE
berean: answer records, source classes and block-bound reads

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4442,3 +4442,18 @@ rather than passing as a superset; and citation digest and display text are
 checked separately so neither can vouch for the other.
 
 Leads not pursued: none.
+
+## Berean from its Commons specification, step 2, round 2 -- 2026-08-20
+
+Scope: the step 2 tree with `c8c72d3` applied. Both fixes re-reviewed
+against the current tree: the constant hook refuses all three JSON
+constants with a guard test per spelling, and the drift loop reports a
+swapped symlink as a named `corpus-bytes` failure with the refusal in its
+detail. Lints phylax, ephoros and hypomnema exit 0; root suite 34 and
+berean suite 61 green.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | No findings. | clean |
+
+Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4420,3 +4420,25 @@ Leads not pursued: brevitas B011 flags the runtime contract's selection and
 capability tables (1x3 and 5x2); the shipped template in every existing
 plugin carries the same shapes and the same flags, so the tables stay with
 the house form. Nothing else.
+
+## Berean from its Commons specification, step 2, round 1 -- 2026-08-20
+
+Scope: `c3bec0c..4438d2e`, the corpus and citation core. The suite waiver
+stands; the mechanical part ran phylax, ephoros and hypomnema over the
+changed trees, all exit 0, with the root suite (34) and berean suite (59 at
+review, 61 after fixes) green.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| B2-R1-01 | medium | `plugins/berean/scripts/berean_lib/jsonio.py` | NaN and Infinity reach `json.loads` through `parse_constant`, not `parse_float`, so a document carrying them passed the reader built to refuse non-finite numbers. | fixed in `c8c72d3` |
+| B2-R1-02 | low | `plugins/berean/scripts/berean_lib/corpus.py` | A pinned path swapped for a symlink between the walk and the drift read raised out of `verify` as a usage error instead of failing a named check. | fixed in `c8c72d3` |
+
+The look beyond the lints traced the risk register's concerns through the
+new code: traversal and backslash refusals sit in one place and both
+builders go through it; the staged write cannot leave a half manifest that
+later verifies, and a crashed staging file inside the corpus is itself a
+refusal; verification is set equality, so an unpinned extra file fails
+rather than passing as a superset; and citation digest and display text are
+checked separately so neither can vouch for the other.
+
+Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4476,3 +4476,16 @@ empty, evidence nothing cites is refused, and the per-class evidence rules
 hold user-supplied facts to no artefact at all.
 
 Leads not pursued: none.
+
+## Berean from its Commons specification, step 3, round 2 -- 2026-08-20
+
+Scope: the step 3 tree with `2883291` applied. The collision refusal
+re-reviewed against the current tree with its guard test; nothing new
+surfaced. Lints phylax, ephoros and hypomnema exit 0; root suite 34 and
+berean suite 96 green.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | No findings. | clean |
+
+Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4457,3 +4457,22 @@ berean suite 61 green.
 | -- | -- | -- | No findings. | clean |
 
 Leads not pursued: none.
+
+## Berean from its Commons specification, step 3, round 1 -- 2026-08-20
+
+Scope: `d1df164..cf9d9d2`, answer records, source classes and block-bound
+reads. The suite waiver stands; phylax, ephoros and hypomnema exit 0, root
+suite 34 and berean suite 95 green at review, 96 after the fix.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| B3-R1-01 | low | `plugins/berean/scripts/berean_lib/answers.py` | Citation ids and read ids lived in separate namespaces, so one id naming both left a calculation's evidence reference resolving to two artefacts. | fixed in `2883291` |
+| B3-R1-02 | note | `plugins/berean/scripts/berean_lib/answers.py` | A dead constant and an unused import survived drafting. | fixed in `2883291` |
+
+The look traced the register's step 3 concerns: request keys are recomputed
+rather than trusted, an outcome is exactly a result or an error, reads files
+must arrive sorted and unique so one spelling exists, refusals are enforced
+empty, evidence nothing cites is refused, and the per-class evidence rules
+hold user-supplied facts to no artefact at all.
+
+Leads not pursued: none.

--- a/plugins/berean/docs/answers.md
+++ b/plugins/berean/docs/answers.md
@@ -1,0 +1,51 @@
+# Answer records
+
+<!-- marketplace-context:start -->
+> **Marketplace context: Berean.** Berean pins the corpus, chain readings and evaluation record a protocol agent's answers rest on, so a release can be checked without the model that produced it. Use Lemma to produce source-linked chunks, Lazarus to preserve the chain evidence itself, and Ariadne to bind a released artefact digest to its evidence. **Current frontier:** The reference release answers against a frozen demonstration corpus and preserved Goldfinch mainnet reads; no release yet cites live Wildcat documentation or a captured Wildcat market read, and no Ariadne statement binds a berean release.
+<!-- marketplace-context:end -->
+
+The `berean-answer/v1` vocabulary, and why each enum is closed. The schema
+is [answer-v1.json](../schemas/answer-v1.json); the checks live in
+`scripts/berean_lib/answers.py`.
+
+## Source classes
+
+Four, and exactly four: `document`, `chain_read`, `calculation`,
+`user_supplied`. Every factual sentence carries one. The set is closed at
+read time because widening it is how a fifth class appears in one answer,
+verifies nowhere, and reads to a human as though it verified somewhere.
+
+- `document` sentences cite byte-exact citations into the pinned corpus.
+- `chain_read` sentences cite preserved read records by recomputed request
+  key, and the read names the chain and block the release declared.
+- `calculation` sentences derive from evidence already in the answer, so a
+  number with no visible inputs has nowhere to hide.
+- `user_supplied` sentences carry no evidence at all. The fact came from
+  the asker; attaching an artefact to it would dress a claim as a check.
+  Their retention is the release's declaration, not the answer's.
+
+The classes never upgrade. A recorded read does not become proof-backed
+here, and a document claim does not become a chain reading because the
+chain happens to agree with it.
+
+## Time domains
+
+A document speaks as of its version; a read speaks as of its block. When
+the two disagree about a subject, the answer carries a `discrepancies`
+entry naming the citation, the read and the disagreement. The checker
+proves both sides exist and resolve; whether an answer that stayed silent
+should have declared one is an evaluation question, and the eval corpus
+carries those cases.
+
+## Refusals
+
+A refusal is `kind: "refusal"` with a named boundary and nothing else: no
+sentences, no citations, no reads. The emptiness is enforced, because a
+refusal that also answers is an answer that dodged its evidence rules.
+
+## Evidence hygiene
+
+Ids are unique, every evidence reference resolves, and evidence nothing
+cites is refused. An answer carries only the evidence it uses, so a reader
+auditing one sentence is never sent through artefacts the answer merely
+decorated itself with.

--- a/plugins/berean/schemas/answer-v1.json
+++ b/plugins/berean/schemas/answer-v1.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://berean.wildcat.finance/answer/v1/schema.json",
+  "title": "Berean answer record v1",
+  "description": "One answer or refusal for berean-answer/v1: classified sentences, embedded citations, block-bound reads and declared disagreements. The verifier enforces this shape plus the cross-checks a schema cannot express: citation spans against the pinned corpus, request keys against the preserved records, and the kind-dependent emptiness rules.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "question", "kind", "refusal", "sentences", "citations", "reads", "discrepancies"],
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "id": { "type": "string", "pattern": "\\S" }
+  },
+  "properties": {
+    "format": { "const": "berean-answer/v1" },
+    "question": { "type": "string", "pattern": "\\S" },
+    "kind": { "enum": ["answer", "refusal"] },
+    "refusal": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["boundary", "detail"],
+          "properties": {
+            "boundary": { "type": "string", "pattern": "\\S" },
+            "detail": { "type": "string", "pattern": "\\S" }
+          }
+        }
+      ]
+    },
+    "sentences": {
+      "type": "array",
+      "maxItems": 500,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["text", "source_class", "evidence"],
+        "properties": {
+          "text": { "type": "string", "pattern": "\\S" },
+          "source_class": { "enum": ["document", "chain_read", "calculation", "user_supplied"] },
+          "evidence": { "type": "array", "items": { "$ref": "#/$defs/id" } }
+        }
+      }
+    },
+    "citations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "format", "doc", "byte_start", "byte_end", "sha256", "display_text"],
+        "properties": {
+          "id": { "$ref": "#/$defs/id" },
+          "format": { "const": "berean-citation/v1" },
+          "doc": { "type": "string", "pattern": "^[^/\\\\][^\\\\]*$" },
+          "byte_start": { "type": "integer", "minimum": 0 },
+          "byte_end": { "type": "integer", "minimum": 1 },
+          "sha256": { "$ref": "#/$defs/sha256" },
+          "display_text": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "reads": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "chain_id", "block_number", "request_key"],
+        "properties": {
+          "id": { "$ref": "#/$defs/id" },
+          "chain_id": { "type": "integer", "minimum": 0 },
+          "block_number": { "type": "integer", "minimum": 0 },
+          "request_key": { "$ref": "#/$defs/sha256" }
+        }
+      }
+    },
+    "discrepancies": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["subject", "document_evidence", "chain_evidence", "note"],
+        "properties": {
+          "subject": { "type": "string", "pattern": "\\S" },
+          "document_evidence": { "$ref": "#/$defs/id" },
+          "chain_evidence": { "$ref": "#/$defs/id" },
+          "note": { "type": "string", "pattern": "\\S" }
+        }
+      }
+    }
+  }
+}

--- a/plugins/berean/schemas/corpus-manifest-v1.json
+++ b/plugins/berean/schemas/corpus-manifest-v1.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://berean.wildcat.finance/corpus/v1/schema.json",
+  "title": "Berean corpus manifest v1",
+  "description": "The digest-pinned inventory of a document tree for berean-corpus/v1. The verifier enforces this shape plus set equality against the tree it pins; a schema cannot express that equality, which is why both ship.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "corpus_version", "files", "corpus_digest"],
+  "properties": {
+    "format": { "const": "berean-corpus/v1" },
+    "corpus_version": { "type": "string", "pattern": "\\S" },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 10000,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "bytes", "sha256"],
+        "properties": {
+          "path": { "type": "string", "pattern": "^[^/\\\\][^\\\\]*$" },
+          "bytes": { "type": "integer", "minimum": 0, "maximum": 4194304 },
+          "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+        }
+      }
+    },
+    "corpus_digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+  }
+}

--- a/plugins/berean/scripts/berean.py
+++ b/plugins/berean/scripts/berean.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Berean: release, verify and evaluate evidence-backed protocol agents."""
+
+import argparse
+import sys
+
+from berean_lib import BereanError
+from berean_lib import corpus as corpus_lib
+from berean_lib import citations as citations_lib
+from berean_lib import jsonio
+
+
+def report(checks):
+    failed = 0
+    for check in checks:
+        print(check.line())
+        if not check.passed:
+            failed += 1
+    if failed:
+        print(f"refused: {failed} check(s) failed")
+        return 1
+    print("all checks passed")
+    return 0
+
+
+def cmd_build_corpus(args):
+    document = corpus_lib.build(args.tree, args.corpus_version)
+    corpus_lib.write(document, args.out)
+    print(f"pinned {len(document['files'])} file(s); corpus digest {document['corpus_digest']}")
+    return 0
+
+
+def cmd_verify_corpus(args):
+    document = jsonio.load(args.manifest, "corpus manifest")
+    return report(corpus_lib.verify(document, args.root))
+
+
+def cmd_check_citation(args):
+    citation = jsonio.load(args.citation, "citation")
+    manifest = jsonio.load(args.corpus, "corpus manifest")
+    corpus_lib.validate(manifest)
+    return report(citations_lib.check(citation, manifest, args.root))
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(prog="berean", description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    build = commands.add_parser("build-corpus", help="pin a document tree into a corpus manifest")
+    build.add_argument("tree", help="the document tree to pin")
+    build.add_argument("--out", required=True, help="where the manifest lands")
+    build.add_argument("--corpus-version", default="v1", help="the corpus version label")
+    build.set_defaults(handler=cmd_build_corpus)
+
+    verify = commands.add_parser("verify-corpus", help="hold a tree to its corpus manifest")
+    verify.add_argument("manifest", help="the corpus manifest")
+    verify.add_argument("--root", required=True, help="the document tree it pins")
+    verify.set_defaults(handler=cmd_verify_corpus)
+
+    check = commands.add_parser("check-citation", help="prove a citation as exact bytes")
+    check.add_argument("citation", help="the citation document")
+    check.add_argument("--corpus", required=True, help="the corpus manifest")
+    check.add_argument("--root", required=True, help="the document tree the manifest pins")
+    check.set_defaults(handler=cmd_check_citation)
+
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.handler(args)
+    except BereanError as error:
+        print(f"refused: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/berean/scripts/berean.py
+++ b/plugins/berean/scripts/berean.py
@@ -5,9 +5,11 @@ import argparse
 import sys
 
 from berean_lib import BereanError
+from berean_lib import answers as answers_lib
 from berean_lib import corpus as corpus_lib
 from berean_lib import citations as citations_lib
 from berean_lib import jsonio
+from berean_lib import reads as reads_lib
 
 
 def report(checks):
@@ -42,6 +44,18 @@ def cmd_check_citation(args):
     return report(citations_lib.check(citation, manifest, args.root))
 
 
+def cmd_check_answer(args):
+    answer = jsonio.load(args.answer, "answer")
+    manifest = jsonio.load(args.corpus, "corpus manifest")
+    corpus_lib.validate(manifest)
+    records = reads_lib.load(args.reads)
+    return report(
+        answers_lib.check(
+            answer, manifest, args.root, records, args.chain_id, args.block_number
+        )
+    )
+
+
 def build_parser():
     parser = argparse.ArgumentParser(prog="berean", description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
@@ -62,6 +76,19 @@ def build_parser():
     check.add_argument("--corpus", required=True, help="the corpus manifest")
     check.add_argument("--root", required=True, help="the document tree the manifest pins")
     check.set_defaults(handler=cmd_check_citation)
+
+    answer = commands.add_parser(
+        "check-answer", help="prove an answer's classes, citations and reads"
+    )
+    answer.add_argument("answer", help="the answer document")
+    answer.add_argument("--corpus", required=True, help="the corpus manifest")
+    answer.add_argument("--root", required=True, help="the document tree the manifest pins")
+    answer.add_argument("--reads", required=True, help="the preserved reads file")
+    answer.add_argument("--chain-id", required=True, type=int, help="the declared chain id")
+    answer.add_argument(
+        "--block-number", required=True, type=int, help="the declared block number"
+    )
+    answer.set_defaults(handler=cmd_check_answer)
 
     return parser
 

--- a/plugins/berean/scripts/berean_lib/__init__.py
+++ b/plugins/berean/scripts/berean_lib/__init__.py
@@ -1,0 +1,12 @@
+"""Berean: evidence-backed protocol-agent releases.
+
+Every module here reads untrusted documents, so the shared posture is
+refusal: wrong hex case, a float, a duplicate key, a symlink or a path that
+leaves its tree are errors, never normalised. `BereanError` is the one
+domain error; the CLI turns it into exit status 2, and a named check that
+fails into exit status 1.
+"""
+
+
+class BereanError(Exception):
+    """A document or argument berean refuses to work with."""

--- a/plugins/berean/scripts/berean_lib/answers.py
+++ b/plugins/berean/scripts/berean_lib/answers.py
@@ -13,7 +13,6 @@ written at all is the evaluation corpus's job, not this module's.
 from . import BereanError
 from . import citations as citations_lib
 from . import jsonio
-from . import reads as reads_lib
 from .corpus import Check
 
 FORMAT = "berean-answer/v1"
@@ -34,7 +33,6 @@ READ_FIELDS = ("id", "chain_id", "block_number", "request_key")
 REFUSAL_FIELDS = ("boundary", "detail")
 DISCREPANCY_FIELDS = ("subject", "document_evidence", "chain_evidence", "note")
 MAX_SENTENCES = 500
-_ID_KINDS = {"document": "citation", "chain_read": "read"}
 
 
 def validate(answer):
@@ -67,6 +65,12 @@ def validate(answer):
 
     citation_ids = _collect_ids(answer["citations"], "citation", _validate_citation)
     read_ids = _collect_ids(answer["reads"], "read", _validate_read)
+    shared = citation_ids & read_ids
+    if shared:
+        raise BereanError(
+            f"id used for both a citation and a read: {', '.join(sorted(shared))}; "
+            "a calculation's evidence must resolve to one artefact"
+        )
 
     used = set()
     for index, sentence in enumerate(answer["sentences"]):

--- a/plugins/berean/scripts/berean_lib/answers.py
+++ b/plugins/berean/scripts/berean_lib/answers.py
@@ -1,0 +1,196 @@
+"""Answer records: classified sentences, proven evidence, clean refusals.
+
+An answer document carries every factual sentence with exactly one source
+class and the evidence ids behind it. A refusal is the other kind of
+answer: it names the evidence boundary it could not satisfy and carries
+nothing else. `check` proves what can be proved mechanically: shape,
+closed vocabularies, citation spans against the pinned corpus, read keys
+against the preserved records and the declared chain and block, and both
+sides of every declared disagreement. Whether a sentence should have been
+written at all is the evaluation corpus's job, not this module's.
+"""
+
+from . import BereanError
+from . import citations as citations_lib
+from . import jsonio
+from . import reads as reads_lib
+from .corpus import Check
+
+FORMAT = "berean-answer/v1"
+FIELDS = (
+    "format",
+    "question",
+    "kind",
+    "refusal",
+    "sentences",
+    "citations",
+    "reads",
+    "discrepancies",
+)
+KINDS = ("answer", "refusal")
+SOURCE_CLASSES = ("document", "chain_read", "calculation", "user_supplied")
+SENTENCE_FIELDS = ("text", "source_class", "evidence")
+READ_FIELDS = ("id", "chain_id", "block_number", "request_key")
+REFUSAL_FIELDS = ("boundary", "detail")
+DISCREPANCY_FIELDS = ("subject", "document_evidence", "chain_evidence", "note")
+MAX_SENTENCES = 500
+_ID_KINDS = {"document": "citation", "chain_read": "read"}
+
+
+def validate(answer):
+    """Hold an answer document to its closed tables and vocabularies."""
+    jsonio.require(answer, FIELDS, "answer")
+    if answer["format"] != FORMAT:
+        raise BereanError(f"answer format is {answer['format']!r}, not {FORMAT!r}")
+    jsonio.stated(answer["question"], "question")
+    if answer["kind"] not in KINDS:
+        raise BereanError(f"unknown answer kind: {answer['kind']!r}")
+    for name in ("sentences", "citations", "reads", "discrepancies"):
+        if not isinstance(answer[name], list):
+            raise BereanError(f"{name} is not a list")
+
+    if answer["kind"] == "refusal":
+        jsonio.require(answer["refusal"], REFUSAL_FIELDS, "refusal")
+        jsonio.stated(answer["refusal"]["boundary"], "refusal boundary")
+        jsonio.stated(answer["refusal"]["detail"], "refusal detail")
+        for name in ("sentences", "citations", "reads", "discrepancies"):
+            if answer[name]:
+                raise BereanError(f"a refusal carries no {name}")
+        return answer
+
+    if answer["refusal"] is not None:
+        raise BereanError("an answer carries no refusal block")
+    if not answer["sentences"]:
+        raise BereanError("an answer carries at least one sentence")
+    if len(answer["sentences"]) > MAX_SENTENCES:
+        raise BereanError(f"answer over the {MAX_SENTENCES} sentence ceiling")
+
+    citation_ids = _collect_ids(answer["citations"], "citation", _validate_citation)
+    read_ids = _collect_ids(answer["reads"], "read", _validate_read)
+
+    used = set()
+    for index, sentence in enumerate(answer["sentences"]):
+        jsonio.require(sentence, SENTENCE_FIELDS, f"sentence {index}")
+        jsonio.stated(sentence["text"], f"sentence {index} text")
+        source_class = sentence["source_class"]
+        if source_class not in SOURCE_CLASSES:
+            raise BereanError(f"sentence {index} has no source class: {source_class!r}")
+        evidence = sentence["evidence"]
+        if not isinstance(evidence, list):
+            raise BereanError(f"sentence {index} evidence is not a list")
+        if source_class == "user_supplied":
+            if evidence:
+                raise BereanError(
+                    f"sentence {index} is user_supplied and cites evidence; "
+                    "a supplied fact has no artefact behind it"
+                )
+            continue
+        if not evidence:
+            raise BereanError(f"sentence {index} ({source_class}) cites no evidence")
+        for ref in evidence:
+            if source_class == "document" and ref not in citation_ids:
+                raise BereanError(f"sentence {index} cites unknown citation: {ref!r}")
+            if source_class == "chain_read" and ref not in read_ids:
+                raise BereanError(f"sentence {index} cites unknown read: {ref!r}")
+            if source_class == "calculation" and ref not in citation_ids | read_ids:
+                raise BereanError(f"sentence {index} derives from unknown evidence: {ref!r}")
+            used.add(ref)
+
+    for index, item in enumerate(answer["discrepancies"]):
+        jsonio.require(item, DISCREPANCY_FIELDS, f"discrepancy {index}")
+        jsonio.stated(item["subject"], f"discrepancy {index} subject")
+        jsonio.stated(item["note"], f"discrepancy {index} note")
+        if item["document_evidence"] not in citation_ids:
+            raise BereanError(f"discrepancy {index} names an unknown citation")
+        if item["chain_evidence"] not in read_ids:
+            raise BereanError(f"discrepancy {index} names an unknown read")
+
+    unused = (citation_ids | read_ids) - used - {
+        item["document_evidence"] for item in answer["discrepancies"]
+    } - {item["chain_evidence"] for item in answer["discrepancies"]}
+    if unused:
+        raise BereanError(
+            f"evidence nothing cites: {', '.join(sorted(unused))}; "
+            "an answer carries only the evidence it uses"
+        )
+    return answer
+
+
+def _collect_ids(items, what, validator):
+    ids = set()
+    for index, item in enumerate(items):
+        validator(item, index)
+        identifier = item["id"]
+        if identifier in ids:
+            raise BereanError(f"{what} id used twice: {identifier!r}")
+        ids.add(identifier)
+    return ids
+
+
+def _validate_citation(item, index):
+    if not isinstance(item, dict) or "id" not in item:
+        raise BereanError(f"citation {index} has no id")
+    jsonio.stated(item["id"], f"citation {index} id")
+    body = {key: value for key, value in item.items() if key != "id"}
+    citations_lib.validate(body)
+
+
+def _validate_read(item, index):
+    jsonio.require(item, READ_FIELDS, f"read {index}")
+    jsonio.stated(item["id"], f"read {index} id")
+    jsonio.whole_number(item["chain_id"], f"read {index} chain_id")
+    jsonio.whole_number(item["block_number"], f"read {index} block_number")
+    from . import digests
+
+    digests.check_hex(item["request_key"], f"read {index} request_key")
+
+
+def check(answer, manifest, root, records, chain_id, block_number):
+    """Prove or refuse one answer; named checks out, model not required."""
+    checks = []
+    try:
+        validate(answer)
+        checks.append(Check("answer-shape", True))
+    except BereanError as error:
+        return [Check("answer-shape", False, str(error))]
+
+    if answer["kind"] == "refusal":
+        checks.append(Check("answer-refusal", True, answer["refusal"]["boundary"]))
+        return checks
+
+    bad = []
+    for item in answer["citations"]:
+        body = {key: value for key, value in item.items() if key != "id"}
+        for result in citations_lib.check(body, manifest, root):
+            if not result.passed:
+                bad.append(f"{item['id']}: {result.name} ({result.detail})")
+    if bad:
+        checks.append(Check("answer-citations", False, "; ".join(bad)))
+    else:
+        checks.append(Check("answer-citations", True))
+
+    bad = []
+    for item in answer["reads"]:
+        if item["chain_id"] != chain_id or item["block_number"] != block_number:
+            bad.append(
+                f"{item['id']}: names chain {item['chain_id']} block {item['block_number']}, "
+                f"not the declared chain {chain_id} block {block_number}"
+            )
+        elif item["request_key"] not in records:
+            bad.append(f"{item['id']}: no preserved record for {item['request_key']}")
+    if bad:
+        checks.append(Check("answer-reads", False, "; ".join(bad)))
+    else:
+        checks.append(Check("answer-reads", True))
+
+    unclassified = [
+        str(index)
+        for index, sentence in enumerate(answer["sentences"])
+        if sentence["source_class"] not in SOURCE_CLASSES
+    ]
+    checks.append(
+        Check("answer-classes", not unclassified, ", ".join(unclassified))
+    )
+
+    checks.append(Check("answer-domains", True, f"{len(answer['discrepancies'])} declared"))
+    return checks

--- a/plugins/berean/scripts/berean_lib/canonical.py
+++ b/plugins/berean/scripts/berean_lib/canonical.py
@@ -1,0 +1,40 @@
+"""Canonical JSON for digested documents.
+
+One spelling per document: sorted keys, compact separators, UTF-8 without
+escaping, no trailing newline. Floats are refused rather than serialised,
+because two runtimes disagree about their text long before they disagree
+about anything else, and a digest over disagreeing bytes pins nothing.
+"""
+
+import json
+import math
+
+from . import BereanError
+
+
+def _refuse_floats(value, path):
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            raise BereanError(f"non-finite number at {path}")
+        raise BereanError(f"float at {path}; canonical documents carry integers and strings")
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise BereanError(f"non-string key at {path}")
+            _refuse_floats(item, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _refuse_floats(item, f"{path}[{index}]")
+    elif value is not None and not isinstance(value, (str, int, bool)):
+        raise BereanError(f"unserialisable value at {path}: {type(value).__name__}")
+
+
+def dumps(value):
+    """Serialise to the one canonical spelling, refusing floats."""
+    _refuse_floats(value, "$")
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def encode(value):
+    """Canonical bytes for digesting."""
+    return dumps(value).encode("utf-8")

--- a/plugins/berean/scripts/berean_lib/citations.py
+++ b/plugins/berean/scripts/berean_lib/citations.py
@@ -1,0 +1,81 @@
+"""Citations: exact bytes in a pinned corpus, or nothing.
+
+A citation names a pinned document, a byte range, the range's digest and
+its display text. It passes only when the pinned file still matches the
+corpus manifest, the slice reproduces the digest, and the slice decodes to
+exactly the display text. Digest and text are both checked because either
+alone can lie: a digest with no text pins bytes nobody can read back, and
+text with no digest is a claim about bytes nobody sliced.
+"""
+
+from . import BereanError
+from . import digests
+from . import jsonio
+from . import paths
+from .corpus import Check
+
+FORMAT = "berean-citation/v1"
+FIELDS = ("format", "doc", "byte_start", "byte_end", "sha256", "display_text")
+
+
+def validate(citation):
+    jsonio.require(citation, FIELDS, "citation")
+    if citation["format"] != FORMAT:
+        raise BereanError(f"citation format is {citation['format']!r}, not {FORMAT!r}")
+    paths.usable(citation["doc"], "citation doc")
+    start = jsonio.whole_number(citation["byte_start"], "byte_start")
+    end = jsonio.whole_number(citation["byte_end"], "byte_end")
+    if end <= start:
+        raise BereanError(f"empty or inverted byte range: {start}..{end}")
+    digests.check_hex(citation["sha256"], "citation digest")
+    if not isinstance(citation["display_text"], str) or not citation["display_text"]:
+        raise BereanError("display_text is blank or not a string")
+    return citation
+
+
+def check(citation, manifest, root):
+    """Prove or refuse one citation against a pinned corpus; named checks out."""
+    checks = []
+    try:
+        validate(citation)
+        checks.append(Check("citation-shape", True))
+    except BereanError as error:
+        return [Check("citation-shape", False, str(error))]
+
+    pinned = {entry["path"]: entry for entry in manifest["files"]}
+    entry = pinned.get(citation["doc"])
+    if entry is None:
+        return checks + [Check("citation-doc", False, f"not in the corpus: {citation['doc']}")]
+    checks.append(Check("citation-doc", True))
+
+    try:
+        data = digests.read_file(paths.resolve(root, citation["doc"], "citation doc"))
+    except BereanError as error:
+        return checks + [Check("citation-pin", False, str(error))]
+    if len(data) != entry["bytes"] or digests.of_bytes(data) != entry["sha256"]:
+        return checks + [
+            Check("citation-pin", False, f"{citation['doc']} no longer matches the corpus manifest")
+        ]
+    checks.append(Check("citation-pin", True))
+
+    start, end = citation["byte_start"], citation["byte_end"]
+    if end > len(data):
+        return checks + [Check("citation-range", False, f"range {start}..{end} leaves the {len(data)} byte file")]
+    checks.append(Check("citation-range", True))
+
+    piece = data[start:end]
+    if digests.of_bytes(piece) != citation["sha256"]:
+        checks.append(Check("citation-bytes", False, "the slice does not reproduce the cited digest"))
+        return checks
+    checks.append(Check("citation-bytes", True))
+
+    try:
+        text = piece.decode("utf-8")
+    except UnicodeDecodeError:
+        checks.append(Check("citation-text", False, "the slice is not whole UTF-8; the range splits a character"))
+        return checks
+    if text != citation["display_text"]:
+        checks.append(Check("citation-text", False, "display_text is not the decoded slice"))
+    else:
+        checks.append(Check("citation-text", True))
+    return checks

--- a/plugins/berean/scripts/berean_lib/corpus.py
+++ b/plugins/berean/scripts/berean_lib/corpus.py
@@ -135,7 +135,11 @@ def verify(document, root):
     drifted = []
     for relative in sorted(set(pinned) & on_disk):
         entry = pinned[relative]
-        data = digests.read_file(paths.resolve(root, relative, "corpus path"))
+        try:
+            data = digests.read_file(paths.resolve(root, relative, "corpus path"))
+        except BereanError as error:
+            drifted.append(f"{relative} ({error})")
+            continue
         if len(data) != entry["bytes"] or digests.of_bytes(data) != entry["sha256"]:
             drifted.append(relative)
     if drifted:

--- a/plugins/berean/scripts/berean_lib/corpus.py
+++ b/plugins/berean/scripts/berean_lib/corpus.py
@@ -1,0 +1,145 @@
+"""Corpus manifests: the digest-pinned inventory of a document tree.
+
+`build` walks the tree and writes `berean-corpus/v1`; `verify` re-reads the
+tree and requires exact agreement in both directions, so a drifted byte, a
+missing file and an unpinned extra file are all refusals. A citation can
+only be as strong as this pin, which is why verification is set equality
+rather than a subset check.
+"""
+
+import os
+
+from . import BereanError
+from . import canonical
+from . import digests
+from . import jsonio
+from . import paths
+
+FORMAT = "berean-corpus/v1"
+FIELDS = ("format", "corpus_version", "files", "corpus_digest")
+FILE_FIELDS = ("path", "bytes", "sha256")
+
+
+class Check:
+    """One named verification result."""
+
+    def __init__(self, name, passed, detail=""):
+        self.name = name
+        self.passed = passed
+        self.detail = detail
+
+    def line(self):
+        state = "pass" if self.passed else "fail"
+        detail = f": {self.detail}" if self.detail else ""
+        return f"{state}  {self.name}{detail}"
+
+
+def _walk(root):
+    """Sorted relative paths of every regular file under root, refusing links."""
+    if os.path.islink(root) or not os.path.isdir(root):
+        raise BereanError(f"corpus root is not a plain directory: {root}")
+    found = []
+    for current, directories, files in os.walk(root):
+        directories.sort()
+        for name in directories:
+            if os.path.islink(os.path.join(current, name)):
+                raise BereanError(f"refusing symlink: {os.path.join(current, name)}")
+        for name in sorted(files):
+            full = os.path.join(current, name)
+            relative = os.path.relpath(full, root).replace(os.sep, "/")
+            if name.startswith(".") and name.endswith(".staging"):
+                raise BereanError(f"staging file inside the corpus: {relative}")
+            found.append(relative)
+    if len(found) > digests.MAX_FILES:
+        raise BereanError(f"corpus over the {digests.MAX_FILES} file ceiling")
+    if not found:
+        raise BereanError(f"corpus tree is empty: {root}")
+    return sorted(found)
+
+
+def build(root, corpus_version):
+    """Pin a tree into a corpus manifest document."""
+    entries = []
+    for relative in _walk(root):
+        paths.usable(relative, "corpus path")
+        full = paths.resolve(root, relative, "corpus path")
+        data = digests.read_file(full)
+        entries.append({"path": relative, "bytes": len(data), "sha256": digests.of_bytes(data)})
+    document = {
+        "format": FORMAT,
+        "corpus_version": jsonio.stated(corpus_version, "corpus_version"),
+        "files": entries,
+        "corpus_digest": digests.of_listing((e["path"], e["sha256"]) for e in entries),
+    }
+    validate(document)
+    return document
+
+
+def validate(document):
+    """Hold a corpus manifest to its closed field table."""
+    jsonio.require(document, FIELDS, "corpus manifest")
+    if document["format"] != FORMAT:
+        raise BereanError(f"corpus manifest format is {document['format']!r}, not {FORMAT!r}")
+    jsonio.stated(document["corpus_version"], "corpus_version")
+    files = document["files"]
+    if not isinstance(files, list) or not files:
+        raise BereanError("corpus manifest carries no files")
+    seen = set()
+    for entry in files:
+        jsonio.require(entry, FILE_FIELDS, "corpus file entry")
+        paths.usable(entry["path"], "corpus path")
+        jsonio.whole_number(entry["bytes"], f"bytes for {entry['path']}")
+        digests.check_hex(entry["sha256"], f"digest for {entry['path']}")
+        if entry["path"] in seen:
+            raise BereanError(f"corpus path pinned twice: {entry['path']}")
+        seen.add(entry["path"])
+    listed = [entry["path"] for entry in files]
+    if listed != sorted(listed):
+        raise BereanError("corpus files are not in sorted order")
+    expected = digests.of_listing((e["path"], e["sha256"]) for e in files)
+    if document["corpus_digest"] != expected:
+        raise BereanError("corpus_digest does not match the file listing")
+    return document
+
+
+def write(document, out):
+    validate(document)
+    jsonio.write_canonical(out, document, canonical.dumps)
+
+
+def verify(document, root):
+    """Re-read the tree and report named checks; no repair, no subsets."""
+    checks = []
+    try:
+        validate(document)
+        checks.append(Check("manifest-shape", True))
+    except BereanError as error:
+        return [Check("manifest-shape", False, str(error))]
+
+    try:
+        on_disk = set(_walk(root))
+    except BereanError as error:
+        return checks + [Check("corpus-tree", False, str(error))]
+    checks.append(Check("corpus-tree", True))
+
+    pinned = {entry["path"]: entry for entry in document["files"]}
+    missing = sorted(set(pinned) - on_disk)
+    extra = sorted(on_disk - set(pinned))
+    if missing:
+        checks.append(Check("corpus-complete", False, f"pinned but absent: {', '.join(missing)}"))
+    elif extra:
+        checks.append(Check("corpus-complete", False, f"present but unpinned: {', '.join(extra)}"))
+    else:
+        checks.append(Check("corpus-complete", True))
+
+    drifted = []
+    for relative in sorted(set(pinned) & on_disk):
+        entry = pinned[relative]
+        data = digests.read_file(paths.resolve(root, relative, "corpus path"))
+        if len(data) != entry["bytes"] or digests.of_bytes(data) != entry["sha256"]:
+            drifted.append(relative)
+    if drifted:
+        checks.append(Check("corpus-bytes", False, f"drifted: {', '.join(drifted)}"))
+    else:
+        checks.append(Check("corpus-bytes", True))
+    return checks

--- a/plugins/berean/scripts/berean_lib/digests.py
+++ b/plugins/berean/scripts/berean_lib/digests.py
@@ -1,0 +1,61 @@
+"""Digest discipline: lowercase sha256 hex, files read without following links.
+
+Uppercase hex is refused rather than folded because two spellings of one
+digest would let the same bytes carry two identities through a comparison.
+"""
+
+import hashlib
+import os
+import re
+
+from . import BereanError
+
+HEX64 = re.compile(r"^[0-9a-f]{64}$")
+
+# One pinned file is at most 4 MiB and one corpus at most 10000 files. These
+# are correctness ceilings for a documentation corpus, not tuning knobs: a
+# reader that accepts unbounded input can be parsed into a hang.
+MAX_FILE_BYTES = 4 * 1024 * 1024
+MAX_FILES = 10000
+
+
+def check_hex(value, what):
+    if not isinstance(value, str) or not HEX64.match(value):
+        raise BereanError(f"{what} is not lowercase sha256 hex: {value!r}")
+    return value
+
+
+def of_bytes(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def read_file(path):
+    """Read a regular file's bytes, refusing symlinks and oversize files."""
+    if os.path.islink(path):
+        raise BereanError(f"refusing symlink: {path}")
+    if not os.path.isfile(path):
+        raise BereanError(f"not a regular file: {path}")
+    size = os.stat(path).st_size
+    if size > MAX_FILE_BYTES:
+        raise BereanError(f"file over the {MAX_FILE_BYTES} byte ceiling: {path}")
+    with open(path, "rb") as handle:
+        return handle.read()
+
+
+def of_file(path):
+    return of_bytes(read_file(path))
+
+
+def of_listing(entries):
+    """Digest a corpus listing: sorted `path\\0digest\\n` lines.
+
+    The path is part of the digested line so a rename changes the corpus
+    identity even when every file's bytes survive.
+    """
+    lines = []
+    for path, digest in sorted(entries):
+        check_hex(digest, f"digest for {path}")
+        if "\x00" in path or "\n" in path:
+            raise BereanError(f"control character in path: {path!r}")
+        lines.append(f"{path}\x00{digest}\n")
+    return of_bytes("".join(lines).encode("utf-8"))

--- a/plugins/berean/scripts/berean_lib/jsonio.py
+++ b/plugins/berean/scripts/berean_lib/jsonio.py
@@ -39,7 +39,12 @@ def loads(text, what="document"):
     if len(text.encode("utf-8")) > MAX_JSON_BYTES:
         raise BereanError(f"{what} over the {MAX_JSON_BYTES} byte ceiling")
     try:
-        value = json.loads(text, object_pairs_hook=_no_duplicates, parse_float=_refuse_float)
+        value = json.loads(
+            text,
+            object_pairs_hook=_no_duplicates,
+            parse_float=_refuse_float,
+            parse_constant=_refuse_float,
+        )
     except BereanError:
         raise
     except ValueError as error:

--- a/plugins/berean/scripts/berean_lib/jsonio.py
+++ b/plugins/berean/scripts/berean_lib/jsonio.py
@@ -1,0 +1,104 @@
+"""Reading untrusted JSON documents.
+
+Size is checked before the read, depth during parsing, and duplicate keys
+are refused: the second spelling of a key is how a checked value and a used
+value end up being different values.
+"""
+
+import json
+import os
+
+from . import BereanError
+from . import digests
+
+MAX_JSON_BYTES = 4 * 1024 * 1024
+MAX_DEPTH = 32
+
+
+def _no_duplicates(pairs):
+    out = {}
+    for key, value in pairs:
+        if key in out:
+            raise BereanError(f"duplicate key: {key!r}")
+        out[key] = value
+    return out
+
+
+def _check_depth(value, depth, path):
+    if depth > MAX_DEPTH:
+        raise BereanError(f"document deeper than {MAX_DEPTH} at {path}")
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _check_depth(item, depth + 1, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _check_depth(item, depth + 1, f"{path}[{index}]")
+
+
+def loads(text, what="document"):
+    if len(text.encode("utf-8")) > MAX_JSON_BYTES:
+        raise BereanError(f"{what} over the {MAX_JSON_BYTES} byte ceiling")
+    try:
+        value = json.loads(text, object_pairs_hook=_no_duplicates, parse_float=_refuse_float)
+    except BereanError:
+        raise
+    except ValueError as error:
+        raise BereanError(f"{what} is not JSON: {error}") from error
+    _check_depth(value, 0, "$")
+    return value
+
+
+def _refuse_float(text):
+    raise BereanError(f"float in document: {text}")
+
+
+def load(path, what=None):
+    what = what or os.path.basename(path)
+    if os.path.islink(path):
+        raise BereanError(f"refusing symlink: {path}")
+    if not os.path.isfile(path):
+        raise BereanError(f"not a regular file: {path}")
+    if os.stat(path).st_size > MAX_JSON_BYTES:
+        raise BereanError(f"{what} over the {MAX_JSON_BYTES} byte ceiling")
+    with open(path, "rb") as handle:
+        data = handle.read()
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise BereanError(f"{what} is not UTF-8: {error}") from error
+    return loads(text, what)
+
+
+def require(document, fields, what):
+    """Hold a document to a closed field table."""
+    if not isinstance(document, dict):
+        raise BereanError(f"{what} is not an object")
+    missing = [name for name in fields if name not in document]
+    if missing:
+        raise BereanError(f"{what} is missing {', '.join(sorted(missing))}")
+    unknown = [name for name in document if name not in fields]
+    if unknown:
+        raise BereanError(f"{what} carries undeclared fields: {', '.join(sorted(unknown))}")
+    return document
+
+
+def whole_number(value, what):
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise BereanError(f"{what} is not a whole number: {value!r}")
+    return value
+
+
+def stated(value, what):
+    if not isinstance(value, str) or not value.strip():
+        raise BereanError(f"{what} is blank or not a string")
+    return value
+
+
+def write_canonical(path, document, dumps):
+    """Stage the canonical bytes beside the destination and land with one rename."""
+    text = dumps(document) + "\n"
+    directory = os.path.dirname(os.path.abspath(path)) or "."
+    staging = os.path.join(directory, f".{os.path.basename(path)}.staging")
+    with open(staging, "w", encoding="utf-8") as handle:
+        handle.write(text)
+    os.replace(staging, path)

--- a/plugins/berean/scripts/berean_lib/paths.py
+++ b/plugins/berean/scripts/berean_lib/paths.py
@@ -1,0 +1,34 @@
+"""Path discipline for documents that name files.
+
+A corpus or release path is relative, forward-slashed and stays inside its
+tree. Backslashes are refused rather than normalised, because a path that
+means different files on different systems pins neither.
+"""
+
+import os
+
+from . import BereanError
+
+
+def usable(path, what="path"):
+    if not isinstance(path, str) or not path:
+        raise BereanError(f"{what} is blank or not a string")
+    if "\\" in path:
+        raise BereanError(f"{what} carries a backslash: {path!r}")
+    if path.startswith("/") or (len(path) > 1 and path[1] == ":"):
+        raise BereanError(f"{what} is absolute: {path!r}")
+    parts = path.split("/")
+    if any(part in ("", ".", "..") for part in parts):
+        raise BereanError(f"{what} leaves or re-enters its tree: {path!r}")
+    return path
+
+
+def resolve(root, relative, what="path"):
+    """Join a checked relative path onto a root, refusing symlinked parents."""
+    usable(relative, what)
+    current = root
+    for part in relative.split("/"):
+        current = os.path.join(current, part)
+        if os.path.islink(current):
+            raise BereanError(f"{what} crosses a symlink: {relative!r}")
+    return current

--- a/plugins/berean/scripts/berean_lib/reads.py
+++ b/plugins/berean/scripts/berean_lib/reads.py
@@ -1,0 +1,95 @@
+"""Preserved chain reads, held by recomputed request keys.
+
+Berean consumes read records in the Lazarus preservation shape: one JSONL
+record per request, keyed by the digest of its canonical method and params,
+with the outcome exactly a result or an error and the evidence class one of
+the three the preserver assigned. Berean recomputes the key and keeps the
+class; it never interprets a method's semantics and never restates recorded
+RPC as anything stronger. All records in one reads file belong to one chain
+and one block, the fixed-block model the release declares around them.
+"""
+
+from . import BereanError
+from . import canonical
+from . import digests
+from . import jsonio
+
+EVIDENCE_CLASSES = ("proof-backed", "header-bound", "recorded-rpc")
+REQUIRED_FIELDS = ("schema_version", "request_key", "method", "params", "required", "evidence", "outcome")
+OPTIONAL_FIELDS = ("name",)
+MAX_RECORDS = 10000
+
+
+def request_key(method, params):
+    """The digest of the canonical request, the same spelling Lazarus uses."""
+    jsonio.stated(method, "method")
+    if not isinstance(params, list):
+        raise BereanError("params is not a list")
+    return digests.of_bytes(canonical.encode({"method": method, "params": params}))
+
+
+def validate_record(record):
+    if not isinstance(record, dict):
+        raise BereanError("read record is not an object")
+    for field in REQUIRED_FIELDS:
+        if field not in record:
+            raise BereanError(f"read record is missing {field}")
+    unknown = [f for f in record if f not in REQUIRED_FIELDS + OPTIONAL_FIELDS]
+    if unknown:
+        raise BereanError(f"read record carries undeclared fields: {', '.join(sorted(unknown))}")
+    if record["schema_version"] != 1:
+        raise BereanError(f"read record schema_version is {record['schema_version']!r}, not 1")
+    if not isinstance(record["required"], bool):
+        raise BereanError("read record required is not a boolean")
+    if record["evidence"] not in EVIDENCE_CLASSES:
+        raise BereanError(f"unknown evidence class: {record['evidence']!r}")
+    outcome = record["outcome"]
+    if not isinstance(outcome, dict) or set(outcome) not in ({"result"}, {"error"}):
+        raise BereanError("read outcome is not exactly a result or an error")
+    if "error" in outcome:
+        error = outcome["error"]
+        if not isinstance(error, dict) or "code" not in error or "message" not in error:
+            raise BereanError("read error outcome is missing code or message")
+    expected = request_key(record["method"], record["params"])
+    digests.check_hex(record["request_key"], "request_key")
+    if record["request_key"] != expected:
+        raise BereanError(
+            f"request_key does not match the canonical request: {record['request_key']}"
+        )
+    return record
+
+
+def load(path):
+    """Read a reads file into a mapping keyed by request key.
+
+    The file is sorted by request key with no duplicates, the same discipline
+    the preserver writes with, so one spelling of the file exists.
+    """
+    import os
+
+    if os.path.islink(path):
+        raise BereanError(f"refusing symlink: {path}")
+    if not os.path.isfile(path):
+        raise BereanError(f"not a regular file: {path}")
+    if os.stat(path).st_size > jsonio.MAX_JSON_BYTES:
+        raise BereanError(f"reads file over the {jsonio.MAX_JSON_BYTES} byte ceiling")
+    records = {}
+    previous = None
+    with open(path, "r", encoding="utf-8") as handle:
+        for number, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                raise BereanError(f"blank line in reads file at line {number}")
+            record = validate_record(jsonio.loads(line, f"read record at line {number}"))
+            key = record["request_key"]
+            if key in records:
+                raise BereanError(f"duplicate request_key at line {number}: {key}")
+            if previous is not None and key < previous:
+                raise BereanError(f"reads file is not sorted by request_key at line {number}")
+            previous = key
+            records[key] = record
+    if not records:
+        raise BereanError(f"reads file is empty: {path}")
+    if len(records) > MAX_RECORDS:
+        raise BereanError(f"reads file over the {MAX_RECORDS} record ceiling")
+    return records

--- a/plugins/berean/tests/test_answers.py
+++ b/plugins/berean/tests/test_answers.py
@@ -1,0 +1,283 @@
+"""Answer records: the specification's first five gates, mechanically."""
+
+import json
+import os
+import tempfile
+import unittest
+
+from tests.support import SCRIPTS, SCHEMAS  # noqa: F401
+
+from berean_lib import answers, citations, corpus, digests, reads
+from tests.test_corpus import make_tree, failures
+from tests.test_reads import record, write_reads
+
+DOC = "# Terms\n\nThe pause flag halts new entries. Version 3 keeps it set.\n".encode("utf-8")
+CHAIN_ID = 1
+BLOCK = 13097494
+
+
+def span(data, needle):
+    start = data.index(needle.encode("utf-8"))
+    return start, start + len(needle.encode("utf-8"))
+
+
+class AnswerFixture(unittest.TestCase):
+    def setUp(self):
+        self.holder = tempfile.TemporaryDirectory()
+        self.root = os.path.join(self.holder.name, "docs")
+        make_tree(self.root, {"terms.md": DOC})
+        self.manifest = corpus.build(self.root, "v1")
+        self.read_record = record("eth_getStorageAt", ["0x8bbd", "0x0", "0xc7da16"])
+        self.reads_path = os.path.join(self.holder.name, "reads.jsonl")
+        write_reads(self.reads_path, [self.read_record])
+        self.records = reads.load(self.reads_path)
+
+    def tearDown(self):
+        self.holder.cleanup()
+
+    def citation(self, needle, identifier="c1"):
+        start, end = span(DOC, needle)
+        return {
+            "id": identifier,
+            "format": citations.FORMAT,
+            "doc": "terms.md",
+            "byte_start": start,
+            "byte_end": end,
+            "sha256": digests.of_bytes(DOC[start:end]),
+            "display_text": needle,
+        }
+
+    def read(self, identifier="r1"):
+        return {
+            "id": identifier,
+            "chain_id": CHAIN_ID,
+            "block_number": BLOCK,
+            "request_key": self.read_record["request_key"],
+        }
+
+    def answer(self, **overrides):
+        base = {
+            "format": answers.FORMAT,
+            "question": "Is the pause flag set?",
+            "kind": "answer",
+            "refusal": None,
+            "sentences": [
+                {
+                    "text": "The documentation says the pause flag halts new entries.",
+                    "source_class": "document",
+                    "evidence": ["c1"],
+                },
+                {
+                    "text": "Slot zero reads one at the declared block.",
+                    "source_class": "chain_read",
+                    "evidence": ["r1"],
+                },
+            ],
+            "citations": [self.citation("The pause flag halts new entries.")],
+            "reads": [self.read()],
+            "discrepancies": [],
+        }
+        base.update(overrides)
+        return base
+
+    def check(self, answer):
+        return answers.check(
+            answer, self.manifest, self.root, self.records, CHAIN_ID, BLOCK
+        )
+
+
+class GateOneTests(AnswerFixture):
+    def test_a_classified_answer_passes(self):
+        self.assertEqual(failures(self.check(self.answer())), [])
+
+    def test_an_unknown_source_class_fails_the_shape(self):
+        bad = self.answer()
+        bad["sentences"][0]["source_class"] = "vibes"
+        self.assertEqual(failures(self.check(bad)), ["answer-shape"])
+
+    def test_an_evidence_free_document_sentence_fails(self):
+        bad = self.answer()
+        bad["sentences"][0]["evidence"] = []
+        self.assertEqual(failures(self.check(bad)), ["answer-shape"])
+
+    def test_a_user_supplied_fact_carries_no_evidence(self):
+        good = self.answer()
+        good["sentences"].append(
+            {"text": "You said the lender is fund A.", "source_class": "user_supplied", "evidence": []}
+        )
+        self.assertEqual(failures(self.check(good)), [])
+        bad = self.answer()
+        bad["sentences"].append(
+            {"text": "You said the lender is fund A.", "source_class": "user_supplied", "evidence": ["c1"]}
+        )
+        self.assertEqual(failures(self.check(bad)), ["answer-shape"])
+
+    def test_a_calculation_derives_from_known_evidence(self):
+        good = self.answer()
+        good["sentences"].append(
+            {"text": "So one of one flag is set.", "source_class": "calculation", "evidence": ["c1", "r1"]}
+        )
+        self.assertEqual(failures(self.check(good)), [])
+
+
+class GateTwoTests(AnswerFixture):
+    def test_a_mismatched_span_fails_answer_citations(self):
+        bad = self.answer()
+        bad["citations"][0]["display_text"] = "The pause flag halts all entries."
+        self.assertEqual(failures(self.check(bad)), ["answer-citations"])
+
+    def test_a_drifted_corpus_file_fails_answer_citations(self):
+        with open(os.path.join(self.root, "terms.md"), "ab") as handle:
+            handle.write(b"\n")
+        self.assertEqual(failures(self.check(self.answer())), ["answer-citations"])
+
+
+class GateThreeTests(AnswerFixture):
+    def test_a_read_without_a_preserved_record_fails(self):
+        bad = self.answer()
+        bad["reads"][0]["request_key"] = "0" * 64
+        self.assertEqual(failures(self.check(bad)), ["answer-reads"])
+
+    def test_a_read_naming_another_block_fails(self):
+        bad = self.answer()
+        bad["reads"][0]["block_number"] = BLOCK + 1
+        self.assertEqual(failures(self.check(bad)), ["answer-reads"])
+
+    def test_a_read_naming_another_chain_fails(self):
+        bad = self.answer()
+        bad["reads"][0]["chain_id"] = 10
+        self.assertEqual(failures(self.check(bad)), ["answer-reads"])
+
+    def test_a_boolean_block_number_fails_the_shape(self):
+        bad = self.answer()
+        bad["reads"][0]["block_number"] = True
+        self.assertEqual(failures(self.check(bad)), ["answer-shape"])
+
+
+class GateFourTests(AnswerFixture):
+    def test_a_declared_disagreement_passes_and_is_counted(self):
+        good = self.answer()
+        good["discrepancies"] = [
+            {
+                "subject": "pause flag",
+                "document_evidence": "c1",
+                "chain_evidence": "r1",
+                "note": "the document says set; the block read disagrees",
+            }
+        ]
+        checks = self.check(good)
+        self.assertEqual(failures(checks), [])
+        domains = [c for c in checks if c.name == "answer-domains"][0]
+        self.assertIn("1 declared", domains.detail)
+
+    def test_a_disagreement_naming_unknown_evidence_fails_the_shape(self):
+        bad = self.answer()
+        bad["discrepancies"] = [
+            {
+                "subject": "pause flag",
+                "document_evidence": "c9",
+                "chain_evidence": "r1",
+                "note": "the sides disagree",
+            }
+        ]
+        self.assertEqual(failures(self.check(bad)), ["answer-shape"])
+
+
+class GateFiveTests(AnswerFixture):
+    def refusal(self):
+        return {
+            "format": answers.FORMAT,
+            "question": "What is the lender's home address?",
+            "kind": "refusal",
+            "refusal": {
+                "boundary": "outside the declared question families",
+                "detail": "the release answers protocol questions, not personal ones",
+            },
+            "sentences": [],
+            "citations": [],
+            "reads": [],
+            "discrepancies": [],
+        }
+
+    def test_a_clean_refusal_passes(self):
+        checks = self.check(self.refusal())
+        self.assertEqual(failures(checks), [])
+        self.assertEqual([c.name for c in checks], ["answer-shape", "answer-refusal"])
+
+    def test_a_refusal_carrying_sentences_fails_the_shape(self):
+        bad = self.refusal()
+        bad["sentences"] = [
+            {"text": "Here it is anyway.", "source_class": "document", "evidence": []}
+        ]
+        self.assertEqual(failures(self.check(bad)), ["answer-shape"])
+
+    def test_a_refusal_without_a_boundary_fails_the_shape(self):
+        bad = self.refusal()
+        bad["refusal"] = {"boundary": " ", "detail": "unnamed"}
+        self.assertEqual(failures(self.check(bad)), ["answer-shape"])
+
+
+class HygieneTests(AnswerFixture):
+    def test_unused_evidence_fails_the_shape(self):
+        bad = self.answer()
+        bad["citations"].append(self.citation("Version 3 keeps it set.", "c2"))
+        self.assertEqual(failures(self.check(bad)), ["answer-shape"])
+
+    def test_duplicate_evidence_ids_fail_the_shape(self):
+        bad = self.answer()
+        bad["citations"].append(self.citation("Version 3 keeps it set.", "c1"))
+        self.assertEqual(failures(self.check(bad)), ["answer-shape"])
+
+    def test_an_undeclared_field_fails_the_shape(self):
+        bad = self.answer()
+        bad["model"] = "gpt"
+        self.assertEqual(failures(self.check(bad)), ["answer-shape"])
+
+
+class SchemaAgreementTests(unittest.TestCase):
+    def test_the_shipped_schema_matches_the_module(self):
+        with open(SCHEMAS / "answer-v1.json", "r", encoding="utf-8") as handle:
+            schema = json.load(handle)
+        self.assertEqual(schema["properties"]["format"]["const"], answers.FORMAT)
+        self.assertFalse(schema["additionalProperties"])
+        self.assertEqual(tuple(schema["required"]), answers.FIELDS)
+        self.assertEqual(tuple(schema["properties"]["kind"]["enum"]), answers.KINDS)
+        sentence = schema["properties"]["sentences"]["items"]
+        self.assertEqual(tuple(sentence["required"]), answers.SENTENCE_FIELDS)
+        self.assertEqual(
+            tuple(sentence["properties"]["source_class"]["enum"]), answers.SOURCE_CLASSES
+        )
+        self.assertEqual(
+            tuple(schema["properties"]["reads"]["items"]["required"]), answers.READ_FIELDS
+        )
+        self.assertEqual(
+            schema["properties"]["sentences"]["maxItems"], answers.MAX_SENTENCES
+        )
+
+
+class CliTests(AnswerFixture):
+    def test_the_cli_proves_and_refuses_an_answer(self):
+        import importlib
+
+        berean = importlib.import_module("berean")
+        from berean_lib import canonical
+
+        manifest_path = os.path.join(self.holder.name, "corpus-manifest.json")
+        corpus.write(self.manifest, manifest_path)
+        answer_path = os.path.join(self.holder.name, "answer.json")
+        with open(answer_path, "w", encoding="utf-8") as handle:
+            handle.write(canonical.dumps(self.answer()) + "\n")
+        argv = [
+            "check-answer", answer_path,
+            "--corpus", manifest_path,
+            "--root", self.root,
+            "--reads", self.reads_path,
+            "--chain-id", str(CHAIN_ID),
+            "--block-number", str(BLOCK),
+        ]
+        self.assertEqual(berean.main(argv), 0)
+        self.assertEqual(berean.main(argv[:-1] + [str(BLOCK + 1)]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/berean/tests/test_answers.py
+++ b/plugins/berean/tests/test_answers.py
@@ -228,6 +228,12 @@ class HygieneTests(AnswerFixture):
         bad["citations"].append(self.citation("Version 3 keeps it set.", "c1"))
         self.assertEqual(failures(self.check(bad)), ["answer-shape"])
 
+    def test_a_shared_citation_and_read_id_fails_the_shape(self):
+        bad = self.answer()
+        bad["reads"][0]["id"] = "c1"
+        bad["sentences"][1]["evidence"] = ["c1"]
+        self.assertEqual(failures(self.check(bad)), ["answer-shape"])
+
     def test_an_undeclared_field_fails_the_shape(self):
         bad = self.answer()
         bad["model"] = "gpt"

--- a/plugins/berean/tests/test_canonical.py
+++ b/plugins/berean/tests/test_canonical.py
@@ -1,0 +1,47 @@
+"""Canonical JSON refusals and determinism."""
+
+import unittest
+
+from tests.support import SCRIPTS  # noqa: F401  (puts scripts on sys.path)
+
+from berean_lib import BereanError, canonical
+
+
+class CanonicalTests(unittest.TestCase):
+    def test_one_spelling_sorted_and_compact(self):
+        self.assertEqual(canonical.dumps({"b": 1, "a": [1, 2]}), '{"a":[1,2],"b":1}')
+
+    def test_utf8_is_not_escaped(self):
+        self.assertEqual(canonical.dumps({"s": "café"}), '{"s":"café"}')
+
+    def test_floats_are_refused(self):
+        with self.assertRaises(BereanError):
+            canonical.dumps({"x": 1.5})
+
+    def test_nested_floats_are_refused_with_a_path(self):
+        with self.assertRaises(BereanError) as caught:
+            canonical.dumps({"a": [{"b": 2.0}]})
+        self.assertIn("$.a[0].b", str(caught.exception))
+
+    def test_non_finite_numbers_are_refused(self):
+        with self.assertRaises(BereanError):
+            canonical.dumps({"x": float("nan")})
+
+    def test_non_string_keys_are_refused(self):
+        with self.assertRaises(BereanError):
+            canonical.dumps({1: "x"})
+
+    def test_unserialisable_values_are_refused(self):
+        with self.assertRaises(BereanError):
+            canonical.dumps({"x": object()})
+
+    def test_booleans_and_integers_stay_distinct(self):
+        self.assertEqual(canonical.dumps({"a": True, "b": 1}), '{"a":true,"b":1}')
+
+    def test_encode_is_the_dumps_bytes(self):
+        value = {"k": "v"}
+        self.assertEqual(canonical.encode(value), canonical.dumps(value).encode("utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/berean/tests/test_citations.py
+++ b/plugins/berean/tests/test_citations.py
@@ -1,0 +1,166 @@
+"""Citations pass as exact bytes or fail by name."""
+
+import os
+import tempfile
+import unittest
+
+from tests.support import SCRIPTS  # noqa: F401
+
+from berean_lib import citations, corpus, digests
+from tests.test_corpus import make_tree, failures
+
+TEXT = "# Guide\n\nThe registry refuses café entries after close.\n".encode("utf-8")
+
+
+def cite(data, start, end, doc="guide.md"):
+    piece = data[start:end]
+    return {
+        "format": citations.FORMAT,
+        "doc": doc,
+        "byte_start": start,
+        "byte_end": end,
+        "sha256": digests.of_bytes(piece),
+        "display_text": piece.decode("utf-8"),
+    }
+
+
+class CitationTests(unittest.TestCase):
+    def setUp(self):
+        self.root_holder = tempfile.TemporaryDirectory()
+        self.root = self.root_holder.name
+        make_tree(self.root, {"guide.md": TEXT})
+        self.manifest = corpus.build(self.root, "v1")
+
+    def tearDown(self):
+        self.root_holder.cleanup()
+
+    def test_an_exact_span_passes_every_check(self):
+        citation = cite(TEXT, 9, 21)
+        self.assertEqual(failures(citations.check(citation, self.manifest, self.root)), [])
+
+    def test_a_multibyte_span_passes_when_whole(self):
+        start = TEXT.index("café".encode("utf-8"))
+        citation = cite(TEXT, start, start + len("café".encode("utf-8")))
+        self.assertEqual(failures(citations.check(citation, self.manifest, self.root)), [])
+        self.assertEqual(citation["display_text"], "café")
+
+    def test_a_span_splitting_a_character_fails_citation_text(self):
+        start = TEXT.index("café".encode("utf-8"))
+        citation = {
+            "format": citations.FORMAT,
+            "doc": "guide.md",
+            "byte_start": start,
+            "byte_end": start + 4,
+            "sha256": digests.of_bytes(TEXT[start:start + 4]),
+            "display_text": "caf?",
+        }
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-text"]
+        )
+
+    def test_a_wrong_digest_fails_citation_bytes(self):
+        citation = cite(TEXT, 9, 21)
+        citation["sha256"] = "0" * 64
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-bytes"]
+        )
+
+    def test_wrong_display_text_fails_citation_text(self):
+        citation = cite(TEXT, 9, 21)
+        citation["display_text"] = "something else"
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-text"]
+        )
+
+    def test_a_range_past_the_file_fails_citation_range(self):
+        citation = cite(TEXT, 0, 8)
+        citation["byte_end"] = len(TEXT) + 1
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-range"]
+        )
+
+    def test_an_empty_range_fails_the_shape(self):
+        citation = cite(TEXT, 0, 8)
+        citation["byte_end"] = 0
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-shape"]
+        )
+
+    def test_a_boolean_offset_fails_the_shape(self):
+        citation = cite(TEXT, 0, 8)
+        citation["byte_start"] = False
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-shape"]
+        )
+
+    def test_an_unpinned_document_fails_citation_doc(self):
+        citation = cite(TEXT, 0, 8, doc="elsewhere.md")
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-doc"]
+        )
+
+    def test_a_drifted_file_fails_citation_pin(self):
+        citation = cite(TEXT, 0, 8)
+        with open(os.path.join(self.root, "guide.md"), "ab") as handle:
+            handle.write(b"\n")
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-pin"]
+        )
+
+    def test_an_undeclared_field_fails_the_shape(self):
+        citation = cite(TEXT, 0, 8)
+        citation["confidence"] = "high"
+        self.assertEqual(
+            failures(citations.check(citation, self.manifest, self.root)), ["citation-shape"]
+        )
+
+
+class CliTests(unittest.TestCase):
+    def test_the_cli_proves_and_refuses_end_to_end(self):
+        import importlib
+
+        berean = importlib.import_module("berean")
+        from berean_lib import canonical
+
+        with tempfile.TemporaryDirectory() as work:
+            root = os.path.join(work, "docs")
+            make_tree(root, {"guide.md": TEXT})
+            manifest_path = os.path.join(work, "corpus-manifest.json")
+            self.assertEqual(
+                berean.main(["build-corpus", root, "--out", manifest_path]), 0
+            )
+            self.assertEqual(
+                berean.main(["verify-corpus", manifest_path, "--root", root]), 0
+            )
+            citation_path = os.path.join(work, "quote.json")
+            with open(citation_path, "w", encoding="utf-8") as handle:
+                handle.write(canonical.dumps(cite(TEXT, 9, 21)) + "\n")
+            self.assertEqual(
+                berean.main(
+                    ["check-citation", citation_path, "--corpus", manifest_path, "--root", root]
+                ),
+                0,
+            )
+            with open(os.path.join(root, "guide.md"), "wb") as handle:
+                handle.write(TEXT.replace(b"refuses", b"accepts"))
+            self.assertEqual(
+                berean.main(["verify-corpus", manifest_path, "--root", root]), 1
+            )
+            self.assertEqual(
+                berean.main(
+                    ["check-citation", citation_path, "--corpus", manifest_path, "--root", root]
+                ),
+                1,
+            )
+
+    def test_usage_errors_exit_two(self):
+        import importlib
+
+        berean = importlib.import_module("berean")
+        self.assertEqual(
+            berean.main(["verify-corpus", "/no/such/manifest.json", "--root", "/tmp"]), 2
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/berean/tests/test_corpus.py
+++ b/plugins/berean/tests/test_corpus.py
@@ -1,0 +1,148 @@
+"""Corpus build and verify, and every refusal class the pin rests on."""
+
+import json
+import os
+import tempfile
+import unittest
+
+from tests.support import SCRIPTS  # noqa: F401
+
+from berean_lib import BereanError, corpus
+
+
+def make_tree(root, files):
+    for relative, data in files.items():
+        full = os.path.join(root, *relative.split("/"))
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "wb") as handle:
+            handle.write(data)
+
+
+def failures(checks):
+    return [check.name for check in checks if not check.passed]
+
+
+TREE = {"guide/a.md": "alpha café\n".encode("utf-8"), "b.md": b"bravo\n"}
+
+
+class BuildTests(unittest.TestCase):
+    def test_build_then_verify_is_clean(self):
+        with tempfile.TemporaryDirectory() as root:
+            make_tree(root, TREE)
+            document = corpus.build(root, "v1")
+            self.assertEqual(failures(corpus.verify(document, root)), [])
+
+    def test_two_builds_are_byte_identical(self):
+        from berean_lib import canonical
+
+        with tempfile.TemporaryDirectory() as root:
+            make_tree(root, TREE)
+            one = canonical.dumps(corpus.build(root, "v1"))
+            two = canonical.dumps(corpus.build(root, "v1"))
+            self.assertEqual(one, two)
+
+    def test_an_empty_tree_is_refused(self):
+        with tempfile.TemporaryDirectory() as root:
+            with self.assertRaises(BereanError):
+                corpus.build(root, "v1")
+
+    def test_a_symlink_in_the_tree_is_refused(self):
+        with tempfile.TemporaryDirectory() as root:
+            make_tree(root, TREE)
+            os.symlink(os.path.join(root, "b.md"), os.path.join(root, "c.md"))
+            with self.assertRaises(BereanError):
+                corpus.build(root, "v1")
+
+    def test_write_stages_and_lands_whole(self):
+        with tempfile.TemporaryDirectory() as root:
+            make_tree(root, TREE)
+            out = os.path.join(root, "..", "manifest.json")
+            out = os.path.abspath(out)
+            document = corpus.build(root, "v1")
+            corpus.write(document, out)
+            with open(out, "r", encoding="utf-8") as handle:
+                self.assertEqual(json.loads(handle.read()), document)
+            staging = [n for n in os.listdir(os.path.dirname(out)) if n.endswith(".staging")]
+            self.assertEqual(staging, [])
+
+    def test_write_refuses_an_invalid_document(self):
+        with tempfile.TemporaryDirectory() as root:
+            make_tree(root, TREE)
+            document = corpus.build(root, "v1")
+            document["corpus_digest"] = "0" * 64
+            out = os.path.join(root, "manifest.json")
+            with self.assertRaises(BereanError):
+                corpus.write(document, out)
+            self.assertFalse(os.path.exists(out))
+
+
+class VerifyTests(unittest.TestCase):
+    def build(self, root):
+        make_tree(root, TREE)
+        return corpus.build(root, "v1")
+
+    def test_a_one_byte_edit_fails_corpus_bytes(self):
+        with tempfile.TemporaryDirectory() as root:
+            document = self.build(root)
+            with open(os.path.join(root, "b.md"), "wb") as handle:
+                handle.write(b"Bravo\n")
+            self.assertEqual(failures(corpus.verify(document, root)), ["corpus-bytes"])
+
+    def test_a_missing_file_fails_corpus_complete(self):
+        with tempfile.TemporaryDirectory() as root:
+            document = self.build(root)
+            os.remove(os.path.join(root, "b.md"))
+            self.assertIn("corpus-complete", failures(corpus.verify(document, root)))
+
+    def test_an_unpinned_extra_file_fails_corpus_complete(self):
+        with tempfile.TemporaryDirectory() as root:
+            document = self.build(root)
+            make_tree(root, {"extra.md": b"stray\n"})
+            self.assertEqual(failures(corpus.verify(document, root)), ["corpus-complete"])
+
+    def test_a_tampered_listing_digest_fails_the_shape(self):
+        with tempfile.TemporaryDirectory() as root:
+            document = self.build(root)
+            document["corpus_digest"] = "0" * 64
+            self.assertEqual(failures(corpus.verify(document, root)), ["manifest-shape"])
+
+    def test_an_undeclared_field_fails_the_shape(self):
+        with tempfile.TemporaryDirectory() as root:
+            document = self.build(root)
+            document["verdict"] = "fine"
+            self.assertEqual(failures(corpus.verify(document, root)), ["manifest-shape"])
+
+    def test_a_duplicate_pin_fails_the_shape(self):
+        with tempfile.TemporaryDirectory() as root:
+            document = self.build(root)
+            document["files"].append(dict(document["files"][0]))
+            self.assertEqual(failures(corpus.verify(document, root)), ["manifest-shape"])
+
+    def test_an_absolute_pinned_path_fails_the_shape(self):
+        with tempfile.TemporaryDirectory() as root:
+            document = self.build(root)
+            document["files"][0]["path"] = "/etc/passwd"
+            self.assertEqual(failures(corpus.verify(document, root)), ["manifest-shape"])
+
+
+class SchemaAgreementTests(unittest.TestCase):
+    def test_the_shipped_schema_names_the_format_and_closes_the_table(self):
+        from tests.support import SCHEMAS
+
+        with open(SCHEMAS / "corpus-manifest-v1.json", "r", encoding="utf-8") as handle:
+            schema = json.load(handle)
+        self.assertEqual(schema["properties"]["format"]["const"], corpus.FORMAT)
+        self.assertFalse(schema["additionalProperties"])
+        self.assertEqual(
+            tuple(schema["required"]), corpus.FIELDS
+        )
+        entry = schema["properties"]["files"]["items"]
+        self.assertEqual(tuple(entry["required"]), corpus.FILE_FIELDS)
+        from berean_lib import digests
+
+        self.assertEqual(entry["properties"]["bytes"]["maximum"], digests.MAX_FILE_BYTES)
+        self.assertEqual(schema["properties"]["files"]["maxItems"], digests.MAX_FILES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/berean/tests/test_corpus.py
+++ b/plugins/berean/tests/test_corpus.py
@@ -100,6 +100,17 @@ class VerifyTests(unittest.TestCase):
             make_tree(root, {"extra.md": b"stray\n"})
             self.assertEqual(failures(corpus.verify(document, root)), ["corpus-complete"])
 
+    def test_a_pinned_path_swapped_for_a_symlink_fails_corpus_bytes(self):
+        with tempfile.TemporaryDirectory() as root:
+            document = self.build(root)
+            target = os.path.join(root, "b.md")
+            os.remove(target)
+            os.symlink(os.path.join(root, "guide", "a.md"), target)
+            checks = corpus.verify(document, root)
+            self.assertEqual(failures(checks), ["corpus-bytes"])
+            detail = [c.detail for c in checks if c.name == "corpus-bytes"][0]
+            self.assertIn("symlink", detail)
+
     def test_a_tampered_listing_digest_fails_the_shape(self):
         with tempfile.TemporaryDirectory() as root:
             document = self.build(root)

--- a/plugins/berean/tests/test_digests.py
+++ b/plugins/berean/tests/test_digests.py
@@ -71,6 +71,11 @@ class JsonTests(unittest.TestCase):
         with self.assertRaises(BereanError):
             jsonio.loads('{"a": 1.5}')
 
+    def test_nan_and_infinity_constants_are_refused(self):
+        for text in ('{"a": NaN}', '{"a": Infinity}', '{"a": -Infinity}'):
+            with self.assertRaises(BereanError):
+                jsonio.loads(text)
+
     def test_depth_over_the_ceiling_is_refused(self):
         text = "[" * 40 + "]" * 40
         with self.assertRaises(BereanError):

--- a/plugins/berean/tests/test_digests.py
+++ b/plugins/berean/tests/test_digests.py
@@ -1,0 +1,108 @@
+"""Digest and untrusted-reader refusals."""
+
+import os
+import tempfile
+import unittest
+
+from tests.support import SCRIPTS  # noqa: F401
+
+from berean_lib import BereanError, digests, jsonio, paths
+
+
+class HexTests(unittest.TestCase):
+    def test_lowercase_hex_passes(self):
+        digests.check_hex("a" * 64, "digest")
+
+    def test_uppercase_hex_is_refused_not_folded(self):
+        with self.assertRaises(BereanError):
+            digests.check_hex("A" * 64, "digest")
+
+    def test_wrong_length_is_refused(self):
+        with self.assertRaises(BereanError):
+            digests.check_hex("ab", "digest")
+
+
+class FileTests(unittest.TestCase):
+    def test_symlinks_are_refused(self):
+        with tempfile.TemporaryDirectory() as root:
+            target = os.path.join(root, "real.txt")
+            with open(target, "w") as handle:
+                handle.write("x")
+            link = os.path.join(root, "link.txt")
+            os.symlink(target, link)
+            with self.assertRaises(BereanError):
+                digests.read_file(link)
+
+    def test_missing_files_are_refused(self):
+        with self.assertRaises(BereanError):
+            digests.read_file("/no/such/file")
+
+    def test_oversize_files_are_refused(self):
+        with tempfile.TemporaryDirectory() as root:
+            big = os.path.join(root, "big.bin")
+            with open(big, "wb") as handle:
+                handle.truncate(digests.MAX_FILE_BYTES + 1)
+            with self.assertRaises(BereanError):
+                digests.read_file(big)
+
+
+class ListingTests(unittest.TestCase):
+    def test_a_rename_changes_the_listing_digest(self):
+        digest = digests.of_bytes(b"same bytes")
+        one = digests.of_listing([("a.md", digest)])
+        two = digests.of_listing([("b.md", digest)])
+        self.assertNotEqual(one, two)
+
+    def test_order_does_not_change_the_listing_digest(self):
+        entries = [("a.md", digests.of_bytes(b"a")), ("b.md", digests.of_bytes(b"b"))]
+        self.assertEqual(digests.of_listing(entries), digests.of_listing(reversed(entries)))
+
+    def test_control_characters_in_paths_are_refused(self):
+        with self.assertRaises(BereanError):
+            digests.of_listing([("a\nb.md", digests.of_bytes(b"a"))])
+
+
+class JsonTests(unittest.TestCase):
+    def test_duplicate_keys_are_refused(self):
+        with self.assertRaises(BereanError):
+            jsonio.loads('{"a": 1, "a": 2}')
+
+    def test_floats_are_refused(self):
+        with self.assertRaises(BereanError):
+            jsonio.loads('{"a": 1.5}')
+
+    def test_depth_over_the_ceiling_is_refused(self):
+        text = "[" * 40 + "]" * 40
+        with self.assertRaises(BereanError):
+            jsonio.loads(text)
+
+    def test_closed_field_tables_refuse_extras_and_absences(self):
+        with self.assertRaises(BereanError):
+            jsonio.require({"a": 1, "z": 2}, ("a", "b"), "thing")
+        with self.assertRaises(BereanError):
+            jsonio.require({"a": 1}, ("a", "b"), "thing")
+
+    def test_booleans_are_not_whole_numbers(self):
+        with self.assertRaises(BereanError):
+            jsonio.whole_number(True, "count")
+
+
+class PathTests(unittest.TestCase):
+    def test_absolute_paths_are_refused(self):
+        with self.assertRaises(BereanError):
+            paths.usable("/etc/passwd")
+
+    def test_parent_traversal_is_refused(self):
+        with self.assertRaises(BereanError):
+            paths.usable("a/../b.md")
+
+    def test_backslashes_are_refused_not_normalised(self):
+        with self.assertRaises(BereanError):
+            paths.usable("a\\b.md")
+
+    def test_plain_relative_paths_pass(self):
+        self.assertEqual(paths.usable("docs/a.md"), "docs/a.md")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/berean/tests/test_reads.py
+++ b/plugins/berean/tests/test_reads.py
@@ -1,0 +1,125 @@
+"""Preserved read records: recomputed keys, closed outcomes, one spelling."""
+
+import os
+import tempfile
+import unittest
+
+from tests.support import SCRIPTS  # noqa: F401
+
+from berean_lib import BereanError, canonical, reads
+
+
+def record(method, params, result="0x01", **overrides):
+    body = {
+        "schema_version": 1,
+        "request_key": reads.request_key(method, params),
+        "method": method,
+        "params": params,
+        "required": True,
+        "evidence": "recorded-rpc",
+        "outcome": {"result": result},
+    }
+    body.update(overrides)
+    return body
+
+
+def write_reads(path, records):
+    lines = [canonical.dumps(item) for item in records]
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+
+class RequestKeyTests(unittest.TestCase):
+    def test_the_key_is_the_canonical_request_digest(self):
+        key = reads.request_key("eth_getStorageAt", ["0xabc", "0x0", "0xc7da16"])
+        self.assertRegex(key, "^[0-9a-f]{64}$")
+        again = reads.request_key("eth_getStorageAt", ["0xabc", "0x0", "0xc7da16"])
+        self.assertEqual(key, again)
+
+    def test_params_order_changes_the_key(self):
+        one = reads.request_key("m", ["a", "b"])
+        two = reads.request_key("m", ["b", "a"])
+        self.assertNotEqual(one, two)
+
+    def test_non_list_params_are_refused(self):
+        with self.assertRaises(BereanError):
+            reads.request_key("m", {"a": 1})
+
+
+class RecordTests(unittest.TestCase):
+    def test_a_preserved_record_validates(self):
+        reads.validate_record(record("eth_getCode", ["0xabc", "0xc7da16"]))
+
+    def test_a_forged_key_is_refused(self):
+        item = record("eth_getCode", ["0xabc", "0xc7da16"])
+        item["request_key"] = reads.request_key("eth_getCode", ["0xdef", "0xc7da16"])
+        with self.assertRaises(BereanError):
+            reads.validate_record(item)
+
+    def test_an_outcome_with_result_and_error_is_refused(self):
+        item = record("m", [])
+        item["outcome"] = {"result": "0x01", "error": {"code": 1, "message": "no"}}
+        with self.assertRaises(BereanError):
+            reads.validate_record(item)
+
+    def test_an_unknown_evidence_class_is_refused(self):
+        item = record("m", [], evidence="proof_backed")
+        with self.assertRaises(BereanError):
+            reads.validate_record(item)
+
+    def test_an_undeclared_field_is_refused(self):
+        item = record("m", [])
+        item["verdict"] = "fine"
+        with self.assertRaises(BereanError):
+            reads.validate_record(item)
+
+    def test_an_error_outcome_needs_code_and_message(self):
+        item = record("m", [])
+        item["outcome"] = {"error": {"code": -32070}}
+        with self.assertRaises(BereanError):
+            reads.validate_record(item)
+
+
+class FileTests(unittest.TestCase):
+    def test_a_sorted_file_loads_keyed_by_request(self):
+        with tempfile.TemporaryDirectory() as root:
+            items = sorted(
+                (record("eth_getCode", ["0xabc", "0xc7da16"]), record("eth_getStorageAt", ["0xabc", "0x0", "0xc7da16"])),
+                key=lambda item: item["request_key"],
+            )
+            path = os.path.join(root, "reads.jsonl")
+            write_reads(path, items)
+            loaded = reads.load(path)
+            self.assertEqual(sorted(loaded), [item["request_key"] for item in items])
+
+    def test_an_unsorted_file_is_refused(self):
+        with tempfile.TemporaryDirectory() as root:
+            items = sorted(
+                (record("a_method", []), record("b_method", [])),
+                key=lambda item: item["request_key"],
+                reverse=True,
+            )
+            path = os.path.join(root, "reads.jsonl")
+            write_reads(path, items)
+            with self.assertRaises(BereanError):
+                reads.load(path)
+
+    def test_a_duplicate_key_is_refused(self):
+        with tempfile.TemporaryDirectory() as root:
+            item = record("a_method", [])
+            path = os.path.join(root, "reads.jsonl")
+            write_reads(path, [item, item])
+            with self.assertRaises(BereanError):
+                reads.load(path)
+
+    def test_an_empty_file_is_refused(self):
+        with tempfile.TemporaryDirectory() as root:
+            path = os.path.join(root, "reads.jsonl")
+            with open(path, "w", encoding="utf-8"):
+                pass
+            with self.assertRaises(BereanError):
+                reads.load(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Step 3 of 6, stacked on the corpus step. berean-answer/v1 carries the specification's first five gates as far as they go mechanically: every factual sentence classified as document, chain_read, calculation or user_supplied; citations embedded and proved byte-exact against the pinned corpus; reads held to recomputed request keys, the preserved records and the declared chain and block; disagreements between a document and a later block declared with both sides named; and refusals that carry a boundary and nothing else, with the emptiness enforced.

Per-class evidence rules close the four quiet gaps a support desk hits: a document sentence must cite, a calculation must derive from evidence already in the answer, a user-supplied fact must not dress itself in an artefact, and evidence nothing cites is refused. Read records arrive in the Lazarus preservation shape, sorted and unique so one spelling of the file exists. docs/answers.md records the closed vocabularies and why they stay closed.

Audit: two rounds under "step 3" in audit/AUDIT.md. Round 1 found an id collision between the citation and read namespaces that left a calculation's evidence ambiguous, fixed with a guard test; round 2 clean.

Proof: `python3 -m unittest discover -s plugins/berean/tests -t plugins/berean` (96 green) and the root suite (34 green).

wildcat-origin: shoggoth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQm23oFLGTtJh3wtRM1ymS

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQm23oFLGTtJh3wtRM1ymS)_