### PR TITLE
State the prose-reconciliation obligation once, in the contract

### DIFF
--- a/plugins/hexaemeron/skills/VERSIONING.md
+++ b/plugins/hexaemeron/skills/VERSIONING.md
@@ -60,6 +60,21 @@ including its final newline:
   next job to `None -- mature`, record the evidence, and stop. Do not suggest,
   start, or resume another Fiat frontier run for that skill.
 
+## What every frontier run owes
+
+Before a frontier job is recorded as done, cold-read and reconcile all mutable
+first-party marketplace prose. A frontier advance is the point at which a
+skill's behaviour changes, and the documents that describe it to somebody else
+are the ones that go stale silently. This holds for every governed skill in the
+checkout, whichever plugin it sits in.
+
+It is stated here rather than inside each `Next Fiat job` because a rule copied
+into eighteen held targets goes stale in eighteen places, and because amending
+a held target is exactly what the discipline above forbids. A ledger whose job
+text still spells the obligation out is repeating this clause, not extending
+it; the copy retires on its own when a completed frontier run next replaces
+that text.
+
 A mature frontier can reopen only when a maintainer supplies a new external
 failure, requirement, dependency change, or other evidence that invalidates
 the closure. Record that compatibility boundary as an epoch entry, with the

--- a/plugins/hexaemeron/skills/fiat/SKILL.md
+++ b/plugins/hexaemeron/skills/fiat/SKILL.md
@@ -169,7 +169,9 @@ without pretending that it changes Fiat or another skill.
    increment evolution, retain generation and epoch, and either record one
    evidenced next job or set `Frontier status` to `mature` and `Next Fiat
    job` to `None -- mature`. A normal Fiat delivery does not touch skill
-   versions or frontier text.
+   versions or frontier text. The contract also states what every frontier run
+   owes before it is recorded as done, whichever plugin the skill sits in; read
+   it there rather than expecting the held job to spell it out.
 
 **Make step 4 mechanical.** Name the ledger at `init` and the controller holds
 the run to it:


### PR DESCRIPTION
Eleven of the eighteen open ledgers carried `Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.` inside their `Next Fiat job`, byte-identical across all eleven. The seven without it were exactly Hexaemeron's own skills — every standalone plugin had it, every `plugins/hexaemeron/skills/*` ledger did not. That is an oversight, not a carve-out.

## Why the seven were not simply patched

The clause sits inside the held target, so adding it rewrites the canonical frontier line and moves its SHA-256. `tests/test_evolution_contract.py` asserts the latest history row carries that digest, so the change cannot land without a new row, and no axis fits:

- a generation entry must retain the prior revision and digest byte for byte
- an evolution entry requires a completed frontier job
- epoch is the only remaining door, and the contract says plainly not to use it as a patch number

Seven epoch rows for a prose clause would bend the axis out of shape.

## What this does instead

States it once, in `plugins/hexaemeron/skills/VERSIONING.md`, which all 21 ledgers already cite as their policy — the standalone plugins by relative path, Hexaemeron's own by sibling. Fiat's frontier gate gains a one-clause pointer to it rather than a second copy.

No digest moves. No ledger row is owed. The seven are covered immediately. The eleven existing copies now repeat the rule rather than extend it, and each retires on its own when a completed frontier run next replaces that job text — no cleanup operation needed.

This also matches the estate's own rule about restated content: a rule copied into eighteen held targets goes stale in eighteen places.

## Proof

```bash
python3 -m unittest discover -s tests -p "test_*.py"
python3 plugins/hexaemeron/tests/run_tests.py
```

Root 34/34, plugin 450/450. Both changed documents lint clean at 100/100, hypomnema link check clean. No `EVOLUTION.md` is touched. Prose-only, so no version bump: the contract is unversioned and the Fiat edit is a citation, which `VERSIONING.md` excludes from the generation axis explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
