### PR TITLE
The hook-manifest schema and its validator

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4472,3 +4472,38 @@ thirteen plugins; the Janus Python suite passes; every shipped document lints
 the ecosystem-standard `forge-std` cheatcode handle, and is not a defect.
 
 Leads not pursued: none.
+
+## Step 2, round 1 -- 2026-08-20
+
+Python and JSON step: the JSON manifest schema, the stdlib validator, and its
+fixtures. No Solidity ships, so `x-ray` and `solidity-auditor` have nothing to
+review this step; the review surface is the validator, an untrusted-JSON
+boundary. The three bundled lints ran clean over the changed files (phylax 0,
+ephoros 0, hypomnema 0), and the validator was read against the risk register.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S2-R1-01 | medium | plugins/janus/scripts/janus.py | The validator scanned effect free-text for wildcards but did not enforce the `scope` and `kind` enumerations the schema documents, so a manifest with an unrecognised storage scope or call kind validated. Gate 1 promises effects are enumerated; an unrecognised enum value slipping through is a fail-open hole. | fixed in ae61738509855e47ba687299fb0705e609d2f478 |
+
+The fix adds code J015: an unrecognised `scope` or `kind` is rejected, fail
+closed, with a fixture. The validator otherwise fails closed correctly: it uses
+`json.load` with no `eval` or code execution, raises on the first broken rule,
+and returns invalid on any parse or rule failure. Gate 1's "omitted list is
+forbidden" is enforced through the required-keys check (J006) and the non-list
+check (J008); wildcards are refused in every free-text field (J009).
+
+Leads not pursued: none.
+
+## Step 2, round 2 -- 2026-08-20
+
+Against the tree with round 1's fix applied. The bundled lints re-ran clean
+(phylax 0), the Janus validator suite passes with the J015 fixture, and the
+repository suite passes. The look checked that the enum enforcement did not
+narrow a legitimate manifest: the honest Wildcat manifest still validates, and
+the J015 path fires only on a scope or kind outside the documented sets.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | none | -- |
+
+Leads not pursued: none.

--- a/plugins/janus/harness/manifests/wildcat-open-term.json
+++ b/plugins/janus/harness/manifests/wildcat-open-term.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "../schemas/hook-manifest.schema.json",
+  "manifestVersion": "1",
+  "host": "wildcat-v2.5",
+  "hook": "OpenTermHooks-shaped honest access-control hook",
+  "rollbackRule": "full",
+  "thresholds": [
+    {
+      "action": "deposit",
+      "entryPoints": ["deposit(uint256)", "depositUpTo(uint256)"],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {"scope": "hook", "slot": "lenderStatus[lender]"},
+        {"scope": "hook", "slot": "isKnownLenderOnMarket[lender][market]"}
+      ],
+      "permittedCalls": [
+        {"target": "roleProvider.getCredential", "kind": "staticcall"},
+        {"target": "roleProvider.validateCredential", "kind": "call"}
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "queueWithdrawal",
+      "entryPoints": [
+        "queueWithdrawal(uint256)",
+        "queueWithdrawalScaled(uint256)",
+        "queueFullWithdrawal()"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {"scope": "hook", "slot": "lenderStatus[lender]"}
+      ],
+      "permittedCalls": [
+        {"target": "roleProvider.getCredential", "kind": "staticcall"},
+        {"target": "roleProvider.validateCredential", "kind": "call"}
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "transfer",
+      "entryPoints": ["transfer(address,uint256)", "transferFrom(address,address,uint256)"],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {"scope": "hook", "slot": "lenderStatus[to]"},
+        {"scope": "hook", "slot": "isKnownLenderOnMarket[to][market]"}
+      ],
+      "permittedCalls": [
+        {"target": "roleProvider.getCredential", "kind": "staticcall"},
+        {"target": "roleProvider.validateCredential", "kind": "call"}
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "setAnnualInterestAndReserveRatioBips",
+      "entryPoints": ["setAnnualInterestAndReserveRatioBips(uint16,uint16)"],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {"scope": "hook", "slot": "temporaryExcessReserveRatio[market]"}
+      ],
+      "permittedCalls": [],
+      "permittedValueMovements": [],
+      "gasBudget": 1000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": true
+    }
+  ],
+  "liveness": {
+    "withdrawal": "A known lender may queue and execute a withdrawal after a credential lapses and after the granting provider is removed, because isKnownLenderOnMarket is monotone and onExecuteWithdrawal is never enabled.",
+    "uninstall": "The market's hooks binding is immutable, so uninstall is out of scope for this host; the honest hook adds no state that could block one.",
+    "emergency": "A sanctioned lender is quarantined through the ordinary queueWithdrawal path, so the hook's queue gate must not block nukeFromOrbit beyond the host's own term and window rules."
+  }
+}

