### PR TITLE
The five hostile reference hooks and the gate engine

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -4602,3 +4602,61 @@ suites pass.
 | -- | -- | -- | none | -- |
 
 Leads not pursued: none.
+
+## Step 5, round 1 -- 2026-08-20
+
+Solidity step shipping the five hostile reference hooks and the completed gate
+engine. This is the round where invariant fuzzing applies: `fizz`'s stateful
+approach is realised as a Foundry invariant that keeps the reentry hook in the
+loop over 2048 calls. The vendored `solidity-auditor` reviewed the hostile
+hooks, the engine, and the tests for two properties: no false pass, and each
+hostile hook genuinely exercising the class it claims. `x-ray` is deferred with
+reason: the harness is not a protocol to profile.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S5-R1-01 | high | plugins/janus/harness/src/JanusHarness.sol | The accessor-closure attribution swept the host's own base-action calls into the hook's set once a hook merely read host state, wrongly failing a legitimate hook. A false fail, not a false pass, but it broke soundness for real hooks that read host state. | fixed in 1ef5bab6e4b91bb25eeae04654ca0b80a78ee209 |
+| S5-R1-02 | medium | plugins/janus/harness/src/JanusHarness.sol | No gate validated storage writes; the storage-mutation hook only exercised the call allowlist, so a hook-caused write to non-permitted storage was ungated. | fixed in 1ef5bab6e4b91bb25eeae04654ca0b80a78ee209 |
+| S5-R1-03 | medium | plugins/janus/harness/src/JanusHarness.sol | The findings JSON was concatenated with no escaping, so a field carrying a quote could inject or hide a finding (a detail overrode a gate number in the auditor's proof). | fixed in 1ef5bab6e4b91bb25eeae04654ca0b80a78ee209 |
+| S5-R1-04 | low | plugins/janus/harness/test/HostileHooks.t.sol | The reentry invariant asserted only that no deposit landed; a re-entering deposit would revert on a balance underflow even if the guard were removed, so it did not isolate gate 6. | fixed in 1ef5bab6e4b91bb25eeae04654ca0b80a78ee209 |
+| S5-R1-05 | low | plugins/janus/harness/test/HostileHooks.t.sol | The stale-auth exit test did not pin the revert reason. | fixed in 1ef5bab6e4b91bb25eeae04654ca0b80a78ee209 |
+
+The depth-subtree attribution resolves the earlier laundering finding and this
+round's over-attribution together: it captures the hook's descendant calls
+without the host's siblings, and gate 1 now enforces state-changing calls only,
+so a read is never an effect. Gate 1 also refuses a hook-caused write to an
+account outside its permitted write scopes. The auditor confirmed no false pass
+among the five hostile hooks as tested, that the attribution terminates and
+does not under-attribute, and that the sequence guard and the invariant target
+restriction are correct.
+
+Accepted limitations, recorded rather than fixed:
+
+- The one value-returning hook can return an adversarial but in-bounds rate,
+  and no gate constrains the returned value beyond the market's own `<= 10000`
+  bound. Constraining it needs a rate-band field the manifest format does not
+  carry. Left as a documented gap; a hook cannot exceed the market's bound, so
+  the exposure is policy griefing, not an out-of-bound write or value theft.
+- The gas gate is exercised on deposit; a hook cheap on deposit and grief-heavy
+  on another action is not covered by the hostile set, though the gate itself
+  reads a per-action budget and applies to any action driven.
+
+Leads not pursued: the two accepted limitations above, both needing a manifest
+extension out of this step's scope.
+
+## Step 5, round 2 -- 2026-08-20
+
+Against the tree with round 1's fixes. The depth-subtree attribution is a
+strict correction: the honest hook and the host-reading hook both clear gate 1
+now, the laundering and storage-mutation hooks are still caught, and the
+injection regression shows an escaped field cannot rewrite another. The
+strengthened invariant runs 2048 calls with every block confirmed to be the
+reentrancy guard. All 24 harness tests pass, and the repository and Janus
+Python suites pass. The two accepted limitations from round 1 stand as
+recorded; no new issue surfaced.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | none | -- |
+
+Leads not pursued: the two accepted limitations recorded in round 1.

--- a/plugins/janus/harness/src/JanusHarness.sol
+++ b/plugins/janus/harness/src/JanusHarness.sol
@@ -53,54 +53,44 @@ abstract contract JanusHarness is StateDeltaRecorder {
     result.valueAfter = adapter.valueSnapshot();
   }
 
-  /// @dev The transitive closure of the hook's causal effects: a call is the
-  ///      hook's if its accessor is the hook, or the accessor is a target the
-  ///      hook already reached. Attributing by the immediate accessor alone
-  ///      would only see the hook's direct callees, and a hook could launder a
-  ///      forbidden call one hop through a permitted target. Iterating to a
-  ///      fixpoint over (accessor, target) pairs closes that hole with no need
-  ///      for frame depth.
+  /// @dev The hook's causal subtree, by call-frame depth. The recorder lists
+  ///      account accesses in DFS pre-order, so the calls the hook made are the
+  ///      contiguous run after the host-to-hook entry frame with a strictly
+  ///      greater depth, up to where the depth returns to the entry. Depth is
+  ///      the field that tells the hook's descendants apart from the host's own
+  ///      sibling calls: attributing by the immediate accessor would miss a
+  ///      laundered call one hop out, while attributing by a naive
+  ///      accessor-closure would wrongly sweep in the host's base-action calls
+  ///      once a hook merely read host state.
   function _hookAttributed(
     Delta memory delta,
     address hookAddr
   ) internal pure returns (bool[] memory attributed) {
     uint256 n = delta.calls.length;
     attributed = new bool[](n);
-    bool changed = true;
-    while (changed) {
-      changed = false;
-      for (uint256 i; i < n; ++i) {
-        if (attributed[i]) continue;
-        address acc = delta.calls[i].accessor;
-        bool causal = acc == hookAddr;
-        if (!causal) {
-          for (uint256 k; k < n; ++k) {
-            if (attributed[k] && delta.calls[k].target == acc) {
-              causal = true;
-              break;
-            }
-          }
-        }
-        if (causal) {
-          attributed[i] = true;
-          changed = true;
-        }
+    for (uint256 i; i < n; ++i) {
+      if (delta.calls[i].target != hookAddr) continue; // a host-to-hook entry
+      uint64 entryDepth = delta.calls[i].depth;
+      for (uint256 j = i + 1; j < n; ++j) {
+        if (delta.calls[j].depth <= entryDepth) break; // subtree closed
+        attributed[j] = true;
       }
     }
   }
 
-  /// @dev The number of external calls the hook caused, directly or through a
-  ///      target it reached.
+  /// @dev The number of state-changing calls the hook caused. Static calls are
+  ///      reads, not effects, so they do not count.
   function _hookCallCount(Delta memory delta, address hookAddr) internal pure returns (uint256 n) {
     bool[] memory attributed = _hookAttributed(delta, hookAddr);
     for (uint256 i; i < attributed.length; ++i) {
-      if (attributed[i]) ++n;
+      if (attributed[i] && _isStateChanging(delta.calls[i].kind)) ++n;
     }
   }
 
-  /// @dev Gate 1: every call the hook caused targets an allowed address. A call
-  ///      anywhere in the hook's causal subtree to a target outside `allowed`
-  ///      is an effect the manifest did not enumerate, so it is forbidden.
+  /// @dev Gate 1, calls: every state-changing call the hook caused, anywhere in
+  ///      its causal subtree, targets an allowed address. A static call is a
+  ///      read and is never an effect, so a hook may read any address; only a
+  ///      call that could change state is enumerated.
   function _gate1_hookCallsWithinAllowed(
     Delta memory delta,
     address hookAddr,
@@ -108,26 +98,55 @@ abstract contract JanusHarness is StateDeltaRecorder {
   ) internal pure returns (bool) {
     bool[] memory attributed = _hookAttributed(delta, hookAddr);
     for (uint256 i; i < delta.calls.length; ++i) {
-      if (!attributed[i]) continue;
-      bool ok;
-      for (uint256 j; j < allowed.length; ++j) {
-        if (delta.calls[i].target == allowed[j]) {
-          ok = true;
-          break;
-        }
-      }
-      if (!ok) return false;
+      if (!attributed[i] || !_isStateChanging(delta.calls[i].kind)) continue;
+      if (!_inSet(delta.calls[i].target, allowed)) return false;
     }
     return true;
   }
 
-  /// @dev The fresh value the hook caused to move, across its whole causal
-  ///      subtree, counting only kinds that move fresh value.
+  /// @dev Gate 1, storage: the hook may write only storage the manifest lists.
+  ///      A write to any account outside `allowedWriteAccounts` that the hook
+  ///      caused, meaning the written account is one its subtree made a
+  ///      state-changing call into, is a storage effect the manifest did not
+  ///      enumerate. The hook's own storage (its address) is passed in when the
+  ///      manifest permits hook-scope writes.
+  function _gate1_hookStorageWithinScopes(
+    Delta memory delta,
+    address hookAddr,
+    address[] memory allowedWriteAccounts
+  ) internal pure returns (bool) {
+    bool[] memory attributed = _hookAttributed(delta, hookAddr);
+    for (uint256 w; w < delta.writes.length; ++w) {
+      address acct = delta.writes[w].account;
+      if (_inSet(acct, allowedWriteAccounts)) continue;
+      // A write the hook caused: the written account is one its subtree called.
+      for (uint256 i; i < delta.calls.length; ++i) {
+        if (attributed[i] && _isStateChanging(delta.calls[i].kind) && delta.calls[i].target == acct) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  /// @dev The fresh value the hook caused to move, across its causal subtree,
+  ///      counting only kinds that move fresh value.
   function _hookValueMoved(Delta memory delta, address hookAddr) internal pure returns (uint256 v) {
     bool[] memory attributed = _hookAttributed(delta, hookAddr);
     for (uint256 i; i < delta.calls.length; ++i) {
       if (attributed[i] && _movesValue(delta.calls[i].kind)) v += delta.calls[i].value;
     }
+  }
+
+  function _isStateChanging(Vm.AccountAccessKind kind) internal pure returns (bool) {
+    return kind != Vm.AccountAccessKind.StaticCall;
+  }
+
+  function _inSet(address needle, address[] memory set) private pure returns (bool) {
+    for (uint256 i; i < set.length; ++i) {
+      if (set[i] == needle) return true;
+    }
+    return false;
   }
 
   /// @dev Whether a recording captured any effect at all. A gate for an action
@@ -170,11 +189,11 @@ abstract contract JanusHarness is StateDeltaRecorder {
         '{"gate":',
         _uintToString(findings[i].gate),
         ',"action":"',
-        findings[i].action,
+        _escape(findings[i].action),
         '","hook":"',
-        findings[i].hook,
+        _escape(findings[i].hook),
         '","detail":"',
-        findings[i].detail,
+        _escape(findings[i].detail),
         '"}'
       );
     }
@@ -190,6 +209,33 @@ abstract contract JanusHarness is StateDeltaRecorder {
       arr,
       "}"
     );
+  }
+
+  /// @dev Escape a string for embedding in a JSON string literal, so a field
+  ///      carrying a quote, backslash, or control character cannot end the
+  ///      literal early and inject or hide a field. The reporter parses the
+  ///      result, so an unescaped quote would let one field rewrite another.
+  function _escape(string memory input) internal pure returns (string memory) {
+    bytes memory b = bytes(input);
+    bytes memory out;
+    for (uint256 i; i < b.length; ++i) {
+      bytes1 c = b[i];
+      if (c == '"') {
+        out = abi.encodePacked(out, '\\"');
+      } else if (c == "\\") {
+        out = abi.encodePacked(out, "\\\\");
+      } else if (uint8(c) < 0x20) {
+        // Control characters, including newline and tab, as \u00XX.
+        out = abi.encodePacked(out, "\\u00", _hexNibble(uint8(c) >> 4), _hexNibble(uint8(c) & 0x0f));
+      } else {
+        out = abi.encodePacked(out, c);
+      }
+    }
+    return string(out);
+  }
+
+  function _hexNibble(uint8 nibble) private pure returns (bytes1) {
+    return bytes1(nibble < 10 ? 48 + nibble : 87 + nibble);
   }
 
   function _uintToString(uint256 value) internal pure returns (string memory) {

--- a/plugins/janus/harness/src/JanusHarness.sol
+++ b/plugins/janus/harness/src/JanusHarness.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.25;
 
 import {StateDeltaRecorder} from "./StateDeltaRecorder.sol";
 import {HostAdapter} from "./HostAdapter.sol";
+import {Vm} from "./Vm.sol";
 
 /// @dev The gate engine. It drives one action through a host adapter, records
 ///      the delta around it, and offers the checks a conformance test uses to
@@ -11,12 +12,24 @@ import {HostAdapter} from "./HostAdapter.sol";
 ///      accessor is the hook address, which is how gate 1 tells the hook's own
 ///      calls apart from the host's.
 abstract contract JanusHarness is StateDeltaRecorder {
+  Vm private constant _hvm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+  error NoSequencesExercised();
+
   struct DriveResult {
     bool reverted;
     bytes revertData;
     Delta delta;
     uint256 valueBefore;
     uint256 valueAfter;
+  }
+
+  /// @dev One conformance finding, the unit the reports render.
+  struct Finding {
+    uint256 gate;
+    string action;
+    string hook;
+    string detail;
   }
 
   /// @dev Drive an action and record the state delta around it. A revert is
@@ -122,5 +135,77 @@ abstract contract JanusHarness is StateDeltaRecorder {
   ///      vacuously on an action that reverted or did nothing.
   function _deltaHasEffects(Delta memory delta) internal pure returns (bool) {
     return delta.writes.length > 0 || delta.calls.length > 0;
+  }
+
+  /// @dev A conformance run must have exercised at least one sequence; a run
+  ///      that drove nothing is a failure, not a vacuous pass.
+  function _requireExercised(uint256 sequences) internal pure {
+    if (sequences == 0) revert NoSequencesExercised();
+  }
+
+  /// @dev Render a findings set to the report interchange JSON and write it
+  ///      through the scoped filesystem cheatcode. The Python reporter renders
+  ///      the human and SARIF outputs from this file.
+  function _writeFindings(
+    string memory path,
+    string memory host,
+    string memory manifest,
+    uint256 sequences,
+    Finding[] memory findings
+  ) internal {
+    _hvm.writeFile(path, _findingsJson(host, manifest, sequences, findings));
+  }
+
+  function _findingsJson(
+    string memory host,
+    string memory manifest,
+    uint256 sequences,
+    Finding[] memory findings
+  ) internal pure returns (string memory json) {
+    string memory arr = "[";
+    for (uint256 i; i < findings.length; ++i) {
+      arr = string.concat(
+        arr,
+        i == 0 ? "" : ",",
+        '{"gate":',
+        _uintToString(findings[i].gate),
+        ',"action":"',
+        findings[i].action,
+        '","hook":"',
+        findings[i].hook,
+        '","detail":"',
+        findings[i].detail,
+        '"}'
+      );
+    }
+    arr = string.concat(arr, "]");
+    json = string.concat(
+      '{"host":"',
+      host,
+      '","manifest":"',
+      manifest,
+      '","sequences":',
+      _uintToString(sequences),
+      ',"findings":',
+      arr,
+      "}"
+    );
+  }
+
+  function _uintToString(uint256 value) internal pure returns (string memory) {
+    if (value == 0) return "0";
+    uint256 temp = value;
+    uint256 digits;
+    while (temp != 0) {
+      digits++;
+      temp /= 10;
+    }
+    bytes memory buffer = new bytes(digits);
+    while (value != 0) {
+      digits -= 1;
+      buffer[digits] = bytes1(uint8(48 + (value % 10)));
+      value /= 10;
+    }
+    return string(buffer);
   }
 }

--- a/plugins/janus/harness/src/StateDeltaRecorder.sol
+++ b/plugins/janus/harness/src/StateDeltaRecorder.sol
@@ -26,6 +26,7 @@ abstract contract StateDeltaRecorder {
     address accessor;
     Vm.AccountAccessKind kind;
     uint256 value;
+    uint64 depth;
   }
 
   struct Delta {
@@ -84,7 +85,8 @@ abstract contract StateDeltaRecorder {
           target: a.account,
           accessor: a.accessor,
           kind: a.kind,
-          value: a.value
+          value: a.value,
+          depth: a.depth
         });
       }
       for (uint256 j; j < a.storageAccesses.length; ++j) {

--- a/plugins/janus/harness/src/hostile/HostileHooks.sol
+++ b/plugins/janus/harness/src/hostile/HostileHooks.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.25;
+
+import {IWildcatHook} from "../wildcat/IWildcatHook.sol";
+import {WildcatHostModel} from "../wildcat/WildcatHostModel.sol";
+
+/// @dev The five hostile reference hooks, one per failure class the gates own.
+///      Each is a real, non-conformant hook that the matching gate must catch;
+///      shipping one whose gate does not catch it would be a hole in the suite.
+///      A no-op body is given for the callbacks a hook does not exercise.
+
+/// @dev Gate 6: re-enters a different host action from its callback. The host's
+///      global reentrancy guard blocks it, so the action reverts.
+contract ReentryHook is IWildcatHook {
+  function onDeposit(address lender, uint256, MarketState calldata, bytes calldata) external override {
+    WildcatHostModel(msg.sender).queueWithdrawal(lender, uint32(1), 1, "");
+  }
+
+  function onQueueWithdrawal(address, uint32, uint256, MarketState calldata, bytes calldata) external override {}
+  function onTransfer(address, address, address, uint256, MarketState calldata, bytes calldata) external override {}
+  function onSetAnnualInterestAndReserveRatioBips(uint16 a, uint16 r, MarketState calldata, bytes calldata)
+    external pure override returns (uint16, uint16) { return (a, r); }
+}
+
+/// @dev Gate 5: consumes far more gas than the manifest budget by writing many
+///      cold storage slots. The call succeeds, so only a gas gate catches it.
+contract GasGriefHook is IWildcatHook {
+  mapping(uint256 => uint256) private junk;
+
+  function onDeposit(address, uint256, MarketState calldata, bytes calldata) external override {
+    for (uint256 i; i < 400; ++i) {
+      junk[i] = i + 1;
+    }
+  }
+
+  function onQueueWithdrawal(address, uint32, uint256, MarketState calldata, bytes calldata) external override {}
+  function onTransfer(address, address, address, uint256, MarketState calldata, bytes calldata) external override {}
+  function onSetAnnualInterestAndReserveRatioBips(uint16 a, uint16 r, MarketState calldata, bytes calldata)
+    external pure override returns (uint16, uint16) { return (a, r); }
+}
+
+interface IAsset {
+  function transferFrom(address from, address to, uint256 amount) external returns (bool);
+}
+
+/// @dev Gate 2: given an allowance it should never have, it pulls the host's
+///      assets to itself while reporting success, so value conservation must be
+///      checked from balances, not from the call's return.
+contract ValueRedirectHook is IWildcatHook {
+  IAsset public immutable asset;
+  address public immutable market;
+  uint256 public immutable amount;
+
+  constructor(IAsset asset_, address market_, uint256 amount_) {
+    asset = asset_;
+    market = market_;
+    amount = amount_;
+  }
+
+  function onDeposit(address, uint256, MarketState calldata, bytes calldata) external override {
+    asset.transferFrom(market, address(this), amount);
+  }
+
+  function onQueueWithdrawal(address, uint32, uint256, MarketState calldata, bytes calldata) external override {}
+  function onTransfer(address, address, address, uint256, MarketState calldata, bytes calldata) external override {}
+  function onSetAnnualInterestAndReserveRatioBips(uint16 a, uint16 r, MarketState calldata, bytes calldata)
+    external pure override returns (uint16, uint16) { return (a, r); }
+}
+
+/// @dev A shared external contract a hook has no business touching.
+contract ExternalRegistry {
+  mapping(bytes32 => uint256) public value;
+
+  function set(bytes32 key, uint256 val) external {
+    value[key] = val;
+  }
+}
+
+/// @dev Gate 1: mutates external state by calling a registry the manifest does
+///      not list among permitted call targets.
+contract StorageMutationHook is IWildcatHook {
+  ExternalRegistry public immutable registry;
+
+  constructor(ExternalRegistry registry_) {
+    registry = registry_;
+  }
+
+  function onDeposit(address lender, uint256, MarketState calldata, bytes calldata) external override {
+    registry.set(keccak256(abi.encode(lender)), 1);
+  }
+
+  function onQueueWithdrawal(address, uint32, uint256, MarketState calldata, bytes calldata) external override {}
+  function onTransfer(address, address, address, uint256, MarketState calldata, bytes calldata) external override {}
+  function onSetAnnualInterestAndReserveRatioBips(uint16 a, uint16 r, MarketState calldata, bytes calldata)
+    external pure override returns (uint16, uint16) { return (a, r); }
+}
+
+/// @dev Gate 3: an access hook with no monotone known-lender bit. It re-checks
+///      the live credential on withdrawal, so once a credential lapses a lender
+///      who deposited can no longer exit. The failure shows only on the exit
+///      path, never on entry.
+contract StaleAuthHook is IWildcatHook {
+  error NotApprovedLender();
+
+  mapping(address => bool) public approved;
+  mapping(address => uint256) public credentialExpiry;
+
+  function grant(address lender, uint256 expiry) external {
+    approved[lender] = true;
+    credentialExpiry[lender] = expiry;
+  }
+
+  function removeProvider(address lender) external {
+    approved[lender] = false;
+  }
+
+  function _hasCredential(address lender) internal view returns (bool) {
+    return approved[lender] && block.timestamp <= credentialExpiry[lender];
+  }
+
+  function onDeposit(address lender, uint256, MarketState calldata, bytes calldata) external view override {
+    if (!_hasCredential(lender)) revert NotApprovedLender();
+  }
+
+  function onQueueWithdrawal(address lender, uint32, uint256, MarketState calldata, bytes calldata)
+    external view override {
+    // No monotone bit: a lapsed credential strands a lender who already
+    // deposited. This is the liveness violation gate 3 exists to catch.
+    if (!_hasCredential(lender)) revert NotApprovedLender();
+  }
+
+  function onTransfer(address, address, address, uint256, MarketState calldata, bytes calldata) external override {}
+  function onSetAnnualInterestAndReserveRatioBips(uint16 a, uint16 r, MarketState calldata, bytes calldata)
+    external pure override returns (uint16, uint16) { return (a, r); }
+}

--- a/plugins/janus/harness/test/HostileHooks.t.sol
+++ b/plugins/janus/harness/test/HostileHooks.t.sol
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.25;
+
+import {JanusBase} from "../src/JanusBase.sol";
+import {JanusHarness} from "../src/JanusHarness.sol";
+import {Vm} from "../src/Vm.sol";
+import {WildcatHostModel, MockAsset} from "../src/wildcat/WildcatHostModel.sol";
+import {WildcatHostAdapter} from "../src/wildcat/WildcatHostAdapter.sol";
+import {
+  ReentryHook,
+  GasGriefHook,
+  ValueRedirectHook,
+  IAsset,
+  ExternalRegistry,
+  StorageMutationHook,
+  StaleAuthHook
+} from "../src/hostile/HostileHooks.sol";
+
+contract HostileHooksTest is JanusBase, JanusHarness {
+  string constant MANIFEST = "manifests/wildcat-open-term.json";
+
+  MockAsset asset;
+  WildcatHostModel model;
+  WildcatHostAdapter adapter;
+  address lender = address(0xBEEF);
+
+  function setUp() public {
+    asset = new MockAsset();
+    model = new WildcatHostModel(asset);
+    adapter = new WildcatHostAdapter(model, asset, address(0));
+    model.setBorrower(address(adapter));
+    asset.mint(lender, 1_000_000);
+    vm.prank(lender);
+    asset.approve(address(model), type(uint256).max);
+  }
+
+  function _deposit(uint256 amount) internal returns (DriveResult memory) {
+    return _drive(adapter, "deposit", lender, abi.encode(lender, amount, bytes("")));
+  }
+
+  function test_reentry_hook_caught_by_gate6() external {
+    model.setHook(address(new ReentryHook()));
+    DriveResult memory r = _deposit(100);
+    assertTrue(r.reverted, "gate6: the re-entering deposit is blocked");
+    assertEq(
+      bytes4(r.revertData),
+      WildcatHostModel.Reentrancy.selector,
+      "gate6: blocked by the host reentrancy guard"
+    );
+  }
+
+  function test_gas_grief_hook_caught_by_gate5() external {
+    model.setHook(address(new GasGriefHook()));
+    _deposit(100);
+    uint256 budget = vm.parseJsonUint(vm.readFile(MANIFEST), ".thresholds[0].gasBudget");
+    assertTrue(
+      model.lastHookGasUsed() > budget,
+      "gate5: the hook consumed more than the manifest budget"
+    );
+  }
+
+  function test_value_redirect_hook_caught_by_gate2() external {
+    asset.mint(address(model), 500);
+    ValueRedirectHook hook = new ValueRedirectHook(IAsset(address(asset)), address(model), 500);
+    model.setHook(address(hook));
+    vm.prank(address(model));
+    asset.approve(address(hook), type(uint256).max);
+
+    uint256 hookBefore = asset.balanceOf(address(hook));
+    DriveResult memory r = _deposit(100);
+    assertTrue(!r.reverted, "the redirecting deposit reports success");
+
+    assertTrue(
+      r.valueAfter != r.valueBefore + 100,
+      "gate2: market value did not move by exactly the deposit"
+    );
+    assertTrue(asset.balanceOf(address(hook)) > hookBefore, "gate2: value moved to the hook");
+  }
+
+  function test_storage_mutation_hook_caught_by_gate1() external {
+    ExternalRegistry registry = new ExternalRegistry();
+    StorageMutationHook hook = new StorageMutationHook(registry);
+    model.setHook(address(hook));
+
+    DriveResult memory r = _deposit(100);
+    assertTrue(!r.reverted, "the mutating deposit reports success");
+
+    address[] memory allowed = new address[](0);
+    assertTrue(
+      !_gate1_hookCallsWithinAllowed(r.delta, address(hook), allowed),
+      "gate1: the call to the external registry is caught"
+    );
+  }
+
+  function test_stale_auth_hook_caught_by_gate3() external {
+    StaleAuthHook hook = new StaleAuthHook();
+    model.setHook(address(hook));
+    hook.grant(lender, block.timestamp + 1000);
+
+    DriveResult memory d = _deposit(100);
+    assertTrue(!d.reverted, "the lender deposits while credentialled");
+
+    vm.warp(block.timestamp + 5000);
+    DriveResult memory q = _drive(
+      adapter,
+      "queueWithdrawal",
+      lender,
+      abi.encode(lender, uint32(1000), uint256(100), bytes(""))
+    );
+    assertTrue(q.reverted, "gate3: the lender is stranded on exit after the credential lapses");
+  }
+
+  function test_run_emits_findings_and_requires_sequences() external {
+    Finding[] memory findings = new Finding[](5);
+    findings[0] = Finding(6, "deposit", "ReentryHook", "re-entered queueWithdrawal from onDeposit");
+    findings[1] = Finding(5, "deposit", "GasGriefHook", "consumed gas beyond the manifest budget");
+    findings[2] = Finding(2, "deposit", "ValueRedirectHook", "drained market assets while reporting success");
+    findings[3] = Finding(1, "deposit", "StorageMutationHook", "called an external registry not in the manifest");
+    findings[4] = Finding(3, "queueWithdrawal", "StaleAuthHook", "stranded a known lender after credential lapse");
+
+    string memory path = "out/findings.test.json";
+    _writeFindings(path, "wildcat-v2.5", "wildcat-open-term", 5, findings);
+
+    string memory json = vm.readFile(path);
+    assertEq(vm.parseJsonUint(json, ".sequences"), uint256(5), "findings record the sequence count");
+    assertEq(vm.parseJsonUint(json, ".findings[3].gate"), uint256(1), "the storage-mutation finding is gate 1");
+
+    vm.expectRevert(JanusHarness.NoSequencesExercised.selector);
+    this.exerciseZero();
+  }
+
+  function exerciseZero() external pure {
+    _requireExercised(0);
+  }
+}
+
+/// @dev A handler that keeps the reentry hook in a stateful fuzz loop: every
+///      driven deposit must be blocked by the host guard. If one ever landed,
+///      the invariant would see it.
+contract ReentryHandler {
+  Vm constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+  WildcatHostModel public model;
+  MockAsset public asset;
+  address public lender = address(0xBEEF);
+  bool public everLanded;
+
+  constructor() {
+    asset = new MockAsset();
+    model = new WildcatHostModel(asset);
+    model.setHook(address(new ReentryHook()));
+    asset.mint(lender, type(uint128).max);
+    vm.prank(lender);
+    asset.approve(address(model), type(uint256).max);
+  }
+
+  function poke(uint256 amount) external {
+    amount = (amount % 1000) + 1;
+    try model.deposit(lender, amount, "") {
+      everLanded = true;
+    } catch {
+      // expected: the reentrancy guard blocked it
+    }
+  }
+}
+
+contract ReentryInvariantTest is JanusBase {
+  ReentryHandler handler;
+
+  function setUp() public {
+    handler = new ReentryHandler();
+  }
+
+  /// @dev Restrict the invariant engine to the handler, so the fuzzer drives
+  ///      only `poke` and cannot repoint the model's hook or mint through the
+  ///      other deployed contracts.
+  function targetContracts() public view returns (address[] memory addrs) {
+    addrs = new address[](1);
+    addrs[0] = address(handler);
+  }
+
+  function invariant_reentry_never_lands() external view {
+    assertTrue(!handler.everLanded(), "a re-entering deposit was never allowed to land");
+  }
+}

--- a/plugins/janus/harness/test/HostileHooks.t.sol
+++ b/plugins/janus/harness/test/HostileHooks.t.sol
@@ -85,10 +85,20 @@ contract HostileHooksTest is JanusBase, JanusHarness {
     DriveResult memory r = _deposit(100);
     assertTrue(!r.reverted, "the mutating deposit reports success");
 
-    address[] memory allowed = new address[](0);
+    address[] memory allowedCalls = new address[](0);
     assertTrue(
-      !_gate1_hookCallsWithinAllowed(r.delta, address(hook), allowed),
+      !_gate1_hookCallsWithinAllowed(r.delta, address(hook), allowedCalls),
       "gate1: the call to the external registry is caught"
+    );
+
+    // The registry's storage was written by the hook's subtree. The storage
+    // scope check catches it independently of the call-target check: only the
+    // hook's own storage is a permitted write scope here.
+    address[] memory allowedWrites = new address[](1);
+    allowedWrites[0] = address(hook);
+    assertTrue(
+      !_gate1_hookStorageWithinScopes(r.delta, address(hook), allowedWrites),
+      "gate1: the hook-caused write to external storage is caught"
     );
   }
 
@@ -108,6 +118,11 @@ contract HostileHooksTest is JanusBase, JanusHarness {
       abi.encode(lender, uint32(1000), uint256(100), bytes(""))
     );
     assertTrue(q.reverted, "gate3: the lender is stranded on exit after the credential lapses");
+    assertEq(
+      bytes4(q.revertData),
+      StaleAuthHook.NotApprovedLender.selector,
+      "gate3: the exit is blocked by the stale credential check, not an unrelated revert"
+    );
   }
 
   function test_run_emits_findings_and_requires_sequences() external {
@@ -132,6 +147,20 @@ contract HostileHooksTest is JanusBase, JanusHarness {
   function exerciseZero() external pure {
     _requireExercised(0);
   }
+
+  /// @dev A finding field that tries to inject JSON is escaped, so it cannot
+  ///      rewrite or hide another field.
+  function test_findings_json_escapes_injection() external {
+    Finding[] memory findings = new Finding[](1);
+    findings[0] = Finding(1, "deposit", "Evil", 'x","gate":9999,"hidden":"');
+
+    string memory path = "out/findings.inject.json";
+    _writeFindings(path, "wildcat-v2.5", "wildcat-open-term", 1, findings);
+    string memory json = vm.readFile(path);
+
+    // The gate is still 1; the injected 9999 did not override it.
+    assertEq(vm.parseJsonUint(json, ".findings[0].gate"), uint256(1), "the injected gate did not take effect");
+  }
 }
 
 /// @dev A handler that keeps the reentry hook in a stateful fuzz loop: every
@@ -143,6 +172,7 @@ contract ReentryHandler {
   MockAsset public asset;
   address public lender = address(0xBEEF);
   bool public everLanded;
+  bool public sawNonGuardRevert;
 
   constructor() {
     asset = new MockAsset();
@@ -157,8 +187,12 @@ contract ReentryHandler {
     amount = (amount % 1000) + 1;
     try model.deposit(lender, amount, "") {
       everLanded = true;
-    } catch {
-      // expected: the reentrancy guard blocked it
+    } catch (bytes memory data) {
+      // The block must be the reentrancy guard. If the guard were removed, the
+      // re-entering queueWithdrawal would revert for a different reason (a
+      // balance underflow), which this flag would catch, so the invariant
+      // genuinely exercises gate 6 rather than an incidental revert.
+      if (bytes4(data) != WildcatHostModel.Reentrancy.selector) sawNonGuardRevert = true;
     }
   }
 }
@@ -180,5 +214,9 @@ contract ReentryInvariantTest is JanusBase {
 
   function invariant_reentry_never_lands() external view {
     assertTrue(!handler.everLanded(), "a re-entering deposit was never allowed to land");
+    assertTrue(
+      !handler.sawNonGuardRevert(),
+      "every blocked deposit was blocked by the reentrancy guard, so the invariant exercises gate 6"
+    );
   }
 }

--- a/plugins/janus/harness/test/WildcatConformance.t.sol
+++ b/plugins/janus/harness/test/WildcatConformance.t.sol
@@ -116,6 +116,22 @@ contract LaunderProbe is IWildcatHook {
   }
 }
 
+/// @dev A benign hook that reads host state through a staticcall on deposit. A
+///      read is not an effect, so gate 1 must not reject it even though the
+///      host is not in the permitted call set.
+contract HostReadHook is IWildcatHook {
+  uint256 public seen;
+
+  function onDeposit(address, uint256, MarketState calldata, bytes calldata) external override {
+    seen = WildcatHostModel(msg.sender).scaledTotalSupply();
+  }
+
+  function onQueueWithdrawal(address, uint32, uint256, MarketState calldata, bytes calldata) external override {}
+  function onTransfer(address, address, address, uint256, MarketState calldata, bytes calldata) external override {}
+  function onSetAnnualInterestAndReserveRatioBips(uint16 a, uint16 r, MarketState calldata, bytes calldata)
+    external pure override returns (uint16, uint16) { return (a, r); }
+}
+
 contract WildcatConformanceTest is JanusBase, JanusHarness {
   string constant MANIFEST = "manifests/wildcat-open-term.json";
 
@@ -209,6 +225,24 @@ contract WildcatConformanceTest is JanusBase, JanusHarness {
     assertTrue(
       !_gate1_hookCallsWithinAllowed(r.delta, address(probe), allowed),
       "gate1: a forbidden call laundered one hop through an allowed target is caught"
+    );
+  }
+
+  function test_gate1_does_not_reject_a_host_read() external {
+    // A hook that reads host state via a staticcall makes no effect. Gate 1
+    // must pass it even with an empty permitted-call set: reads are not
+    // enumerated effects, and the host is not swept in as a laundering relay.
+    HostReadHook reader = new HostReadHook();
+    model.setHook(address(reader));
+    honest.grant(lender, block.timestamp + 1000); // not used by the reader, harmless
+
+    DriveResult memory r = _drive(adapter, "deposit", lender, _depositParams(100));
+    assertTrue(!r.reverted, "the host-reading deposit succeeds");
+
+    address[] memory allowed = new address[](0);
+    assertTrue(
+      _gate1_hookCallsWithinAllowed(r.delta, address(reader), allowed),
+      "gate1: a staticcall read of host state is not a forbidden effect"
     );
   }
 


### PR DESCRIPTION
Step 5 of the Janus run. It ships one hostile reference hook per failure class and completes the gate engine that catches each.

Each hook is a real, non-conformant hook caught by exactly the gate that owns its failure: ReentryHook re-enters a different action and the host guard blocks it (gate 6); GasGriefHook consumes gas beyond the manifest budget (gate 5); ValueRedirectHook drains the market while reporting success, caught from balances rather than the return (gate 2); StorageMutationHook writes external storage through a call the manifest does not permit (gate 1); and StaleAuthHook keeps no monotone bit, so a lender is stranded on exit once a credential lapses (gate 3).

The engine attributes a hook's effects by its call-frame subtree, so it captures a forbidden call laundered one hop out without sweeping in the host's own base-action calls when a hook merely reads host state; a staticcall is treated as a read, not an effect. Gate 1 covers both calls and hook-caused writes to non-permitted storage. The engine emits findings as an escaped JSON interchange the reporter renders, and refuses a run that exercised nothing. A stateful invariant keeps the reentry hook in the loop over 2048 calls and confirms every block is the reentrancy guard.

Audit: two rounds in `audit/AUDIT.md`. Round 1 found five issues, the material one being over-attribution that wrongly failed a hook reading host state; all are fixed and round 2 is clean. Two limitations are recorded as accepted: no gate yet constrains the value-returning hook's in-bounds return, and the gas gate is exercised on deposit; both need a manifest field the format does not yet carry.

Proof:

```text
cd plugins/janus/harness && forge test
```

Stacks on step 4 (#275).

`wildcat-origin: shoggoth` — stated visibly because this runtime's GitHub tooling strips HTML comments from pull-request bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzYExBFMq2oyrosJteQC5S

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzYExBFMq2oyrosJteQC5S)_