### PR TITLE
The Wildcat host model, the honest hook, and the gate engine

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4553,3 +4553,52 @@ and double-begin cases. The repository and Janus Python suites pass.
 | -- | -- | -- | none | -- |
 
 Leads not pursued: none.
+
+## Step 4, round 1 -- 2026-08-20
+
+Solidity step shipping the Wildcat host model, the honest hook, the adapter and
+the gate engine, the fidelity core. The vendored `solidity-auditor` reviewed
+all five files against two properties: fidelity to the real v2.5 seam, and no
+false pass. Fidelity was verified against the checked-out v2-protocol source at
+the anchor commit and confirmed on every cited mechanic (the hook call
+primitive and its bubble, the value-return `>= 0x40` contract and bounds, the
+hook-before-effects ordering and the queueWithdrawal expiry exception, the
+global reentrancy guard, and onExecuteWithdrawal never being hook-gated).
+`x-ray` and `fizz` are deferred with reason: the harness is not a protocol to
+x-ray, and the invariant suite lands in step 5 with the hostile hooks.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S4-R1-01 | high | plugins/janus/harness/src/JanusHarness.sol | Gate 1 and the value measure attributed a hook's effects by the immediate `accessor`, so they saw only the hook's direct callees. A hook could launder a forbidden call or value movement one hop through a permitted or reachable non-hook accessor and be reported conformant. | fixed in 657c1f1a4746cf0f69ba4eca9e45b056173e5ca1 |
+| S4-R1-02 | medium | plugins/janus/harness/src/JanusHarness.sol | `_hookValueMoved` shared the immediate-accessor limitation and did not filter by value-moving kind, so a delegatecall's inherited value was double-counted. | fixed in 657c1f1a4746cf0f69ba4eca9e45b056173e5ca1 |
+| S4-R1-03 | medium | plugins/janus/harness/src/JanusHarness.sol | Honest-path gates could pass vacuously on an empty or reverted delta; nothing forced a drive expected to have effects to have produced any. | fixed in 657c1f1a4746cf0f69ba4eca9e45b056173e5ca1 |
+
+The fix attributes effects by the transitive closure of the hook's causal
+subtree, iterated to a fixpoint over the recorded (accessor, target) pairs, and
+a new test launders a call through an allowed forwarder to show gate 1 now
+catches it. The auditor confirmed `_drive`'s revert handling sound (a caught,
+fully-reverted action yields an effect-free delta and a conserved value
+snapshot, so a reverting hook is never mis-attributed effects). One documented
+fidelity note (low): the model's setAPR omits the market's own
+reserve-ratio-versus-liquidity reverts, which guard the returned value
+independently of hook honesty and cannot pass a hook here that the real market
+would reject on the seam.
+
+Leads not pursued: none.
+
+## Step 4, round 2 -- 2026-08-20
+
+Against the tree with round 1's fixes applied. The transitive attribution is a
+strict strengthening: the honest hook makes no calls, so its closure stays
+empty and it still clears gate 1; the laundering test confirms a forbidden call
+one hop past an allowed forwarder is now caught. The re-review checked the
+fixpoint terminates (it only ever sets bits true, bounded by the call count)
+and that the value sum's new kind filter does not drop a real Call or Create
+value. All fifteen harness tests pass, and the repository and Janus Python
+suites pass.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | none | -- |
+
+Leads not pursued: none.

--- a/plugins/janus/harness/src/JanusHarness.sol
+++ b/plugins/janus/harness/src/JanusHarness.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.25;
+
+import {StateDeltaRecorder} from "./StateDeltaRecorder.sol";
+import {HostAdapter} from "./HostAdapter.sol";
+
+/// @dev The gate engine. It drives one action through a host adapter, records
+///      the delta around it, and offers the checks a conformance test uses to
+///      compare the delta against a manifest. It attributes an effect to the
+///      hook by the recorded accessor: a call the hook made is one whose
+///      accessor is the hook address, which is how gate 1 tells the hook's own
+///      calls apart from the host's.
+abstract contract JanusHarness is StateDeltaRecorder {
+  struct DriveResult {
+    bool reverted;
+    bytes revertData;
+    Delta delta;
+    uint256 valueBefore;
+    uint256 valueAfter;
+  }
+
+  /// @dev Drive an action and record the state delta around it. A revert is
+  ///      caught so the harness can inspect the delta and the rollback rather
+  ///      than aborting the test.
+  function _drive(
+    HostAdapter adapter,
+    string memory action,
+    address caller,
+    bytes memory params
+  ) internal returns (DriveResult memory result) {
+    result.valueBefore = adapter.valueSnapshot();
+    _beginRecording();
+    try adapter.driveAction(action, caller, params) {
+      result.reverted = false;
+    } catch (bytes memory data) {
+      result.reverted = true;
+      result.revertData = data;
+    }
+    result.delta = _endRecording(0);
+    result.valueAfter = adapter.valueSnapshot();
+  }
+
+  /// @dev The number of external calls the hook itself initiated.
+  function _hookCallCount(Delta memory delta, address hookAddr) internal pure returns (uint256 n) {
+    for (uint256 i; i < delta.calls.length; ++i) {
+      if (delta.calls[i].accessor == hookAddr) ++n;
+    }
+  }
+
+  /// @dev Gate 1: every call the hook made targets an allowed address. A call
+  ///      the hook made to anything outside `allowed` is an effect the manifest
+  ///      did not enumerate, so it is forbidden.
+  function _gate1_hookCallsWithinAllowed(
+    Delta memory delta,
+    address hookAddr,
+    address[] memory allowed
+  ) internal pure returns (bool) {
+    for (uint256 i; i < delta.calls.length; ++i) {
+      if (delta.calls[i].accessor != hookAddr) continue;
+      bool ok;
+      for (uint256 j; j < allowed.length; ++j) {
+        if (delta.calls[i].target == allowed[j]) {
+          ok = true;
+          break;
+        }
+      }
+      if (!ok) return false;
+    }
+    return true;
+  }
+
+  /// @dev The ETH value the hook itself moved.
+  function _hookValueMoved(Delta memory delta, address hookAddr) internal pure returns (uint256 v) {
+    for (uint256 i; i < delta.calls.length; ++i) {
+      if (delta.calls[i].accessor == hookAddr) v += delta.calls[i].value;
+    }
+  }
+}