--- a/plugins/janus/harness/schemas/hook-manifest.schema.json
+++ b/plugins/janus/harness/schemas/hook-manifest.schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wildcat.finance/janus/hook-manifest.schema.json",
+  "title": "Janus hook manifest",
+  "description": "Declares what a hook may observe and change at each host-action threshold. Every effect list must be present; an omitted list means no such effect is permitted, never that any effect is allowed. Wildcards are rejected, so a manifest cannot say a hook may change anything.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["manifestVersion", "host", "hook", "rollbackRule", "thresholds", "liveness"],
+  "properties": {
+    "manifestVersion": {
+      "description": "The manifest format version. Only 1 is defined.",
+      "const": "1"
+    },
+    "host": {
+      "description": "The host adapter this manifest is written against. A manifest is scoped to one host; passing it makes no claim about another.",
+      "type": "string",
+      "minLength": 1
+    },
+    "hook": {
+      "description": "A human name for the hook the manifest describes.",
+      "type": "string",
+      "minLength": 1
+    },
+    "rollbackRule": {
+      "description": "The host's declared behaviour on hook revert, host revert, and partial batch failure. 'full' means the whole action rolls back; 'none' means the host declares no rollback and each effect must be justified on its own.",
+      "enum": ["full", "none"]
+    },
+    "thresholds": {
+      "description": "One entry per host action the hook runs around. Must be non-empty.",
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/threshold"}
+    },
+    "liveness": {
+      "description": "The conditions under which a user must still be able to leave, uninstall, or invoke an emergency path, tested on exit rather than only on entry.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["withdrawal", "uninstall", "emergency"],
+      "properties": {
+        "withdrawal": {"type": "string", "minLength": 1},
+        "uninstall": {"type": "string", "minLength": 1},
+        "emergency": {"type": "string", "minLength": 1}
+      }
+    }
+  },
+  "$defs": {
+    "hostAction": {
+      "description": "A Wildcat v2.5 host action. Adding a host adds its own actions in a separate adapter.",
+      "enum": [
+        "createMarket",
+        "deposit",
+        "queueWithdrawal",
+        "executeWithdrawal",
+        "transfer",
+        "borrow",
+        "repay",
+        "closeMarket",
+        "nukeFromOrbit",
+        "setMaxTotalSupply",
+        "setAnnualInterestAndReserveRatioBips",
+        "setProtocolFeeBips",
+        "executePendingAnnualInterestBipsReduction"
+      ]
+    },
+    "storageWrite": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scope", "slot"],
+      "properties": {
+        "scope": {"enum": ["hook", "host", "external"]},
+        "slot": {
+          "description": "A named storage location the hook may write. A literal wildcard is rejected by the validator.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "call": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "kind"],
+      "properties": {
+        "target": {
+          "description": "A named call target the hook may reach. A literal wildcard is rejected by the validator.",
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {"enum": ["call", "staticcall", "delegatecall"]}
+      }
+    },
+    "valueMovement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["asset", "recipient"],
+      "properties": {
+        "asset": {"type": "string", "minLength": 1},
+        "recipient": {"type": "string", "minLength": 1}
+      }
+    },
+    "threshold": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "entryPoints",
+        "extraDataAllowed",
+        "permittedStorageWrites",
+        "permittedCalls",
+        "permittedValueMovements",
+        "gasBudget",
+        "failureMode",
+        "mayReturnValues"
+      ],
+      "properties": {
+        "action": {"$ref": "#/$defs/hostAction"},
+        "entryPoints": {
+          "description": "The host function signatures whose calls run this threshold.",
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "extraDataAllowed": {
+          "description": "Whether the host forwards appended extraData to the hook at this threshold.",
+          "type": "boolean"
+        },
+        "permittedStorageWrites": {
+          "description": "The storage the hook may change. An empty list permits none.",
+          "type": "array",
+          "items": {"$ref": "#/$defs/storageWrite"}
+        },
+        "permittedCalls": {
+          "description": "The external calls and callbacks the hook may make. An empty list permits none.",
+          "type": "array",
+          "items": {"$ref": "#/$defs/call"}
+        },
+        "permittedValueMovements": {
+          "description": "The assets and recipients the hook may cause to move. An empty list permits none.",
+          "type": "array",
+          "items": {"$ref": "#/$defs/valueMovement"}
+        },
+        "gasBudget": {
+          "description": "The maximum gas the hook may consume at this threshold.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureMode": {
+          "description": "Whether a hook failure blocks the action (fail-closed) or lets it proceed (fail-open).",
+          "enum": ["fail-open", "fail-closed"]
+        },
+        "mayReturnValues": {
+          "description": "Whether the hook may return values the host applies, which only setAnnualInterestAndReserveRatioBips and executePendingAnnualInterestBipsReduction do on Wildcat.",
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/plugins/janus/scripts/janus.py
+++ b/plugins/janus/scripts/janus.py
@@ -11,16 +11,209 @@ grow with it.
 from __future__ import annotations
 
 import argparse
+import json
 import sys
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 
 VERSION = "0.1.0"
 
 
+# ---------------------------------------------------------------------------
+# Manifest validation
+#
+# The codes below are an interface other tools cite; renumbering them breaks
+# those citations. A manifest is rejected the moment one rule fails, and the
+# first failure's code and message are what the caller sees. The rules enforce
+# gate 1 directly: every effect list must be present, an omitted list is an
+# error rather than a silent permit, and no effect may be a wildcard, so a
+# manifest can never say a hook may change anything.
+# ---------------------------------------------------------------------------
+
+HOST_ACTIONS = {
+    "createMarket",
+    "deposit",
+    "queueWithdrawal",
+    "executeWithdrawal",
+    "transfer",
+    "borrow",
+    "repay",
+    "closeMarket",
+    "nukeFromOrbit",
+    "setMaxTotalSupply",
+    "setAnnualInterestAndReserveRatioBips",
+    "setProtocolFeeBips",
+    "executePendingAnnualInterestBipsReduction",
+}
+
+TOP_LEVEL_KEYS = {
+    "manifestVersion",
+    "host",
+    "hook",
+    "rollbackRule",
+    "thresholds",
+    "liveness",
+    # Tolerated documentation keys that carry no rule.
+    "$schema",
+    "$id",
+}
+
+REQUIRED_TOP_LEVEL = ["manifestVersion", "host", "hook", "rollbackRule", "thresholds", "liveness"]
+
+THRESHOLD_KEYS = {
+    "action",
+    "entryPoints",
+    "extraDataAllowed",
+    "permittedStorageWrites",
+    "permittedCalls",
+    "permittedValueMovements",
+    "gasBudget",
+    "failureMode",
+    "mayReturnValues",
+}
+
+EFFECT_LISTS = ("permittedStorageWrites", "permittedCalls", "permittedValueMovements")
+
+WILDCARDS = {"*", "any", "all", "ANY", "ALL", "*.*"}
+
+LIVENESS_KEYS = {"withdrawal", "uninstall", "emergency"}
+
+
+class ManifestError(Exception):
+    """A single, coded validation failure."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+
+
+def _require_keys(obj: dict, required, code: str, where: str) -> None:
+    for key in required:
+        if key not in obj:
+            raise ManifestError(code, f"{where} is missing required key '{key}'")
+
+
+def _no_unknown_keys(obj: dict, allowed, code: str, where: str) -> None:
+    for key in obj:
+        if key not in allowed:
+            raise ManifestError(code, f"{where} carries unknown key '{key}'")
+
+
+def _effect_values(effect: dict) -> List[str]:
+    """The free-text fields of one effect, where a wildcard would hide."""
+    values = []
+    for key in ("slot", "target", "asset", "recipient"):
+        if key in effect and isinstance(effect[key], str):
+            values.append(effect[key])
+    return values
+
+
+def validate_manifest_obj(manifest) -> None:
+    """Raise ManifestError on the first rule a manifest breaks."""
+    if not isinstance(manifest, dict):
+        raise ManifestError("J002", "manifest is not a JSON object")
+
+    _require_keys(manifest, REQUIRED_TOP_LEVEL, "J002", "manifest")
+    _no_unknown_keys(manifest, TOP_LEVEL_KEYS, "J014", "manifest")
+
+    if manifest["manifestVersion"] != "1":
+        raise ManifestError(
+            "J003", f"manifestVersion must be \"1\", got {manifest['manifestVersion']!r}"
+        )
+
+    if manifest["rollbackRule"] not in ("full", "none"):
+        raise ManifestError(
+            "J004", f"rollbackRule must be 'full' or 'none', got {manifest['rollbackRule']!r}"
+        )
+
+    thresholds = manifest["thresholds"]
+    if not isinstance(thresholds, list) or not thresholds:
+        raise ManifestError("J005", "thresholds must be a non-empty array")
+
+    for index, threshold in enumerate(thresholds):
+        where = f"threshold[{index}]"
+        if not isinstance(threshold, dict):
+            raise ManifestError("J006", f"{where} is not an object")
+        _require_keys(threshold, THRESHOLD_KEYS, "J006", where)
+        _no_unknown_keys(threshold, THRESHOLD_KEYS, "J014", where)
+
+        if threshold["action"] not in HOST_ACTIONS:
+            raise ManifestError("J007", f"{where} names unknown action {threshold['action']!r}")
+
+        entry_points = threshold["entryPoints"]
+        if not isinstance(entry_points, list) or not entry_points:
+            raise ManifestError("J006", f"{where}.entryPoints must be a non-empty array")
+
+        for name in EFFECT_LISTS:
+            effects = threshold[name]
+            if not isinstance(effects, list):
+                raise ManifestError(
+                    "J008",
+                    f"{where}.{name} must be a list; an omitted or non-list effect list is "
+                    "forbidden, since a hook's permitted effects are enumerated, not assumed",
+                )
+            for effect in effects:
+                if not isinstance(effect, dict):
+                    raise ManifestError("J008", f"{where}.{name} entry is not an object")
+                for value in _effect_values(effect):
+                    if value in WILDCARDS:
+                        raise ManifestError(
+                            "J009",
+                            f"{where}.{name} contains the wildcard {value!r}; a manifest may "
+                            "not say a hook can change anything",
+                        )
+
+        if not isinstance(threshold["extraDataAllowed"], bool):
+            raise ManifestError("J006", f"{where}.extraDataAllowed must be a boolean")
+
+        gas = threshold["gasBudget"]
+        if not isinstance(gas, int) or isinstance(gas, bool) or gas < 1:
+            raise ManifestError("J010", f"{where}.gasBudget must be a positive integer")
+
+        if threshold["failureMode"] not in ("fail-open", "fail-closed"):
+            raise ManifestError(
+                "J011", f"{where}.failureMode must be 'fail-open' or 'fail-closed'"
+            )
+
+        if not isinstance(threshold["mayReturnValues"], bool):
+            raise ManifestError("J012", f"{where}.mayReturnValues must be a boolean")
+
+    liveness = manifest["liveness"]
+    if not isinstance(liveness, dict):
+        raise ManifestError("J013", "liveness must be an object")
+    _require_keys(liveness, LIVENESS_KEYS, "J013", "liveness")
+    _no_unknown_keys(liveness, LIVENESS_KEYS, "J014", "liveness")
+    for key in LIVENESS_KEYS:
+        if not isinstance(liveness[key], str) or not liveness[key].strip():
+            raise ManifestError("J013", f"liveness.{key} must be a non-empty string")
+
+
+def validate_manifest_file(path: str) -> Tuple[bool, str]:
+    """Return (ok, message) for one manifest file, never raising."""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            manifest = json.load(handle)
+    except json.JSONDecodeError as error:
+        return False, f"J001: {path}: not valid JSON: {error}"
+    except OSError as error:
+        return False, f"J001: {path}: cannot read: {error}"
+    try:
+        validate_manifest_obj(manifest)
+    except ManifestError as error:
+        return False, f"{error.code}: {path}: {error.message}"
+    return True, f"{path}: valid"
+
+
 def cmd_validate(args: argparse.Namespace) -> int:
-    """Validate hook manifests against the schema. Lands in step 2."""
-    raise NotImplementedError("janus validate lands in runbook step 2")
+    """Validate hook manifests against the schema rules."""
+    failures = 0
+    for path in args.manifests:
+        ok, message = validate_manifest_file(path)
+        print(message)
+        if not ok:
+            failures += 1
+    return 1 if failures else 0
 
 
 def cmd_report(args: argparse.Namespace) -> int:

--- a/plugins/janus/scripts/janus.py
+++ b/plugins/janus/scripts/janus.py
@@ -76,6 +76,9 @@ EFFECT_LISTS = ("permittedStorageWrites", "permittedCalls", "permittedValueMovem
 
 WILDCARDS = {"*", "any", "all", "ANY", "ALL", "*.*"}
 
+STORAGE_SCOPES = {"hook", "host", "external"}
+CALL_KINDS = {"call", "staticcall", "delegatecall"}
+
 LIVENESS_KEYS = {"withdrawal", "uninstall", "emergency"}
 
 
@@ -163,6 +166,22 @@ def validate_manifest_obj(manifest) -> None:
                             f"{where}.{name} contains the wildcard {value!r}; a manifest may "
                             "not say a hook can change anything",
                         )
+                # The scope and kind fields are enumerations. Enforce them here,
+                # not only in the schema, or an unrecognised scope or call kind
+                # would validate and the harness would meet it as an unknown
+                # effect at run time. Fail closed on the unrecognised value.
+                if name == "permittedStorageWrites" and effect.get("scope") not in STORAGE_SCOPES:
+                    raise ManifestError(
+                        "J015",
+                        f"{where}.{name} has scope {effect.get('scope')!r}; "
+                        f"must be one of {sorted(STORAGE_SCOPES)}",
+                    )
+                if name == "permittedCalls" and effect.get("kind") not in CALL_KINDS:
+                    raise ManifestError(
+                        "J015",
+                        f"{where}.{name} has kind {effect.get('kind')!r}; "
+                        f"must be one of {sorted(CALL_KINDS)}",
+                    )
 
         if not isinstance(threshold["extraDataAllowed"], bool):
             raise ManifestError("J006", f"{where}.extraDataAllowed must be a boolean")

--- a/plugins/janus/tests/fixtures/j001_bad_json.json
+++ b/plugins/janus/tests/fixtures/j001_bad_json.json
@@ -1,0 +1,1 @@
+{ this is not json ]

--- a/plugins/janus/tests/fixtures/j002_missing_key.json
+++ b/plugins/janus/tests/fixtures/j002_missing_key.json
@@ -1,0 +1,119 @@
+{
+  "manifestVersion": "1",
+  "host": "wildcat-v2.5",
+  "hook": "OpenTermHooks-shaped honest access-control hook",
+  "rollbackRule": "full",
+  "thresholds": [
+    {
+      "action": "deposit",
+      "entryPoints": [
+        "deposit(uint256)",
+        "depositUpTo(uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[lender][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "queueWithdrawal",
+      "entryPoints": [
+        "queueWithdrawal(uint256)",
+        "queueWithdrawalScaled(uint256)",
+        "queueFullWithdrawal()"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "transfer",
+      "entryPoints": [
+        "transfer(address,uint256)",
+        "transferFrom(address,address,uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[to]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[to][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "setAnnualInterestAndReserveRatioBips",
+      "entryPoints": [
+        "setAnnualInterestAndReserveRatioBips(uint16,uint16)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "temporaryExcessReserveRatio[market]"
+        }
+      ],
+      "permittedCalls": [],
+      "permittedValueMovements": [],
+      "gasBudget": 1000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": true
+    }
+  ]
+}

--- a/plugins/janus/tests/fixtures/j003_bad_version.json
+++ b/plugins/janus/tests/fixtures/j003_bad_version.json
@@ -1,0 +1,124 @@
+{
+  "manifestVersion": "2",
+  "host": "wildcat-v2.5",
+  "hook": "OpenTermHooks-shaped honest access-control hook",
+  "rollbackRule": "full",
+  "thresholds": [
+    {
+      "action": "deposit",
+      "entryPoints": [
+        "deposit(uint256)",
+        "depositUpTo(uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[lender][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "queueWithdrawal",
+      "entryPoints": [
+        "queueWithdrawal(uint256)",
+        "queueWithdrawalScaled(uint256)",
+        "queueFullWithdrawal()"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "transfer",
+      "entryPoints": [
+        "transfer(address,uint256)",
+        "transferFrom(address,address,uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[to]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[to][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "setAnnualInterestAndReserveRatioBips",
+      "entryPoints": [
+        "setAnnualInterestAndReserveRatioBips(uint16,uint16)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "temporaryExcessReserveRatio[market]"
+        }
+      ],
+      "permittedCalls": [],
+      "permittedValueMovements": [],
+      "gasBudget": 1000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": true
+    }
+  ],
+  "liveness": {
+    "withdrawal": "A known lender may queue and execute a withdrawal after a credential lapses and after the granting provider is removed, because isKnownLenderOnMarket is monotone and onExecuteWithdrawal is never enabled.",
+    "uninstall": "The market's hooks binding is immutable, so uninstall is out of scope for this host; the honest hook adds no state that could block one.",
+    "emergency": "A sanctioned lender is quarantined through the ordinary queueWithdrawal path, so the hook's queue gate must not block nukeFromOrbit beyond the host's own term and window rules."
+  }
+}

--- a/plugins/janus/tests/fixtures/j004_bad_rollback.json
+++ b/plugins/janus/tests/fixtures/j004_bad_rollback.json
@@ -1,0 +1,124 @@
+{
+  "manifestVersion": "1",
+  "host": "wildcat-v2.5",
+  "hook": "OpenTermHooks-shaped honest access-control hook",
+  "rollbackRule": "maybe",
+  "thresholds": [
+    {
+      "action": "deposit",
+      "entryPoints": [
+        "deposit(uint256)",
+        "depositUpTo(uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[lender][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "queueWithdrawal",
+      "entryPoints": [
+        "queueWithdrawal(uint256)",
+        "queueWithdrawalScaled(uint256)",
+        "queueFullWithdrawal()"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "transfer",
+      "entryPoints": [
+        "transfer(address,uint256)",
+        "transferFrom(address,address,uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[to]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[to][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "setAnnualInterestAndReserveRatioBips",
+      "entryPoints": [
+        "setAnnualInterestAndReserveRatioBips(uint16,uint16)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "temporaryExcessReserveRatio[market]"
+        }
+      ],
+      "permittedCalls": [],
+      "permittedValueMovements": [],
+      "gasBudget": 1000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": true
+    }
+  ],
+  "liveness": {
+    "withdrawal": "A known lender may queue and execute a withdrawal after a credential lapses and after the granting provider is removed, because isKnownLenderOnMarket is monotone and onExecuteWithdrawal is never enabled.",
+    "uninstall": "The market's hooks binding is immutable, so uninstall is out of scope for this host; the honest hook adds no state that could block one.",
+    "emergency": "A sanctioned lender is quarantined through the ordinary queueWithdrawal path, so the hook's queue gate must not block nukeFromOrbit beyond the host's own term and window rules."
+  }
+}

--- a/plugins/janus/tests/fixtures/j005_empty_thresholds.json
+++ b/plugins/janus/tests/fixtures/j005_empty_thresholds.json
@@ -1,0 +1,12 @@
+{
+  "manifestVersion": "1",
+  "host": "wildcat-v2.5",
+  "hook": "OpenTermHooks-shaped honest access-control hook",
+  "rollbackRule": "full",
+  "thresholds": [],
+  "liveness": {
+    "withdrawal": "A known lender may queue and execute a withdrawal after a credential lapses and after the granting provider is removed, because isKnownLenderOnMarket is monotone and onExecuteWithdrawal is never enabled.",
+    "uninstall": "The market's hooks binding is immutable, so uninstall is out of scope for this host; the honest hook adds no state that could block one.",
+    "emergency": "A sanctioned lender is quarantined through the ordinary queueWithdrawal path, so the hook's queue gate must not block nukeFromOrbit beyond the host's own term and window rules."
+  }
+}

--- a/plugins/janus/tests/fixtures/j006_threshold_missing.json
+++ b/plugins/janus/tests/fixtures/j006_threshold_missing.json
@@ -1,0 +1,123 @@
+{
+  "manifestVersion": "1",
+  "host": "wildcat-v2.5",
+  "hook": "OpenTermHooks-shaped honest access-control hook",
+  "rollbackRule": "full",
+  "thresholds": [
+    {
+      "action": "deposit",
+      "entryPoints": [
+        "deposit(uint256)",
+        "depositUpTo(uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[lender][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "queueWithdrawal",
+      "entryPoints": [
+        "queueWithdrawal(uint256)",
+        "queueWithdrawalScaled(uint256)",
+        "queueFullWithdrawal()"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "transfer",
+      "entryPoints": [
+        "transfer(address,uint256)",
+        "transferFrom(address,address,uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[to]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[to][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "setAnnualInterestAndReserveRatioBips",
+      "entryPoints": [
+        "setAnnualInterestAndReserveRatioBips(uint16,uint16)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "temporaryExcessReserveRatio[market]"
+        }
+      ],
+      "permittedCalls": [],
+      "permittedValueMovements": [],
+      "gasBudget": 1000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": true
+    }
+  ],
+  "liveness": {
+    "withdrawal": "A known lender may queue and execute a withdrawal after a credential lapses and after the granting provider is removed, because isKnownLenderOnMarket is monotone and onExecuteWithdrawal is never enabled.",
+    "uninstall": "The market's hooks binding is immutable, so uninstall is out of scope for this host; the honest hook adds no state that could block one.",
+    "emergency": "A sanctioned lender is quarantined through the ordinary queueWithdrawal path, so the hook's queue gate must not block nukeFromOrbit beyond the host's own term and window rules."
+  }
+}

--- a/plugins/janus/tests/fixtures/j007_unknown_action.json
+++ b/plugins/janus/tests/fixtures/j007_unknown_action.json
@@ -1,0 +1,124 @@
+{
+  "manifestVersion": "1",
+  "host": "wildcat-v2.5",
+  "hook": "OpenTermHooks-shaped honest access-control hook",
+  "rollbackRule": "full",
+  "thresholds": [
+    {
+      "action": "frobnicate",
+      "entryPoints": [
+        "deposit(uint256)",
+        "depositUpTo(uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[lender][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "queueWithdrawal",
+      "entryPoints": [
+        "queueWithdrawal(uint256)",
+        "queueWithdrawalScaled(uint256)",
+        "queueFullWithdrawal()"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "transfer",
+      "entryPoints": [
+        "transfer(address,uint256)",
+        "transferFrom(address,address,uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[to]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[to][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "setAnnualInterestAndReserveRatioBips",
+      "entryPoints": [
+        "setAnnualInterestAndReserveRatioBips(uint16,uint16)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "temporaryExcessReserveRatio[market]"
+        }
+      ],
+      "permittedCalls": [],
+      "permittedValueMovements": [],
+      "gasBudget": 1000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": true
+    }
+  ],
+  "liveness": {
+    "withdrawal": "A known lender may queue and execute a withdrawal after a credential lapses and after the granting provider is removed, because isKnownLenderOnMarket is monotone and onExecuteWithdrawal is never enabled.",
+    "uninstall": "The market's hooks binding is immutable, so uninstall is out of scope for this host; the honest hook adds no state that could block one.",
+    "emergency": "A sanctioned lender is quarantined through the ordinary queueWithdrawal path, so the hook's queue gate must not block nukeFromOrbit beyond the host's own term and window rules."
+  }
+}

--- a/plugins/janus/tests/fixtures/j008_effect_not_list.json
+++ b/plugins/janus/tests/fixtures/j008_effect_not_list.json
@@ -1,0 +1,115 @@
+{
+  "manifestVersion": "1",
+  "host": "wildcat-v2.5",
+  "hook": "OpenTermHooks-shaped honest access-control hook",
+  "rollbackRule": "full",
+  "thresholds": [
+    {
+      "action": "deposit",
+      "entryPoints": [
+        "deposit(uint256)",
+        "depositUpTo(uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": "anything goes",
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "queueWithdrawal",
+      "entryPoints": [
+        "queueWithdrawal(uint256)",
+        "queueWithdrawalScaled(uint256)",
+        "queueFullWithdrawal()"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "transfer",
+      "entryPoints": [
+        "transfer(address,uint256)",
+        "transferFrom(address,address,uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[to]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[to][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "setAnnualInterestAndReserveRatioBips",
+      "entryPoints": [
+        "setAnnualInterestAndReserveRatioBips(uint16,uint16)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "temporaryExcessReserveRatio[market]"
+        }
+      ],
+      "permittedCalls": [],
+      "permittedValueMovements": [],
+      "gasBudget": 1000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": true
+    }
+  ],
+  "liveness": {
+    "withdrawal": "A known lender may queue and execute a withdrawal after a credential lapses and after the granting provider is removed, because isKnownLenderOnMarket is monotone and onExecuteWithdrawal is never enabled.",
+    "uninstall": "The market's hooks binding is immutable, so uninstall is out of scope for this host; the honest hook adds no state that could block one.",
+    "emergency": "A sanctioned lender is quarantined through the ordinary queueWithdrawal path, so the hook's queue gate must not block nukeFromOrbit beyond the host's own term and window rules."
+  }
+}

--- a/plugins/janus/tests/fixtures/j009_wildcard.json
+++ b/plugins/janus/tests/fixtures/j009_wildcard.json
@@ -1,0 +1,120 @@
+{
+  "manifestVersion": "1",
+  "host": "wildcat-v2.5",
+  "hook": "OpenTermHooks-shaped honest access-control hook",
+  "rollbackRule": "full",
+  "thresholds": [
+    {
+      "action": "deposit",
+      "entryPoints": [
+        "deposit(uint256)",
+        "depositUpTo(uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "*"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "queueWithdrawal",
+      "entryPoints": [
+        "queueWithdrawal(uint256)",
+        "queueWithdrawalScaled(uint256)",
+        "queueFullWithdrawal()"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "transfer",
+      "entryPoints": [
+        "transfer(address,uint256)",
+        "transferFrom(address,address,uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[to]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[to][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "setAnnualInterestAndReserveRatioBips",
+      "entryPoints": [
+        "setAnnualInterestAndReserveRatioBips(uint16,uint16)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "temporaryExcessReserveRatio[market]"
+        }
+      ],
+      "permittedCalls": [],
+      "permittedValueMovements": [],
+      "gasBudget": 1000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": true
+    }
+  ],
+  "liveness": {
+    "withdrawal": "A known lender may queue and execute a withdrawal after a credential lapses and after the granting provider is removed, because isKnownLenderOnMarket is monotone and onExecuteWithdrawal is never enabled.",
+    "uninstall": "The market's hooks binding is immutable, so uninstall is out of scope for this host; the honest hook adds no state that could block one.",
+    "emergency": "A sanctioned lender is quarantined through the ordinary queueWithdrawal path, so the hook's queue gate must not block nukeFromOrbit beyond the host's own term and window rules."
+  }
+}

--- a/plugins/janus/tests/fixtures/j010_bad_gas.json
+++ b/plugins/janus/tests/fixtures/j010_bad_gas.json
@@ -1,0 +1,124 @@
+{
+  "manifestVersion": "1",
+  "host": "wildcat-v2.5",
+  "hook": "OpenTermHooks-shaped honest access-control hook",
+  "rollbackRule": "full",
+  "thresholds": [
+    {
+      "action": "deposit",
+      "entryPoints": [
+        "deposit(uint256)",
+        "depositUpTo(uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[lender][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 0,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "queueWithdrawal",
+      "entryPoints": [
+        "queueWithdrawal(uint256)",
+        "queueWithdrawalScaled(uint256)",
+        "queueFullWithdrawal()"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "transfer",
+      "entryPoints": [
+        "transfer(address,uint256)",
+        "transferFrom(address,address,uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[to]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[to][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "setAnnualInterestAndReserveRatioBips",
+      "entryPoints": [
+        "setAnnualInterestAndReserveRatioBips(uint16,uint16)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "temporaryExcessReserveRatio[market]"
+        }
+      ],
+      "permittedCalls": [],
+      "permittedValueMovements": [],
+      "gasBudget": 1000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": true
+    }
+  ],
+  "liveness": {
+    "withdrawal": "A known lender may queue and execute a withdrawal after a credential lapses and after the granting provider is removed, because isKnownLenderOnMarket is monotone and onExecuteWithdrawal is never enabled.",
+    "uninstall": "The market's hooks binding is immutable, so uninstall is out of scope for this host; the honest hook adds no state that could block one.",
+    "emergency": "A sanctioned lender is quarantined through the ordinary queueWithdrawal path, so the hook's queue gate must not block nukeFromOrbit beyond the host's own term and window rules."
+  }
+}

--- a/plugins/janus/tests/fixtures/j011_bad_failuremode.json
+++ b/plugins/janus/tests/fixtures/j011_bad_failuremode.json
@@ -1,0 +1,124 @@
+{
+  "manifestVersion": "1",
+  "host": "wildcat-v2.5",
+  "hook": "OpenTermHooks-shaped honest access-control hook",
+  "rollbackRule": "full",
+  "thresholds": [
+    {
+      "action": "deposit",
+      "entryPoints": [
+        "deposit(uint256)",
+        "depositUpTo(uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[lender][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "whatever",
+      "mayReturnValues": false
+    },
+    {
+      "action": "queueWithdrawal",
+      "entryPoints": [
+        "queueWithdrawal(uint256)",
+        "queueWithdrawalScaled(uint256)",
+        "queueFullWithdrawal()"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "transfer",
+      "entryPoints": [
+        "transfer(address,uint256)",
+        "transferFrom(address,address,uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[to]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[to][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "setAnnualInterestAndReserveRatioBips",
+      "entryPoints": [
+        "setAnnualInterestAndReserveRatioBips(uint16,uint16)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "temporaryExcessReserveRatio[market]"
+        }
+      ],
+      "permittedCalls": [],
+      "permittedValueMovements": [],
+      "gasBudget": 1000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": true
+    }
+  ],
+  "liveness": {
+    "withdrawal": "A known lender may queue and execute a withdrawal after a credential lapses and after the granting provider is removed, because isKnownLenderOnMarket is monotone and onExecuteWithdrawal is never enabled.",
+    "uninstall": "The market's hooks binding is immutable, so uninstall is out of scope for this host; the honest hook adds no state that could block one.",
+    "emergency": "A sanctioned lender is quarantined through the ordinary queueWithdrawal path, so the hook's queue gate must not block nukeFromOrbit beyond the host's own term and window rules."
+  }
+}

--- a/plugins/janus/tests/fixtures/j012_bad_mayreturn.json
+++ b/plugins/janus/tests/fixtures/j012_bad_mayreturn.json
@@ -1,0 +1,124 @@
+{
+  "manifestVersion": "1",
+  "host": "wildcat-v2.5",
+  "hook": "OpenTermHooks-shaped honest access-control hook",
+  "rollbackRule": "full",
+  "thresholds": [
+    {
+      "action": "deposit",
+      "entryPoints": [
+        "deposit(uint256)",
+        "depositUpTo(uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[lender][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": "yes"
+    },
+    {
+      "action": "queueWithdrawal",
+      "entryPoints": [
+        "queueWithdrawal(uint256)",
+        "queueWithdrawalScaled(uint256)",
+        "queueFullWithdrawal()"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "transfer",
+      "entryPoints": [
+        "transfer(address,uint256)",
+        "transferFrom(address,address,uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[to]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[to][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "setAnnualInterestAndReserveRatioBips",
+      "entryPoints": [
+        "setAnnualInterestAndReserveRatioBips(uint16,uint16)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "temporaryExcessReserveRatio[market]"
+        }
+      ],
+      "permittedCalls": [],
+      "permittedValueMovements": [],
+      "gasBudget": 1000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": true
+    }
+  ],
+  "liveness": {
+    "withdrawal": "A known lender may queue and execute a withdrawal after a credential lapses and after the granting provider is removed, because isKnownLenderOnMarket is monotone and onExecuteWithdrawal is never enabled.",
+    "uninstall": "The market's hooks binding is immutable, so uninstall is out of scope for this host; the honest hook adds no state that could block one.",
+    "emergency": "A sanctioned lender is quarantined through the ordinary queueWithdrawal path, so the hook's queue gate must not block nukeFromOrbit beyond the host's own term and window rules."
+  }
+}

--- a/plugins/janus/tests/fixtures/j013_missing_liveness.json
+++ b/plugins/janus/tests/fixtures/j013_missing_liveness.json
@@ -1,0 +1,123 @@
+{
+  "manifestVersion": "1",
+  "host": "wildcat-v2.5",
+  "hook": "OpenTermHooks-shaped honest access-control hook",
+  "rollbackRule": "full",
+  "thresholds": [
+    {
+      "action": "deposit",
+      "entryPoints": [
+        "deposit(uint256)",
+        "depositUpTo(uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[lender][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "queueWithdrawal",
+      "entryPoints": [
+        "queueWithdrawal(uint256)",
+        "queueWithdrawalScaled(uint256)",
+        "queueFullWithdrawal()"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "transfer",
+      "entryPoints": [
+        "transfer(address,uint256)",
+        "transferFrom(address,address,uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[to]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[to][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "setAnnualInterestAndReserveRatioBips",
+      "entryPoints": [
+        "setAnnualInterestAndReserveRatioBips(uint16,uint16)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "temporaryExcessReserveRatio[market]"
+        }
+      ],
+      "permittedCalls": [],
+      "permittedValueMovements": [],
+      "gasBudget": 1000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": true
+    }
+  ],
+  "liveness": {
+    "withdrawal": "A known lender may queue and execute a withdrawal after a credential lapses and after the granting provider is removed, because isKnownLenderOnMarket is monotone and onExecuteWithdrawal is never enabled.",
+    "uninstall": "The market's hooks binding is immutable, so uninstall is out of scope for this host; the honest hook adds no state that could block one."
+  }
+}

--- a/plugins/janus/tests/fixtures/j014_unknown_key.json
+++ b/plugins/janus/tests/fixtures/j014_unknown_key.json
@@ -1,0 +1,125 @@
+{
+  "manifestVersion": "1",
+  "host": "wildcat-v2.5",
+  "hook": "OpenTermHooks-shaped honest access-control hook",
+  "rollbackRule": "full",
+  "thresholds": [
+    {
+      "action": "deposit",
+      "entryPoints": [
+        "deposit(uint256)",
+        "depositUpTo(uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[lender][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "queueWithdrawal",
+      "entryPoints": [
+        "queueWithdrawal(uint256)",
+        "queueWithdrawalScaled(uint256)",
+        "queueFullWithdrawal()"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "transfer",
+      "entryPoints": [
+        "transfer(address,uint256)",
+        "transferFrom(address,address,uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[to]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[to][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "setAnnualInterestAndReserveRatioBips",
+      "entryPoints": [
+        "setAnnualInterestAndReserveRatioBips(uint16,uint16)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "temporaryExcessReserveRatio[market]"
+        }
+      ],
+      "permittedCalls": [],
+      "permittedValueMovements": [],
+      "gasBudget": 1000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": true
+    }
+  ],
+  "liveness": {
+    "withdrawal": "A known lender may queue and execute a withdrawal after a credential lapses and after the granting provider is removed, because isKnownLenderOnMarket is monotone and onExecuteWithdrawal is never enabled.",
+    "uninstall": "The market's hooks binding is immutable, so uninstall is out of scope for this host; the honest hook adds no state that could block one.",
+    "emergency": "A sanctioned lender is quarantined through the ordinary queueWithdrawal path, so the hook's queue gate must not block nukeFromOrbit beyond the host's own term and window rules."
+  },
+  "surpriseKey": 1
+}

--- a/plugins/janus/tests/fixtures/j015_unknown_scope.json
+++ b/plugins/janus/tests/fixtures/j015_unknown_scope.json
@@ -1,0 +1,120 @@
+{
+  "manifestVersion": "1",
+  "host": "wildcat-v2.5",
+  "hook": "OpenTermHooks-shaped honest access-control hook",
+  "rollbackRule": "full",
+  "thresholds": [
+    {
+      "action": "deposit",
+      "entryPoints": [
+        "deposit(uint256)",
+        "depositUpTo(uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "universe",
+          "slot": "lenderStatus[lender]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "queueWithdrawal",
+      "entryPoints": [
+        "queueWithdrawal(uint256)",
+        "queueWithdrawalScaled(uint256)",
+        "queueFullWithdrawal()"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[lender]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "transfer",
+      "entryPoints": [
+        "transfer(address,uint256)",
+        "transferFrom(address,address,uint256)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "lenderStatus[to]"
+        },
+        {
+          "scope": "hook",
+          "slot": "isKnownLenderOnMarket[to][market]"
+        }
+      ],
+      "permittedCalls": [
+        {
+          "target": "roleProvider.getCredential",
+          "kind": "staticcall"
+        },
+        {
+          "target": "roleProvider.validateCredential",
+          "kind": "call"
+        }
+      ],
+      "permittedValueMovements": [],
+      "gasBudget": 2000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": false
+    },
+    {
+      "action": "setAnnualInterestAndReserveRatioBips",
+      "entryPoints": [
+        "setAnnualInterestAndReserveRatioBips(uint16,uint16)"
+      ],
+      "extraDataAllowed": true,
+      "permittedStorageWrites": [
+        {
+          "scope": "hook",
+          "slot": "temporaryExcessReserveRatio[market]"
+        }
+      ],
+      "permittedCalls": [],
+      "permittedValueMovements": [],
+      "gasBudget": 1000000,
+      "failureMode": "fail-closed",
+      "mayReturnValues": true
+    }
+  ],
+  "liveness": {
+    "withdrawal": "A known lender may queue and execute a withdrawal after a credential lapses and after the granting provider is removed, because isKnownLenderOnMarket is monotone and onExecuteWithdrawal is never enabled.",
+    "uninstall": "The market's hooks binding is immutable, so uninstall is out of scope for this host; the honest hook adds no state that could block one.",
+    "emergency": "A sanctioned lender is quarantined through the ordinary queueWithdrawal path, so the hook's queue gate must not block nukeFromOrbit beyond the host's own term and window rules."
+  }
+}

--- a/plugins/janus/tests/test_validator.py
+++ b/plugins/janus/tests/test_validator.py
@@ -1,0 +1,75 @@
+"""The manifest validator accepts the honest manifest and rejects each fault.
+
+The honest Wildcat manifest under `harness/manifests/` must validate, and each
+fixture under `fixtures/` must fail with the specific code its name carries.
+The codes are an interface other tools cite, so a fixture that failed with the
+wrong code would be a silent contract break; the test pins the code, not just
+the failure.
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+JANUS = ROOT / "scripts" / "janus.py"
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+HONEST = ROOT / "harness" / "manifests" / "wildcat-open-term.json"
+
+
+def load_janus():
+    spec = importlib.util.spec_from_file_location("janus_cli", JANUS)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ValidatorTests(unittest.TestCase):
+    def setUp(self):
+        self.janus = load_janus()
+
+    def test_the_honest_manifest_validates(self):
+        ok, message = self.janus.validate_manifest_file(str(HONEST))
+        self.assertTrue(ok, message)
+
+    def test_each_fixture_fails_with_its_named_code(self):
+        fixtures = sorted(FIXTURES.glob("j*.json"))
+        self.assertGreaterEqual(len(fixtures), 14, "fixtures are missing")
+        for path in fixtures:
+            expected = path.name.split("_", 1)[0].upper()  # e.g. "J009"
+            with self.subTest(fixture=path.name):
+                ok, message = self.janus.validate_manifest_file(str(path))
+                self.assertFalse(ok, f"{path.name} unexpectedly validated")
+                self.assertTrue(
+                    message.startswith(expected + ":"),
+                    f"{path.name}: expected {expected}, got {message}",
+                )
+
+    def test_validate_command_exit_code(self):
+        # A valid file exits 0; a batch containing one bad file exits 1.
+        self.assertEqual(self.janus.main(["validate", str(HONEST)]), 0)
+        bad = str(FIXTURES / "j009_wildcard.json")
+        self.assertEqual(self.janus.main(["validate", str(HONEST), bad]), 1)
+
+    def test_wildcard_is_rejected_everywhere_it_could_hide(self):
+        # Gate 1: a wildcard in a call target or a value recipient is refused
+        # just as it is in a storage slot.
+        import json
+
+        honest = json.loads(HONEST.read_text(encoding="utf-8"))
+        honest.pop("$schema", None)
+        for name, entry in (
+            ("permittedCalls", {"target": "any", "kind": "call"}),
+            ("permittedValueMovements", {"asset": "USDC", "recipient": "*"}),
+        ):
+            with self.subTest(field=name):
+                probe = json.loads(json.dumps(honest))
+                probe["thresholds"][0][name] = [entry]
+                with self.assertRaises(self.janus.ManifestError) as caught:
+                    self.janus.validate_manifest_obj(probe)
+                self.assertEqual(caught.exception.code, "J009")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Step 2 of the Janus run. It adds the manifest format and the check that holds a manifest to it.

The JSON Schema under `harness/schemas/` documents every field a manifest carries: the thresholds and their host actions, the storage a hook may write, the calls and value movements it may make, its gas budget, its failure mode, its rollback rule, and the liveness a user's exit depends on. The stdlib validator in `scripts/janus.py` is the authority, and it enforces gate 1 directly. Every effect list must be present; an omitted list is an error rather than a silent permit, and no effect may be a wildcard, so a manifest can never say a hook may change anything. Its coded failures, J001 through J015, are an interface later tools cite.

The honest Wildcat OpenTermHooks-shaped manifest validates. Fifteen malformed fixtures, one per failure class, each fail with their own code.

Audit: two rounds in `audit/AUDIT.md`. Round 1 found that the validator did not enforce the scope and kind enumerations the schema documents, a fail-open hole in gate 1; the fix adds code J015 and a fixture. Round 2 is clean.

Proof:

```text
python3 -m unittest discover -s plugins/janus/tests -t plugins/janus
python3 plugins/janus/scripts/janus.py validate plugins/janus/harness/manifests/wildcat-open-term.json
```

Stacks on step 1 (#271).

`wildcat-origin: shoggoth` — stated visibly because this runtime's GitHub tooling strips HTML comments from pull-request bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzYExBFMq2oyrosJteQC5S

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzYExBFMq2oyrosJteQC5S)_