### PR TITLE
Scaffold the Janus plugin, its Foundry harness, and packaging

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -135,6 +135,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Developer Tools"
+    },
+    {
+      "name": "janus",
+      "source": {
+        "source": "local",
+        "path": "./plugins/janus"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
     }
   ]
 }

--- a/.agents/skills/janus/SKILL.md
+++ b/.agents/skills/janus/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: janus
+description: Route hook-conformance work to Janus. Use it to state and enforce what a contract hook may observe and change around a host action, checked by a manifest and a stateful Foundry harness; use Fizz to generate a protocol-specific fuzz harness instead.
+---
+
+# Janus portable entrypoint
+
+<!-- marketplace-context:start -->
+## Where this sits
+
+Janus tests a contract hook at the threshold it controls: what it may observe and change before a host action, what it may change after, and what it must never touch.
+
+**Use another tool when.** Use Hexaemeron Fizz to generate a protocol-specific fuzz harness, Pandects for the economic laws a hook-driven transition must preserve, and Ariadne to carry a manifest revision and its conformance result with a release.
+
+**Current frontier.** Janus ships the Wildcat v2.5 host adapter and its seven gates against modeled hooks, and no second host adapter yet shows the manifest format holds for another callback model.
+<!-- marketplace-context:end -->
+
+Read [the Janus runtime contract](../../../plugins/janus/AGENTS.md). Use its
+selection table to choose the skill, then read that canonical `SKILL.md` in
+full and follow it.
+
+Invocation prefixes are aliases:
+
+- `/janus:janus`, `$janus`, and a plain request to check a hook's permitted
+  effects around a host action all select `janus`.
+
+The suite reaches no network and has no Solidity dependency to fetch. Running a
+host adapter's suite compiles and executes that host's modeled code locally, so
+obey the target repository's own instructions first.
+
+The canonical skill and the runtime contract are authoritative if this
+entrypoint disagrees with them.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -72,6 +72,27 @@
       ]
     },
     {
+      "name": "janus",
+      "displayName": "Janus",
+      "source": "./plugins/janus",
+      "description": "A conformance suite for what a contract hook may observe and change before and after a host action.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Wildcat Labs",
+        "url": "https://wildcat.finance"
+      },
+      "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/janus",
+      "repository": "https://github.com/wildcat-finance/skills",
+      "category": "Developer Tools",
+      "tags": [
+        "solidity",
+        "hooks",
+        "conformance",
+        "foundry",
+        "security"
+      ]
+    },
+    {
       "name": "sapheneia",
       "displayName": "Sapheneia",
       "source": "./plugins/sapheneia",

--- a/.github/workflows/janus.yml
+++ b/.github/workflows/janus.yml
@@ -1,0 +1,53 @@
+name: janus
+
+on:
+  push:
+    paths:
+      - "plugins/janus/**"
+      - ".claude-plugin/**"
+      - ".agents/**"
+      - "AGENTS.md"
+      - "tests/**"
+      - ".github/workflows/janus.yml"
+  pull_request:
+    paths:
+      - "plugins/janus/**"
+      - ".claude-plugin/**"
+      - ".agents/**"
+      - "AGENTS.md"
+      - "tests/**"
+      - ".github/workflows/janus.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  contracts:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Portable entrypoints and repository contracts
+        run: python3 -m unittest discover -s tests -v
+      - name: Janus command and manifest suite
+        run: python3 -m unittest discover -s plugins/janus/tests -t plugins/janus -v
+
+  harness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+      - name: Build with no dependency to fetch
+        run: forge build
+        working-directory: plugins/janus/harness
+      - name: The gates against ordinary and hostile hooks
+        run: forge test -vv
+        working-directory: plugins/janus/harness

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,12 @@ __pycache__/
 *.py[cod]
 .DS_Store
 
-# Foundry build output inside plugins that carry Solidity
+# Foundry build output inside plugins that carry Solidity, at the plugin root
+# or inside a nested harness directory.
 plugins/*/out/
 plugins/*/cache/
+plugins/*/harness/out/
+plugins/*/harness/cache/
 
 # Fuzzing and audit output. Depth-independent, because an engine writes these
 # beside wherever it was invoked from rather than at the plugin root: a Medusa

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,19 +7,22 @@ the canonical `SKILL.md` it names.
 
 ## Marketplace boundaries
 
-The eleven plugins form one marketplace, not eleven competing descriptions of the
-same job. Alexandria preserves lending inputs; Tabularium interprets preserved
-venue records; Probitas assembles a counterparty dossier. Lazarus preserves the
-finite historical Ethereum state and exact RPC traffic a test needs, while
-Ariadne binds a released artefact digest to its evidence. Pandects supplies
-reviewed credit laws, Hermes measures a single gas-optimisation class,
+The thirteen plugins form one marketplace, not thirteen competing descriptions
+of the same job. Alexandria preserves lending inputs; Tabularium interprets
+preserved venue records; Probitas assembles a counterparty dossier. Lazarus
+preserves the finite historical Ethereum state and exact RPC traffic a test
+needs, while Ariadne binds a released artefact digest to its evidence. Pandects
+supplies reviewed credit laws, Hermes measures a single gas-optimisation class,
 Hexaemeron controls a receipted delivery loop and holds each of its phases to a
 named skill, while Lemma stops after producing
-source-linked chunks. Sapheneia shapes the agent's own replies for AuDHD
-readers without changing another skill's facts or gates. Brevitas controls the
-volume and structure of engineering prose after vocabulary and register passes.
-If a request crosses one of those boundaries, hand it to the named sibling
-rather than broadening the selected skill.
+source-linked chunks. Horos decides what an agent does not read. Janus checks
+what a contract hook may observe and change around a host action, where
+Pandects supplies the economic laws such a transition must preserve. Sapheneia
+shapes the agent's own replies for AuDHD readers without changing another
+skill's facts or gates. Brevitas controls the volume and structure of
+engineering prose after vocabulary and register passes. If a request crosses one
+of those boundaries, hand it to the named sibling rather than broadening the
+selected skill.
 
 ## Repository map
 
@@ -35,6 +38,10 @@ rather than broadening the selected skill.
 - Hexaemeron is under `plugins/hexaemeron/`. Read
   `plugins/hexaemeron/AGENTS.md` before running one of its skills or changing
   that plugin.
+- Horos is under `plugins/horos/`. Read `plugins/horos/AGENTS.md` before
+  running its skill or changing that plugin.
+- Janus is under `plugins/janus/`. Read `plugins/janus/AGENTS.md` before
+  running its skill or changing that plugin.
 - Lemma is under `plugins/lemma/`. Read `plugins/lemma/AGENTS.md` before
   running its skill or changing that plugin.
 - Lazarus is under `plugins/lazarus/`. Read `plugins/lazarus/AGENTS.md` before

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ repository's token sinks with evidence and emits the boundary agents consult
 before reading, so the budget goes to the code that matters.
 
 
+### Janus
+
+[Janus](./plugins/janus) tests a contract hook at the threshold it controls:
+what it may observe and change before a host action, what it may change after,
+and what it must never touch. A host adapter and a JSON manifest state the
+permitted effects; a stateful Foundry harness records the real storage writes,
+call targets, value movements and gas across each threshold and fails when the
+delta exceeds the manifest. The first adapter is Wildcat's v2.5 market hooks.
+
+
 ### Lemma
 
 [Lemma](./plugins/lemma) turns Solidity compiler inputs and Markdown documents
@@ -95,14 +105,14 @@ another person can rebuild after the endpoint that served them is gone.
 
 Scored out of 10 for doing the job, not for reading the output. A marketer can quote a verified gas number without having any use for Hermes itself.
 
-| Role | Alexandria | Ariadne | Brevitas | Hermes | Hexaemeron | Horos | Lemma | Lazarus | Pandects | Probitas | Sapheneia | Tabularium |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Developers | 8 | 8 | 8 | 9 | 9 | 8 | 6 | 8 | 8 | 4 | 8 | 7 |
-| Security and audit | 8 | 9 | 10 | 7 | 8 | 2 | 4 | 8 | 9 | 5 | 7 | 7 |
-| Marketing | 1 | 1 | 1 | 3 | 6 | 1 | 1 | 1 | 1 | 1 | 3 | 1 |
-| Business development | 6 | 2 | 2 | 2 | 5 | 1 | 1 | 2 | 2 | 9 | 4 | 3 |
-| Finance | 8 | 1 | 2 | 3 | 4 | 1 | 1 | 2 | 2 | 7 | 4 | 7 |
-| Legal | 3 | 3 | 2 | 1 | 4 | 1 | 1 | 2 | 2 | 4 | 4 | 2 |
+| Role | Alexandria | Ariadne | Brevitas | Hermes | Hexaemeron | Horos | Janus | Lemma | Lazarus | Pandects | Probitas | Sapheneia | Tabularium |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Developers | 8 | 8 | 8 | 9 | 9 | 8 | 8 | 6 | 8 | 8 | 4 | 8 | 7 |
+| Security and audit | 8 | 9 | 10 | 7 | 8 | 2 | 9 | 4 | 8 | 9 | 5 | 7 | 7 |
+| Marketing | 1 | 1 | 1 | 3 | 6 | 1 | 1 | 1 | 1 | 1 | 1 | 3 | 1 |
+| Business development | 6 | 2 | 2 | 2 | 5 | 1 | 2 | 1 | 2 | 2 | 9 | 4 | 3 |
+| Finance | 8 | 1 | 2 | 3 | 4 | 1 | 1 | 1 | 2 | 2 | 7 | 4 | 7 |
+| Legal | 3 | 3 | 2 | 1 | 4 | 1 | 2 | 1 | 2 | 2 | 4 | 4 | 2 |
 
 Five is the barrier. At or above it, the plugin's entry carries a worked example of what that role would use it for. Below it there is no example, because there is no honest one to give. These are engineering tools, and a 2 means we could not find a reason for that desk to open the plugin rather than read what it produced.
 
@@ -118,6 +128,7 @@ The short map of what each plugin does and what is honestly left to build.
 | [Hermes](./plugins/hermes) | Measuring one Solidity gas-optimisation class through fail-closed Foundry checks. | No complete, reproducible live Wildcat evidence bundle is published. |
 | [Hexaemeron](./plugins/hexaemeron) | Running an explicit, receipted delivery loop, ranking frontier work with Kronos, or using its fuzzing, audit and prose skills separately. | The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery. |
 | [Horos](./plugins/horos) | Classifying a repository's token sinks with evidence and emitting the reading boundary agents respect. | The reopened scope is complete: the three home repositories carry graded boundaries, candidates, censuses and adoption stanzas, with the product pull requests awaiting their own review gates; no evidenced improvement remains. |
+| [Janus](./plugins/janus) | Stating and enforcing what a contract hook may observe and change around a host action, checked by a manifest and a stateful Foundry harness. | Janus ships the Wildcat v2.5 host adapter and its seven gates against modeled hooks, and no second host adapter yet shows the manifest format holds for another callback model. |
 | [Lemma](./plugins/lemma) | Producing source-linked chunks from Solidity compiler inputs or Markdown. | Callable-surface ABI validation does not independently check return types or state mutability. |
 | [Lazarus](./plugins/lazarus) | Capturing a finite fixed-block Ethereum fixture, checking proof-backed state, replaying exact requests without fallback, and releasing the fixture with a statement a stranger can check. | Receipts and logs are recorded RPC evidence only; nothing proves them against the captured header's receiptsRoot. |
 | [Pandects](./plugins/pandects) | Supplying executable credit laws, broken specimens and reduced counterexamples. | The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records. |
@@ -154,6 +165,7 @@ Add the same marketplace and install a plugin from inside Claude Code:
 /plugin install brevitas@wildcat-labs
 /plugin install hermes@wildcat-labs
 /plugin install hexaemeron@wildcat-labs
+/plugin install janus@wildcat-labs
 /plugin install lemma@wildcat-labs
 /plugin install lazarus@wildcat-labs
 /plugin install pandects@wildcat-labs
@@ -175,6 +187,7 @@ Claude namespaces plugin skills, so each entry skill answers as:
 /hermes:hermes
 /hexaemeron:fiat "<topic>"
 /hexaemeron:kronos
+/janus:janus
 /lemma:chunk
 /lazarus:lazarus
 /pandects:pandects
@@ -228,6 +241,7 @@ Use Hexaemeron Phylax to harden the off-chain surface of this change.
 Use Hexaemeron Ephoros to choose the events, metrics and alerts this step must emit.
 Use Hexaemeron Metron to baseline this slow path, change one thing and keep or revert on the numbers.
 Use Hexaemeron Hypomnema to record this decision where the next person will find it.
+Use Janus to check what this hook may observe and change around a host action, against a conformance manifest.
 Use Lemma to chunk this Solidity standard input into JSONL.
 Use Lazarus to capture, verify or replay this finite historical Ethereum fixture.
 Use Pandects to check this credit protocol against the executable laws in the corpus.
@@ -440,6 +454,7 @@ Every plugin has that shape. What each adds beyond it:
 | Brevitas | `brevitas` | evals |
 | Hermes | `hermes` | references and scripts inside the skill |
 | Hexaemeron | `fiat`, `kronos`, `imprimatur`, `vulgate`, the vendored `x-ray`, `solidity-auditor` and `fizz`, and `protasis`, `elenchus`, `phylax`, `ephoros`, `metron`, `hypomnema` | agents, audit, docs |
+| Janus | `janus` | a Foundry harness, hook-manifest schema, hostile reference hooks, the Wildcat host adapter, scripts |
 | Lazarus | `lazarus` | docs, examples, schemas, scripts, pinned requirements |
 | Lemma | `chunk` | chunkers, baseline, schema, solc container, tools |
 | Pandects | `pandects` | Solidity under `src` and `test`, adapters, catalogue, specimens, integrations, audit |

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4436,3 +4436,39 @@ resolves: `docs/commons/janus.md` exists on this branch at the pinned digest.
 The edited README scores 100/100 under imprimatur with no defects.
 
 Leads not pursued: none.
+
+# Run: build the Janus hook-conformance suite against the Wildcat v2.5 hooks
+
+## Step 1, round 1 -- 2026-08-20
+
+Scaffold step. The security_suite receipt lists the bundled Pashov ids; this
+round applies them proportionately to what the step actually ships.
+`solidity-auditor` was run over the step's Solidity, its own exclude pattern
+skipping `*.t.sol`. The two remaining files are `harness/src/Vm.sol` (a
+cheatcode interface declaration with no logic) and `harness/src/JanusBase.sol`
+(an abstract test base of pure `require` assertions). Neither holds state,
+makes an external call, moves value, uses assembly, delegatecall, payable, or
+selfdestruct. `foundry.toml` leaves `ffi` unset (default false) and scopes
+`fs_permissions` to read `./manifests` and `./examples` and read-write `./out`.
+
+`x-ray` and `fizz` are deferred with reason, not run: x-ray produces a
+pre-audit readiness report over a protocol's entry points, state transitions
+and value flow, and this step ships none of those; fizz builds an invariant
+fuzz suite over shipped contracts, and the harness gates and invariants arrive
+in steps 4 and 5. Both apply there, against the Wildcat host model, the gate
+engine and the hostile hooks, and are recorded when they run.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | none | -- |
+
+The risk-register look went at the one boundary this step opens, the harness
+filesystem and cheatcode surface (phylax). It is closed: no `ffi`, no network,
+`fs_permissions` scoped to the plugin's own directories, no absolute paths.
+`forge build` and `forge test` pass; the repository packaging suite passes at
+thirteen plugins; the Janus Python suite passes; every shipped document lints
+100/100. One `forge lint` advisory remains, `screaming-snake-case-const` on the
+`vm` constant in `JanusBase.sol`; it is kept lowercase deliberately, matching
+the ecosystem-standard `forge-std` cheatcode handle, and is not a defect.
+
+Leads not pursued: none.

--- a/docs/janus-suite/runbook.md
+++ b/docs/janus-suite/runbook.md
@@ -1,0 +1,211 @@
+# Runbook: Build the Janus hook-conformance suite against the Wildcat v2.5 hooks
+
+Derived from the study beside this file. One module, the `janus` plugin,
+sliced into six stacked steps. Each is one pull request, green at both ends.
+Step 1 scaffolds the plugin, its Foundry harness, and every packaging
+contract, and commits the study and runbook. The last step runs the whole
+demo path from the study's problem statement and deletes the anchor spec.
+
+Dependency order: packaging and toolchain first, then the manifest format,
+then the recorder that reads real deltas, then the faithful host model that an
+honest hook passes, then the hostile hooks and the gate engine that catch
+each failure, then the reports and the end-to-end demonstration.
+
+Each Solidity step incurs the full audit suite because the run ships
+Solidity. The Disciplines line on each step names why the five phase skills
+apply.
+
+## Step 1: Scaffold the janus plugin, harness, and packaging
+
+**Goal.** A thirteenth plugin `janus` exists with every host manifest,
+portable entry, ledger, landing prose, and a compiling Foundry harness that
+runs one trivial passing test; the repository suite and the new CI workflow
+are green.
+
+**Entry.** Run branch `claude/janus-wildcat-skill-bejdy0` at `1fc9f6a`.
+
+**Exit.** `python3 -m unittest discover -s tests` passes with `janus` added to
+every packaging surface; `forge build` and `forge test` pass in
+`plugins/janus/harness`; `python3 -m unittest discover -s plugins/janus/tests
+-t plugins/janus` passes; the imprimatur lint scores every new document clean;
+`.github/workflows/janus.yml` mirrors the Pandects Python-and-Foundry shape.
+
+**Files.** `plugins/janus/.claude-plugin/plugin.json`,
+`plugins/janus/.codex-plugin/plugin.json`, `plugins/janus/AGENTS.md`,
+`plugins/janus/README.md`, `plugins/janus/skills/janus/SKILL.md`,
+`plugins/janus/skills/janus/EVOLUTION.md`, `plugins/janus/tests/` (a Python
+placeholder suite), `plugins/janus/harness/foundry.toml`,
+`plugins/janus/harness/src/Vm.sol` (minimal cheatcode interface),
+`plugins/janus/harness/src/JanusBase.sol` (test base, no forge-std),
+`plugins/janus/harness/test/Scaffold.t.sol`, `.claude-plugin/marketplace.json`,
+`.agents/plugins/marketplace.json`, `.agents/skills/janus/SKILL.md`,
+`AGENTS.md`, `README.md`, `.github/workflows/janus.yml`,
+`tests/test_marketplace_prose.py` (PLUGINS 12 to 13, landings count),
+plus `docs/janus-suite/study.md` and `docs/janus-suite/runbook.md`.
+
+**Tests.** No new gates yet: one trivial `forge test` proving the harness
+compiles and the minimal `Vm` interface links, and a Python placeholder suite
+that imports the (empty) validator module. The repository packaging suite is
+the real check that the thirteenth plugin is wired on every surface.
+
+**Disciplines.** phylax: the harness declares `fs_permissions` and a cheatcode
+surface; this step opens that boundary and must scope it. ephoros: none, the
+scaffold emits no signals yet. metron: none, no performance claim. elenchus:
+any packaging-test failure is worked to cause here. hypomnema: the ledger is
+created at baseline and the design decisions get their home in the committed
+study and the plugin design doc.
+
+## Step 2: Hook-manifest schema and validator
+
+**Goal.** A JSON Schema for a hook manifest and a Python validator that
+accepts a well-formed manifest and rejects an under-specified or malformed
+one.
+
+**Entry.** Step 1 exit state, on a branch from step 1.
+
+**Exit.** `python3 plugins/janus/scripts/janus.py validate <manifest>` exits 0
+on the example honest manifest and non-zero with a named reason on each
+malformed fixture; `python3 -m unittest discover -s plugins/janus/tests -t
+plugins/janus` passes; both repository and harness suites stay green.
+
+**Files.** `plugins/janus/harness/schemas/hook-manifest.schema.json`,
+`plugins/janus/scripts/janus.py` (the `validate` subcommand),
+`plugins/janus/harness/manifests/wildcat-open-term.json` (example honest
+manifest), `plugins/janus/tests/test_validator.py`,
+`plugins/janus/tests/fixtures/` (malformed manifests).
+
+**Tests.** Python unit tests: one valid manifest passes; fixtures that omit a
+required enumeration, permit an unbounded effect, or break the JSON each fail
+with a distinct code.
+
+**Disciplines.** phylax: the validator parses untrusted JSON; this is the
+manifest-ingestion boundary. ephoros: none. metron: none. elenchus: a
+validator verdict it did not earn is worked to cause. hypomnema: the schema's
+enumerations are the manifest format other tools will cite; the field set is
+recorded in the design doc.
+
+## Step 3: Host-adapter interface and state-delta recorder
+
+**Goal.** A Solidity host-adapter interface and a state-delta recorder that
+captures storage writes, external call targets, value movements, and gas
+across a threshold, proven by unit tests against a fixture host.
+
+**Entry.** Step 2 exit state, on a branch from step 2.
+
+**Exit.** `forge test` in the harness passes recorder unit tests that show
+each effect class is captured and that an unrecorded effect fails closed;
+repository and Python suites stay green.
+
+**Files.** `plugins/janus/harness/src/HostAdapter.sol` (abstract interface),
+`plugins/janus/harness/src/StateDeltaRecorder.sol`,
+`plugins/janus/harness/test/StateDeltaRecorder.t.sol`, a small fixture host
+under `plugins/janus/harness/test/fixtures/`.
+
+**Tests.** Recorder tests: a write inside the threshold is captured; an
+external call target is captured; a value movement is captured; a gas figure
+is recorded; an effect the recorder cannot classify is reported as a
+violation, not ignored.
+
+**Disciplines.** phylax: the recorder is the boundary between observed reality
+and the gate verdict; a blind spot is a false pass. ephoros: the recorder is
+where the per-finding delta fields originate. metron: none. elenchus: a missed
+effect is the failure to guard against. hypomnema: the recorder's captured
+effect classes are recorded, since a later effect class not captured is a
+silent hole.
+
+## Step 4: Wildcat host model and the honest-hook conformance path
+
+**Goal.** A faithful in-tree model of the v2.5 market-to-hook seam, an honest
+Wildcat-shaped hook, its manifest, and a conformance run in which the honest
+hook passes every applicable gate, including exit liveness.
+
+**Entry.** Step 3 exit state, on a branch from step 3.
+
+**Exit.** `forge test` passes: a fidelity test pins the model's call primitive
+against the cited v2.5 convention (all-gas call, zero value, bubbled revert,
+the value-returning APR hook's `>= 0x40` return contract, the appended
+extraData tail, the global reentrancy guard); the honest hook passes gates 1
+through 7 over ordinary sequences; an exit-liveness scenario shows a
+known-lender can still queue and execute a withdrawal after a credential
+lapses and after a provider is removed. Repository and Python suites stay
+green.
+
+**Files.** `plugins/janus/harness/src/wildcat/WildcatHostModel.sol`,
+`plugins/janus/harness/src/wildcat/HonestAccessHook.sol`,
+`plugins/janus/harness/manifests/wildcat-open-term.json` (completed),
+`plugins/janus/harness/test/WildcatConformance.t.sol`,
+`plugins/janus/harness/src/JanusHarness.sol` (the gate engine, honest path).
+
+**Tests.** The fidelity test; the honest-hook pass over each applicable gate;
+the exit-liveness scenarios (credential expiry, provider removal). Every
+modeled behaviour cites its source line in a comment.
+
+**Disciplines.** phylax: the model opens the external-call surface a hook can
+abuse; the honest path establishes the baseline the hostile hooks violate.
+ephoros: the pass report emits the manifest revision and sequence count.
+metron: none. elenchus: a fidelity gap is worked to the cited source.
+hypomnema: model-versus-host divergence risk is recorded beside the fidelity
+test.
+
+## Step 5: Hostile reference hooks and the gate engine
+
+**Goal.** Five hostile reference hooks, one per failure class, and the gate
+engine that catches each with the gate that owns it.
+
+**Entry.** Step 4 exit state, on a branch from step 4.
+
+**Exit.** `forge test` passes: each hostile hook is caught, and by the correct
+gate. Callback re-entry is caught by gate 6; gas grief by gate 5; value
+redirection by gate 2; storage mutation outside declared slots by gate 1;
+stale authorisation by gate 3 or 4 as the manifest declares. A conformance run
+that exercised zero sequences fails. Repository and Python suites stay green.
+
+**Files.** `plugins/janus/harness/src/hostile/ReentryHook.sol`,
+`GasGriefHook.sol`, `ValueRedirectHook.sol`, `StorageMutationHook.sol`,
+`StaleAuthHook.sol`, `plugins/janus/harness/test/HostileHooks.t.sol`,
+`plugins/janus/harness/src/JanusHarness.sol` (gate engine completed),
+findings emission via `writeFile`.
+
+**Tests.** One test per hostile hook asserting the specific gate id fires and
+no other gate fires incidentally; a non-zero-sequence assertion; a
+stateful-fuzz handler that keeps a hostile hook in the loop and asserts the
+gate holds.
+
+**Disciplines.** phylax: the hostile hooks are the boundary probes; each must
+fail closed. ephoros: each finding names gate, rule, action, and delta.
+metron: none. elenchus: a hostile hook that passes, or is caught by the wrong
+gate, is worked to cause. hypomnema: the gate-to-failure-class mapping is
+recorded, since it is the suite's contract.
+
+## Step 6: Reports, the demo path, and retiring the anchor
+
+**Goal.** Human-readable and SARIF reports from the findings artifact, the
+full demo path passing end to end, and the anchor `docs/commons/janus.md`
+deleted with the Commons pointer updated.
+
+**Entry.** Step 5 exit state, on a branch from step 5.
+
+**Exit.** `python3 plugins/janus/scripts/janus.py report` produces a human
+markdown report and a SARIF 2.1.0 file from the sample findings, each finding
+linking a gate and manifest rule to a trace; the Python suite validates the
+SARIF shape; the whole study demo path passes; `docs/commons/janus.md` is
+removed and the README Commons entry points at the shipped plugin instead;
+`docs/commons/` is deleted if empty; repository, harness, and Python suites
+all green.
+
+**Files.** `plugins/janus/scripts/janus.py` (the `report` subcommand),
+`plugins/janus/examples/findings.sample.json`,
+`plugins/janus/tests/test_reporter.py`, `plugins/janus/README.md` and
+`docs/janus-suite/` (final prose), `README.md` (Commons entry retargeted),
+removal of `docs/commons/janus.md`.
+
+**Tests.** Reporter tests: the sample findings render to human markdown and to
+schema-valid SARIF; a clean run renders an empty-findings report that states
+the manifest revision and sequence count.
+
+**Disciplines.** phylax: the reporter writes files; the output path is scoped.
+ephoros: the report is the run's evidence surface; this step finalises its
+fields. metron: none. elenchus: a malformed SARIF is worked to cause.
+hypomnema: retiring the anchor and repointing the Commons entry is the last
+recorded decision; the plugin's landing prose replaces the spec as the
+reader's entry point.

--- a/docs/janus-suite/study.md
+++ b/docs/janus-suite/study.md
@@ -1,0 +1,339 @@
+# Study: Build the Janus hook-conformance suite against the Wildcat v2.5 hooks
+
+**Run branch:** `claude/janus-wildcat-skill-bejdy0`, cut from `main` at
+`1fc9f6a7a649fd0d1c495d639d6b971e1055a050`. That SHA is the run's real start.
+
+**Anchor commit:** `wildcat-finance/v2-protocol` branch
+`feat/v2.5-events-data-model`, HEAD
+`9716e78e345a84fa1491c794aa5ae162790ce378`, the likely head of the V2.5
+release. All hook mechanics cited below are read from that tree.
+
+Assuming, unless corrected:
+
+1. "Build the Janus skill" means shipping a real, installable Janus plugin
+   whose Foundry harness runs and enforces the seven gates, not another
+   specification document. The delivered `docs/commons/janus.md` is the
+   anchor and is deleted at the end of the run, as instructed.
+2. Janus does not compile the live v2-protocol. That tree's `lib/`
+   submodules are unpopulated in a shallow clone and its own `forge build`
+   fails without eight submodule fetches. Janus instead models the v2.5
+   market-to-hook seam faithfully in-tree and cites the exact source
+   `file:line` for every modeled behaviour. This is also the correct design:
+   a suite that needs the whole host to compile cannot serve "any host", which
+   is the stated public goal.
+3. Foundry and solc are available. This environment blocks the usual
+   installer domains, so `forge` 1.5.1 and `solc` 0.8.25 were fetched from
+   GitHub release assets; both work. CI uses `foundry-rs/foundry-toolchain`,
+   which fetches solc normally.
+4. Janus ships with no external Solidity dependency, matching Pandects:
+   `libs = []`, no `forge-std`. It declares the minimal `Vm` cheatcode
+   interface it needs (`record`, `accesses`, `getRecordedLogs`,
+   `snapshotState`, `revertToState`, `readFile`, `writeFile`, `parseJson`)
+   in-tree.
+5. Python 3.9+ and stdlib only for the manifest validator and the reporter,
+   matching the repository's other Python tools and its 3.9/3.13 CI matrix.
+6. Janus becomes the repository's thirteenth plugin. The first janus run
+   deliberately kept it a spec because it was unbuilt; building it is exactly
+   the condition under which it earns an install surface.
+7. This runtime has no `gh`; pull requests and merges use the GitHub MCP
+   tools. The `origin:ai` label exists and HTML comments are stripped from PR
+   bodies, so the `wildcat-origin: shoggoth` marker is stated as a visible
+   line.
+
+## 1. Problem statement
+
+Wildcat's v2.5 markets call a configured hooks contract around eleven market
+actions. The interface (`src/access/IHooks.sol`) says which functions exist. It does not say what a hook may observe, what it may change, what it must
+never touch, or that a user can still exit after a credential lapses or a
+provider is removed. That policy is spread across implementation code, comments, and
+the assumptions of whoever wrote the first template. A new hook can satisfy
+the ABI and still redirect value, grief gas, re-enter, or strand a lender.
+
+Janus is a conformance suite that states, in a machine-readable manifest,
+what a hook may observe and change before and after a host action, and a
+harness that drives ordinary and hostile sequences, records the real
+state delta at each threshold, and fails when the delta exceeds the manifest.
+The first host adapter is Wildcat's v2.5 seam; the format is host-neutral so
+another host can declare its own boundary without either host claiming the
+other's guarantees.
+
+A working prototype here means: the Janus plugin installs like the other
+twelve, its harness runs offline, an honest Wildcat-shaped hook passes every
+applicable gate, and each of five hostile reference hooks is caught by the
+gate that owns its failure. The demo path proves it:
+
+```text
+# in plugins/janus/harness
+forge build
+forge test -vv
+# from repo root
+python3 plugins/janus/scripts/janus.py validate plugins/janus/harness/manifests/*.json
+python3 plugins/janus/scripts/janus.py report --findings plugins/janus/examples/findings.sample.json \
+  --md /tmp/janus.md --sarif /tmp/janus.sarif
+python3 -m unittest discover -s plugins/janus/tests -t plugins/janus
+python3 -m unittest discover -s tests
+```
+
+## 2. Prior art
+
+In v2-protocol at the anchor commit:
+
+- `src/access/IHooks.sol`: eleven action callbacks, `onDeposit`,
+  `onQueueWithdrawal`, `onExecuteWithdrawal`, `onTransfer`, `onBorrow`,
+  `onRepay`, `onCloseMarket`, `onNukeFromOrbit`, `onSetMaxTotalSupply`,
+  `onSetAnnualInterestAndReserveRatioBips`, `onSetProtocolFeeBips`, plus
+  `onCreateMarket`, `version()`, `config()`.
+- `src/types/HooksConfig.sol`: the hand-built calldata for each hook.
+  `_callHook` (lines 88-106) forwards all remaining gas with `call(gas(),
+  target, 0, ...)`, sends zero value, discards success return data, and
+  re-reverts the hook's exact revert bytes. `onSetAnnualInterestAndReserve
+  RatioBips` (741-808) is the one value-returning hook: it requires
+  `returndatasize() >= 0x40`, masks each returned word to `uint16`, and the
+  market applies them within bounds (`WildcatMarketConfig.sol:131-168`).
+- `src/access/OpenTermHooks.sol`, `FixedTermHooks.sol`,
+  `PeriodicTermHooks.sol`, `BaseAccessControls.sol`,
+  `MarketConstraintHooks.sol`: the maintained templates. Storage written
+  during hooks is in the hooks contract, keyed by lender or market
+  (`_lenderStatus`, `isKnownLenderOnMarket`, `_hookedMarkets`,
+  `temporaryExcessReserveRatio`). The known-lender bit is monotone: set on a
+  credentialled deposit or a received transfer, never cleared. It is the exit
+  key, because `onExecuteWithdrawal` is never enabled by any template.
+- The exit path: `onQueueWithdrawal` gates on known-lender-or-credential;
+  `onExecuteWithdrawal` is an empty body in every template. So once a
+  withdrawal is queued, execution is not hook-gated.
+- Re-entry: every market entry point is `nonReentrant` on a single global
+  transient flag (`src/ReentrancyGuard.sol`), and market views are
+  `nonReentrantView`. A hook cannot re-enter the market. It can re-enter the
+  hooks contract and call other contracts through role-provider calls
+  (`BaseAccessControls._tryValidateCredential`, an all-gas `call` to a
+  caller-influenced provider address).
+- Value: no market function is `payable`; no ETH, token, or approval ever
+  flows to a hook; the hook is never granted a market role. The hook's only
+  powers are veto and the returned APR/reserve pair.
+- The v2.5 ABI cut: `onExecuteWithdrawal` now takes the exact batch `expiry`
+  (`docs/v2.5-audit-delta.md`, `docs/hooks/How Hooks Work.md:20`). A separate
+  one-method interface `IPeriodicTermAprReductionHooks`
+  (`WildcatMarketConfig.sol:7-11`) is called from the permissionless
+  `executePendingAnnualInterestBipsReduction`, gated by config bit 84.
+- Existing tests: `test/shared/mocks/MockHooks.sol` records `keccak256(msg.
+  data)` and emits per-hook events; `RevertingHooks.sol` toggles a revert.
+  There is no reentrant hook, no gas-grief hook, no authority-escalation
+  hook, and no hostile hook inside a stateful fuzz loop. That absence is Janus's
+  reason to exist beyond the host's own suite.
+
+In this repository:
+
+- `plugins/pandects/`: the model for a Solidity plugin here, `foundry.toml`
+  with `libs = []`, tests that import only its own contracts, and a
+  `.github/workflows/pandects.yml` with a Python job and a Foundry job.
+- `docs/commons/janus.md`: the anchor spec, deleted at run end.
+- `tests/test_marketplace_prose.py`, `test_portable_skills.py`,
+  `test_version_propagation.py`, `test_evolution_contract.py`,
+  `test_shipped_prose_lints.py`: the packaging contracts a new plugin must
+  satisfy. Notably `PLUGINS` is a hardcoded 12-tuple and
+  `test_plugin_landing_readmes...` asserts `len(landings) == 12`; both bump to
+  13.
+
+Outside: [ERC-7579](https://eips.ethereum.org/EIPS/eip-7579), the second hook
+architecture named by the spec, deferred and explicitly not sharing claims
+with Wildcat's hooks. SARIF 2.1.0 for the machine-readable report.
+
+## 3. Constraints and non-goals
+
+Constraints: run base `1fc9f6a` on `main`; anchor `9716e78` on v2-protocol;
+Foundry with `solc = 0.8.25`, `evm_version = cancun`; `libs = []`; Python
+stdlib only; every shipped document lint-clean; the harness and Python tests
+green in a new CI workflow mirroring Pandects; the repository's twelve
+packaging tests updated to thirteen and kept green.
+
+Non-goals, deferred past this prototype and recorded in Janus's `EVOLUTION.md`
+as the held frontier: a second host adapter (the spec says one ships "only
+after the generic boundary survives the Wildcat implementation"); an
+ERC-7579 adapter; binding the harness to a live-compiled v2-protocol;
+`Pandects`-driven economic properties across hook transitions and `Fizz`
+sequence generation (named as future integration, not built now); an Ariadne
+release statement for a manifest revision.
+
+## 4. Design options
+
+The topic is one capability, a conformance harness, so it is one module and
+goes straight to a study; the runbook slices it into stepped pull requests.
+The design choice is how the harness reaches the host.
+
+1. **Compile and drive the live v2-protocol.** Highest fidelity: tests run
+   against the real market and templates. Trades away the stated public goal
+   and this environment's reach. It couples Janus to one host's full build,
+   needs eight submodule fetches that fail offline, and makes "any host can
+   declare its boundary" false. Rejected.
+2. **Model the v2.5 seam in-tree behind a host-adapter interface, manifest in
+   JSON, recorder and harness in Solidity, reporter in Python.** The harness
+   drives a faithful minimal market that calls hooks exactly as
+   `HooksConfig.sol` does, all-gas `call`, zero value, bubbled revert, the
+   value-returning APR hook with its `>= 0x40` return contract, the appended
+   `extraData` tail, the global `nonReentrant` guard, the monotone
+   known-lender exit bit. Every modeled behaviour cites its source line, and a
+   fidelity test pins the call primitive against the documented convention.
+   Trades away catching a drift between the model and the real contracts;
+   mitigated by the citations and the fidelity test, and honestly recorded.
+   Chosen: it is the cheapest construction to comprehend that still meets the
+   problem statement and the host-neutral goal, and it runs offline like every
+   other plugin here.
+3. **Pure Python simulation of the seam.** No Foundry, no real EVM. Rejected:
+   the spec names a "stateful Foundry harness", gas grief and re-entry are EVM
+   behaviours a Python model would fake, and the recorder needs real
+   cheatcodes (`vm.record`, `vm.accesses`) to observe storage writes.
+4. **Manifest as Solidity structs rather than JSON.** Rejected: the spec names
+   a "hook-manifest schema" and a machine-readable report; JSON Schema gives a
+   host-neutral, validator-checkable format the reporter can also consume, and
+   Foundry reads it through `vm.parseJson`.
+
+## 5. Risk register seed
+
+What the audit loop should look hardest at. The worst outcome of a
+conformance tool is a false pass: a hook that violates the boundary while
+Janus reports conformant.
+
+- **Recorder blind spots.** If the state-delta recorder misses a storage
+  write, an external call, or a value movement, a hostile hook passes. The
+  recorder is what every gate trusts, so its own tests must prove it catches
+  each effect class, and each hostile hook must be caught by the specific gate that owns
+  its failure, not incidentally by another.
+- **Model infidelity.** If the modeled seam diverges from the real v2.5 call
+  convention, a gate proven here need not hold on Wildcat. The fidelity test
+  pins the call primitive (gas, value, revert bubbling, return-data contract,
+  extraData tail) against the cited source.
+- **Manifest under-specification.** A manifest that permits "any storage
+  write" makes gate 1 vacuous. The schema must force enumeration; an omitted
+  slot, target, or movement is forbidden, not implicitly allowed (gate 1).
+- **Liveness overclaim.** A bounded exit test does not prove an exit always
+  completes. The report must state exit liveness as "held over the tested
+  scenarios", never as a proof (open question 4 in the spec).
+- **FFI and filesystem.** The harness reads manifests and writes findings
+  through cheatcodes. `fs_permissions` must be scoped to the plugin's own
+  directories; no `vm.ffi`, no network, no absolute paths.
+- **Packaging regressions.** Adding a thirteenth plugin touches the
+  marketplace manifests, the README's five tables, the portable layer, and
+  four packaging tests. A missed surface fails CI; the audit look covers every
+  surface the tests enumerate.
+
+## 6. Glossary seeds
+
+- Host action: a market operation a hook runs around, such as deposit or
+  queueWithdrawal.
+- Threshold: the before-and-after boundary of one host action, where the hook
+  runs and where Janus snapshots state.
+- Hook manifest: the JSON declaration of what a hook may observe and change at
+  each threshold, plus its rollback rule, gas budget, and exit liveness
+  conditions.
+- Host adapter: the piece that exposes one host's actions, state readers, and
+  economic roles to the harness, and that limits every result to that host.
+- State delta: the recorded difference across a threshold, storage writes,
+  external call targets, value movements, gas consumed.
+- Gate: one of the seven conformance properties the harness checks.
+- Hostile reference hook: a deliberately non-conformant hook that exercises
+  one failure class so the matching gate is proven to catch it.
+- Known-lender bit: Wildcat's monotone per-market flag that keeps the
+  withdrawal exit open after a credential lapses.
+
+## 7. Sources
+
+- v2-protocol `feat/v2.5-events-data-model` @ `9716e78`:
+  `src/access/IHooks.sol`, `src/types/HooksConfig.sol`,
+  `src/access/{OpenTermHooks,FixedTermHooks,PeriodicTermHooks,BaseAccessControls,MarketConstraintHooks}.sol`,
+  `src/market/{WildcatMarket,WildcatMarketWithdrawals,WildcatMarketConfig,WildcatMarketToken,WildcatMarketBase}.sol`,
+  `src/{HooksFactory,HooksFactoryRevolving}.sol`, `src/ReentrancyGuard.sol`,
+  `docs/hooks/*`, `docs/v2.5 Event Model.md`, `docs/v2.5-audit-delta.md`,
+  `test/shared/mocks/{MockHooks,RevertingHooks,MockHookCaller}.sol`,
+  `foundry.toml`.
+- This repo: `plugins/pandects/foundry.toml`,
+  `.github/workflows/pandects.yml`, `plugins/hexaemeron/skills/VERSIONING.md`,
+  `tests/test_*.py`, `docs/commons/janus.md`.
+- SARIF 2.1.0 (OASIS). ERC-7579 (deferred).
+
+## 8. Signals, and the questions behind them
+
+The harness is a developer tool run from a terminal and in CI; it has no
+unattended runtime and no on-call. What it must emit instead is evidence a
+reviewer reads after a run:
+
+- "Which gate failed and on what trace?" Every finding names the gate, the
+  manifest rule, the host action, and the recorded delta that broke it, in
+  both the human report and the SARIF. A pass emits the manifest revision and
+  the sequence count it held over.
+- "Did the suite actually run, or vacuously pass?" The harness reports the
+  number of ordinary and hostile sequences exercised and asserts it is
+  non-zero; a conformance run that drove nothing is a failure, not a pass.
+
+[ephoros](../../plugins/hexaemeron/skills/ephoros/SKILL.md) owns what a signal
+must carry; these are report fields, not telemetry, because nothing here runs
+unattended.
+
+## 9. Boundaries, per capability
+
+- **Manifest ingestion.** The harness reads JSON manifests and the validator
+  parses them. Worth taking: a malformed or over-broad manifest that makes a
+  gate vacuous. Control: JSON Schema validation with `additionalProperties:
+  false` and required enumerations; the validator rejects an unparseable or
+  under-specified manifest before any run.
+- **Filesystem.** Cheatcode `readFile`/`writeFile` for manifests and findings.
+  Worth taking: a path escape or a write outside the plugin. Control:
+  `fs_permissions` scoped to the plugin's `manifests/` and an output dir; no
+  absolute paths; no `vm.ffi`.
+- **The modeled external-call surface.** The seam model makes an all-gas call
+  to a hook and the hook may call back. Worth taking: unbounded gas, return-
+  data expansion, cross-action re-entry. Control: gates 5 and 6 exercise
+  exactly these; the model's reentrancy guard mirrors the host's.
+
+[phylax](../../plugins/hexaemeron/skills/phylax/SKILL.md) owns the boundary
+list and the controls; each audit round runs its lint over the changed tree so
+a claim of "no boundary opened" is checked, not trusted.
+
+## 10. The budget, or its absence
+
+No wall-clock or gas budget is a success criterion of the prototype, so
+`metron` has nothing to hold. Gas is instead a conformance dimension: gate 5
+asserts a hook stays within the manifest's declared gas budget, and that
+budget is a manifest field the harness reads, not a performance target for
+Janus itself. [metron](../../plugins/hexaemeron/skills/metron/SKILL.md) owns
+budgets where one is a target; here there is none.
+
+## 11. The fail-closed posture
+
+A red `forge test`, a red `forge build`, a failing manifest validation, or a
+red repository suite stops the step: no commit, no push while any is red. A
+false pass is the outcome that matters most, so the harness fails closed
+on ambiguity, an unrecognised effect in a delta is a violation, not an
+ignored unknown; a conformance run that exercised zero sequences fails. Any
+failure surfaced mid-step is worked to its cause under
+[elenchus](../../plugins/hexaemeron/skills/elenchus/SKILL.md), and its guard
+lands in the harness or the Python suite where the regression would recur.
+
+## 12. Decisions and their homes
+
+- The held frontier and the maturity posture live in Janus's own
+  `EVOLUTION.md` at `plugins/janus/skills/janus/EVOLUTION.md`, governed by the
+  [versioning contract](../../plugins/hexaemeron/skills/VERSIONING.md). This
+  run creates it at baseline `janus-v0.1.0`, status `open`, with the second
+  adapter as the held next job.
+- The design decisions that are expensive to reverse, modeling the seam
+  rather than compiling the host, JSON manifest, `libs = []`, the gate-to-test
+  mapping, are recorded in this study's Design options and Risk sections,
+  committed under `docs/` in step 1, and summarised in the plugin's design
+  doc. No `docs/decisions/` scheme is introduced:
+  [hypomnema](../../plugins/hexaemeron/skills/hypomnema/SKILL.md) warns against
+  a second decision-record scheme beside the existing per-skill ledgers, and
+  unmerged branches show that scheme was tried and rolled back here.
+
+## Boundaries the study must state
+
+- **Always.** The repository suite and the plugin's `forge test` and Python
+  suite before every commit. The imprimatur lint on every shipped document.
+  The full Pashov audit suite each round, since the run ships Solidity.
+- **Ask first.** Changing the modeled seam's call convention away from the
+  cited v2.5 source. Adding an external Solidity dependency. Widening
+  `fs_permissions`. Editing an exact sentence a packaging test asserts.
+  Introducing a `docs/decisions/` scheme.
+- **Never.** Claim a hook is conformant on a delta the recorder did not fully
+  capture. Weaken a gate to make a hostile hook pass. Commit a hostile hook
+  that is not caught by its owning gate. Edit a vendored directory. Delete a
+  failing test to go green. Claim a command ran when it did not.

--- a/plugins/janus/.claude-plugin/plugin.json
+++ b/plugins/janus/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "janus",
+  "displayName": "Janus",
+  "version": "0.1.0",
+  "description": "A conformance suite for what a contract hook may observe and change before and after a host action.",
+  "author": {
+    "name": "Wildcat Labs",
+    "url": "https://wildcat.finance"
+  },
+  "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/janus",
+  "repository": "https://github.com/wildcat-finance/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "solidity",
+    "hooks",
+    "conformance",
+    "foundry",
+    "invariants",
+    "security",
+    "wildcat"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/janus/.codex-plugin/plugin.json
+++ b/plugins/janus/.codex-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "name": "janus",
+  "version": "0.1.0",
+  "description": "A conformance suite for what a contract hook may observe and change before and after a host action.",
+  "author": {
+    "name": "Wildcat Labs",
+    "url": "https://wildcat.finance"
+  },
+  "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/janus",
+  "repository": "https://github.com/wildcat-finance/skills",
+  "keywords": [
+    "solidity",
+    "hooks",
+    "conformance",
+    "foundry",
+    "invariants",
+    "security",
+    "wildcat"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Janus",
+    "shortDescription": "A conformance suite for what a contract hook may observe and change before and after a host action.",
+    "longDescription": "A host protocol calls a hook around an action, and the interface says only which function runs. It does not say whether the hook may move value, write host state, consume all remaining gas, change an authorisation result, or leave a user unable to exit. Janus makes that boundary machine-readable: a host adapter exposes the actions, state and economic roles, and a manifest declares what a hook may observe and change at each threshold, its rollback rule, its gas budget, and the liveness a user's exit depends on. A stateful Foundry harness drives ordinary and hostile sequences, records the real storage writes, call targets, value movements and gas across each threshold, and fails when the observed delta exceeds the manifest. The first host adapter is Wildcat's v2.5 market-to-hook seam; the format is host-neutral, and passing the Wildcat suite makes no claim about another protocol's callback model.",
+    "developerName": "Wildcat Labs",
+    "category": "Developer Tools",
+    "capabilities": [],
+    "defaultPrompt": "Use $janus to check a contract hook against a conformance manifest for what it may observe and change around a host action."
+  }
+}

--- a/plugins/janus/AGENTS.md
+++ b/plugins/janus/AGENTS.md
@@ -1,0 +1,74 @@
+# Janus runtime contract
+
+<!-- marketplace-context:start -->
+> **Marketplace context: Janus.** Janus tests a contract hook at the threshold it controls: what it may observe and change before a host action, what it may change after, and what it must never touch. Use Hexaemeron Fizz to generate a protocol-specific fuzz harness, Pandects for the economic laws a hook-driven transition must preserve, and Ariadne to carry a manifest revision and its conformance result with a release. **Current frontier:** Janus ships the Wildcat v2.5 host adapter and its seven gates against modeled hooks, and no second host adapter yet shows the manifest format holds for another callback model.
+<!-- marketplace-context:end -->
+
+Janus contains one Agent Skill. Select from this table, then read the chosen
+`SKILL.md` in full.
+
+| Skill | Canonical instructions | Select when |
+| --- | --- | --- |
+| `janus` | `skills/janus/SKILL.md` | State and enforce what a hook may observe and change around a host action, or add a host adapter and its manifest to the suite |
+
+`skills/janus/SKILL.md` is the only canonical instruction document. Do not add a
+sibling browsing README.
+
+## Translate tool names by capability
+
+The canonical skill was written for hosts that name their tools. A local agent
+must map those names to equivalent capabilities:
+
+| Instruction term | Required capability |
+| --- | --- |
+| `Read` | Read the named file completely or at the stated range |
+| `Write` or `Edit` | Create or patch the named file |
+| `Bash` | Execute the command in a shell and inspect its exit status |
+| `Glob`, `Grep`, or `find` | Enumerate or search files with the stated pattern |
+
+Tool names describe capabilities, not mandatory API identifiers. Preserve the
+arguments, ordering, output files, and exit codes when using an equivalent
+local tool. A non-zero exit from a check means the check failed; do not report a
+run as clean when it exited 1.
+
+## Resolve placeholders
+
+- `$SKILL_DIR` means the directory containing the active `SKILL.md`, unless that
+  file defines it differently.
+- `$PLUGIN_ROOT` means this `plugins/janus/` directory.
+- The harness is the Foundry project under `harness/`; `forge` runs there. The
+  validator and reporter are `scripts/janus.py`, resolved against `$PLUGIN_ROOT`
+  and not the user's target repository.
+- Names such as `janus:janus` and `/janus:janus` are logical aliases. Load the
+  canonical path from the table above.
+
+## Network and side effects
+
+Nothing here reaches the network, and the Solidity has no dependency to fetch.
+`forge` compiles and runs the harness locally against modeled host code;
+`janus.py` reads a manifest or a findings file and prints. The harness reads
+manifests and writes findings only under the plugin's own directories, through a
+declared `fs_permissions` set, and uses no `vm.ffi`.
+
+Running a host adapter's suite compiles and executes that host's modeled code
+in a local EVM. Treat a target repository as the user's, and obey its own
+instructions before writing anything into it.
+
+## What this skill must refuse
+
+These are properties of the tool rather than reminders, and a local agent must
+not route around them:
+
+- No conformance verdict on an incompletely recorded delta. An effect the
+  state-delta recorder cannot classify is a violation, not an ignored unknown.
+- No gate weakened to let a hostile hook pass, and no hostile reference hook
+  committed that its owning gate does not catch.
+- No exit liveness reported as a proof. A bounded run holds a property over the
+  sequences it drove; it does not prove that an exit always completes.
+- No claim that a hook is safe. The suite says a hook stayed inside a declared
+  boundary under a described search, for one host adapter.
+- No cross-host claim. Passing one adapter's suite says nothing about another
+  host's callback model.
+
+If a build, a test, a validation, or a report did not run, say so plainly and
+do not describe its result.

--- a/plugins/janus/README.md
+++ b/plugins/janus/README.md
@@ -1,0 +1,90 @@
+# Janus
+
+<!-- marketplace-context:start -->
+## In one line
+
+Janus tests a contract hook at the threshold it controls: what it may observe and change before a host action, what it may change after, and what it must never touch.
+
+**Try something else when.** Use Hexaemeron Fizz to generate a protocol-specific fuzz harness, Pandects for the economic laws a hook-driven transition must preserve, and Ariadne to carry a manifest revision and its conformance result with a release.
+
+**Current frontier.** Janus ships the Wildcat v2.5 host adapter and its seven gates against modeled hooks, and no second host adapter yet shows the manifest format holds for another callback model.
+
+**Next Fiat job.** Use /hexaemeron:fiat to add a second host adapter once the Wildcat boundary survives its own suite, so the manifest format is shown to describe more than one callback model, starting with the ERC-7579 pre- and post-execution hooks. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
+<!-- marketplace-context:end -->
+
+A conformance suite for what a contract hook may observe and change around a
+host action.
+
+A host protocol calls a hook before and after an action, and the interface
+says only which function runs. It does not say whether the hook may move value,
+write host state, consume all remaining gas, change an authorisation result, or
+leave a user unable to exit. That policy is otherwise spread across
+implementation code, comments, and the assumptions of whoever wrote the first
+hook. A new module can satisfy the ABI and still break the host's economic
+contract.
+
+## How it works
+
+A host adapter exposes a host's actions, the state that matters, and its
+economic roles. A manifest, JSON checked against a schema, declares what a hook
+may observe and change at each threshold, its rollback rule, its gas budget,
+and the liveness a user's exit depends on. A stateful Foundry harness drives
+ordinary and hostile sequences, records the real storage writes, call targets,
+value movements, and gas across each threshold, and fails when the observed
+delta exceeds the manifest. A deterministic unit mode runs the same checks over
+fixed sequences.
+
+## What it ships
+
+- the hook-manifest JSON schema and a stdlib Python validator;
+- the Solidity host-adapter interface and the state-delta recorder;
+- the stateful Foundry harness and the deterministic unit mode;
+- five hostile reference hooks, one each for callback re-entry, gas grief,
+  value redirection, storage mutation, and stale authorisation;
+- the Wildcat host adapter, a faithful model of the v2.5 market-to-hook seam
+  with an honest hook that passes every applicable gate; and
+- human and SARIF reports linking each violation to a manifest rule and a trace.
+
+## The seven gates
+
+1. Permitted effects are enumerated; an omitted write, call target, or value
+   movement is forbidden rather than implicitly accepted.
+2. Value conservation is checked from balances and claims, independent of what
+   the calls return.
+3. Exit gets a liveness property, tested after credential expiry, provider
+   removal, sanctions changes, and hook failure.
+4. Revert behaviour is part of conformance: state and value after nested or
+   partial failure must match the host's declared rollback rule.
+5. Gas grief is exercised with hooks that burn gas, expand return data, and
+   build expensive callback paths.
+6. Re-entry crosses actions: a callback enters a different host action, not
+   only the one that invoked the hook.
+7. A host adapter limits every result; passing the Wildcat suite makes no claim
+   about another protocol's callback model.
+
+## Day to day
+
+**Developers.** A hook is written for a market and has to satisfy more than the
+ABI. Declare the effects it is allowed in a manifest, run the harness, and see
+whether the hook wrote a slot, called a target, moved value, or griefed gas
+that the manifest did not permit, before the hook reaches an auditor.
+
+**Security and audit.** A hook arrives for review beside lender funds and
+borrower permissions. The host's suite tests that an honest hook works; Janus
+tests the boundary the type system cannot express. Its hostile reference hooks
+prove the gates catch callback re-entry, gas grief, value redirection, storage
+mutation outside the declared slots, and stale authorisation, and the exit gate
+shows a user can still leave after a credential lapses or a provider is removed.
+
+## Use
+
+Janus needs [Foundry](https://getfoundry.sh/) and Python 3. The harness has no
+external Solidity dependency and the validator and reporter use only the Python
+standard library. Ask:
+
+```text
+Use $janus to check this hook against a conformance manifest for what it may observe and change around a host action.
+```
+
+The gates, the manifest fields, and the refusals live in
+[Janus's `SKILL.md`](./skills/janus/SKILL.md).

--- a/plugins/janus/harness/foundry.toml
+++ b/plugins/janus/harness/foundry.toml
@@ -1,0 +1,26 @@
+[profile.default]
+src = "src"
+test = "test"
+out = "out"
+libs = []
+solc = "0.8.25"
+evm_version = "cancun"
+optimizer = true
+optimizer_runs = 200
+bytecode_hash = "none"
+
+# The harness reads manifests and writes findings only under its own tree.
+# No absolute paths, no ffi, no network.
+fs_permissions = [
+  { access = "read", path = "./manifests" },
+  { access = "read", path = "./examples" },
+  { access = "read-write", path = "./out" },
+]
+
+[fuzz]
+runs = 256
+
+[invariant]
+runs = 64
+depth = 32
+fail_on_revert = false

--- a/plugins/janus/harness/src/JanusBase.sol
+++ b/plugins/janus/harness/src/JanusBase.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.25;
+
+import {Vm} from "./Vm.sol";
+
+/// @dev The Janus test base. It carries no external dependency: the cheatcode
+///      handle and a small set of `require`-based assertions are all a Janus
+///      test contract needs. A failing assertion reverts, which Foundry reports
+///      as a failed test, so no DSTest `failed()` flag is used.
+abstract contract JanusBase {
+  Vm internal constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+  function assertTrue(bool condition, string memory message) internal pure {
+    require(condition, message);
+  }
+
+  function assertEq(uint256 a, uint256 b, string memory message) internal pure {
+    require(a == b, message);
+  }
+
+  function assertEq(address a, address b, string memory message) internal pure {
+    require(a == b, message);
+  }
+
+  function assertEq(bytes32 a, bytes32 b, string memory message) internal pure {
+    require(a == b, message);
+  }
+
+  function assertEq(bool a, bool b, string memory message) internal pure {
+    require(a == b, message);
+  }
+}

--- a/plugins/janus/harness/src/Vm.sol
+++ b/plugins/janus/harness/src/Vm.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.25;
+
+/// @dev The minimal Foundry cheatcode surface Janus needs, declared in-tree so
+///      the harness carries no external Solidity dependency. Every signature
+///      matches the Foundry `Vm` interface at the canonical cheatcode address;
+///      Janus uses only this subset.
+interface Vm {
+  struct Log {
+    bytes32[] topics;
+    bytes data;
+    address emitter;
+  }
+
+  // Storage-access recording, for the state-delta recorder.
+  function record() external;
+  function accesses(
+    address target
+  ) external returns (bytes32[] memory readSlots, bytes32[] memory writeSlots);
+
+  // Event recording, for observing emitted logs across a threshold.
+  function recordLogs() external;
+  function getRecordedLogs() external returns (Log[] memory logs);
+
+  // State snapshots, for revert-behaviour and rollback gates.
+  function snapshotState() external returns (uint256 snapshotId);
+  function revertToState(uint256 snapshotId) external returns (bool success);
+
+  // Filesystem, scoped by fs_permissions, for manifests and findings.
+  function readFile(string calldata path) external view returns (string memory data);
+  function writeFile(string calldata path, string calldata data) external;
+  function exists(string calldata path) external view returns (bool);
+
+  // JSON parsing, for reading a manifest.
+  function parseJson(string calldata json) external pure returns (bytes memory abiEncoded);
+  function parseJson(
+    string calldata json,
+    string calldata key
+  ) external pure returns (bytes memory abiEncoded);
+  function parseJsonUint(string calldata json, string calldata key) external pure returns (uint256);
+  function parseJsonBool(string calldata json, string calldata key) external pure returns (bool);
+  function parseJsonAddress(
+    string calldata json,
+    string calldata key
+  ) external pure returns (address);
+  function parseJsonString(
+    string calldata json,
+    string calldata key
+  ) external pure returns (string memory);
+  function parseJsonKeys(
+    string calldata json,
+    string calldata key
+  ) external pure returns (string[] memory keys);
+
+  // Identities and balances, for driving sequences.
+  function addr(uint256 privateKey) external pure returns (address keyAddr);
+  function deal(address account, uint256 newBalance) external;
+  function prank(address sender) external;
+  function startPrank(address sender) external;
+  function stopPrank() external;
+  function warp(uint256 newTimestamp) external;
+
+  // Expectations, for asserting a threshold reverts as declared.
+  function expectRevert() external;
+  function expectRevert(bytes4 revertData) external;
+  function expectRevert(bytes calldata revertData) external;
+}

--- a/plugins/janus/harness/test/Scaffold.t.sol
+++ b/plugins/janus/harness/test/Scaffold.t.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.25;
+
+import {JanusBase} from "../src/JanusBase.sol";
+
+/// @dev The scaffold proof: the harness compiles, the minimal `Vm` interface
+///      links against the cheatcode address, and the test base asserts. The
+///      gates arrive in later steps; this only shows the project stands up.
+contract ScaffoldTest is JanusBase {
+  function test_harness_compiles_and_base_asserts() external pure {
+    assertEq(uint256(2), uint256(2), "arithmetic base holds");
+    assertTrue(true, "assertion base holds");
+  }
+
+  function test_cheatcode_handle_is_the_canonical_address() external pure {
+    assertEq(
+      address(vm),
+      0x7109709ECfa91a80626fF3989D68f67F5b1DD12D,
+      "vm points at the canonical cheatcode address"
+    );
+  }
+}

--- a/plugins/janus/scripts/janus.py
+++ b/plugins/janus/scripts/janus.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Janus command-line surface: manifest validation and report rendering.
+
+This module is built across the Fiat runbook. Step 1 establishes the module and
+its command dispatch; `validate` lands in step 2 and `report` in step 6. Each
+subcommand is registered here and raises `NotImplementedError` until its step
+lands, so the module imports cleanly from the first step and the test suite can
+grow with it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import List, Optional
+
+
+VERSION = "0.1.0"
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    """Validate hook manifests against the schema. Lands in step 2."""
+    raise NotImplementedError("janus validate lands in runbook step 2")
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    """Render human and SARIF reports from a findings file. Lands in step 6."""
+    raise NotImplementedError("janus report lands in runbook step 6")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="janus",
+        description="Hook-conformance manifest validation and report rendering.",
+    )
+    parser.add_argument("--version", action="version", version=f"janus {VERSION}")
+    sub = parser.add_subparsers(dest="command")
+
+    validate = sub.add_parser("validate", help="validate hook manifests")
+    validate.add_argument("manifests", nargs="+", help="manifest JSON files")
+    validate.set_defaults(func=cmd_validate)
+
+    report = sub.add_parser("report", help="render human and SARIF reports")
+    report.add_argument("--findings", required=True, help="findings JSON file")
+    report.add_argument("--md", help="human-readable Markdown output path")
+    report.add_argument("--sarif", help="SARIF 2.1.0 output path")
+    report.set_defaults(func=cmd_report)
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not getattr(args, "command", None):
+        parser.print_help()
+        return 2
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/janus/skills/janus/EVOLUTION.md
+++ b/plugins/janus/skills/janus/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Janus evolution ledger
+
+Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
+
+- Current version: `janus-v0.1.0`
+- Frontier status: `open`
+- Frontier revision: `second-host-adapter`
+- Current frontier: Janus ships the Wildcat v2.5 host adapter and its seven gates against modeled hooks, and no second host adapter yet shows the manifest format holds for another callback model.
+- Next Fiat job: Ship a second host adapter for a different callback model, added only after the Wildcat adapter's suite passes, so the manifest format is shown host-neutral rather than asserted. Accepted when the second adapter's honest hook passes its gates, its hostile hooks are each caught, and the shared harness runs both adapters green.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `janus-v0.1.0` | baseline | `second-host-adapter` | `c244247ec1071dda04c29206e52efe3eab264e8c323eaf15468f03e3a9688764` | [the anchor specification](../../../../docs/janus-suite/study.md) | Versioning starts here. Janus ships as a built conformance suite: a JSON hook-manifest schema and validator, a Solidity host-adapter interface and state-delta recorder, a stateful Foundry harness with a deterministic unit mode, five hostile reference hooks, a faithful model of the Wildcat v2.5 market-to-hook seam with an honest hook that passes all seven gates, and human and SARIF reports. The held frontier is the second host adapter, deferred until the Wildcat boundary survives its own suite, as the anchor specification required. |

--- a/plugins/janus/skills/janus/SKILL.md
+++ b/plugins/janus/skills/janus/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: janus
+description: >
+  Check a contract hook at the threshold it controls: what it may observe and
+  change before a host action, what it may change after, and what it must never
+  touch. Use when someone has a host protocol that calls hooks and wants to
+  state and enforce the permitted effects, when reviewing a new hook against a
+  host's economic contract rather than only its ABI, or when a hook must be
+  shown safe on its exit and revert paths, not only its entry. Do not use it to
+  fuzz one repository for generic Solidity defects; that is fizz. Never report a
+  hook as conformant on a delta the recorder did not fully capture.
+metadata:
+  version: "0.1.0"
+---
+
+# Janus
+
+## Frontier
+
+Janus owns the hook-conformance frontier, not Hexaemeron's delivery or Solidity
+frontier. Its version, held target, next job, and maturity state live in
+[EVOLUTION.md](EVOLUTION.md). Do not recommend or run another frontier pass
+after that ledger becomes mature.
+
+<!-- marketplace-context:start -->
+## Where this sits
+
+Janus tests a contract hook at the threshold it controls: what may happen before the host action, what may happen after it, and what the hook must never change.
+
+**Use another tool when.** Use Hexaemeron Fizz to generate a protocol-specific fuzz harness, Pandects for the economic laws a hook-driven transition must preserve, and Ariadne to carry a manifest revision and its conformance result with a release.
+
+**Current frontier.** Janus ships the Wildcat v2.5 host adapter and its seven gates against modeled hooks, and no second host adapter yet shows the manifest format holds for another callback model.
+<!-- marketplace-context:end -->
+
+Janus is named for the Roman god of gates and passages, shown looking in both
+directions. A hook sits on exactly that boundary and inspects or alters an
+action as it enters and leaves its host. An interface says which function runs.
+It does not say whether the hook may move value, write host state, consume all
+remaining gas, change an authorisation result, or leave a user unable to exit.
+That policy is otherwise spread across implementation code, comments, and the
+assumptions of whoever wrote the first hook, so a new module can satisfy the
+ABI and still break the host's economic contract.
+
+## What it is
+
+A host adapter exposes a host's actions, the state that matters, and its
+economic roles. A hook manifest declares, in JSON checked against a schema:
+
+- the entry points and the host actions each threshold runs around;
+- the calls and callbacks the hook may make;
+- the host, hook, and external storage it may change;
+- the assets and recipients it may cause to move;
+- the required behaviour on hook revert, host revert, and partial batch failure;
+- the gas budget, and whether failure is fail-open or fail-closed;
+- the liveness conditions for withdrawal, uninstall, and emergency paths.
+
+A stateful Foundry harness drives ordinary and hostile sequences through the
+adapter, records the real storage writes, call targets, value movements, and
+gas across each threshold, and compares the observed delta against the manifest.
+A deterministic unit mode runs the same checks over fixed sequences.
+
+## The seven gates
+
+1. Permitted effects are enumerated. An omitted storage write, call target, or
+   value movement is forbidden, not implicitly accepted.
+2. Value conservation is independent of return values. The harness checks
+   balances and claims even when every call reports success.
+3. Exit gets a liveness property. Credential expiry, provider removal, sanctions
+   changes, and hook failure are tested on the exit path, not only on entry.
+4. Revert behaviour is part of conformance. State and value after nested or
+   partial failure must match the host's declared rollback rule.
+5. Gas grief is exercised. The suite includes hooks that consume gas, expand
+   return data, and create expensive callback paths.
+6. Re-entry crosses actions. Tests enter a different host action from a
+   callback, not only the function that invoked the hook.
+7. A host adapter limits every result. Passing the Wildcat suite makes no claim
+   about an ERC-7579 account or another protocol's callback model.
+
+## What ships
+
+- the hook-manifest JSON schema and a stdlib Python validator;
+- the Solidity host-adapter interface and the state-delta recorder;
+- the stateful Foundry harness and the deterministic unit mode;
+- five hostile reference hooks: callback re-entry, gas grief, value redirection,
+  storage mutation, and stale authorisation;
+- the Wildcat host adapter, a faithful model of the v2.5 market-to-hook seam
+  with an honest hook that passes every applicable gate; and
+- human and SARIF reports linking each violation to a manifest rule and a trace.
+
+## Run it
+
+The harness is a Foundry project under `harness/` with no external Solidity
+dependency; it declares the minimal cheatcode interface it needs in
+`harness/src/Vm.sol`. The validator and reporter sit in one stdlib Python
+file, `scripts/janus.py`.
+
+```text
+cd harness && forge build && forge test -vv
+python3 ../scripts/janus.py validate manifests/*.json
+python3 ../scripts/janus.py report --findings ../examples/findings.sample.json \
+  --md report.md --sarif report.sarif
+```
+
+Running the suite against a host adapter compiles and executes that host's
+modeled code in a local EVM. Treat a target repository as the user's, and obey
+its own instructions before writing anything into it.
+
+## What it refuses
+
+- No conformance verdict on an incompletely recorded delta. An effect the
+  recorder cannot classify is a violation, not an ignored unknown.
+- No gate weakened to let a hostile hook pass, and no hostile reference hook
+  committed that its owning gate does not catch.
+- No exit liveness reported as a proof. A bounded run holds a property over the
+  sequences it drove; it does not prove an exit always completes.
+- No claim that a hook is safe. The suite says a hook stayed inside a declared
+  boundary under a described search, for one host adapter.
+- No cross-host claim. Passing one adapter's suite says nothing about another
+  host's callback model.
+
+If a build, a test, a validation, or a report did not run, say so plainly and
+do not describe its result.

--- a/plugins/janus/tests/test_cli.py
+++ b/plugins/janus/tests/test_cli.py
@@ -1,0 +1,45 @@
+"""The janus command surface imports and dispatches from the first step.
+
+The subcommands fill in across the runbook; what this step proves is that the
+module loads, the parser is built, and the two subcommands are registered so
+later steps have somewhere to land their behaviour.
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+JANUS = ROOT / "scripts" / "janus.py"
+
+
+def load_janus():
+    spec = importlib.util.spec_from_file_location("janus_cli", JANUS)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class CliSurfaceTests(unittest.TestCase):
+    def test_module_is_where_this_test_expects_it(self):
+        self.assertTrue(JANUS.is_file(), JANUS)
+
+    def test_parser_registers_both_subcommands(self):
+        janus = load_janus()
+        parser = janus.build_parser()
+        # argparse exposes registered subcommands through the subparsers action.
+        choices = set()
+        for action in parser._actions:
+            if hasattr(action, "choices") and action.choices:
+                choices.update(action.choices)
+        self.assertIn("validate", choices)
+        self.assertIn("report", choices)
+
+    def test_no_command_prints_help_and_returns_two(self):
+        janus = load_janus()
+        self.assertEqual(janus.main([]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_marketplace_prose.py
+++ b/tests/test_marketplace_prose.py
@@ -15,6 +15,7 @@ PLUGINS = (
     "hermes",
     "hexaemeron",
     "horos",
+    "janus",
     "lemma",
     "lazarus",
     "pandects",
@@ -29,6 +30,7 @@ CANONICAL_SKILLS = {
     "hermes": ROOT / "plugins" / "hermes" / "skills" / "hermes" / "SKILL.md",
     "hexaemeron": ROOT / "plugins" / "hexaemeron" / "skills" / "fiat" / "SKILL.md",
     "horos": ROOT / "plugins" / "horos" / "skills" / "horos" / "SKILL.md",
+    "janus": ROOT / "plugins" / "janus" / "skills" / "janus" / "SKILL.md",
     "lemma": ROOT / "plugins" / "lemma" / "skills" / "chunk" / "SKILL.md",
     "lazarus": ROOT / "plugins" / "lazarus" / "skills" / "lazarus" / "SKILL.md",
     "pandects": ROOT / "plugins" / "pandects" / "skills" / "pandects" / "SKILL.md",
@@ -165,7 +167,7 @@ class MarketplaceProseTests(unittest.TestCase):
     def test_plugin_landing_readmes_publish_unique_rolling_fiat_jobs(self):
         landings = plugin_landing_readmes()
         self.assertEqual(set(landings), set(PLUGINS))
-        self.assertEqual(len(landings), 12)
+        self.assertEqual(len(landings), 13)
 
         topics = {}
         for name, path in landings.items():

--- a/tests/test_portable_skills.py
+++ b/tests/test_portable_skills.py
@@ -36,6 +36,7 @@ class PortableSkillTests(unittest.TestCase):
             "hermes",
             "hexaemeron",
             "horos",
+            "janus",
             "lazarus",
             "lemma",
             "pandects",
@@ -134,6 +135,7 @@ class PortableSkillTests(unittest.TestCase):
         skills += list(
             (ROOT / "plugins" / "hexaemeron" / "skills" / "fizz" / "skills").glob("*/SKILL.md")
         )