--- a/plugins/janus/harness/src/JanusHarness.sol
+++ b/plugins/janus/harness/src/JanusHarness.sol
@@ -40,23 +40,62 @@ abstract contract JanusHarness is StateDeltaRecorder {
     result.valueAfter = adapter.valueSnapshot();
   }
 
-  /// @dev The number of external calls the hook itself initiated.
-  function _hookCallCount(Delta memory delta, address hookAddr) internal pure returns (uint256 n) {
-    for (uint256 i; i < delta.calls.length; ++i) {
-      if (delta.calls[i].accessor == hookAddr) ++n;
+  /// @dev The transitive closure of the hook's causal effects: a call is the
+  ///      hook's if its accessor is the hook, or the accessor is a target the
+  ///      hook already reached. Attributing by the immediate accessor alone
+  ///      would only see the hook's direct callees, and a hook could launder a
+  ///      forbidden call one hop through a permitted target. Iterating to a
+  ///      fixpoint over (accessor, target) pairs closes that hole with no need
+  ///      for frame depth.
+  function _hookAttributed(
+    Delta memory delta,
+    address hookAddr
+  ) internal pure returns (bool[] memory attributed) {
+    uint256 n = delta.calls.length;
+    attributed = new bool[](n);
+    bool changed = true;
+    while (changed) {
+      changed = false;
+      for (uint256 i; i < n; ++i) {
+        if (attributed[i]) continue;
+        address acc = delta.calls[i].accessor;
+        bool causal = acc == hookAddr;
+        if (!causal) {
+          for (uint256 k; k < n; ++k) {
+            if (attributed[k] && delta.calls[k].target == acc) {
+              causal = true;
+              break;
+            }
+          }
+        }
+        if (causal) {
+          attributed[i] = true;
+          changed = true;
+        }
+      }
     }
   }
 
-  /// @dev Gate 1: every call the hook made targets an allowed address. A call
-  ///      the hook made to anything outside `allowed` is an effect the manifest
-  ///      did not enumerate, so it is forbidden.
+  /// @dev The number of external calls the hook caused, directly or through a
+  ///      target it reached.
+  function _hookCallCount(Delta memory delta, address hookAddr) internal pure returns (uint256 n) {
+    bool[] memory attributed = _hookAttributed(delta, hookAddr);
+    for (uint256 i; i < attributed.length; ++i) {
+      if (attributed[i]) ++n;
+    }
+  }
+
+  /// @dev Gate 1: every call the hook caused targets an allowed address. A call
+  ///      anywhere in the hook's causal subtree to a target outside `allowed`
+  ///      is an effect the manifest did not enumerate, so it is forbidden.
   function _gate1_hookCallsWithinAllowed(
     Delta memory delta,
     address hookAddr,
     address[] memory allowed
   ) internal pure returns (bool) {
+    bool[] memory attributed = _hookAttributed(delta, hookAddr);
     for (uint256 i; i < delta.calls.length; ++i) {
-      if (delta.calls[i].accessor != hookAddr) continue;
+      if (!attributed[i]) continue;
       bool ok;
       for (uint256 j; j < allowed.length; ++j) {
         if (delta.calls[i].target == allowed[j]) {
@@ -69,10 +108,19 @@ abstract contract JanusHarness is StateDeltaRecorder {
     return true;
   }
 
-  /// @dev The ETH value the hook itself moved.
+  /// @dev The fresh value the hook caused to move, across its whole causal
+  ///      subtree, counting only kinds that move fresh value.
   function _hookValueMoved(Delta memory delta, address hookAddr) internal pure returns (uint256 v) {
+    bool[] memory attributed = _hookAttributed(delta, hookAddr);
     for (uint256 i; i < delta.calls.length; ++i) {
-      if (delta.calls[i].accessor == hookAddr) v += delta.calls[i].value;
+      if (attributed[i] && _movesValue(delta.calls[i].kind)) v += delta.calls[i].value;
     }
+  }
+
+  /// @dev Whether a recording captured any effect at all. A gate for an action
+  ///      expected to do something must assert this, so it cannot pass
+  ///      vacuously on an action that reverted or did nothing.
+  function _deltaHasEffects(Delta memory delta) internal pure returns (bool) {
+    return delta.writes.length > 0 || delta.calls.length > 0;
   }
 }

--- a/plugins/janus/harness/src/StateDeltaRecorder.sol
+++ b/plugins/janus/harness/src/StateDeltaRecorder.sol
@@ -23,6 +23,7 @@ abstract contract StateDeltaRecorder {
 
   struct CallObs {
     address target;
+    address accessor;
     Vm.AccountAccessKind kind;
     uint256 value;
   }
@@ -79,7 +80,12 @@ abstract contract StateDeltaRecorder {
       Vm.AccountAccess memory a = accesses[i];
       if (a.reverted) continue;
       if (_reachesAccount(a.kind)) {
-        delta.calls[c++] = CallObs({target: a.account, kind: a.kind, value: a.value});
+        delta.calls[c++] = CallObs({
+          target: a.account,
+          accessor: a.accessor,
+          kind: a.kind,
+          value: a.value
+        });
       }
       for (uint256 j; j < a.storageAccesses.length; ++j) {
         Vm.StorageAccess memory s = a.storageAccesses[j];

--- a/plugins/janus/harness/src/StateDeltaRecorder.sol
+++ b/plugins/janus/harness/src/StateDeltaRecorder.sol
@@ -114,7 +114,7 @@ abstract contract StateDeltaRecorder {
   /// @dev Whether a kind moves fresh value. A delegatecall inherits the
   ///      enclosing call's value, so summing it would double-count; a
   ///      staticcall can move none. Create and selfdestruct do move value.
-  function _movesValue(Vm.AccountAccessKind kind) private pure returns (bool) {
+  function _movesValue(Vm.AccountAccessKind kind) internal pure returns (bool) {
     return
       kind == Vm.AccountAccessKind.Call ||
       kind == Vm.AccountAccessKind.CallCode ||

--- a/plugins/janus/harness/src/wildcat/HonestAccessHook.sol
+++ b/plugins/janus/harness/src/wildcat/HonestAccessHook.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.25;
+
+import {IWildcatHook} from "./IWildcatHook.sol";
+
+/// @dev An honest access-control hook shaped like the Wildcat OpenTermHooks
+///      template. It gates deposits, queued withdrawals and transfers on a
+///      credential, keeps a monotone known-lender bit so a lender who once
+///      qualified can always exit, writes only its own storage, makes no
+///      external call, moves no value, and returns the APR and reserve pair
+///      unchanged. It is the baseline the hostile hooks are measured against:
+///      it passes every applicable gate.
+contract HonestAccessHook is IWildcatHook {
+  error NotApprovedLender();
+
+  address public immutable admin;
+
+  mapping(address => bool) public approved;
+  mapping(address => uint256) public credentialExpiry;
+  mapping(address => bool) public knownLender;
+
+  constructor() {
+    admin = msg.sender;
+  }
+
+  /// @dev Stand-in for a role provider granting a credential.
+  function grant(address lender, uint256 expiry) external {
+    approved[lender] = true;
+    credentialExpiry[lender] = expiry;
+  }
+
+  /// @dev Stand-in for provider removal: the credential stops validating, but
+  ///      the monotone known-lender bit is deliberately left untouched, which
+  ///      is what keeps the exit open.
+  function removeProvider(address lender) external {
+    approved[lender] = false;
+  }
+
+  function _hasCredential(address lender) internal view returns (bool) {
+    return approved[lender] && block.timestamp <= credentialExpiry[lender];
+  }
+
+  function onDeposit(
+    address lender,
+    uint256,
+    MarketState calldata,
+    bytes calldata
+  ) external override {
+    if (!knownLender[lender] && !_hasCredential(lender)) revert NotApprovedLender();
+    knownLender[lender] = true;
+  }
+
+  function onQueueWithdrawal(
+    address lender,
+    uint32,
+    uint256,
+    MarketState calldata,
+    bytes calldata
+  ) external view override {
+    // Monotone: a known lender always clears this, so the exit stays open even
+    // after the credential lapses or the provider is removed.
+    if (!knownLender[lender] && !_hasCredential(lender)) revert NotApprovedLender();
+  }
+
+  function onTransfer(
+    address,
+    address,
+    address to,
+    uint256,
+    MarketState calldata,
+    bytes calldata
+  ) external override {
+    if (!knownLender[to] && !_hasCredential(to)) revert NotApprovedLender();
+    knownLender[to] = true;
+  }
+
+  function onSetAnnualInterestAndReserveRatioBips(
+    uint16 annualInterestBips,
+    uint16 reserveRatioBips,
+    MarketState calldata,
+    bytes calldata
+  ) external pure override returns (uint16, uint16) {
+    return (annualInterestBips, reserveRatioBips);
+  }
+}

--- a/plugins/janus/harness/src/wildcat/IWildcatHook.sol
+++ b/plugins/janus/harness/src/wildcat/IWildcatHook.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.25;
+
+/// @dev The subset of the Wildcat v2.5 `IHooks` surface the host model calls.
+///      Signatures mirror src/access/IHooks.sol at the v2.5 anchor commit
+///      9716e78. Only the reactive hooks the maintained templates actually
+///      enable are modeled: deposit, queueWithdrawal, transfer, and the one
+///      value-returning hook. `intermediateState` is reduced to the fields a
+///      conformance hook reads.
+interface IWildcatHook {
+  struct MarketState {
+    uint256 scaledTotalSupply;
+    uint256 scaledPendingWithdrawals;
+    uint32 pendingWithdrawalExpiry;
+    uint16 annualInterestBips;
+    uint16 reserveRatioBips;
+    bool isClosed;
+  }
+
+  /// @dev Called before a deposit's effects are applied. IHooks.sol:47.
+  function onDeposit(
+    address lender,
+    uint256 scaledAmount,
+    MarketState calldata intermediateState,
+    bytes calldata extraData
+  ) external;
+
+  /// @dev Called after pendingWithdrawalExpiry is set but before the balance is
+  ///      debited. The documented queueWithdrawal state exception. IHooks.sol:54.
+  function onQueueWithdrawal(
+    address lender,
+    uint32 expiry,
+    uint256 scaledAmount,
+    MarketState calldata intermediateState,
+    bytes calldata extraData
+  ) external;
+
+  /// @dev Called before a transfer's effects are applied. IHooks.sol:73.
+  function onTransfer(
+    address caller,
+    address from,
+    address to,
+    uint256 scaledAmount,
+    MarketState calldata intermediateState,
+    bytes calldata extraData
+  ) external;
+
+  /// @dev The one value-returning hook: the market applies the returned pair
+  ///      within its own bounds. IHooks.sol:118, HooksConfig.sol:741-808.
+  function onSetAnnualInterestAndReserveRatioBips(
+    uint16 annualInterestBips,
+    uint16 reserveRatioBips,
+    MarketState calldata intermediateState,
+    bytes calldata extraData
+  ) external returns (uint16 updatedAnnualInterestBips, uint16 updatedReserveRatioBips);
+}

--- a/plugins/janus/harness/src/wildcat/WildcatHostAdapter.sol
+++ b/plugins/janus/harness/src/wildcat/WildcatHostAdapter.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.25;
+
+import {HostAdapter} from "../HostAdapter.sol";
+import {WildcatHostModel, MockAsset} from "./WildcatHostModel.sol";
+
+/// @dev The Wildcat host adapter. It drives the v2.5 market model's actions,
+///      reads the value gate 2 conserves, and classifies addresses so a gate
+///      can tell a call to a role provider from a call back into the host.
+///      Every result is scoped to this adapter; passing its suite says nothing
+///      about another host's callback model (gate 7).
+contract WildcatHostAdapter is HostAdapter {
+  enum Category {
+    Hook,
+    Host,
+    Asset,
+    RoleProvider,
+    Unknown
+  }
+
+  WildcatHostModel public immutable model;
+  MockAsset public immutable asset;
+  address public immutable roleProvider;
+
+  constructor(WildcatHostModel model_, MockAsset asset_, address roleProvider_) {
+    model = model_;
+    asset = asset_;
+    roleProvider = roleProvider_;
+  }
+
+  function host() external view override returns (address) {
+    return address(model);
+  }
+
+  function hook() external view override returns (address) {
+    return model.hook();
+  }
+
+  function rollbackRule() external pure override returns (RollbackRule) {
+    return RollbackRule.Full;
+  }
+
+  function valueSnapshot() external view override returns (uint256 total) {
+    return asset.balanceOf(address(model));
+  }
+
+  function roles() external view override returns (address[] memory r) {
+    r = new address[](1);
+    r[0] = model.borrower();
+  }
+
+  function categoryOf(address account) external view returns (Category) {
+    if (account == model.hook()) return Category.Hook;
+    if (account == address(model)) return Category.Host;
+    if (account == address(asset)) return Category.Asset;
+    if (account == roleProvider) return Category.RoleProvider;
+    return Category.Unknown;
+  }
+
+  function driveAction(
+    string calldata action,
+    address caller,
+    bytes calldata params
+  ) external override {
+    bytes32 tag = keccak256(bytes(action));
+    if (tag == keccak256("deposit")) {
+      (address lender, uint256 amount, bytes memory extra) = abi.decode(
+        params,
+        (address, uint256, bytes)
+      );
+      model.deposit(lender, amount, extra);
+    } else if (tag == keccak256("queueWithdrawal")) {
+      (address lender, uint32 expiry, uint256 scaled, bytes memory extra) = abi.decode(
+        params,
+        (address, uint32, uint256, bytes)
+      );
+      model.queueWithdrawal(lender, expiry, scaled, extra);
+    } else if (tag == keccak256("executeWithdrawal")) {
+      (address lender, uint32 expiry) = abi.decode(params, (address, uint32));
+      model.executeWithdrawal(lender, expiry);
+    } else if (tag == keccak256("transfer")) {
+      (address from, address to, uint256 scaled, bytes memory extra) = abi.decode(
+        params,
+        (address, address, uint256, bytes)
+      );
+      model.transfer(from, to, scaled, extra);
+    } else if (tag == keccak256("setAnnualInterestAndReserveRatioBips")) {
+      (uint16 apr, uint16 rr, bytes memory extra) = abi.decode(params, (uint16, uint16, bytes));
+      model.setAnnualInterestAndReserveRatioBips(apr, rr, extra);
+    } else {
+      revert("unknown action");
+    }
+    caller; // caller identity is not needed by this host's modeled actions
+  }
+}

--- a/plugins/janus/harness/src/wildcat/WildcatHostModel.sol
+++ b/plugins/janus/harness/src/wildcat/WildcatHostModel.sol
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.25;
+
+import {IWildcatHook} from "./IWildcatHook.sol";
+
+/// @dev A minimal ERC20 the model uses as its underlying asset, so deposits,
+///      withdrawals and any hostile value redirection show up as real token
+///      movements the recorder can observe.
+contract MockAsset {
+  mapping(address => uint256) public balanceOf;
+  mapping(address => mapping(address => uint256)) public allowance;
+
+  function mint(address to, uint256 amount) external {
+    balanceOf[to] += amount;
+  }
+
+  function approve(address spender, uint256 amount) external returns (bool) {
+    allowance[msg.sender][spender] = amount;
+    return true;
+  }
+
+  function transfer(address to, uint256 amount) public returns (bool) {
+    balanceOf[msg.sender] -= amount;
+    balanceOf[to] += amount;
+    return true;
+  }
+
+  function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+    uint256 allowed = allowance[from][msg.sender];
+    if (allowed != type(uint256).max) allowance[from][msg.sender] = allowed - amount;
+    balanceOf[from] -= amount;
+    balanceOf[to] += amount;
+    return true;
+  }
+}
+
+/// @dev A faithful model of the Wildcat v2.5 market-to-hook seam. It is not the
+///      whole protocol: it reproduces exactly the mechanics a hook conformance
+///      suite depends on, each cited to the anchor commit 9716e78:
+///
+///      - the hook is called with all remaining gas and zero value, and its
+///        revert bytes are bubbled unchanged (HooksConfig.sol:88-106);
+///      - the hook runs before the action's effects are applied, on an
+///        intermediate state (e.g. WildcatMarket.sol:72), and queueWithdrawal
+///        sets pendingWithdrawalExpiry before the hook, the documented state
+///        exception (WildcatMarketWithdrawals.sol:115-119);
+///      - onSetAnnualInterestAndReserveRatioBips must return at least 0x40
+///        bytes; the market masks each word to uint16 and applies it within
+///        bounds (HooksConfig.sol:794-804, WildcatMarketConfig.sol:131-168);
+///      - every entry point is nonReentrant on one global guard, so a hook
+///        cannot re-enter any market action (ReentrancyGuard.sol);
+///      - onExecuteWithdrawal is never enabled, so a queued withdrawal's
+///        execution is not hook-gated: the exit the liveness gate depends on
+///        (OpenTermHooks.sol:330-336 empty body, useOnExecuteWithdrawal false).
+///
+///      The hook calldata is built with ordinary ABI encoding rather than the
+///      hand-rolled extraData tail; the semantics the gates test are identical.
+contract WildcatHostModel {
+  error Reentrancy();
+  error NotBorrower();
+  error BipsTooHigh();
+
+  MockAsset public immutable asset;
+  address public borrower;
+  address public hook;
+
+  mapping(address => uint256) public scaledBalanceOf;
+  uint256 public scaledTotalSupply;
+  uint256 public scaledPendingWithdrawals;
+  mapping(uint32 => uint256) public batchScaledAmount;
+  mapping(uint32 => mapping(address => uint256)) public queuedOf;
+  uint32 public pendingWithdrawalExpiry;
+  uint16 public annualInterestBips = 1000;
+  uint16 public reserveRatioBips = 2000;
+  bool public isClosed;
+
+  /// @dev Gas consumed by the most recent hook call, for the gas-grief gate.
+  uint256 public lastHookGasUsed;
+
+  bool private _entered;
+
+  modifier nonReentrant() {
+    if (_entered) revert Reentrancy();
+    _entered = true;
+    _;
+    _entered = false;
+  }
+
+  constructor(MockAsset asset_) {
+    asset = asset_;
+  }
+
+  /// @dev Set once, to break the adapter/model construction cycle.
+  function setBorrower(address borrower_) external {
+    require(borrower == address(0), "borrower set");
+    borrower = borrower_;
+  }
+
+  function setHook(address hook_) external {
+    hook = hook_;
+  }
+
+  function _state() internal view returns (IWildcatHook.MarketState memory) {
+    return
+      IWildcatHook.MarketState({
+        scaledTotalSupply: scaledTotalSupply,
+        scaledPendingWithdrawals: scaledPendingWithdrawals,
+        pendingWithdrawalExpiry: pendingWithdrawalExpiry,
+        annualInterestBips: annualInterestBips,
+        reserveRatioBips: reserveRatioBips,
+        isClosed: isClosed
+      });
+  }
+
+  // --------------------------------------------------------------------- //
+  //                            Market actions                             //
+  // --------------------------------------------------------------------- //
+
+  function deposit(address lender, uint256 amount, bytes calldata extraData) external nonReentrant {
+    // Hook first, on the pre-effect state, then the transfer and the mint.
+    if (hook != address(0)) {
+      _callHook(abi.encodeCall(IWildcatHook.onDeposit, (lender, amount, _state(), extraData)));
+    }
+    asset.transferFrom(lender, address(this), amount);
+    scaledBalanceOf[lender] += amount;
+    scaledTotalSupply += amount;
+  }
+
+  function queueWithdrawal(
+    address lender,
+    uint32 expiry,
+    uint256 scaledAmount,
+    bytes calldata extraData
+  ) external nonReentrant {
+    // The documented exception: expiry is assigned before the hook runs.
+    pendingWithdrawalExpiry = expiry;
+    if (hook != address(0)) {
+      _callHook(
+        abi.encodeCall(
+          IWildcatHook.onQueueWithdrawal,
+          (lender, expiry, scaledAmount, _state(), extraData)
+        )
+      );
+    }
+    scaledBalanceOf[lender] -= scaledAmount;
+    scaledPendingWithdrawals += scaledAmount;
+    batchScaledAmount[expiry] += scaledAmount;
+    queuedOf[expiry][lender] += scaledAmount;
+  }
+
+  /// @dev No hook is called: onExecuteWithdrawal is never enabled by a template,
+  ///      so this is the exit path a queued lender can always complete.
+  function executeWithdrawal(address lender, uint32 expiry) external nonReentrant {
+    uint256 amount = queuedOf[expiry][lender];
+    queuedOf[expiry][lender] = 0;
+    batchScaledAmount[expiry] -= amount;
+    scaledPendingWithdrawals -= amount;
+    asset.transfer(lender, amount);
+  }
+
+  function transfer(
+    address from,
+    address to,
+    uint256 scaledAmount,
+    bytes calldata extraData
+  ) external nonReentrant {
+    if (hook != address(0)) {
+      _callHook(
+        abi.encodeCall(IWildcatHook.onTransfer, (msg.sender, from, to, scaledAmount, _state(), extraData))
+      );
+    }
+    scaledBalanceOf[from] -= scaledAmount;
+    scaledBalanceOf[to] += scaledAmount;
+  }
+
+  function setAnnualInterestAndReserveRatioBips(
+    uint16 apr,
+    uint16 rr,
+    bytes calldata extraData
+  ) external nonReentrant {
+    if (msg.sender != borrower) revert NotBorrower();
+    uint16 newApr = apr;
+    uint16 newRr = rr;
+    if (hook != address(0)) {
+      (newApr, newRr) = _callHookReturns(
+        abi.encodeCall(
+          IWildcatHook.onSetAnnualInterestAndReserveRatioBips,
+          (apr, rr, _state(), extraData)
+        )
+      );
+    }
+    if (newApr > 10000 || newRr > 10000) revert BipsTooHigh();
+    annualInterestBips = newApr;
+    reserveRatioBips = newRr;
+  }
+
+  // --------------------------------------------------------------------- //
+  //                             Hook calls                                //
+  // --------------------------------------------------------------------- //
+
+  /// @dev All remaining gas, zero value, revert bytes bubbled unchanged.
+  ///      Mirrors LibHooksConfig._callHook (HooksConfig.sol:88-106).
+  function _callHook(bytes memory data) private {
+    address target = hook;
+    uint256 g0 = gasleft();
+    assembly {
+      if iszero(call(gas(), target, 0, add(data, 0x20), mload(data), 0, 0)) {
+        returndatacopy(0, 0, returndatasize())
+        revert(0, returndatasize())
+      }
+    }
+    lastHookGasUsed = g0 - gasleft();
+  }
+
+  /// @dev The value-returning path: at least 0x40 bytes of return data are
+  ///      required, each word masked to uint16. The `or(lt(returndatasize,
+  ///      0x40), iszero(call))` form depends on right-to-left argument
+  ///      evaluation so returndatasize refers to this call, exactly as the
+  ///      market does (HooksConfig.sol:794-804).
+  function _callHookReturns(bytes memory data) private returns (uint16 a, uint16 r) {
+    address target = hook;
+    uint256 g0 = gasleft();
+    assembly {
+      if or(
+        lt(returndatasize(), 0x40),
+        iszero(call(gas(), target, 0, add(data, 0x20), mload(data), 0, 0x40))
+      ) {
+        returndatacopy(0, 0, returndatasize())
+        revert(0, returndatasize())
+      }
+      a := and(mload(0), 0xffff)
+      r := and(mload(0x20), 0xffff)
+    }
+    lastHookGasUsed = g0 - gasleft();
+  }
+}

--- a/plugins/janus/harness/test/WildcatConformance.t.sol
+++ b/plugins/janus/harness/test/WildcatConformance.t.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.25;
+
+import {JanusBase} from "../src/JanusBase.sol";
+import {JanusHarness} from "../src/JanusHarness.sol";
+import {IWildcatHook} from "../src/wildcat/IWildcatHook.sol";
+import {WildcatHostModel, MockAsset} from "../src/wildcat/WildcatHostModel.sol";
+import {HonestAccessHook} from "../src/wildcat/HonestAccessHook.sol";
+import {WildcatHostAdapter} from "../src/wildcat/WildcatHostAdapter.sol";
+
+/// @dev A hook that reverts on deposit with a custom error, to prove the model
+///      bubbles the exact revert bytes and rolls the action back (gate 4).
+contract RevertingProbe is IWildcatHook {
+  error Refused();
+
+  function onDeposit(address, uint256, MarketState calldata, bytes calldata) external pure override {
+    revert Refused();
+  }
+
+  function onQueueWithdrawal(address, uint32, uint256, MarketState calldata, bytes calldata) external override {}
+
+  function onTransfer(address, address, address, uint256, MarketState calldata, bytes calldata) external override {}
+
+  function onSetAnnualInterestAndReserveRatioBips(
+    uint16 a,
+    uint16 r,
+    MarketState calldata,
+    bytes calldata
+  ) external pure override returns (uint16, uint16) {
+    return (a, r);
+  }
+}
+
+/// @dev A hook whose value-returning callback returns only 32 bytes, to prove
+///      the model enforces the >=0x40 return contract.
+contract ShortReturnProbe is IWildcatHook {
+  function onDeposit(address, uint256, MarketState calldata, bytes calldata) external override {}
+
+  function onQueueWithdrawal(address, uint32, uint256, MarketState calldata, bytes calldata) external override {}
+
+  function onTransfer(address, address, address, uint256, MarketState calldata, bytes calldata) external override {}
+
+  function onSetAnnualInterestAndReserveRatioBips(
+    uint16,
+    uint16,
+    MarketState calldata,
+    bytes calldata
+  ) external pure override returns (uint16, uint16) {
+    assembly {
+      return(0, 0x20)
+    }
+  }
+}
+
+/// @dev A hook that re-enters a different host action from its deposit
+///      callback, to prove the model's global guard blocks cross-action
+///      re-entry (gate 6).
+contract ReentryProbe is IWildcatHook {
+  function onDeposit(address lender, uint256, MarketState calldata, bytes calldata) external override {
+    WildcatHostModel(msg.sender).queueWithdrawal(lender, uint32(1), 1, "");
+  }
+
+  function onQueueWithdrawal(address, uint32, uint256, MarketState calldata, bytes calldata) external override {}
+
+  function onTransfer(address, address, address, uint256, MarketState calldata, bytes calldata) external override {}
+
+  function onSetAnnualInterestAndReserveRatioBips(
+    uint16 a,
+    uint16 r,
+    MarketState calldata,
+    bytes calldata
+  ) external pure override returns (uint16, uint16) {
+    return (a, r);
+  }
+}
+
+contract WildcatConformanceTest is JanusBase, JanusHarness {
+  string constant MANIFEST = "manifests/wildcat-open-term.json";
+
+  MockAsset asset;
+  WildcatHostModel model;
+  HonestAccessHook honest;
+  WildcatHostAdapter adapter;
+  address lender = address(0xBEEF);
+
+  function setUp() public {
+    asset = new MockAsset();
+    model = new WildcatHostModel(asset);
+    honest = new HonestAccessHook();
+    adapter = new WildcatHostAdapter(model, asset, address(0));
+    model.setBorrower(address(adapter));
+    model.setHook(address(honest));
+
+    asset.mint(lender, 1_000_000);
+    vm.prank(lender);
+    asset.approve(address(model), type(uint256).max);
+    honest.grant(lender, block.timestamp + 1000);
+  }
+
+  function _depositParams(uint256 amount) internal view returns (bytes memory) {
+    return abi.encode(lender, amount, bytes(""));
+  }
+
+  // ----------------------------- Honest gates ---------------------------- //
+
+  function test_gate1_and_gate2_honest_deposit() external {
+    uint256 hookAssetBefore = asset.balanceOf(address(honest));
+    DriveResult memory r = _drive(adapter, "deposit", lender, _depositParams(100));
+    assertTrue(!r.reverted, "honest deposit does not revert");
+
+    address[] memory allowed = new address[](0); // the honest hook calls nothing
+    assertTrue(
+      _gate1_hookCallsWithinAllowed(r.delta, address(honest), allowed),
+      "gate1: the hook made no call outside the permitted set"
+    );
+
+    assertEq(_hookValueMoved(r.delta, address(honest)), uint256(0), "gate2: the hook moved no value");
+    assertEq(asset.balanceOf(address(honest)), hookAssetBefore, "gate2: the hook's asset balance is unchanged");
+    assertEq(r.valueAfter - r.valueBefore, uint256(100), "gate2: market value rose by exactly the deposit");
+  }
+
+  function test_gate5_honest_hook_within_manifest_gas_budget() external {
+    _drive(adapter, "deposit", lender, _depositParams(100));
+    uint256 budget = vm.parseJsonUint(vm.readFile(MANIFEST), ".thresholds[0].gasBudget");
+    assertTrue(model.lastHookGasUsed() <= budget, "gate5: the hook stayed within the manifest budget");
+    assertTrue(model.lastHookGasUsed() > 0, "gate5: a real hook gas figure was recorded");
+  }
+
+  function test_gate3_exit_liveness_after_lapse_and_provider_removal() external {
+    // The lender deposits and becomes a known lender.
+    DriveResult memory d = _drive(adapter, "deposit", lender, _depositParams(100));
+    assertTrue(!d.reverted, "deposit succeeds while credentialled");
+
+    // The credential lapses and the provider is removed.
+    vm.warp(block.timestamp + 5000);
+    honest.removeProvider(lender);
+
+    // The exit stays open: queue then execute both succeed.
+    DriveResult memory q = _drive(
+      adapter,
+      "queueWithdrawal",
+      lender,
+      abi.encode(lender, uint32(1000), uint256(100), bytes(""))
+    );
+    assertTrue(!q.reverted, "gate3: a known lender queues after lapse and provider removal");
+
+    DriveResult memory e = _drive(adapter, "executeWithdrawal", lender, abi.encode(lender, uint32(1000)));
+    assertTrue(!e.reverted, "gate3: the queued withdrawal executes");
+    assertEq(asset.balanceOf(lender), uint256(1_000_000), "gate3: the lender recovered its assets");
+  }
+
+  function test_gate7_adapter_names_its_scope() external view {
+    // Passing this suite is scoped to this adapter's host; the adapter is the
+    // thing every result is limited to.
+    assertEq(adapter.host(), address(model), "gate7: the adapter names the host it speaks for");
+    assertEq(adapter.hook(), address(honest), "gate7: the adapter names the hook under test");
+  }
+
+  // ------------------------------- Fidelity ------------------------------ //
+
+  function test_fidelity_hook_revert_bubbles_and_rolls_back() external {
+    RevertingProbe probe = new RevertingProbe();
+    model.setHook(address(probe));
+
+    uint256 lenderBefore = asset.balanceOf(lender);
+    DriveResult memory r = _drive(adapter, "deposit", lender, _depositParams(100));
+
+    assertTrue(r.reverted, "gate4: a hook revert reverts the action");
+    assertEq(bytes4(r.revertData), RevertingProbe.Refused.selector, "gate4: the exact revert bytes bubble");
+    // Full rollback: neither market value nor lender balance moved.
+    assertEq(r.valueAfter, r.valueBefore, "gate4: market value fully rolled back");
+    assertEq(asset.balanceOf(lender), lenderBefore, "gate4: lender balance fully rolled back");
+  }
+
+  function test_fidelity_value_return_shorter_than_0x40_reverts() external {
+    ShortReturnProbe probe = new ShortReturnProbe();
+    model.setHook(address(probe));
+
+    DriveResult memory r = _drive(
+      adapter,
+      "setAnnualInterestAndReserveRatioBips",
+      address(adapter),
+      abi.encode(uint16(500), uint16(3000), bytes(""))
+    );
+    assertTrue(r.reverted, "fidelity: a return shorter than 0x40 bytes reverts, as the market requires");
+  }
+
+  function test_fidelity_reentry_into_another_action_is_blocked() external {
+    ReentryProbe probe = new ReentryProbe();
+    model.setHook(address(probe));
+
+    DriveResult memory r = _drive(adapter, "deposit", lender, _depositParams(100));
+    assertTrue(r.reverted, "gate6: a callback re-entering another action is blocked by the host guard");
+    assertEq(
+      bytes4(r.revertData),
+      WildcatHostModel.Reentrancy.selector,
+      "gate6: the block is the reentrancy guard, bubbled through the hook call"
+    );
+  }
+}

--- a/plugins/janus/harness/test/WildcatConformance.t.sol
+++ b/plugins/janus/harness/test/WildcatConformance.t.sol
@@ -74,6 +74,48 @@ contract ReentryProbe is IWildcatHook {
   }
 }
 
+/// @dev A neutral call sink and a one-hop forwarder, to build a laundering
+///      path the hook routes a forbidden call through.
+contract Sink {
+  function ping() external {}
+}
+
+contract Forwarder {
+  function forward(address sink) external {
+    Sink(sink).ping();
+  }
+}
+
+/// @dev A hook that, on deposit, calls an allowed forwarder which calls a
+///      forbidden sink. Its direct callee is permitted, so only causal-subtree
+///      attribution catches the laundered call.
+contract LaunderProbe is IWildcatHook {
+  address immutable fwd;
+  address immutable sink;
+
+  constructor(address fwd_, address sink_) {
+    fwd = fwd_;
+    sink = sink_;
+  }
+
+  function onDeposit(address, uint256, MarketState calldata, bytes calldata) external override {
+    Forwarder(fwd).forward(sink);
+  }
+
+  function onQueueWithdrawal(address, uint32, uint256, MarketState calldata, bytes calldata) external override {}
+
+  function onTransfer(address, address, address, uint256, MarketState calldata, bytes calldata) external override {}
+
+  function onSetAnnualInterestAndReserveRatioBips(
+    uint16 a,
+    uint16 r,
+    MarketState calldata,
+    bytes calldata
+  ) external pure override returns (uint16, uint16) {
+    return (a, r);
+  }
+}
+
 contract WildcatConformanceTest is JanusBase, JanusHarness {
   string constant MANIFEST = "manifests/wildcat-open-term.json";
 
@@ -107,6 +149,8 @@ contract WildcatConformanceTest is JanusBase, JanusHarness {
     uint256 hookAssetBefore = asset.balanceOf(address(honest));
     DriveResult memory r = _drive(adapter, "deposit", lender, _depositParams(100));
     assertTrue(!r.reverted, "honest deposit does not revert");
+
+    assertTrue(_deltaHasEffects(r.delta), "the drive produced observable effects, so the gate is not vacuous");
 
     address[] memory allowed = new address[](0); // the honest hook calls nothing
     assertTrue(
@@ -147,6 +191,25 @@ contract WildcatConformanceTest is JanusBase, JanusHarness {
     DriveResult memory e = _drive(adapter, "executeWithdrawal", lender, abi.encode(lender, uint32(1000)));
     assertTrue(!e.reverted, "gate3: the queued withdrawal executes");
     assertEq(asset.balanceOf(lender), uint256(1_000_000), "gate3: the lender recovered its assets");
+  }
+
+  function test_gate1_catches_a_call_laundered_through_an_allowed_forwarder() external {
+    Sink sink = new Sink();
+    Forwarder fwd = new Forwarder();
+    LaunderProbe probe = new LaunderProbe(address(fwd), address(sink));
+    model.setHook(address(probe));
+
+    DriveResult memory r = _drive(adapter, "deposit", lender, _depositParams(100));
+    assertTrue(!r.reverted, "the laundering deposit itself does not revert");
+
+    // The forwarder is permitted; the sink it calls is not. Immediate-accessor
+    // attribution would miss the sink call; the causal subtree catches it.
+    address[] memory allowed = new address[](1);
+    allowed[0] = address(fwd);
+    assertTrue(
+      !_gate1_hookCallsWithinAllowed(r.delta, address(probe), allowed),
+      "gate1: a forbidden call laundered one hop through an allowed target is caught"
+    );
   }
 
   function test_gate7_adapter_names_its_scope() external view {


### PR DESCRIPTION
Step 4 of the Janus run, the fidelity core. It builds a faithful model of the Wildcat v2.5 market-to-hook seam, an honest hook, and the engine that judges a hook against a manifest.

`WildcatHostModel` reproduces exactly the mechanics a conformance suite depends on, each cited to the anchor commit: the hook is called with all remaining gas and zero value and its revert bytes are bubbled unchanged; it runs before the action's effects on an intermediate state; queueWithdrawal sets the expiry before the hook, the documented exception; the value-returning hook must return at least 0x40 bytes, masked to uint16 and applied within bounds; every entry point is nonReentrant on one global guard; and onExecuteWithdrawal is never enabled, so a queued withdrawal always executes. The audit verified each of these against the checked-out v2-protocol source.

`HonestAccessHook` is the OpenTermHooks-shaped baseline: a monotone known-lender bit, writes only its own storage, no external call, no value moved. The `JanusHarness` gate engine records the delta around a driven action and attributes effects to the hook by the transitive closure of its causal calls, so a forbidden effect laundered through a permitted target is still caught.

The conformance suite shows the honest hook clears gates 1, 2, 5 and 7 over ordinary sequences and gate 3 exit liveness after a credential lapse and a provider removal. The fidelity tests confirm the model bubbles a hook revert with full rollback (gate 4), enforces the return-size contract, and blocks cross-action re-entry (gate 6). The gas budget is read from the manifest JSON.

Audit: two rounds in `audit/AUDIT.md`. Fidelity was verified against the real source. Round 1 found three false-pass issues in the engine, the material one being attribution by immediate caller rather than causal subtree; all three are fixed and round 2 is clean.

Proof:

```text
cd plugins/janus/harness && forge test
```

Stacks on step 3 (#274).

`wildcat-origin: shoggoth` — stated visibly because this runtime's GitHub tooling strips HTML comments from pull-request bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzYExBFMq2oyrosJteQC5S

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzYExBFMq2oyrosJteQC5S)_