### PR TITLE
Push the marketplace mirror with a token that may carry workflow files

### DIFF
--- a/.github/workflows/sync-skills-marketplace.yml
+++ b/.github/workflows/sync-skills-marketplace.yml
@@ -5,8 +5,9 @@ on:
     - cron: "*/5 * * * *"
   workflow_dispatch:
 
-permissions:
-  contents: write
+# Nothing here uses GITHUB_TOKEN: the source clone is public and the push
+# carries a token with the Workflows permission, which GITHUB_TOKEN cannot hold.
+permissions: {}
 
 concurrency:
   group: sync-skills-marketplace
@@ -17,18 +18,24 @@ jobs:
     if: github.repository == 'wildcat-finance/skills-marketplace'
     runs-on: ubuntu-latest
     steps:
-      # Only main and tags. GitHub refuses any push made with an App token,
-      # which `github.token` is, that creates or updates a file under
-      # `.github/workflows/`, and there is no `permissions:` key that grants it:
-      # the Workflows permission exists for fine-grained tokens and GitHub Apps,
-      # not for GITHUB_TOKEN. Mirroring every branch therefore fails whenever a
-      # branch carries a new workflow file, and one rejected ref fails the whole
-      # push. Widening this back needs a token with Workflows permission first,
-      # not a change here.
+      # Only main and tags, and that is a choice rather than a limit now.
+      #
+      # The push carries MARKETPLACE_SYNC_TOKEN, a fine-grained token holding
+      # Contents and Workflows write on this repository. The Workflows
+      # permission is the one that matters: GitHub refuses any push that
+      # creates or updates a file under `.github/workflows/` unless the token
+      # holds it, and GITHUB_TOKEN never can, which is why mirroring main broke
+      # the moment main gained a workflow file.
+      #
+      # Widening back to `refs/heads/*` would work with this token, and would
+      # also restore every branch the narrowing left behind, which is why it
+      # stays as it is. `--prune` sweeps tags that no longer exist upstream; it
+      # cannot sweep branches, because a single-ref refspec gives it no pattern
+      # to sweep.
       - name: Mirror public repository
         env:
           DESTINATION_REPOSITORY: ${{ github.repository }}
-          DESTINATION_TOKEN: ${{ github.token }}
+          DESTINATION_TOKEN: ${{ secrets.MARKETPLACE_SYNC_TOKEN }}
         run: |
           git clone --bare https://github.com/wildcat-finance/skills.git source.git
           git -C source.git push --force --prune \


### PR DESCRIPTION
The mirror is failing again, exactly as predicted, and this fixes the cause
rather than the symptom.

[#279](https://github.com/wildcat-finance/skills/pull/279) landed
`.github/workflows/janus.yml` on `main`. The mirror pushes `main` with
`github.token`, and GitHub refuses any push made with an App token that creates
or updates a file under `.github/workflows/`. So the private mirror has been
stuck at `85f1d9e` since 13:31, three failures deep, and no amount of narrowing
the refspec could have helped: the blocked ref is `main` itself.

The push now carries `MARKETPLACE_SYNC_TOKEN`, a fine-grained token with
Contents and Workflows write on `skills-marketplace`. The Workflows permission
is the whole point of it, and `GITHUB_TOKEN` can never hold one.

Two smaller consequences:

- `permissions: {}`, because nothing in the job uses `GITHUB_TOKEN` any more.
  The source clone is public and the push carries its own credential.
- The refspec stays at `main` plus tags. Widening it back would work with this
  token, and would also restore the 84 branches the narrowing left behind, so it
  stays a choice rather than a limit. The comment above the step now says that,
  along with why `--prune` sweeps tags but not branches.

## Landing it

Same two pushes as [#280](https://github.com/wildcat-finance/skills/pull/280),
for the last time. The destination still runs the old workflow until a push
lands there, and that push is the one the old token cannot make, so `main` goes
across once with a user token. Every run after that mints the fine-grained token
and can carry workflow files on its own.

## Carried forward

- The 84 stale branches in `skills-marketplace` are still there. The deletion
  was approved and the harness classifier blocked the bulk call, so it is the
  maintainer's to run.
- `plugins/horos/**` still has no CI workflow, from
  [#267](https://github.com/wildcat-finance/skills/pull/267). It is unblocked
  now: a new workflow file on `main` no longer breaks the mirror.
- The token expires. When it does, the mirror stops silently, and a GitHub App
  installation is the version of this with no expiry to diary.

<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