+        skills += list((ROOT / "plugins" / "janus" / "skills").glob("*/SKILL.md"))
         skills += list((ROOT / "plugins" / "lemma" / "skills").glob("*/SKILL.md"))
         skills += list((ROOT / "plugins" / "lazarus" / "skills").glob("*/SKILL.md"))
         skills += list((ROOT / "plugins" / "pandects" / "skills").glob("*/SKILL.md"))


### PR DESCRIPTION
This is step 1 of the Fiat run that builds Janus, the hook-conformance suite, against the Wildcat v2.5 hooks. It establishes the thirteenth marketplace plugin and everything the packaging contracts require, so later steps can add the manifest format, the recorder, the host model, the hostile hooks, and the reports on a green base.

What lands:

- Host manifests for both hosts, the portable entry, and both marketplace listings, extended to thirteen plugins.
- The governed ledger at baseline `janus-v0.1.0`, status open, holding the second host adapter as the next frontier job.
- Landing and canonical prose carrying one identical frontier sentence across the landing README, `AGENTS.md`, the portable entry, the canonical `SKILL.md`, and the root status table.
- A self-contained Foundry harness under `harness/`: `libs = []`, a minimal in-tree `Vm` cheatcode interface, a `require`-based test base, and a trivial test proving the project compiles and links.
- The Python command surface in `scripts/janus.py` registering the `validate` and `report` subcommands that steps 2 and 6 fill in.
- A CI workflow mirroring Pandects: a Python job for the repository and Janus suites, and a Foundry job for the harness, with no dependency to fetch.
- The committed study and runbook under `docs/janus-suite/`.

Audit: step 1, round 1 in `audit/AUDIT.md` is clean. `solidity-auditor` ran over the two `src` files, which are an interface and pure assert helpers with no attack surface; `x-ray` and `fizz` are deferred with reason to the steps that ship the host model, the gates, and the invariants.

Proof:

```text
python3 -m unittest discover -s tests
cd plugins/janus/harness && forge build && forge test
python3 -m unittest discover -s plugins/janus/tests -t plugins/janus
```

Stacks on the run branch; step 2 stacks on this.

`wildcat-origin: shoggoth` — stated visibly because this runtime's GitHub tooling strips HTML comments from pull-request bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzYExBFMq2oyrosJteQC5S

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzYExBFMq2oyrosJteQC5S)_