### PR TITLE
Mirror main and tags to the private marketplace, not every branch

### DIFF
--- a/.github/workflows/sync-skills-marketplace.yml
+++ b/.github/workflows/sync-skills-marketplace.yml
@@ -17,6 +17,14 @@ jobs:
     if: github.repository == 'wildcat-finance/skills-marketplace'
     runs-on: ubuntu-latest
     steps:
+      # Only main and tags. GitHub refuses any push made with an App token,
+      # which `github.token` is, that creates or updates a file under
+      # `.github/workflows/`, and there is no `permissions:` key that grants it:
+      # the Workflows permission exists for fine-grained tokens and GitHub Apps,
+      # not for GITHUB_TOKEN. Mirroring every branch therefore fails whenever a
+      # branch carries a new workflow file, and one rejected ref fails the whole
+      # push. Widening this back needs a token with Workflows permission first,
+      # not a change here.
       - name: Mirror public repository
         env:
           DESTINATION_REPOSITORY: ${{ github.repository }}
@@ -25,5 +33,5 @@ jobs:
           git clone --bare https://github.com/wildcat-finance/skills.git source.git
           git -C source.git push --force --prune \
             "https://x-access-token:${DESTINATION_TOKEN}@github.com/${DESTINATION_REPOSITORY}.git" \
-            "refs/heads/*:refs/heads/*" \
+            "refs/heads/main:refs/heads/main" \
             "refs/tags/*:refs/tags/*"


### PR DESCRIPTION
The private marketplace mirror has been failing every five minutes. This
narrows what it pushes, which stops the failure without pretending to fix its
cause.

## Why it fails

`sync-skills-marketplace.yml` force-pushes every branch and tag from this
repository into `skills-marketplace` using `github.token`. GitHub refuses any
push made with an App token that creates or updates a file under
`.github/workflows/`, and `github.token` is an App token. The five open janus
branches add `.github/workflows/janus.yml`, so each of them is rejected, and one
rejected ref fails the whole `git push`.

No `permissions:` block fixes that. The Workflows permission exists for
fine-grained personal tokens and GitHub App installations, not for
`GITHUB_TOKEN`, so it cannot be granted here.

`main` still mirrors today only because the destination already holds identical
copies of the three workflow files, so pushing it creates or updates nothing
under that path. That ends when a workflow file on `main` changes, and janus
adds one, so the mirror of `main` was going to start failing on its own.

## What this does

Mirrors `refs/heads/main` and all tags. A comment above the step records why,
and records that widening it back needs a token with Workflows permission rather
than an edit to the refspec.

`--prune` stays, so the 84 other branches already in `skills-marketplace` are
removed on the next run. Every one is a copy of a public ref here, so nothing
unique is destroyed, and widening the refspec restores them on the following
tick.

## Landing it takes two pushes

This change updates a workflow file, so the mirror's own push of `main` is
rejected until the destination's copy matches byte for byte: it cannot deploy
itself through the pipe it repairs. Once this merges, the same `main` is pushed
to `skills-marketplace` with a user token, which the App restriction does not
cover, after which the two copies agree and the cron carries on unaided.

## Carried forward

- The real fix is a token with Workflows permission, a fine-grained PAT or a
  GitHub App installation with Contents and Workflows write, replacing
  `github.token` in this workflow. Deferred by the maintainer; until it exists,
  no branch carrying a workflow file can be mirrored.
- `plugins/horos/**` still has no CI workflow, from
  [#267](https://github.com/wildcat-finance/skills/pull/267).

<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
