### PR TITLE
Declare Hexaemeron Promise Machine contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ state, evidence and unknowns visible from turn to turn.
 
 [Tabularium](./plugins/tabularium) preserves on-chain credit events in a form
 another person can rebuild after the endpoint that served them is gone.
+Its checked-in releases include the reproducible
+[`goldfinch-v0`](./plugins/tabularium/examples/goldfinch-v0) specimen.
 
 
 ## Who these are for

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5296,3 +5296,34 @@ Zero findings.
 ### Leads not pursued
 
 The behavioural-conformance boundary recorded in round 1 remains unchanged.
+
+## Promise Machine, step 5, round 1 -- 2026-08-20
+
+### Review scope
+
+The Solidity suite remained waived because this step changes first-party
+Markdown contracts, a standard-library checker and its Python tests. The
+review compared all 18 Hexaemeron declarations with their canonical
+instructions and checked the five vendored overlays against their unchanged
+upstream bytes. It also inspected overlay discovery, confinement, bounded
+reads, suite-wide identifier uniqueness, exact coverage, digest drift,
+first-party rejection and the runtime digest-check instruction.
+
+### Findings
+
+Zero findings.
+
+### Evidence
+
+The checker reports 61 canonical first-party promises and five digest-bound
+vendored overlays. All 44 focused Promise Machine tests, 80 root tests and 451
+Hexaemeron tests pass. A one-byte mutation of a vendored instruction is
+refused with `PM057`; the five vendored instruction paths have no diff.
+Imprimatur, Brevitas, Phylax, Ephoros, Hypomnema and Horos are clean.
+
+### Leads not pursued
+
+The declarations state evidence contracts but do not yet prove every skill's
+runtime implementation conforms to them. Executable, prompt, transformation
+and vendored conformance are the explicit subjects of the next two runbook
+steps, so treating that work as a finding here would duplicate their scope.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5254,3 +5254,26 @@ The 255 Alexandria tests, 15 Brevitas tests, 364 Lazarus tests and four
 Sapheneia tests pass. The 74-test root suite also passes. Lazarus was exercised
 in a fresh environment built from its committed `requirements.lock`, matching
 the dependency boundary used by CI.
+
+## Promise Machine, step 4, round 1 -- 2026-08-20
+
+### Review scope
+
+The Solidity audit suite remained waived because the step changes Markdown
+declarations, Python contract checks and packaging guards. The review compared
+all 43 standalone promises with their canonical commands and existing refusal
+boundaries, then exercised absent-contract and declaration-identity mutations.
+
+### Findings
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S4-R1-01 | high | `scripts/promise_machine.py` | The documented `contracts` component was only an alias for the earlier optional structure pass, so an absent standalone declaration still passed | fixed by requiring a contract for every non-Hexaemeron first-party skill and guarding an absent section |
+| S4-R1-02 | high | `plugins/pandects/skills/pandects/SKILL.md` | `pandects-law-contract` said `pandects.py check` established generated catalogue-byte equality, although that relation belongs to the separate renderer regression | fixed by narrowing the law check and adding a separate render promise |
+| S4-R1-03 | medium | `tests/test_promise_machine_contract.py` | The population guard collected expected promise ids from every level-three heading in a skill, so an id moved outside the contract section could satisfy the repository-specific assertion | fixed by confining exact id-set comparison to the contract section |
+
+### Leads not pursued
+
+This round does not claim behavioural conformance from the new Markdown.
+Executable, prompt and transformation evidence receives its own coverage and
+negative-evidence work in the following runbook steps.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5277,3 +5277,22 @@ boundaries, then exercised absent-contract and declaration-identity mutations.
 This round does not claim behavioural conformance from the new Markdown.
 Executable, prompt and transformation evidence receives its own coverage and
 negative-evidence work in the following runbook steps.
+
+## Promise Machine, step 4, round 2 -- 2026-08-20
+
+### Review scope
+
+The corrected contracts component requires all 13 standalone first-party
+declarations while leaving the next step's Hexaemeron population explicit.
+The exact contract-section id sets contain 43 promises. Pandects now gives
+structural law checking and catalogue rendering separate evidence and
+consequences. The absent-section mutation, 75 root tests, 116 Pandects Python
+tests and the Pandects Foundry suite pass.
+
+### Findings
+
+Zero findings.
+
+### Leads not pursued
+
+The behavioural-conformance boundary recorded in round 1 remains unchanged.

--- a/docs/decisions/ADR-003-bind-vendored-promises-with-digests.md
+++ b/docs/decisions/ADR-003-bind-vendored-promises-with-digests.md
@@ -1,0 +1,49 @@
+# ADR-003: Bind vendored promises with digests
+
+- Status: Accepted
+- Date: 2026-08-20
+- Promise Machine contract: `promise-machine/v1`
+
+## Context
+
+Five Hexaemeron skills are vendored from an upstream source. Their instruction
+files must remain attributable and byte-exact, but the Wildcat suite still
+needs to state what evidence it accepts from those operations and what each
+result authorises. Writing the suite contract into a vendored instruction
+would silently fork the upstream work. An unbound note elsewhere could survive
+an upstream change while describing behaviour the new bytes no longer have.
+
+## Decision
+
+Keep each upstream `SKILL.md` unchanged. Hold the Wildcat declarations in the
+single first-party file `plugins/hexaemeron/PROMISES.md`. Every declaration
+names one discovered vendored canonical path and the SHA-256 of that file's
+exact bytes, followed by the nine Promise Machine fields.
+
+The repository checker recomputes each digest and rejects a missing overlay,
+an extra overlay location, an unsafe or absent path, a first-party target, a
+duplicate path or promise identifier, incomplete fields, uncovered vendored
+skills and byte drift. A runtime that selects a vendored skill reads its block
+and compares the recorded digest before relying on the overlay. Digest drift
+blocks the Wildcat promise; it does not authorise editing the upstream file.
+
+## Alternatives rejected
+
+- Editing vendored instructions would create an unattributed local fork and
+  make upstream comparison unreliable.
+- A notice without a digest would not show whether the declaration still
+  described the instruction actually installed.
+- Separate overlay files beside each vendored skill would widen discovery and
+  make omission and duplicate ownership harder to check.
+
+## Consequences
+
+An upstream update now fails closed until its changed instruction is reviewed
+and the corresponding declaration and digest are deliberately updated. The
+overlay remains Wildcat-authored; the upstream instruction and attribution
+remain intact. The digest binds bytes, not truth: executable and review
+evidence must still satisfy the declaration before it authorises anything.
+
+Rollback is all-or-nothing. Remove the overlay, its runtime binding, checker
+component and tests together; do not leave an unchecked promise beside
+vendored instructions.

--- a/plugins/alexandria/skills/alexandria/SKILL.md
+++ b/plugins/alexandria/skills/alexandria/SKILL.md
@@ -193,3 +193,53 @@ Read the [study](../../docs/study.md) for the selected construction and the
 A digest can establish that bytes match a manifest. It does not establish who
 published them, that an indexer captured a complete chain history, or that a
 reported block is canonical. Those claims require separate evidence.
+
+## Promise Machine contract
+
+### alexandria-raw-release
+
+- Promise: A successful `ingest` followed by `verify` preserves the named local source bytes and binds them to the canonical manifest, release identity, declared capture boundary, coverage and gaps.
+- Evidence: The capture plan, copied objects, canonical manifest, printed release id and a passing `alexandria.py verify` result for the same release directory.
+- Evidence classes: recorded, checked, recomputed
+- Boundary: The result does not establish publisher identity, source completeness, chain finality or any fact outside the declared capture scope.
+- Authorises: Retention or hand-off of the verified raw release as a bounded preservation artefact.
+- Consequence: 2
+- Refuses: Installing, moving or describing a release as verified when a source path, digest, byte count, scope, coverage declaration or tree-membership check is absent or fails.
+- Recovery: Inspect the named verification failure, repair the plan or source set, ingest into a new output directory and rerun verification.
+- Exceptions: none
+
+### alexandria-derived-view
+
+- Promise: A successful `derive` followed by `verify` reproduces every emitted credit event and observation from a verified raw release under the named registered mapping and reconciles its selectors and counts.
+- Evidence: The verified raw release, adapter and mapping versions, derived JSONL, coverage records and a passing verification that reruns the mapping.
+- Evidence classes: recorded, checked, recomputed
+- Boundary: The view preserves venue and evidence classes; it does not infer default, full repayment, current balance, source completeness or universal event meaning.
+- Authorises: Use of the verified derived release as bounded input to Tabularium or an explicitly archive-backed Probitas collection.
+- Consequence: 2
+- Refuses: Using rows whose source selectors do not resolve, whose counts conflict, whose mapping is unknown or whose raw release did not verify.
+- Recovery: Inspect the failed selector, mapping or count, correct the adapter or source release without changing published evidence, derive a new release and verify it.
+- Exceptions: none
+
+### alexandria-address-query
+
+- Promise: A successful `index` and `query` returns only rows from verified derived partitions whose identities and logical digest match the disposable index.
+- Evidence: The verified derived releases, SQLite schema and logical digest checks, partition identities and the exact query result for the requested address.
+- Evidence classes: checked, recomputed
+- Boundary: SQLite is not release evidence, and zero rows does not mean a clean history unless complete declared coverage spans every requested address, venue, chain and time boundary with no unsupported records.
+- Authorises: Presentation or downstream use of the source-bound query result with its coverage and gaps kept visible.
+- Consequence: 1
+- Refuses: Querying a mutable or mismatched index, collapsing conflicting rows, or presenting an uncovered zero-row result as absence of activity.
+- Recovery: Rebuild the disposable index from verified releases, rerun the query and report any remaining coverage gap instead of a clean result.
+- Exceptions: none
+
+### alexandria-compound-method-proof
+
+- Promise: A successful Compound Phase 0 `check` binds the fixed registry and captured transaction witness to the named Comet revision, proxy implementation, code, old-state reads, calls and ordered writes under the implemented method.
+- Evidence: The pinned registry, captured input, built release and passing `compound_v3_phase0.py check` result, including the proof-checked state relation and separately labelled provider records.
+- Evidence classes: recorded, checked, recomputed, proved: EIP-1186 state relation
+- Boundary: The result covers the fixed corpus and implemented method only; it is not an interval history, independent canonical-chain proof, canonical Tabularium mapping or proof of receipts, logs or traces.
+- Authorises: Use of the checked Phase 0 witness as bounded method evidence for the named transactions.
+- Consequence: 1
+- Refuses: Generalising the witness to another deployment, transaction, interval, implementation, layout or evidence class.
+- Recovery: Inspect the named registry, implementation, state, call, write or selector mismatch, recapture under an amended fixed plan and rerun the check.
+- Exceptions: none

--- a/plugins/ariadne/skills/ariadne/SKILL.md
+++ b/plugins/ariadne/skills/ariadne/SKILL.md
@@ -296,3 +296,53 @@ Nothing confirms a deployment against a chain, nothing signs, and nothing runs
 as a GitHub Action. Each of those is a deliberate boundary rather than an
 omission: the first needs a node, the second needs key custody this tool
 declines, and the third needs a workflow that owns neither.
+
+## Promise Machine contract
+
+### ariadne-capture-statement
+
+- Promise: A successful capture command writes an in-toto statement whose subjects, predicate fields and preserved absences are derived from the named local artefact and caller-supplied boundary.
+- Evidence: The capture command, local input bytes, computed subject and component digests, registered predicate schema and the emitted statement that `verify` accepts unedited.
+- Evidence classes: recorded, checked, recomputed
+- Boundary: Capture records caller-supplied claims and local bytes; it does not decide that tests passed, establish chain facts, verify a publisher or turn a producer assertion into truth.
+- Authorises: Use of the statement as a derived evidence-binding artefact for later inspection, verification or external signing.
+- Consequence: 1
+- Refuses: Inventing a result, coverage boundary, evidence count, producer, digest or earlier release that the inputs do not establish.
+- Recovery: Supply the missing input or explicit absence reason, correct the local artefact or boundary and rerun the relevant capture command.
+- Exceptions: none
+
+### ariadne-inspect-statement
+
+- Promise: A successful `inspect` identifies the statement or envelope's predicate registration, subjects, digests and signature-verification status without implying an unchecked author.
+- Evidence: The bounded parsed bytes, in-toto or DSSE structure, predicate registry lookup and the inspection output.
+- Evidence classes: recorded, checked
+- Boundary: Inspection reports document contents and registration only; it does not run predicate gates, verify a signature, authenticate an actor or establish the assertions' truth.
+- Authorises: Presentation of the bounded inspection result with unsigned or unchecked status visible.
+- Consequence: 0
+- Refuses: Naming a signer, publisher or verified predicate result when the corresponding external verification or gate run did not occur.
+- Recovery: Obtain external signature evidence or run `verify` for predicate gates, then report each result as a separate relation.
+- Exceptions: none
+
+### ariadne-verify-statement
+
+- Promise: A successful `verify` establishes that the named statement passed every applicable core and registered-predicate gate, while unknown-predicate gates remain explicitly unchecked.
+- Evidence: The exact statement or envelope bytes, bounded parser result, subject digests and the complete named gate report from `ariadne.py verify`.
+- Evidence classes: checked, recomputed
+- Boundary: Verification establishes the declared evidence binding only; it does not authenticate a publisher, prove underlying claim truth, confirm a deployment or make unchecked gates pass.
+- Authorises: With separate release authority, attaching the verified statement to the exact subject digest as inspectable release evidence.
+- Consequence: 3
+- Refuses: Publication as a complete or authenticated attestation when a gate failed, was unchecked, or no external signature verifier established identity.
+- Recovery: Inspect the failed or unchecked gate, repair or extend the predicate evidence, rerun verification and obtain external signature verification when identity matters.
+- Exceptions: none
+
+### ariadne-replay-command
+
+- Promise: A successful execution-enabled `replay` runs only commands marked exact through argument-vector execution and compares their declared outputs without invoking a shell.
+- Evidence: The verified statement, replay plan, explicit `--allow-execution` authority, executed argv records and exact output-digest comparisons.
+- Evidence classes: checked, recomputed, recorded
+- Boundary: Replay covers only eligible exact commands in the named project and does not make nondeterministic, redacted, path-bearing or hostile commands safe.
+- Authorises: Execution of the accepted replay plan in the caller-selected project and reporting of its exact output comparisons.
+- Consequence: 2
+- Refuses: Executing by default, using a shell, running an ineligible program name, or describing a plan-only run as execution evidence.
+- Recovery: Review the printed plan, remove or correct the unsafe command record, choose a controlled project and rerun with explicit execution authority.
+- Exceptions: none

--- a/plugins/berean/skills/berean/SKILL.md
+++ b/plugins/berean/skills/berean/SKILL.md
@@ -145,3 +145,53 @@ python3 scripts/berean.py export-cases examples/goldfinch-demo-v0/release --out 
 
 If a build, verification, evaluation or test did not run, say so plainly and
 do not describe it as successful.
+
+## Promise Machine contract
+
+### berean-corpus-binding
+
+- Promise: A successful corpus build or verification binds every manifest entry to the exact local file bytes and binds the sorted listing to one corpus digest.
+- Evidence: The corpus tree, `berean-corpus/v1` manifest, per-file byte counts and SHA-256 digests, recomputed corpus digest and passing `verify-corpus` result.
+- Evidence classes: checked, recomputed, recorded
+- Boundary: The binding establishes corpus identity and path confinement; it does not establish document truth, completeness, retrieval quality or answer correctness.
+- Authorises: Use of the verified corpus identity as the document boundary for citation checks and a Berean release.
+- Consequence: 1
+- Refuses: Citation or evaluation against a missing, escaped, symlinked, changed or unpinned corpus file.
+- Recovery: Restore the declared bytes or build a new corpus manifest, then rerun corpus verification before any dependent check.
+- Exceptions: none
+
+### berean-answer-evidence
+
+- Promise: A successful `check-answer` establishes that every factual sentence in the recorded answer has an allowed source class and that each citation, chain read, conflict or refusal satisfies the named release rules.
+- Evidence: The `berean-answer/v1` record, verified release and corpus, byte-exact citation slices, recomputed Lazarus request keys, time-domain conflicts and refusal rules.
+- Evidence classes: checked, recomputed, recorded
+- Boundary: The check establishes rule conformance for a recorded answer; it does not establish factual truth, model quality, canonical-chain status or proof-backed status for a recorded RPC read.
+- Authorises: Retention or presentation of the checked answer with its source classes, time domains, conflicts and refusals unchanged.
+- Consequence: 1
+- Refuses: An unclassified assertion, mismatched citation, blockless live value, silent conflict choice, evidence-class upgrade or answer outside the release boundary.
+- Recovery: Correct or refuse the affected sentence, restore the pinned evidence and rerun `check-answer` against the same release.
+- Exceptions: none
+
+### berean-evaluation-report
+
+- Promise: A successful `run-evals` recomputes the named evaluation cases against the verified release and records their grader results without running a model.
+- Evidence: The pinned evaluation corpus, verified release digest, recorded answer fixtures, named graders, per-case outcomes and emitted evaluation report.
+- Evidence classes: checked, recomputed, recorded
+- Boundary: The report establishes performance on the named recorded cases and thresholds only; it does not establish factual truth, live behaviour, general model quality or performance on another corpus.
+- Authorises: Comparison of the release against its declared evaluation thresholds and preservation of the resulting report.
+- Consequence: 1
+- Refuses: Grading against an unpinned corpus, substituting live model output, hiding a failed or correct-refusal case, or extending the result beyond the named cases.
+- Recovery: Restore the pinned cases or answer records, correct the release boundary and rerun the complete evaluation.
+- Exceptions: none
+
+### berean-release-promotion
+
+- Promise: A successful `promote` or `rollback` appends a record binding the selected release digest to the exact evaluation report, thresholds, result and operator-requested transition.
+- Evidence: A verified release, pinned evaluation report, declared thresholds, promotion or rollback record, record-chain verification and the operator's explicit command.
+- Evidence classes: checked, recorded
+- Boundary: The record proves that declared release gates authorised the transition; it does not establish answer truth, model quality, publisher identity or any unstated approval.
+- Authorises: Activation or restoration of only the named release digest under the operator's recorded release authority.
+- Consequence: 3
+- Refuses: Activation without a passing bound report, mutation of prior records, threshold substitution, digest mismatch or description of promotion as factual approval.
+- Recovery: Inspect the promotion chain, correct the release or evaluation evidence, append a new promotion or rollback record and recheck the chain.
+- Exceptions: none

--- a/plugins/berean/tests/test_scaffold.py
+++ b/plugins/berean/tests/test_scaffold.py
@@ -126,7 +126,9 @@ class FrontierTests(unittest.TestCase):
             r"\*\*Current frontier\.\*\* ([^\n]+)", landing
         ).group(1).strip()
         surfaces = sorted(PLUGIN_ROOT.rglob("*.md"))
-        surfaces.append(REPO_ROOT / ".agents" / "skills" / "berean" / "SKILL.md")
+        surfaces.append(
+            REPO_ROOT / ".agents" / "skills" / "promise-machine" / "SKILL.md"
+        )
         checked = 0
         for path in surfaces:
             text = read(path)

--- a/plugins/brevitas/skills/brevitas/SKILL.md
+++ b/plugins/brevitas/skills/brevitas/SKILL.md
@@ -112,3 +112,29 @@ compression and exact retention for the evidence-exception case.
 
 Do not apply this skill to code comments, commit messages or specifications where
 completeness is the point. Do not change lexicon, tone, register or accessibility.
+
+## Promise Machine contract
+
+### brevitas-structure-check
+
+- Promise: A successful answer- or report-mode lint establishes that the named draft satisfies Brevitas's mechanical line, finding, code-fence, table, heading and qualifier budgets.
+- Evidence: The exact draft bytes, selected lint mode, emitted diagnostics and exit status from `scripts/brevitas.py`.
+- Evidence classes: checked
+- Boundary: The lint does not establish factual accuracy, evidence completeness, severity correctness, voice, accessibility or fitness for a completeness-oriented specification.
+- Authorises: Presentation of the checked draft as structurally conformant to the selected Brevitas mode.
+- Consequence: 0
+- Refuses: Calling prose Brevitas-clean when the checker did not run, reported a diagnostic, inferred the wrong mode or received an excluded document class.
+- Recovery: Select the right mode, preserve protected evidence, remove the named structural defect and rerun the checker.
+- Exceptions: none
+
+### brevitas-evidence-preservation
+
+- Promise: A successful lint with `--source` establishes that protected addresses, transaction hashes, file-line references and numeric tokens from the named source survive in the compressed draft.
+- Evidence: The exact source and draft bytes, source-token comparison, any explicit evidence exception and a zero-exit lint result.
+- Evidence classes: checked, recomputed
+- Boundary: Token survival does not establish semantic equivalence, complete reasoning, correct conclusions or preservation of evidence classes that the token checker cannot represent.
+- Authorises: Saving or handing off the compressed draft as a derived artefact whose mechanically protected tokens remain present.
+- Consequence: 1
+- Refuses: Deleting or weakening protected evidence to meet a volume budget, or claiming preservation without supplying the source comparison.
+- Recovery: Restore the missing evidence, use a scoped evidence exception when ordered proof requires it and rerun with the original source.
+- Exceptions: none

--- a/plugins/hermes/skills/hermes/SKILL.md
+++ b/plugins/hermes/skills/hermes/SKILL.md
@@ -180,3 +180,41 @@ That accepted state becomes the baseline for the next class. Never run two class
 - If someone asks to bundle changes, run them in sequence.
 - If the gas saving cannot be quantified, reject it.
 - If a state-sensitive unchecked change lacks the targeted proof, reject it whatever the gas number says.
+
+## Promise Machine contract
+
+### hermes-sealed-baseline
+
+- Promise: A successful `baseline` seals a green, clean Foundry baseline with the named gas measurements, configuration, seed, source revision, protected layouts and method identifiers.
+- Evidence: The run directory, baseline snapshot, full test log, Foundry version, canonical configuration, Git and source records, storage layouts and method maps.
+- Evidence classes: checked, measured, recorded
+- Boundary: The baseline describes one repository state and environment; it does not establish that a later candidate preserves behaviour or improves gas.
+- Authorises: Evaluation of one declared optimisation class against the sealed baseline and fixed measurement set.
+- Consequence: 1
+- Refuses: Beginning a candidate comparison from a dirty tree, red suite, missing snapshot, unresolved protected set or changed exclusions.
+- Recovery: Restore a clean green repository, re-derive the protected and measured sets and take a fresh baseline.
+- Exceptions: none
+
+### hermes-candidate-acceptance
+
+- Promise: A successful `verify` with `result.json` status `accepted` establishes measured savings for every named target, no deterministic regression, passing pinned and unpinned behaviour suites, preserved protected layouts and selectors, and the required unchecked-arithmetic evidence for one declared class.
+- Evidence: The sealed baseline, candidate Solidity diff, gas snapshot comparison, gas report, both full test runs, layout and selector comparisons, targeted property result when required and accepted `result.json`.
+- Evidence classes: checked, measured, recomputed, recorded
+- Boundary: Acceptance covers one candidate, repository state, toolchain, measurement set and optimisation class; it is not a general security proof or permission to combine another change.
+- Authorises: Retaining and reviewing that exact gas candidate as a repository mutation with its complete evidence directory.
+- Consequence: 2
+- Refuses: Acceptance after any gate fails, a target lacks a saving, the measurement set moves, a protected interface changes or sensitive unchecked arithmetic lacks its named property evidence.
+- Recovery: Remove only the rejected candidate, return to the sealed green state, correct prerequisite tests separately and start a new Hermes run.
+- Exceptions: none
+
+### hermes-baseline-promotion
+
+- Promise: A successful `promote` advances the Hermes baseline only to the exact candidate already accepted by the same run record.
+- Evidence: The accepted `result.json`, matching run directory, candidate snapshot and promotion command result.
+- Evidence classes: checked, recorded
+- Boundary: Promotion changes the local measurement baseline; it does not publish code, accept another optimisation class or validate unrecorded edits.
+- Authorises: Using the promoted accepted snapshot as the baseline for the next separately declared optimisation class.
+- Consequence: 2
+- Refuses: Promotion of a rejected, changed, missing or differently scoped candidate record.
+- Recovery: Restore the accepted run directory or take a fresh baseline from the intended repository state.
+- Exceptions: none

--- a/plugins/hexaemeron/AGENTS.md
+++ b/plugins/hexaemeron/AGENTS.md
@@ -35,6 +35,26 @@ Hexaemeron skill matches a task.
 | `metron` | `skills/metron/SKILL.md` | Baseline something slow, change one thing, re-measure, and keep or revert on the numbers |
 | `hypomnema` | `skills/hypomnema/SKILL.md` | Record the reason behind a decision, and put each kind of record where it will be found |
 
+## Vendored Promise Machine overlays
+
+Before selecting `fizz`, `fizz-convert`, `fizz-sync`, `x-ray` or
+`solidity-auditor`, read its declaration in [PROMISES.md](PROMISES.md) and
+recompute the SHA-256 of the exact canonical `SKILL.md`. The path and digest
+must match before the Wildcat promise is available. A mismatch blocks the
+overlay and requires review of the upstream change; it never authorises an
+edit to the vendored instruction.
+
+From this distribution repository, check the complete binding with:
+
+```bash
+python3 scripts/promise_machine.py check --only contracts,overlays
+```
+
+A standalone installation without the repository checker performs the same
+local path and digest comparison before it relies on an overlay. The overlay
+states what the Wildcat suite accepts from the vendored operation; the
+unchanged upstream file still controls how that operation runs.
+
 The first-party `fiat`, `imprimatur`, `vulgate`, and `kronos` directories each
 carry an `EVOLUTION.md` ledger governed by `skills/VERSIONING.md`. Read the
 selected skill's ledger before proposing a frontier run. A `mature` frontier

--- a/plugins/hexaemeron/PROMISES.md
+++ b/plugins/hexaemeron/PROMISES.md
@@ -1,0 +1,77 @@
+# Hexaemeron Promise Machine overlays
+
+This first-party file declares the promises Hexaemeron makes around vendored
+instructions. Each declaration is bound to one canonical path and the SHA-256
+of its exact bytes. The overlay is unavailable when that digest changes; the
+upstream instruction remains unchanged and must be reviewed before this file
+is updated.
+
+### hexaemeron-fizz-harness-campaign
+
+- Path: `plugins/hexaemeron/skills/fizz/SKILL.md`
+- SHA-256: `62a60df4cec160511b8ef36433eef7c8805d0b4a398491293eb4542ab73539bd`
+- Promise: A completed Fizz run establishes that the generated Echidna or Medusa harness builds and that the named campaign actually ran against it with its preserved configuration and results.
+- Evidence: The digest-matched instruction, source snapshot, generated harness and manifest, build result, named engine command, campaign configuration, bounded raw output and machine-readable result where the engine supplies one.
+- Evidence classes: checked, recorded
+- Boundary: The result covers the generated harness and campaign that ran; it does not establish exhaustive property discovery, semantic adequacy of every property, absence of vulnerabilities or a security sign-off.
+- Authorises: Using the generated harness and recorded campaign result as evidence for the properties and target boundary explicitly exercised.
+- Consequence: 3
+- Refuses: A stale overlay digest, a harness that does not build, a campaign inferred from generated files but never run, missing configuration, narrowed bounds used to hide a failure or a claim broader than the exercised properties.
+- Recovery: Reconcile the upstream instruction digest, regenerate the harness from the named source, restore the campaign configuration, run the selected engine and retain its actual result.
+- Exceptions: none
+
+### hexaemeron-fizz-convert-properties
+
+- Path: `plugins/hexaemeron/skills/fizz/skills/fizz-convert/SKILL.md`
+- SHA-256: `59cd4b4ef5dc56315782a7d25222afb286a24e63e438530cbd0044293ea54af7`
+- Promise: A completed Fizz Convert run establishes that the selected pending property was translated into wired Solidity assertion code, the harness builds and the corresponding source checklist entry was updated.
+- Evidence: The digest-matched instruction, selected property text and identifier, generated assertion and handler wiring, build output, changed checkbox and bounded diff.
+- Evidence classes: checked, recorded
+- Boundary: The result proves mechanical conversion and buildability of the selected property; it does not establish that the property is semantically correct, reachable, complete or adequate for security review.
+- Authorises: Treating the selected checklist entry as implemented in the named harness and passing it to a real fuzz campaign.
+- Consequence: 2
+- Refuses: A stale overlay digest, an ambiguous property, unwired assertion, failed build, unchecked source update or a semantic-completeness claim unsupported by execution.
+- Recovery: Reconcile the upstream instruction digest, clarify one property, repair its assertion and wiring, rebuild the harness and update only the matching checklist entry.
+- Exceptions: none
+
+### hexaemeron-fizz-sync-drift
+
+- Path: `plugins/hexaemeron/skills/fizz/skills/fizz-sync/SKILL.md`
+- SHA-256: `e969cd8a447941989715840e24aa6a915c0fd795effabd912b3c627598a95e16`
+- Promise: A completed Fizz Sync run establishes that bounded source-interface drift was reconciled into the existing harness, stale properties were quarantined, generated stubs were refreshed and the updated harness builds.
+- Evidence: The digest-matched instruction, prior and current source snapshots, ABI drift report, quarantined-property record, regenerated stubs, refreshed snapshot, bounded diff and build result.
+- Evidence classes: checked, recorded
+- Boundary: The result covers syntactic and declared interface reconciliation within the inspected source boundary; it does not prove semantic equivalence, preserve unstated assumptions or validate property adequacy.
+- Authorises: Running the reconciled harness against the current named source while treating quarantined properties as unresolved.
+- Consequence: 2
+- Refuses: A stale overlay digest, unbounded or unidentified source drift, silently deleted properties, a failed build, an unrefreshed snapshot or any claim that ABI agreement proves semantic agreement.
+- Recovery: Reconcile the upstream instruction digest, restore the before and after snapshots, classify every drift item, quarantine rather than erase stale properties, regenerate the affected stubs and rebuild.
+- Exceptions: none
+
+### hexaemeron-x-ray-preaudit
+
+- Path: `plugins/hexaemeron/skills/x-ray/SKILL.md`
+- SHA-256: `b23bb94517805c1b8ce717d0e1e0282b0b5c14c7b16f4c32e73940292d3d4a41`
+- Promise: A completed X-Ray run establishes that the required pre-audit views were produced for the named repository snapshot with their source boundary and unresolved gaps visible.
+- Evidence: The digest-matched instruction, repository commit, scoped source inventory and the four required pre-audit artefacts with their cited inputs and generation records.
+- Evidence classes: recorded, inferred
+- Boundary: The artefacts are preparation and analysis aids; they are not an audit, do not establish exploitability or absence of defects and inherit every omission in the inspected repository boundary.
+- Authorises: Beginning a human or agent audit with the four named pre-audit views as scoped orientation material.
+- Consequence: 1
+- Refuses: A stale overlay digest, an unnamed repository snapshot, a missing required artefact, uncited conclusions, hidden exclusions or language that presents pre-audit analysis as security sign-off.
+- Recovery: Reconcile the upstream instruction digest, fix the source boundary, regenerate the missing or stale views and leave every unresolved gap explicit.
+- Exceptions: none
+
+### hexaemeron-solidity-audit-report
+
+- Path: `plugins/hexaemeron/skills/solidity-auditor/SKILL.md`
+- SHA-256: `1c1cf4e99d042e7aadc56b622d97a07d3286f4786838a05510697c814d1e983f`
+- Promise: A completed Solidity Auditor run establishes that all twelve prescribed audit roles inspected the named Solidity scope, their raw results crossed the required wait barrier and the final report deduplicated, completeness-checked and judged the submitted findings.
+- Evidence: The digest-matched instruction, repository commit and Solidity scope, twelve role prompts and raw outputs, completion barrier, deduplication record, completeness pass, judgement record and final report.
+- Evidence classes: checked, recorded, inferred
+- Boundary: The report establishes performance of the prescribed review process over the named scope; findings remain judgements and a clean report does not prove the absence of vulnerabilities or replace independent review.
+- Authorises: Using the scoped report as one security-review input and advancing only according to its explicit findings, uncertainties and unresolved coverage.
+- Consequence: 3
+- Refuses: A stale overlay digest, fewer than twelve isolated role results, synthesis before the wait barrier, missing raw outputs, hidden scope exclusions, undeduplicated findings or a claim of defect absence.
+- Recovery: Reconcile the upstream instruction digest, restore the exact scope, rerun every missing or compromised role independently, wait for all raw results and repeat deduplication, completeness checking and judgement.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/elenchus/SKILL.md
+++ b/plugins/hexaemeron/skills/elenchus/SKILL.md
@@ -269,3 +269,17 @@ saying so costs nothing while claiming otherwise costs the next person's day.
 
 End with one action: the command to rerun, the question that unblocks you, or
 the review the fix now needs.
+
+## Promise Machine contract
+
+### elenchus-fixed-and-guarded
+
+- Promise: A fixed-and-guarded result establishes that the reported failure was reproduced, localised to a causal mechanism, repaired at that mechanism and covered by a regression test observed to fail on the unfixed parent and pass on the fixed tree.
+- Evidence: The reproduction command and output, causal account, minimal case where useful, fix diff, detached-parent guard report, fixed-tree report and both relevant suite results.
+- Evidence classes: checked, inferred
+- Boundary: The result covers the reproduced failure and named guard; it does not prove the surrounding system defect-free or turn an inconclusive, zero-test or infrastructure-failed comparison into a guard.
+- Authorises: Closing the named failure and relying on the regression test for that mechanism within the tested environment.
+- Consequence: 2
+- Refuses: A symptom-only patch, an unreproduced cause, a guard that never failed without the fix, narrowed fuzz bounds, unrelated changes or a stale, malformed, oversized, mixed or empty report.
+- Recovery: Preserve the failure, restore a faithful reproducer, isolate the mechanism, add or repair the guard report and rerun both the unfixed-parent and fixed-tree suites.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/ephoros/SKILL.md
+++ b/plugins/hexaemeron/skills/ephoros/SKILL.md
@@ -242,3 +242,29 @@ asserted, and saying which is which costs a sentence.
 
 End with one action: the alert still needing a threshold, the question with no
 signal behind it, or the sampled output someone should read.
+
+## Promise Machine contract
+
+### ephoros-mechanical-gate
+
+- Promise: A zero-exit Ephoros lint establishes that the bounded parser found none of its specified formatted-log, unbounded-metric-label or mean-duration patterns in the selected Python paths.
+- Evidence: The exact lint version, arguments, selected paths, structured findings and zero exit status.
+- Evidence classes: checked
+- Boundary: A clean lint covers only the three implemented Python rules; it does not prove useful observability, safe output, correct alerting or conformance of another language.
+- Authorises: Passing the mechanical Ephoros gate for the exact paths and checker version recorded.
+- Consequence: 1
+- Refuses: Unreadable or oversized input, an unexplained suppression, a non-zero result or any broader observability claim.
+- Recovery: Repair the offending signal or add a narrowly reasoned suppression when the rule is inapplicable, then rerun the same bounded lint.
+- Exceptions: none
+
+### ephoros-observability-review
+
+- Promise: A completed observability review establishes that the step's on-call questions have bounded signals, correlation and user-symptom alerts, and that emitted samples were checked for sensitive or unbounded data.
+- Evidence: The question-to-signal map, event and metric definitions, trace correlation, alert test, sampled output, staleness signal for long jobs and unresolved-gap list.
+- Evidence classes: checked, inferred, recorded
+- Boundary: The review covers the named step and exercised signals; it does not prove future telemetry availability, alert thresholds under every workload or absence of sensitive data outside the samples reviewed.
+- Authorises: Operating the reviewed step with the recorded signals and escalating through the named runbooks.
+- Consequence: 2
+- Refuses: A new unattended path with no signal, unbounded labels, mean-only duration, missing correlation, untested alerts, absent runbooks or sensitive values in emitted output.
+- Recovery: Write the unanswered on-call question, add or bound the missing signal, exercise the alert, inspect real output and repeat the review.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/fiat/SKILL.md
+++ b/plugins/hexaemeron/skills/fiat/SKILL.md
@@ -407,3 +407,29 @@ hand over: topic, the run branch and the base it landed on, the step list with
 each stacked PR URL and the order the stack merged in, the integration PR and
 its merge SHA, audit rounds per step with the closing state of each, and where
 the study and runbook live.
+
+## Promise Machine contract
+
+### fiat-receipted-delivery
+
+- Promise: A successful `hexctl verify` establishes that the controller state and append-only ledger agree and that every recorded phase transition occurred in the required order with the required receipt shape.
+- Evidence: The exact study and runbook receipts, step branches and commits, audit rounds, prose and push receipts, hash-chained ledger, controller version and zero-exit verification result.
+- Evidence classes: checked, recorded
+- Boundary: Controller verification proves receipt order and integrity, not the truth of a test summary, audit judgement, external check, implementation claim or user authority merely written into a receipt.
+- Authorises: Advancing only to the single next controller directive and reporting the recorded workflow state without strengthening any underlying receipt.
+- Consequence: 2
+- Refuses: Skipping a phase, reconstructing progress from chat, accepting a malformed or missing receipt, or describing an unrun check as complete.
+- Recovery: Inspect `hexctl status`, repair the current phase's real evidence without editing ledger history, submit the required receipt and rerun `hexctl verify`.
+- Exceptions: none
+
+### fiat-final-integration
+
+- Promise: A successful integration receipt establishes that every stacked step was merged in controller order, the run branch passed its required gates and exactly one recorded merge landed the run on the named base under the user's delivery authority.
+- Evidence: The user's explicit Fiat request, green step and integration checks, stacked PR URLs and head commits, merge-step receipts, integration PR and merge commit, final controller state and verified ledger.
+- Evidence classes: checked, recorded
+- Boundary: Integration establishes the recorded repository transition; it does not prove the software defect-free, make audit judgements independent or authorise a deployment, financial action or another repository.
+- Authorises: Publication of the complete run to the named base and a final report limited to the merged artefacts and recorded evidence.
+- Consequence: 3
+- Refuses: Direct step merges to the base, bypassed gates, a second base merge, deletion that closes a stacked PR prematurely or integration without explicit delivery authority.
+- Recovery: Leave the stack open, restore the required branch or check, retarget and merge in controller order, or halt with the exact blocker before any base mutation.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/hypomnema/SKILL.md
+++ b/plugins/hexaemeron/skills/hypomnema/SKILL.md
@@ -198,3 +198,29 @@ diff suggests, and saying which is which is the whole point of the record.
 
 End with one action: the decision still needing a record, the convention
 conflict somebody has to resolve, or the runbook an alert is waiting on.
+
+## Promise Machine contract
+
+### hypomnema-pointer-gate
+
+- Promise: A zero-exit Hypomnema lint establishes that the bounded checker found no unresolved relative links, absent superseding records or missing alert runbooks in the selected first-party documents.
+- Evidence: The exact lint version, arguments, selected paths, structured findings and zero exit status.
+- Evidence classes: checked
+- Boundary: A clean lint proves only that the recognised pointers resolve at check time; it does not prove that records are correct, complete, current or placed well.
+- Authorises: Passing the mechanical record-pointer gate for the exact paths and checker version recorded.
+- Consequence: 1
+- Refuses: Unsafe, unreadable or oversized paths, unresolved recognised pointers, an unexplained suppression or a claim about documents excluded from the run.
+- Recovery: Restore or correct the target, mark supersession accurately, add the missing runbook and rerun the same bounded lint.
+- Exceptions: none
+
+### hypomnema-record-placement
+
+- Promise: A completed record-placement review establishes that each expensive-to-reverse decision introduced by the step has a reasoned record in the repository's established location, with rejected alternatives and resolvable pointers.
+- Evidence: The step diff, decision inventory, authored or superseded records, alternatives and reasons, pointer-gate result and unresolved-decision list.
+- Evidence classes: checked, inferred, recorded
+- Boundary: The review covers the decisions identified in the named step; it does not prove that every future reader agrees with them or that an unidentified decision was documented.
+- Authorises: Treating the recorded choices as the current project decisions until superseded through the same convention.
+- Consequence: 2
+- Refuses: A costly choice with no reason, a second record scheme, deletion of superseded history, an absent target or a decision placed where the repository's readers will not find it.
+- Recovery: Identify the missing choice, write the reason and rejected alternatives in the established location, repair its pointers and repeat the review.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/imprimatur/SKILL.md
+++ b/plugins/hexaemeron/skills/imprimatur/SKILL.md
@@ -111,3 +111,17 @@ Attribution, licence, and the list of deviations are in `NOTICE.md`.
 - Never claim a draft is undetectable, human-passing, or clean because the score is high. The score counts known markers and nothing else.
 - Never let the lint's own vocabulary leak into prose. Words like "defect", "gated", and "pass" belong in reports, not in the writing being fixed.
 - Do not report the lint as run when it was not.
+
+## Promise Machine contract
+
+### imprimatur-prose-gate
+
+- Promise: A successful Imprimatur run establishes that the exact prose crossed the configured hard, gated and structural pattern thresholds and that every reported defect was cleared or evidenced under the checker rules.
+- Evidence: The exact input bytes, lexicon and allowlist, selected mode and threshold, defect and signal output, labelled-corpus provenance and zero exit status.
+- Evidence classes: checked, recorded
+- Boundary: The gate does not establish human authorship, factual accuracy, sound reasoning, an intended voice or absence of every machine-writing pattern.
+- Authorises: Presentation or hand-off of the checked prose as Imprimatur-clean at the named checker version and threshold.
+- Consequence: 0
+- Refuses: Calling prose clean when the gate did not run or failed, hiding a hard hit with a synonym, treating a cadence signal as a defect or deleting a scope-bearing qualifier to clear a word.
+- Recovery: Read the named defect, rewrite the sentence without weakening evidence or uncertainty and rerun the exact gate.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/kronos/SKILL.md
+++ b/plugins/hexaemeron/skills/kronos/SKILL.md
@@ -238,3 +238,41 @@ what it says.
 - Never summarise, shorten or reword a halt reason on the way into a park.
 - Never release a park on the loop's own judgement, and never call the loop
   complete while one stands.
+
+## Promise Machine contract
+
+### kronos-frontier-ranking
+
+- Promise: A successful scoreboard `record` establishes that all eligible in-scope ledgers were represented, each total matches its four declared axes, the recorded selection follows the tie-break and held-job digests came from disk.
+- Evidence: The selected scope and mode, current evolution ledgers, candidate scores and bases, recomputed totals and held-job hashes, append-only scoreboard line and successful `show` result.
+- Evidence classes: checked, recorded, inferred
+- Boundary: The checker validates the ranking record and arithmetic; it does not make subjective scores objective, rank mature, vendored, parked or out-of-scope work, or establish global priority.
+- Authorises: Selection of the recorded highest eligible held job for rank-only hand-off or a separately authorised Fiat dispatch.
+- Consequence: 1
+- Refuses: A changed or unreadable held job, inconsistent total, wrong tie-break, incomplete candidate universe, parked selection or rank-only record naming a run.
+- Recovery: Rescan the complete allowed scope, correct the score or basis, reread the scoreboard drift and record a new pass without rewriting history.
+- Exceptions: none
+
+### kronos-fiat-dispatch
+
+- Promise: A full or phase-only loop dispatches the selected held job to Fiat only when the user explicitly authorised Kronos execution and the candidate remains eligible and unparked at dispatch.
+- Evidence: The user's explicit Kronos request, current ranking record, selected ledger and held-job digest, empty standing park for that job and the newly initialised Fiat run receipt.
+- Evidence classes: checked, recorded, inferred
+- Boundary: Dispatch establishes why this eligible job entered Fiat; it does not prove the ranking globally optimal, the job complete or Fiat's later receipts true.
+- Authorises: Starting one Fiat delivery for the selected held job and reranking from disk only after that run reaches a terminal recorded state.
+- Consequence: 3
+- Refuses: Implicit activation, self-selection, a mature or vendored frontier, a standing park, a lower-ranked skip with no park or continuation after no eligible frontier remains.
+- Recovery: Return to rank-only output, correct scope or eligibility, obtain explicit authority, or park the exact Fiat blocker and rerank the remaining candidates.
+- Exceptions: none
+
+### kronos-parked-lane
+
+- Promise: A successful `park` or `unpark` append records the exact held-job digest and human-supplied reason while `parked` reports the current standing state without rewriting history.
+- Evidence: The readable skill ledger, recomputed held-job hash, exact halt or release reason, append-only parked record and `parked` exit status.
+- Evidence classes: checked, recorded
+- Boundary: A park records a person's blocking claim; it does not judge the claim, expire itself, follow a changed held job automatically or prove the blocker cleared.
+- Authorises: Excluding a standing parked job from selection, or restoring it only after a human-authored unpark record.
+- Consequence: 2
+- Refuses: Selecting a parked job, paraphrasing its halt reason, auto-expiry, autonomous release or declaring the loop complete while any park stands.
+- Recovery: Preserve the park, ask the responsible person whether stale or unknown state still applies and append an explicit unpark record only on their direction.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/metron/SKILL.md
+++ b/plugins/hexaemeron/skills/metron/SKILL.md
@@ -209,3 +209,29 @@ believe rather than profiled gets named as a belief.
 
 End with one action: the next thing worth measuring, the budget that needs a
 threshold, or the reverted idea somebody should stop suggesting.
+
+## Promise Machine contract
+
+### metron-budget-verdict
+
+- Promise: A budget verdict establishes that a named workload was measured against a stated threshold with a fixed command, environment, inputs, repetitions and aggregation rule.
+- Evidence: The benchmark identity, environment, input fixture, warm-up and repetition policy, raw or preserved measurements, aggregation method, variance and threshold comparison.
+- Evidence classes: measured, recorded
+- Boundary: The verdict applies only to the recorded workload and measurement method; it does not generalise to other machines, inputs, workloads or correctness.
+- Authorises: Accepting or refusing the measured subject against the named budget without strengthening the result beyond its measurement boundary.
+- Consequence: 1
+- Refuses: A missing baseline, changed method, mean-only latency, result inside unexplained noise, unbounded workload or comparison across unlike environments.
+- Recovery: Freeze one reproducible method, establish the baseline and variance, rerun the exact workload and compare it to the stated threshold.
+- Exceptions: none
+
+### metron-change-decision
+
+- Promise: A keep decision establishes that one isolated change improved the named measurement beyond variance while the correctness gates remained green; otherwise the attempted change is reverted and recorded.
+- Evidence: Before and after measurements taken the same way, isolated change diff, variance, correctness-suite results, budget results and the attempt-ledger verdict.
+- Evidence classes: measured, checked, recorded
+- Boundary: The decision proves the measured effect of the isolated change on the named workload, not its effect on unmeasured workloads or the reason for the movement unless separately isolated.
+- Authorises: Keeping the change only when both the measured improvement and correctness gates pass, or recording and abandoning it otherwise.
+- Consequence: 2
+- Refuses: Several unisolated edits, an unmeasured optimisation, a neutral or noisy result, a red or weakened correctness gate, or a speed gain bought by removing a guarantee.
+- Recovery: Revert the candidate, restore the baseline, isolate one hypothesis, repeat the same measurement and record the new verdict whether kept or rejected.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/phylax/SKILL.md
+++ b/plugins/hexaemeron/skills/phylax/SKILL.md
@@ -367,3 +367,29 @@ Name what you could not check and why.
 
 End with one action: the boundary that still needs a control, the review a
 dependency needs, or the approval a widened trust boundary is waiting on.
+
+## Promise Machine contract
+
+### phylax-mechanical-gate
+
+- Promise: A zero-exit Phylax lint establishes that the bounded parser found none of its specified external-input, subprocess, fetch, secret, path and model-output patterns in the selected first-party paths.
+- Evidence: The exact lint version, arguments, selected paths, structured findings and zero exit status.
+- Evidence classes: checked
+- Boundary: A clean lint covers only the rules and languages implemented by the parser; it is not a security review, a dependency audit, a privacy assessment or evidence that a control works against hostile input.
+- Authorises: Passing the mechanical Phylax gate for the exact paths and checker version recorded.
+- Consequence: 1
+- Refuses: Unsafe paths, unreadable or oversized input, an unexplained suppression, a non-zero result or any claim about a rule the parser does not implement.
+- Recovery: Correct the input or control, add a narrowly reasoned suppression only when the rule is inapplicable and rerun the same bounded lint.
+- Exceptions: none
+
+### phylax-boundary-review
+
+- Promise: A completed boundary review establishes that every trust boundary introduced by the step is named, paired with a control and classified as verified or merely asserted, with unresolved exposure left visible.
+- Evidence: The step diff, boundary inventory, hostile-input tests where available, dependency and lockfile review, sample output review, unresolved-gap list and reviewer conclusion.
+- Evidence classes: checked, inferred, recorded
+- Boundary: The review is scoped to the introduced boundaries and available evidence; it does not establish whole-system security or convert an asserted control into a verified one.
+- Authorises: Proceeding with the reviewed step only to the consequence level supported by its verified controls and explicitly accepted open gaps.
+- Consequence: 2
+- Refuses: An unnamed boundary, unvalidated external data, data-built shell strings, unsafe host or path handling, exposed credentials, unreviewed dependency drift or model output used directly as authority.
+- Recovery: Name the missing boundary, add and exercise its control, review the affected dependency or data path and repeat the boundary review.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/protasis/SKILL.md
+++ b/plugins/hexaemeron/skills/protasis/SKILL.md
@@ -299,3 +299,29 @@ End with one action, and make it something the reader can do in a couple of
 minutes: confirm an assumption, answer one question, or approve the runbook.
 Name the open question rather than closing it with a guess. Corrected here, an
 assumption costs a sentence. Found in the audit loop, it costs a step.
+
+## Promise Machine contract
+
+### protasis-study-readiness
+
+- Promise: A study accepted by Protasis states the problem, assumptions, current state, chosen design and rejected trade, boundaries, failure and recovery model, affected versions and evidence-bearing success criteria needed to derive a runbook.
+- Evidence: The exact study, source inventory, explicit unknowns and exclusions, answered discipline questions, design comparison and completed study checklist.
+- Evidence classes: checked, inferred, recorded
+- Boundary: Readiness means the study contains material required to plan; it does not establish that the design is correct, implementation exists, tests pass or later receipts are true.
+- Authorises: Derivation of a discrete runbook from the accepted study without silently adding a new design decision.
+- Consequence: 1
+- Refuses: Hidden assumptions, an unstated boundary, solution-first prose, missing trade, untestable success language or a topic still containing several independent deliveries.
+- Recovery: Name the missing question or decision, gather the required evidence, amend the study and repeat the complete Protasis review.
+- Exceptions: none
+
+### protasis-runbook-readiness
+
+- Promise: A runbook accepted by Protasis decomposes the study into ordered steps whose entry, modules, exit commands, files, tests and discipline effects are discrete and provable.
+- Evidence: The accepted study, exact runbook, `protasis.py` structural result, per-step commands and files, dependency order, version boundary and completed pre-receipt checklist.
+- Evidence classes: checked, inferred, recorded
+- Boundary: Runbook readiness establishes buildable specification content, not correct implementation, command success, audit closure or delivery completion.
+- Authorises: Starting implementation at the first step while using the study and runbook as the change-control boundary.
+- Consequence: 1
+- Refuses: A step with no executable exit, mixed independent outcomes, missing affected files or tests, forward references to an undecided design or receipt language with no evidence command.
+- Recovery: Split or reorder the failing step, supply its exact evidence and rerun both the mechanical check and the full content review.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/vulgate/SKILL.md
+++ b/plugins/hexaemeron/skills/vulgate/SKILL.md
@@ -114,3 +114,17 @@ Before returning rewritten text, verify:
    tone changed.
 6. Read it aloud: would a person say this sentence to a colleague? If a
    sentence would embarrass its speaker out loud, rewrite it.
+
+## Promise Machine contract
+
+### vulgate-register-rewrite
+
+- Promise: A completed Vulgate pass rewrites the named prose into the selected plain register while preserving its claims, evidence, uncertainty, scope, logical relations and required structure.
+- Evidence: The exact source and rewritten bytes, selected register, protected facts and structure, line-by-line content comparison and completed rewrite checklist.
+- Evidence classes: checked, inferred
+- Boundary: The pass changes register only; it does not establish truth, improve the underlying argument, supply missing evidence, diagnose authorship or override another skill's required format.
+- Authorises: Presentation of the rewritten prose with its substantive content and evidence boundary unchanged.
+- Consequence: 0
+- Refuses: Added facts, deleted caveats, changed severity, softened refusal, invented quotation, moved attribution or a voice change that alters meaning.
+- Recovery: Restore the source claim and protected evidence, redo only the affected sentence and compare the complete rewrite with the original before hand-off.
+- Exceptions: none

--- a/plugins/horos/skills/horos/SKILL.md
+++ b/plugins/horos/skills/horos/SKILL.md
@@ -171,3 +171,53 @@ reason.
 [../../examples/fixture/](../../examples/fixture/) holds one file per rule
 class and its committed boundary; [../../examples/README.md](../../examples/README.md)
 shows the demo commands and the mutation that makes `check` fail.
+
+## Promise Machine contract
+
+### horos-boundary-scan
+
+- Promise: A successful `scan --write` records every tracked path that the current hard rules classify as a token sink, with category, byte count and the evidence that earned the entry.
+- Evidence: The walked tracked-file universe, hard classification rules, file evidence, canonical `.horos/boundary.json` bytes and atomic write result.
+- Evidence classes: checked, recomputed, recorded
+- Boundary: Classification is fail-open and may omit sinks; candidates do not bind, untracked files are excluded unless requested and no boundary applies during security review.
+- Authorises: Committing the generated reading boundary and adoption stanza for non-security repository reading.
+- Consequence: 2
+- Refuses: Listing an unevidenced path as a hard exclusion, treating an empty directory as covered or using the boundary to hide audit, review or incident scope.
+- Recovery: Inspect the classification evidence, amend the repository-specific rule or source marker, rerun the scan and review the resulting diff.
+- Exceptions: none
+
+### horos-boundary-check
+
+- Promise: A successful `check` establishes that the committed hard boundary equals the current re-derived classification for the stated root or subtree.
+- Evidence: The nearest confined boundary, current tracked-file walk, applicable attributes, recomputed entries, scope counters and zero-drift result.
+- Evidence classes: checked, recomputed
+- Boundary: A scoped pass says nothing about outside-scope drift, candidate findings never change the exit code and a clean boundary does not prove omitted files are cheap to read.
+- Authorises: Leaving listed hard-boundary paths unread by default within the checked non-security scope.
+- Consequence: 0
+- Refuses: Trusting a stale, forged, missing or out-of-scope boundary, or applying any boundary during security review.
+- Recovery: Read the drifted paths as ordinary inputs, rerun `scan --write` for an authorised update and check the intended root again.
+- Exceptions: none
+
+### horos-census
+
+- Promise: A successful `scan --census` counts the files and bytes by suffix from the same walk as the boundary and records how many bytes already sit inside it.
+- Evidence: The walked universe, suffix roll-up, boundary membership counts and canonical census output or `.horos/census.json` bytes.
+- Evidence classes: measured, recomputed
+- Boundary: The census measures file bytes under the selected walk; it does not measure model tokens, reading time, semantic importance or untracked content unless included.
+- Authorises: Choosing the next extractor or classification investigation from the recorded weight distribution, and writing the census when requested.
+- Consequence: 1
+- Refuses: Presenting suffix bytes as token counts or a scoped census as a whole-repository measurement.
+- Recovery: Select the intended root and trackedness mode, rerun the census and keep its scope beside any conclusion.
+- Exceptions: none
+
+### horos-skeleton-map
+
+- Promise: A successful `map` emits the supported source file's recognised declaration skeleton and explicitly counts every region the extractor did not understand.
+- Evidence: The exact source bytes, suffix-selected extractor, verbatim declaration slices, line locations and confession ranges.
+- Evidence classes: checked, recomputed
+- Boundary: A skeleton is an orientation aid, not the full file, an execution trace, a parser proof or evidence about meaning inside confessed regions.
+- Authorises: Using the map to choose bounded follow-up reads of the same source file.
+- Consequence: 0
+- Refuses: Mapping an unsupported suffix, importing or executing the source, or treating omitted and confessed regions as absent behaviour.
+- Recovery: Read the source directly or add and validate an extractor before relying on a map for that language.
+- Exceptions: none

--- a/plugins/janus/skills/janus/SKILL.md
+++ b/plugins/janus/skills/janus/SKILL.md
@@ -120,3 +120,41 @@ its own instructions before writing anything into it.
 
 If a build, a test, a validation, or a report did not run, say so plainly and
 do not describe its result.
+
+## Promise Machine contract
+
+### janus-manifest-validation
+
+- Promise: A successful `janus.py validate` establishes that each named hook manifest satisfies the shipped schema and enumerates the threshold, effects, rollback, gas and liveness fields the format requires.
+- Evidence: The exact manifest bytes, shipped JSON schema, stdlib validator diagnostics and zero exit status.
+- Evidence classes: checked
+- Boundary: Schema acceptance does not establish that a hook obeys the manifest, that the manifest matches a host, or that its permitted effects are safe.
+- Authorises: Use of the validated manifest as input to the matching host-adapter conformance harness.
+- Consequence: 1
+- Refuses: Running or reporting conformance from a malformed, incomplete, escaped or schema-unknown manifest.
+- Recovery: Repair the named manifest field, validate the complete manifest set again and then restart the harness run.
+- Exceptions: none
+
+### janus-bounded-conformance
+
+- Promise: A green harness run establishes that observed hook behaviour stayed within the validated manifest for the named host adapter, manifest revision, recorder coverage and bounded deterministic or stateful search.
+- Evidence: The validated manifest, adapter identity, compiled harness, search configuration, complete recorded storage, call, value and gas deltas, hostile-hook guards and passing Foundry results.
+- Evidence classes: checked, measured, recorded
+- Boundary: The result is bounded conformance, not hook safety, complete exit liveness, coverage of unrecorded effects, another adapter or every possible execution.
+- Authorises: Reporting the exact hook and adapter as conformant under the recorded search and using that bounded result in an authorised security or release decision.
+- Consequence: 3
+- Refuses: A verdict on an unknown delta, absent hostile-hook guard, failed gate, incomplete recorder, unnamed search or cross-host generalisation.
+- Recovery: Inspect the violating trace or unknown effect, repair the hook, manifest, adapter or recorder without weakening a gate and rerun the full bounded search.
+- Exceptions: none
+
+### janus-report-rendering
+
+- Promise: A successful `janus.py report` renders the supplied finding records into Markdown and SARIF without adding, removing or strengthening a conformance result.
+- Evidence: The exact findings JSON, deterministic reporter output, linked manifest rule and trace for each violation and successful render status.
+- Evidence classes: recorded, checked, recomputed
+- Boundary: Rendering establishes format and trace linkage only; it does not validate a manifest, execute a harness, complete a recorder or create a conformance verdict.
+- Authorises: Publication or hand-off of the rendered report only with the originating harness scope and result intact.
+- Consequence: 1
+- Refuses: Reporting an absent run, dropping a violation, changing adapter scope or presenting a rendered sample as observed conformance evidence.
+- Recovery: Restore the originating findings record, rerun the reporter and attach the validated manifest and harness receipt separately.
+- Exceptions: none

--- a/plugins/lazarus/skills/lazarus/SKILL.md
+++ b/plugins/lazarus/skills/lazarus/SKILL.md
@@ -172,3 +172,53 @@ invents a zero value or leaves loopback to answer a miss.
 - Hold a private key, sign a transaction or make an Ariadne publisher claim.
 - Claim proof-backed status for any value that did not pass the offline trie
   and code checks.
+
+## Promise Machine contract
+
+### lazarus-fixture-capture
+
+- Promise: A successful `capture` atomically writes a finite fixed-block fixture only after resolving the expected block, collecting the declared requests and proofs, closing the block bracket and passing complete local verification.
+- Evidence: The explicit plan, opening and closing headers, exact sanitised RPC records, EIP-1186 proofs, manifest, limits and the in-process successful verification result.
+- Evidence classes: recorded, checked, recomputed, proved: EIP-1186 account and storage relation
+- Boundary: Only account and storage values and code with the named proof relation are proof-backed; headers remain externally unanchored and calls, receipts, logs and traces remain recorded RPC evidence.
+- Authorises: Installation of the verified fixture as a durable finite historical test input.
+- Consequence: 2
+- Refuses: Finalising after a required request, proof, block bracket, limit, credential-sanitisation or verification failure, or retaining raw provider errors as evidence.
+- Recovery: Inspect the stable failure, amend the finite plan or provider input, discard the temporary output and perform a fresh capture.
+- Exceptions: none
+
+### lazarus-fixture-verification
+
+- Promise: A successful `verify` recomputes the fixture's schemas, canonical manifest, component digests, header hash, state proofs, response values and evidence-class counts from local bytes.
+- Evidence: The fixture tree, registered schema bytes, manifest, header, proof and RPC records, recomputed hashes and the complete verification report.
+- Evidence classes: checked, recomputed, proved: EIP-1186 account and storage relation
+- Boundary: Verification does not prove canonical-chain membership, receipts or logs against `receiptsRoot`, trace portability or facts outside the finite manifest.
+- Authorises: Use of the verified fixture and its separately counted evidence classes in the named offline test or preservation workflow.
+- Consequence: 1
+- Refuses: Calling a component proof-backed when its trie or code check failed, or using a missing, extra, escaped, changed or schema-unknown component.
+- Recovery: Inspect the named component or proof failure, restore the captured bytes or recapture the finite plan and rerun verification.
+- Exceptions: none
+
+### lazarus-exact-replay
+
+- Promise: A running `replay` verifies the fixture before binding to loopback and answers only exact recorded method-and-parameter keys without provider fallback.
+- Evidence: The in-process verification result, recomputed request-key table, loopback binding, exact response record and stable miss response for an absent request.
+- Evidence classes: checked, recomputed, recorded
+- Boundary: Replay is not arbitrary EVM execution, an archive service or permission to answer writes, subscriptions, unsupported methods or unrecorded variants.
+- Authorises: Supplying the exact verified responses to a local application test within the loopback replay session.
+- Consequence: 2
+- Refuses: Binding beyond loopback, leaving the fixture for a miss, inventing a zero, accepting a near-match or serving a write method.
+- Recovery: Use the emitted capture-plan fragment to extend the finite plan, capture and verify a new fixture, then restart replay.
+- Exceptions: none
+
+### lazarus-preservation-release
+
+- Promise: A successful `release` followed by `verify-release` binds the verified fixture bytes to a separately supplied statement whose evidence counts do not exceed those recomputed from the fixture.
+- Evidence: The verified fixture, supplied statement, binding document, release-tree digests, recomputed evidence counts and passing release verification.
+- Evidence classes: recorded, checked, recomputed
+- Boundary: The release is unsigned, reaches no network and does not establish publisher identity, canonical-chain status or any statement claim beyond the binding checked here.
+- Authorises: With separate publisher authority, publication or archival hand-off of the exact preservation release as inspectable evidence.
+- Consequence: 3
+- Refuses: Writing or publishing when the fixture or statement fails, the binding mismatches, the statement upgrades evidence counts or signature identity is merely assumed.
+- Recovery: Repair or replace the statement, recapture the fixture when its evidence is insufficient, build a new release directory and verify it before publication.
+- Exceptions: none

--- a/plugins/lemma/skills/chunk/SKILL.md
+++ b/plugins/lemma/skills/chunk/SKILL.md
@@ -101,3 +101,41 @@ Preserve these distinctions downstream:
 Read [`INVARIANTS.md`](../../INVARIANTS.md) when changing the chunkers, judging a
 guarantee, or investigating unexpected output. Run the two bundled test files
 after any code change.
+
+## Promise Machine contract
+
+### lemma-solidity-chunks
+
+- Promise: A successful Solidity chunk run emits schema-valid JSONL whose chunks resolve to the named standard-JSON sources and preserve separate quotation, model and embedding text.
+- Evidence: The exact compiler inputs, selected includes, compiler identity and output, source locations, chunk records and successful built-in validation before write.
+- Evidence classes: checked, recomputed
+- Boundary: The output does not establish source truth, retrieval quality, semantic completeness, independent ABI return or mutability validation, or correctness under another compiler.
+- Authorises: Use of the generated JSONL as source-linked retrieval material for the pinned Solidity compilation inputs.
+- Consequence: 1
+- Refuses: Writing or using partial output after compiler, source-location, schema, include or expected-version failure.
+- Recovery: Correct the pinned input, include set or compiler selection, remove the failed output and rerun the chunker.
+- Exceptions: none
+
+### lemma-markdown-chunks
+
+- Promise: A successful Markdown chunk run emits schema-valid JSONL whose chunks resolve to the selected document tree and preserve source locations, exclusions and synthesised-text labels.
+- Evidence: The exact Markdown tree, navigation or manifest, exclusion set, GitBook anchor method, chunk records and successful built-in validation before write.
+- Evidence classes: checked, recomputed
+- Boundary: The output does not establish document truth, corpus completeness outside the selected tree, compatibility with another renderer, retrieval quality or answer correctness.
+- Authorises: Use of the generated JSONL as source-linked retrieval material for the named Markdown corpus.
+- Consequence: 1
+- Refuses: Including excluded or escaped content, hiding a synthesised chunk as quotation, or using partial output after parsing or validation failure.
+- Recovery: Correct the root, navigation, manifest or exclusions, remove the failed output and rerun the chunker.
+- Exceptions: none
+
+### lemma-chunk-validation
+
+- Promise: A successful direct schema validation establishes that every supplied record satisfies Lemma's `Chunk` shape and field invariants.
+- Evidence: The exact JSONL records, `schema.py` contract, per-record validation and zero validation failures.
+- Evidence classes: checked
+- Boundary: Schema validation does not reproduce chunks without their source input or establish that locations, text and digests match an unavailable corpus.
+- Authorises: Structural inspection or hand-off of the existing JSONL with its source-verification status stated separately.
+- Consequence: 0
+- Refuses: Rechunking without source input or describing schema-valid records as source-verified when their corpus was not checked.
+- Recovery: Obtain the named source input and rerun the appropriate chunker, or report the result as schema-only validation.
+- Exceptions: none

--- a/plugins/pandects/skills/pandects/SKILL.md
+++ b/plugins/pandects/skills/pandects/SKILL.md
@@ -248,3 +248,41 @@ means.
   corpus.
 - Decide whether a law is true. The checker decides whether something is a law
   at all, which is a lower bar and the one worth enforcing mechanically.
+
+## Promise Machine contract
+
+### pandects-law-contract
+
+- Promise: A successful `pandects.py check` establishes that every discovered catalogue entry has the six required executable-law parts and that generated catalogue prose matches its authored records.
+- Evidence: The law registry, Solidity component and broken-specimen references, reduced counterexample, applicability, justified bound, judgement interface and checker diagnostics.
+- Evidence classes: checked
+- Boundary: The check establishes that an entry has the law contract; it does not establish that the law is true, applies to a target or catches its specimen.
+- Authorises: Listing or rendering the checked entry as a Pandects law with its applicability and bound intact.
+- Consequence: 1
+- Refuses: Admitting or publishing an entry missing executable judgement, a broken specimen, reduction, applicability, observables or justified bounds.
+- Recovery: Supply the named missing part, rerun `check`, regenerate the catalogue with `render` and compare the committed bytes.
+- Exceptions: none
+
+### pandects-broken-specimen
+
+- Promise: A green `forge test` establishes the shipped diagonal relation: each law fails its named broken specimen and holds against the other shipped specimens under the deterministic harness.
+- Evidence: The exact law and specimen Solidity, reduced replay, compiled harness and complete passing Foundry test result.
+- Evidence classes: checked, recomputed
+- Boundary: The diagonal establishes the named fixture relation only; it is not a formal proof, a verdict on another protocol or evidence that a search engine explored a target.
+- Authorises: Presenting the law as demonstrated to catch its shipped defect and using the specimen as a regression oracle.
+- Consequence: 1
+- Refuses: Calling a law proven to catch a defect when its diagonal test did not run, failed or was replaced by a tautological campaign result.
+- Recovery: Reduce the failing relation, correct the law or specimen without weakening the oracle and rerun the full diagonal.
+- Exceptions: none
+
+### pandects-search-record
+
+- Promise: A successful `pandects.py run` records the engine that actually ran, its argv, configuration, determinism, sequence length, disposition and corpus digest.
+- Evidence: The executed engine command, captured configuration, search output, timeout or result status and generated search-record JSON.
+- Evidence classes: measured, recorded, checked
+- Boundary: The record establishes what the named campaign searched and reported; it does not decide law truth, cover an absent engine, prove universal safety or make a non-applicable law fit a target.
+- Authorises: Reporting the bounded campaign result or attaching its command record to an Ariadne release statement.
+- Consequence: 3
+- Refuses: Inventing an engine result, treating timeout as pass or fail, hiding zero succession calls, or presenting target-specific applicability as universal credit law.
+- Recovery: Correct the adapter or applicability record, run the intended engine with explicit settings and preserve a new search record.
+- Exceptions: none

--- a/plugins/pandects/skills/pandects/SKILL.md
+++ b/plugins/pandects/skills/pandects/SKILL.md
@@ -253,14 +253,26 @@ means.
 
 ### pandects-law-contract
 
-- Promise: A successful `pandects.py check` establishes that every discovered catalogue entry has the six required executable-law parts and that generated catalogue prose matches its authored records.
-- Evidence: The law registry, Solidity component and broken-specimen references, reduced counterexample, applicability, justified bound, judgement interface and checker diagnostics.
+- Promise: A successful `pandects.py check` establishes that every discovered catalogue entry has the six required executable-law parts.
+- Evidence: The law registry, Solidity component and broken-specimen references, reduced counterexample, applicability, justified bound, judgement interface and zero-exit checker diagnostics.
 - Evidence classes: checked
 - Boundary: The check establishes that an entry has the law contract; it does not establish that the law is true, applies to a target or catches its specimen.
-- Authorises: Listing or rendering the checked entry as a Pandects law with its applicability and bound intact.
+- Authorises: Treating the entry as structurally eligible for the separate specimen, rendering and campaign checks.
 - Consequence: 1
-- Refuses: Admitting or publishing an entry missing executable judgement, a broken specimen, reduction, applicability, observables or justified bounds.
-- Recovery: Supply the named missing part, rerun `check`, regenerate the catalogue with `render` and compare the committed bytes.
+- Refuses: Admitting an entry missing executable judgement, a broken specimen, reduction, applicability, observables or justified bounds.
+- Recovery: Supply the named missing part and rerun `check` before any dependent operation.
+- Exceptions: none
+
+### pandects-catalogue-render
+
+- Promise: A successful `pandects.py render` followed by the catalogue-byte regression check reproduces `docs/catalogue.md` from the checked authored registry.
+- Evidence: The checked law registry, deterministic render output, committed catalogue bytes and passing byte-comparison test.
+- Evidence classes: checked, recomputed
+- Boundary: Rendering establishes agreement with the registry; it does not establish law truth, applicability to a target or specimen coverage.
+- Authorises: Publication of the regenerated catalogue as a derived view of the checked law records.
+- Consequence: 1
+- Refuses: Hand-editing the rendered catalogue, publishing drifted bytes or using rendering as evidence that a law holds.
+- Recovery: Correct the authored registry, rerun `check` and `render`, then rerun the exact catalogue comparison.
 - Exceptions: none
 
 ### pandects-broken-specimen

--- a/plugins/probitas/skills/probitas/SKILL.md
+++ b/plugins/probitas/skills/probitas/SKILL.md
@@ -174,3 +174,41 @@ narrative asserts something the evidence does not support: cut the sentence or
 find the record. A gate 2 failure means coverage is incomplete, which is a
 collection problem rather than a writing one. Never edit `verify` to make a
 dossier pass.
+
+## Promise Machine contract
+
+### probitas-evidence-collection
+
+- Promise: A successful `collect` writes evidence only for declared entity addresses and separately labelled inferred addresses, with one source reference per record and explicit coverage or gap for every registered venue.
+- Evidence: The exact entity and address inputs, venue registry, adapter responses or verified Alexandria index, evidence schema, source references and emitted `evidence.json`.
+- Evidence classes: recorded, checked
+- Boundary: Collection does not establish human identity, source completeness, default, full repayment, current balance, creditworthiness or a Wildcat decision.
+- Authorises: Rendering a dossier from the collected evidence while keeping address provenance, venue scope and gaps separate.
+- Consequence: 1
+- Refuses: Feeding inferred addresses into conclusions, omitting an unqueried venue, admitting an unsourced record or treating an archive gap as clean history.
+- Recovery: Correct the declared inputs or source adapter, collect again and retain any unresolved venue or interval as an explicit gap.
+- Exceptions: none
+
+### probitas-dossier-rendering
+
+- Promise: A successful `render` derives the dossier's factual tables from the evidence file and places coverage and unknowns before narrative conclusions.
+- Evidence: The validated evidence JSON, deterministic rendered sections, exact figures and source references, and the emitted dossier bytes.
+- Evidence classes: recorded, recomputed
+- Boundary: Rendering does not validate later human narrative, infer identity, create a rating or decide whether a counterparty should receive a market.
+- Authorises: Completion of narrative sections using only the same evidence and submission of the dossier to `verify`.
+- Consequence: 1
+- Refuses: Introducing a figure, hash, market, identity claim or venue conclusion absent from the evidence file.
+- Recovery: Remove the unsupported narrative or obtain a source record through a fresh collection, rerender and rerun verification.
+- Exceptions: none
+
+### probitas-dossier-verification
+
+- Promise: A successful `verify` establishes that the exact dossier and evidence file pass address provenance, coverage, total sourcing, visible negative space and rating-rubric gates.
+- Evidence: The dossier bytes, evidence JSON, reconstructed allowed figures and hashes, five named gate results and zero exit status.
+- Evidence classes: checked, recomputed, recorded
+- Boundary: Verification establishes dossier conformance, not factual completeness beyond recorded coverage, personal identity, a credit score, underwriting approval or a Wildcat Labs verdict.
+- Authorises: With the decision-maker's separate authority, release of the sourced dossier for an independent lending decision.
+- Consequence: 3
+- Refuses: Shipping a dossier after any gate fails, hiding a gap, allowing inferred-address evidence into a conclusion or presenting the document as Wildcat approval.
+- Recovery: Fix the evidence or dossier named by the failed gate, preserve unresolved gaps and rerun all five gates before release.
+- Exceptions: none

--- a/plugins/sapheneia/skills/sapheneia/SKILL.md
+++ b/plugins/sapheneia/skills/sapheneia/SKILL.md
@@ -170,3 +170,29 @@ Before every user-facing turn, check:
 
 Do not claim that this shape works for every autistic or ADHD reader. It is a
 default contract that yields immediately to the person using it.
+
+## Promise Machine contract
+
+### sapheneia-session-shape
+
+- Promise: While activated, each agent reply exposes the immediate action or result, literal ask, boundary, working state, evidence status and one next action when work remains, subject to the reader's stated preference.
+- Evidence: The user's activation and preferences, the exact reply, visible task state and the completed five-question pre-send check.
+- Evidence classes: recorded, checked
+- Boundary: The reply shape does not diagnose the reader, establish that one format works for every AuDHD person, change another skill's facts or override higher-priority instructions.
+- Authorises: Sending the checked reply and carrying the same interaction contract across topic changes and context compaction.
+- Consequence: 0
+- Refuses: Hidden state, implied obligation, invented urgency, diagnosis from communication style or an unlabelled change to scope.
+- Recovery: Restate the action, boundary, evidence and next step explicitly, apply the reader's correction and check the revised reply before sending.
+- Exceptions: none
+
+### sapheneia-deactivation
+
+- Promise: Sapheneia stops only after an explicit recognised deactivation from the user and one confirmation that default response shape has resumed.
+- Evidence: The recorded user instruction matching a named stop phrase and the agent's confirmation.
+- Evidence classes: recorded, checked
+- Boundary: A topic change, terse reply, delay or context compaction is not deactivation and supplies no evidence about diagnosis, mood or intent.
+- Authorises: Returning subsequent interaction to the default response style while leaving other active skill contracts unchanged.
+- Consequence: 0
+- Refuses: Silent deactivation, inference from user behaviour or removal of another skill's required substance or format.
+- Recovery: Keep Sapheneia active until the user gives an explicit stop instruction, then confirm the state change once.
+- Exceptions: none

--- a/plugins/tabularium/skills/tabularium/SKILL.md
+++ b/plugins/tabularium/skills/tabularium/SKILL.md
@@ -197,3 +197,41 @@ invent a separate protocol generation without new primary evidence.
 
 If a build, verification, source check or test did not run, say so plainly and
 do not describe it as successful.
+
+## Promise Machine contract
+
+### tabularium-release-build
+
+- Promise: A successful `build` writes venue-qualified canonical events and coverage whose rows deterministically map one-to-one from the validated preserved source under the named adapter and mapping versions.
+- Evidence: The preserved source and capture manifest, source digest and count checks, adapter and mapping rules, complete native records, ordered selectors, canonical JSONL and coverage manifest.
+- Evidence classes: recorded, checked, recomputed
+- Boundary: The release reports the preserved source's declared boundary and unsupported collections; it does not prove source completeness, canonical-chain status, repayment completion, identity or creditworthiness.
+- Authorises: Creation of a new immutable versioned event release for offline verification.
+- Consequence: 2
+- Refuses: Aliasing or rewriting source evidence, flattening venue meaning, accepting duplicate or missing selectors, hiding unsupported records or changing published release bytes.
+- Recovery: Correct the source capture or mapping in a new versioned release, rebuild into a fresh directory and verify it.
+- Exceptions: none
+
+### tabularium-release-verification
+
+- Promise: A successful `verify` recomputes the named release's source, capture and canonical digests, counts, schema and mapping versions, selectors and expected JSONL from local files.
+- Evidence: The complete release directory, coverage manifest, source and capture bytes, adapter implementation, rebuilt canonical records and zero-exit verification report.
+- Evidence classes: checked, recomputed, recorded
+- Boundary: Verification establishes internal consistency and implemented mapping only; it does not authenticate a publisher, independently prove the chain boundary or turn venue records into a counterparty verdict.
+- Authorises: With separate publisher authority, publication or downstream use of the exact verified release with its coverage and unsupported records visible.
+- Consequence: 3
+- Refuses: Publication after a digest, path, count, version, selector or rebuild mismatch, or description of an unsigned release as authentic or chain-proved.
+- Recovery: Inspect the named mismatch, preserve published bytes, build a superseding release when interpretation changes and rerun offline verification.
+- Exceptions: none
+
+### tabularium-compound-witness
+
+- Promise: A successful `compound-witness` followed by `verify-compound-witness` reproduces the ordered calls, relevant proxy writes and signed-principal transition for the one named verified Alexandria transaction witness.
+- Evidence: The verified Alexandria release and component digests, pinned Comet commit, implementation and code bindings, emitted facts and witness manifest, and passing witness verification.
+- Evidence classes: recorded, checked, recomputed
+- Boundary: The Phase 0 witness is non-canonical and covers one transaction and method; it is not a coverage-v2 row, interval release, canonical mapping or independent chain proof.
+- Authorises: Use of the checked facts as bounded implementation evidence while Phase 1 canonical mapping remains absent.
+- Consequence: 1
+- Refuses: Generalising to another transaction, implementation, layout, call shape or interval, or publishing the witness as canonical Tabularium credit events.
+- Recovery: Repair or recapture the Alexandria witness, update the named implementation method deliberately and rerun both witness commands.
+- Exceptions: none

--- a/plugins/tabularium/tests/test_scaffold.py
+++ b/plugins/tabularium/tests/test_scaffold.py
@@ -71,6 +71,9 @@ class TabulariumPackagingTests(unittest.TestCase):
             self.assertTrue((PLUGIN_ROOT / relative).is_file(), relative)
 
     def test_public_document_links_resolve_inside_the_plugin(self):
+        shared_versioning = (
+            REPO_ROOT / "plugins" / "hexaemeron" / "skills" / "VERSIONING.md"
+        ).resolve()
         for path in PLUGIN_ROOT.rglob("*.md"):
             if "__pycache__" in path.parts:
                 continue
@@ -79,6 +82,9 @@ class TabulariumPackagingTests(unittest.TestCase):
                     continue
                 target = (path.parent / link.split("#", 1)[0]).resolve()
                 with self.subTest(document=path.relative_to(PLUGIN_ROOT), link=link):
+                    if target == shared_versioning:
+                        self.assertTrue(target.is_file())
+                        continue
                     self.assertIn(PLUGIN_ROOT, target.parents)
                     self.assertTrue(target.exists())
 

--- a/scripts/promise_machine.py
+++ b/scripts/promise_machine.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 from dataclasses import asdict, dataclass
@@ -61,6 +62,9 @@ SUPPORTED_EVIDENCE_CLASSES = {
     "unknown",
 }
 PROMISE_ID = re.compile(r"[a-z][a-z0-9]*(?:-[a-z0-9]+)*")
+OVERLAY_PATH = Path("plugins/hexaemeron/PROMISES.md")
+OVERLAY_HEADING = "# Hexaemeron Promise Machine overlays"
+OVERLAY_FIELDS = ("Path", "SHA-256", *REQUIRED_FIELDS)
 
 
 @dataclass(frozen=True)
@@ -821,6 +825,7 @@ def check_structure(
     inventory: Inventory,
     *,
     require_standalone_contracts: bool = False,
+    require_hexaemeron_contracts: bool = False,
 ):
     findings: list[Finding] = []
     promises: list[tuple[str, str]] = []
@@ -849,7 +854,12 @@ def check_structure(
         parsed, parsed_findings = parse_contract(
             skill,
             root,
-            required=require_standalone_contracts and skill.plugin != "hexaemeron",
+            required=(
+                require_standalone_contracts and skill.plugin != "hexaemeron"
+            )
+            or (
+                require_hexaemeron_contracts and skill.plugin == "hexaemeron"
+            ),
         )
         promises.extend(parsed)
         findings.extend(parsed_findings)
@@ -870,6 +880,324 @@ def check_structure(
                     )
                 )
     return len(promises), findings
+
+
+def check_overlays(root: Path, inventory: Inventory):
+    findings: list[Finding] = []
+    expected_overlay = OVERLAY_PATH.as_posix()
+    discovered = set(inventory.overlays)
+    if expected_overlay not in discovered:
+        findings.append(
+            Finding(
+                "PM050",
+                "structural",
+                expected_overlay,
+                "required Hexaemeron vendored-promise overlay is absent",
+                "add the fixed first-party overlay for every vendored skill",
+            )
+        )
+    for unexpected in sorted(discovered - {expected_overlay}):
+        findings.append(
+            Finding(
+                "PM051",
+                "identity",
+                unexpected,
+                "promise overlay exists outside the fixed Hexaemeron boundary",
+                "remove the unexpected overlay or record a new first-party boundary in the law",
+            )
+        )
+
+    if expected_overlay not in discovered:
+        return 0, findings
+
+    path = root / OVERLAY_PATH
+    loaded, read_findings = read_markdown(
+        path, root, missing_code="PM050", unsafe_code="PM025"
+    )
+    findings.extend(read_findings)
+    if loaded is None:
+        return 0, findings
+    _, text = loaded
+    lines = text.splitlines()
+    if lines.count(OVERLAY_HEADING) != 1:
+        findings.append(
+            Finding(
+                "PM052",
+                "structural",
+                expected_overlay,
+                f"overlay heading must occur once: {OVERLAY_HEADING}",
+                "restore the single Hexaemeron overlay heading",
+            )
+        )
+
+    heading_index = lines.index(OVERLAY_HEADING) if OVERLAY_HEADING in lines else 0
+    section_end = next(
+        (
+            index
+            for index in range(heading_index + 1, len(lines))
+            if lines[index].startswith("# ") or lines[index].startswith("## ")
+        ),
+        len(lines),
+    )
+    blocks = [
+        index
+        for index in range(heading_index + 1, section_end)
+        if lines[index].startswith("### ")
+    ]
+    if not blocks:
+        findings.append(
+            Finding(
+                "PM052",
+                "structural",
+                expected_overlay,
+                "overlay contains no vendored promise block",
+                "add one digest-bound block for every vendored skill",
+            )
+        )
+        return 0, findings
+
+    skills = {item.path: item for item in inventory.skills}
+    vendored = {item.path for item in inventory.skills if item.governance == "vendored"}
+    canonical_ids: set[str] = set()
+    for skill in inventory.skills:
+        if skill.governance != "first-party":
+            continue
+        parsed, _ = parse_contract(skill, root)
+        canonical_ids.update(promise_id for promise_id, _ in parsed)
+    seen_paths: dict[str, list[str]] = {}
+    seen_ids: set[str] = set()
+    for offset, block_start in enumerate(blocks):
+        block_end = blocks[offset + 1] if offset + 1 < len(blocks) else len(lines)
+        promise_id = lines[block_start][4:].strip()
+        if not PROMISE_ID.fullmatch(promise_id):
+            findings.append(
+                Finding(
+                    "PM032",
+                    "structural",
+                    expected_overlay,
+                    "overlay promise id is not a stable lowercase hyphenated identifier",
+                    "use a lowercase identifier made of letters, digits and hyphens",
+                    promise_id=promise_id or None,
+                )
+            )
+        if promise_id in seen_ids or promise_id in canonical_ids:
+            findings.append(
+                Finding(
+                    "PM035",
+                    "identity",
+                    expected_overlay,
+                    "overlay promise id is duplicated across the suite",
+                    "give every suite promise one unique stable promise id",
+                    promise_id=promise_id or None,
+                )
+            )
+        seen_ids.add(promise_id)
+
+        fields: dict[str, list[str]] = {}
+        for line in lines[block_start + 1 : block_end]:
+            match = re.fullmatch(r"- \*\*([^*]+):\*\*\s*(.*)", line)
+            if match is None:
+                match = re.fullmatch(r"- ([^:]+):\s*(.*)", line)
+            if match is not None:
+                fields.setdefault(match.group(1).strip(), []).append(match.group(2).strip())
+        unknown = sorted(set(fields) - set(OVERLAY_FIELDS))
+        if unknown:
+            findings.append(
+                Finding(
+                    "PM053",
+                    "structural",
+                    expected_overlay,
+                    f"overlay declaration contains unknown fields: {unknown!r}",
+                    "use only Path, SHA-256 and the nine promise fields",
+                    promise_id=promise_id or None,
+                )
+            )
+        for field in OVERLAY_FIELDS:
+            values = fields.get(field, [])
+            if len(values) != 1 or not values[0]:
+                findings.append(
+                    Finding(
+                        "PM054",
+                        "structural",
+                        expected_overlay,
+                        f"overlay field must occur once and be non-empty: {field}",
+                        f"provide exactly one non-empty {field} field",
+                        promise_id=promise_id or None,
+                    )
+                )
+
+        declared_paths = fields.get("Path", [])
+        if len(declared_paths) == 1:
+            declared = declared_paths[0].strip("`")
+            seen_paths.setdefault(declared, []).append(promise_id)
+            skill = skills.get(declared)
+            if skill is None:
+                findings.append(
+                    Finding(
+                        "PM055",
+                        "identity",
+                        expected_overlay,
+                        f"overlay path is not a discovered canonical skill: {declared!r}",
+                        "bind the block to one discovered vendored SKILL.md path",
+                        promise_id=promise_id or None,
+                    )
+                )
+            elif skill.governance != "vendored":
+                findings.append(
+                    Finding(
+                        "PM055",
+                        "identity",
+                        expected_overlay,
+                        f"overlay path belongs to a {skill.governance} skill: {declared!r}",
+                        "put first-party promises in the canonical SKILL.md itself",
+                        promise_id=promise_id or None,
+                    )
+                )
+            target = root / declared
+            if (
+                Path(declared).is_absolute()
+                or ".." in Path(declared).parts
+                or target.is_symlink()
+                or not confined(target, root)
+                or not target.is_file()
+            ):
+                findings.append(
+                    Finding(
+                        "PM055",
+                        "identity",
+                        expected_overlay,
+                        f"overlay path is unsafe or absent: {declared!r}",
+                        "use the confined regular path of the vendored SKILL.md",
+                        promise_id=promise_id or None,
+                    )
+                )
+            digests = fields.get("SHA-256", [])
+            if len(digests) == 1:
+                digest = digests[0].strip("`")
+                if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+                    findings.append(
+                        Finding(
+                            "PM056",
+                            "structural",
+                            expected_overlay,
+                            "overlay SHA-256 is not 64 lowercase hexadecimal characters",
+                            "record the full lowercase SHA-256 of the vendored instruction bytes",
+                            promise_id=promise_id or None,
+                        )
+                    )
+                elif target.is_file() and not target.is_symlink() and confined(target, root):
+                    target_loaded, target_findings = read_markdown(
+                        target, root, missing_code="PM055", unsafe_code="PM055"
+                    )
+                    findings.extend(target_findings)
+                    actual = (
+                        hashlib.sha256(target_loaded[0]).hexdigest()
+                        if target_loaded is not None
+                        else ""
+                    )
+                    if actual != digest:
+                        findings.append(
+                            Finding(
+                                "PM057",
+                                "drift",
+                                declared,
+                                f"vendored instruction digest is {actual}; overlay records {digest}",
+                                "review the upstream change and update the first-party overlay deliberately",
+                                promise_id=promise_id or None,
+                            )
+                        )
+
+        evidence_values = fields.get("Evidence classes", [])
+        if len(evidence_values) == 1:
+            classes = [
+                item.strip().strip("`").split(":", 1)[0].strip()
+                for item in re.split(r"[,;]", evidence_values[0])
+                if item.strip()
+            ]
+            unsupported = sorted(set(classes) - SUPPORTED_EVIDENCE_CLASSES)
+            if not classes or unsupported:
+                findings.append(
+                    Finding(
+                        "PM036",
+                        "structural",
+                        expected_overlay,
+                        f"unsupported evidence classes: {unsupported or ['<empty>']!r}",
+                        "use a recognised base evidence class from the law",
+                        promise_id=promise_id or None,
+                    )
+                )
+        consequences = fields.get("Consequence", [])
+        if len(consequences) == 1 and consequences[0] not in {"0", "1", "2", "3"}:
+            findings.append(
+                Finding(
+                    "PM037",
+                    "structural",
+                    expected_overlay,
+                    f"unsupported consequence level: {consequences[0]!r}",
+                    "use consequence level 0, 1, 2 or 3",
+                    promise_id=promise_id or None,
+                )
+            )
+        exceptions = fields.get("Exceptions", [])
+        if len(exceptions) == 1 and exceptions[0].lower() != "none":
+            required = ("authority", "scope", "record", "expiry")
+            absent = [
+                item
+                for item in required
+                if re.search(
+                    rf"(?:^|;)\s*{item}\s*(?::|=)\s*[^;\s].*?(?=;|$)",
+                    exceptions[0],
+                    re.IGNORECASE,
+                )
+                is None
+            ]
+            if absent:
+                findings.append(
+                    Finding(
+                        "PM038",
+                        "structural",
+                        expected_overlay,
+                        f"exception omits required attribution: {absent!r}",
+                        "name authority, scope, record and expiry, or declare none",
+                        promise_id=promise_id or None,
+                    )
+                )
+
+    for declared, owners in sorted(seen_paths.items()):
+        if len(owners) > 1:
+            findings.append(
+                Finding(
+                    "PM058",
+                    "identity",
+                    expected_overlay,
+                    f"vendored path has multiple overlays: {declared!r} -> {owners!r}",
+                    "retain exactly one promise block for each vendored path",
+                )
+            )
+    declared_set = set(seen_paths)
+    for missing in sorted(vendored - declared_set):
+        findings.append(
+            Finding(
+                "PM059",
+                "structural",
+                missing,
+                "vendored skill has no digest-bound Promise Machine overlay",
+                "add one first-party overlay block for the vendored path",
+            )
+        )
+    for extra in sorted(declared_set - vendored):
+        if extra in skills:
+            continue
+        findings.append(
+            Finding(
+                "PM055",
+                "identity",
+                expected_overlay,
+                f"overlay does not belong to the vendored inventory: {extra!r}",
+                "remove the block or correct its path to a discovered vendored skill",
+            )
+        )
+    return len(blocks), findings
 
 
 def check_identity(inventory: Inventory):
@@ -1424,6 +1752,7 @@ def parse_only(raw: str):
         "inventory",
         "structure",
         "contracts",
+        "overlays",
         "identity",
         "routers",
         "versions",
@@ -1496,6 +1825,7 @@ def main(argv=None):
             "inventory",
             "structure",
             "contracts",
+            "overlays",
             "identity",
             "routers",
             "versions",
@@ -1505,13 +1835,18 @@ def main(argv=None):
             inventory, inventory_findings = discover_inventory(root)
             findings.extend(inventory_findings)
             plugins = [root / path for path in inventory.plugins]
-        if only & {"structure", "contracts"} and inventory is not None:
+        if only & {"structure", "contracts", "overlays"} and inventory is not None:
             promises, structure_findings = check_structure(
                 root,
                 inventory,
                 require_standalone_contracts="contracts" in only,
+                require_hexaemeron_contracts="overlays" in only,
             )
             findings.extend(structure_findings)
+        if "overlays" in only and inventory is not None:
+            overlay_promises, overlay_findings = check_overlays(root, inventory)
+            promises += overlay_promises
+            findings.extend(overlay_findings)
         if "identity" in only and inventory is not None:
             findings.extend(check_identity(inventory))
         if "routers" in only and inventory is not None:

--- a/scripts/promise_machine.py
+++ b/scripts/promise_machine.py
@@ -1404,6 +1404,7 @@ def parse_only(raw: str):
         "copies",
         "inventory",
         "structure",
+        "contracts",
         "identity",
         "routers",
         "versions",
@@ -1475,6 +1476,7 @@ def main(argv=None):
         inventory_components = {
             "inventory",
             "structure",
+            "contracts",
             "identity",
             "routers",
             "versions",
@@ -1484,7 +1486,7 @@ def main(argv=None):
             inventory, inventory_findings = discover_inventory(root)
             findings.extend(inventory_findings)
             plugins = [root / path for path in inventory.plugins]
-        if "structure" in only and inventory is not None:
+        if only & {"structure", "contracts"} and inventory is not None:
             promises, structure_findings = check_structure(root, inventory)
             findings.extend(structure_findings)
         if "identity" in only and inventory is not None:

--- a/scripts/promise_machine.py
+++ b/scripts/promise_machine.py
@@ -660,7 +660,7 @@ def discover_inventory(root: Path):
     return inventory, findings
 
 
-def parse_contract(skill: SkillRecord, root: Path):
+def parse_contract(skill: SkillRecord, root: Path, *, required: bool = False):
     path = root / skill.path
     loaded, findings = read_markdown(
         path, root, missing_code="PM020", unsafe_code="PM025"
@@ -671,6 +671,16 @@ def parse_contract(skill: SkillRecord, root: Path):
     lines = text.splitlines()
     headings = [index for index, line in enumerate(lines) if line == "## Promise Machine contract"]
     if not headings:
+        if required:
+            findings.append(
+                Finding(
+                    "PM031",
+                    "structural",
+                    skill.path,
+                    "required Promise Machine contract section is absent",
+                    "add one contract section with at least one stable promise block",
+                )
+            )
         return [], findings
     if len(headings) != 1:
         findings.append(
@@ -806,7 +816,12 @@ def parse_contract(skill: SkillRecord, root: Path):
     return promises, findings
 
 
-def check_structure(root: Path, inventory: Inventory):
+def check_structure(
+    root: Path,
+    inventory: Inventory,
+    *,
+    require_standalone_contracts: bool = False,
+):
     findings: list[Finding] = []
     promises: list[tuple[str, str]] = []
     for skill in inventory.skills:
@@ -831,7 +846,11 @@ def check_structure(root: Path, inventory: Inventory):
             continue
         if skill.governance != "first-party":
             continue
-        parsed, parsed_findings = parse_contract(skill, root)
+        parsed, parsed_findings = parse_contract(
+            skill,
+            root,
+            required=require_standalone_contracts and skill.plugin != "hexaemeron",
+        )
         promises.extend(parsed)
         findings.extend(parsed_findings)
     owners: dict[str, list[str]] = {}
@@ -1487,7 +1506,11 @@ def main(argv=None):
             findings.extend(inventory_findings)
             plugins = [root / path for path in inventory.plugins]
         if only & {"structure", "contracts"} and inventory is not None:
-            promises, structure_findings = check_structure(root, inventory)
+            promises, structure_findings = check_structure(
+                root,
+                inventory,
+                require_standalone_contracts="contracts" in only,
+            )
             findings.extend(structure_findings)
         if "identity" in only and inventory is not None:
             findings.extend(check_identity(inventory))

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -1,4 +1,5 @@
 import json
+import hashlib
 import os
 from pathlib import Path
 import shutil
@@ -78,6 +79,53 @@ def write_skill(plugin, name="example", *, promise_id="example-check", fields=No
     )
     (directory / "EVOLUTION.md").write_text("# Evolution\n", encoding="utf-8")
     return directory
+
+
+def write_vendored_skill(plugin, name="upstream"):
+    directory = plugin / "skills" / name
+    directory.mkdir(parents=True)
+    skill = directory / "SKILL.md"
+    skill.write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: A vendored fixture skill.\n"
+        "---\n\n"
+        f"# {name}\n",
+        encoding="utf-8",
+    )
+    (directory / "NOTICE.md").write_text(
+        "# Notice\n\n"
+        "This directory is vendored verbatim.\n\n"
+        "- Upstream: https://example.invalid/upstream\n"
+        "- Release tag: v0.0.0\n"
+        "- Vendored: 2026-08-20\n",
+        encoding="utf-8",
+    )
+    (directory / "LICENSE").write_text("Fixture licence.\n", encoding="utf-8")
+    return skill
+
+
+def write_overlay(root, skill, *, promise_id="hexaemeron-upstream-run", digest=None):
+    digest = digest or hashlib.sha256(skill.read_bytes()).hexdigest()
+    path = skill.relative_to(root).as_posix()
+    overlay = root / "plugins" / "hexaemeron" / "PROMISES.md"
+    overlay.write_text(
+        "# Hexaemeron Promise Machine overlays\n\n"
+        f"### {promise_id}\n\n"
+        f"- Path: `{path}`\n"
+        f"- SHA-256: `{digest}`\n"
+        "- Promise: The named vendored operation completed.\n"
+        "- Evidence: The digest-matched instruction and operation record.\n"
+        "- Evidence classes: checked, recorded\n"
+        "- Boundary: The result covers only the named operation.\n"
+        "- Authorises: Use of the recorded result inside its boundary.\n"
+        "- Consequence: 1\n"
+        "- Refuses: A stale digest or failed operation.\n"
+        "- Recovery: Reconcile the instruction and rerun the operation.\n"
+        "- Exceptions: none\n",
+        encoding="utf-8",
+    )
+    return overlay
 
 
 class PromiseLawTests(unittest.TestCase):
@@ -407,8 +455,114 @@ class PromiseStructureTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["promises"], 43)
+        self.assertEqual(report["counts"]["promises"], 61)
 
+    def test_hexaemeron_contract_population_is_complete(self):
+        expected = {
+            "elenchus": {"elenchus-fixed-and-guarded"},
+            "ephoros": {"ephoros-mechanical-gate", "ephoros-observability-review"},
+            "fiat": {"fiat-receipted-delivery", "fiat-final-integration"},
+            "hypomnema": {"hypomnema-pointer-gate", "hypomnema-record-placement"},
+            "imprimatur": {"imprimatur-prose-gate"},
+            "kronos": {
+                "kronos-frontier-ranking",
+                "kronos-fiat-dispatch",
+                "kronos-parked-lane",
+            },
+            "metron": {"metron-budget-verdict", "metron-change-decision"},
+            "phylax": {"phylax-mechanical-gate", "phylax-boundary-review"},
+            "protasis": {"protasis-study-readiness", "protasis-runbook-readiness"},
+            "vulgate": {"vulgate-register-rewrite"},
+        }
+        for skill, promise_ids in expected.items():
+            path = ROOT / "plugins" / "hexaemeron" / "skills" / skill / "SKILL.md"
+            with self.subTest(skill=skill):
+                text = path.read_text(encoding="utf-8")
+                self.assertEqual(text.splitlines().count("## Promise Machine contract"), 1)
+                contract = text.split("## Promise Machine contract", 1)[1]
+                contract = contract.split("\n## ", 1)[0]
+                self.assertEqual(
+                    {
+                        line.removeprefix("### ")
+                        for line in contract.splitlines()
+                        if line.startswith("### ")
+                    },
+                    promise_ids,
+                )
+
+
+class PromiseOverlayTests(unittest.TestCase):
+    def test_repository_overlay_population_is_complete_and_digest_bound(self):
+        expected = {
+            "plugins/hexaemeron/skills/fizz/SKILL.md":
+                "62a60df4cec160511b8ef36433eef7c8805d0b4a398491293eb4542ab73539bd",
+            "plugins/hexaemeron/skills/fizz/skills/fizz-convert/SKILL.md":
+                "59cd4b4ef5dc56315782a7d25222afb286a24e63e438530cbd0044293ea54af7",
+            "plugins/hexaemeron/skills/fizz/skills/fizz-sync/SKILL.md":
+                "e969cd8a447941989715840e24aa6a915c0fd795effabd912b3c627598a95e16",
+            "plugins/hexaemeron/skills/x-ray/SKILL.md":
+                "b23bb94517805c1b8ce717d0e1e0282b0b5c14c7b16f4c32e73940292d3d4a41",
+            "plugins/hexaemeron/skills/solidity-auditor/SKILL.md":
+                "1c1cf4e99d042e7aadc56b622d97a07d3286f4786838a05510697c814d1e983f",
+        }
+        text = (ROOT / "plugins" / "hexaemeron" / "PROMISES.md").read_text(
+            encoding="utf-8"
+        )
+        for path, digest in expected.items():
+            with self.subTest(path=path):
+                self.assertIn(f"- Path: `{path}`", text)
+                self.assertIn(f"- SHA-256: `{digest}`", text)
+
+        completed = run_cli("check", "--only", "contracts,overlays", "--json")
+        report = json.loads(completed.stdout)
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["counts"]["promises"], 66)
+        self.assertEqual(report["counts"]["overlays"], 1)
+
+    def test_one_byte_vendored_mutation_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            plugin = make_plugin(target, "hexaemeron")
+            skill = write_vendored_skill(plugin)
+            write_overlay(target, skill)
+            clean = run_cli("check", "--root", target, "--only", "overlays", "--json")
+            skill.write_bytes(skill.read_bytes() + b"x")
+            drifted = run_cli(
+                "check", "--root", target, "--only", "overlays", "--json"
+            )
+        self.assertEqual(clean.returncode, 0, clean.stdout + clean.stderr)
+        report = json.loads(drifted.stdout)
+        self.assertEqual(drifted.returncode, 1)
+        self.assertIn("PM057", [item["code"] for item in report["findings"]])
+
+    def test_missing_overlay_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            plugin = make_plugin(target, "hexaemeron")
+            write_vendored_skill(plugin)
+            completed = run_cli(
+                "check", "--root", target, "--only", "overlays", "--json"
+            )
+        report = json.loads(completed.stdout)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM050", [item["code"] for item in report["findings"]])
+
+    def test_overlay_cannot_bind_a_first_party_skill(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            plugin = make_plugin(target, "hexaemeron")
+            skill = write_skill(plugin) / "SKILL.md"
+            write_overlay(target, skill)
+            completed = run_cli(
+                "check", "--root", target, "--only", "overlays", "--json"
+            )
+        report = json.loads(completed.stdout)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM055", [item["code"] for item in report["findings"]])
+
+
+class PromiseStructureValidationTests(unittest.TestCase):
     def test_contract_component_refuses_an_absent_section(self):
         with tempfile.TemporaryDirectory() as directory:
             target = Path(directory)

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -316,12 +316,96 @@ class PromiseInventoryTests(unittest.TestCase):
 
 
 class PromiseStructureTests(unittest.TestCase):
-    def test_repository_structure_is_clean_before_contract_population(self):
-        completed = run_cli("check", "--only", "inventory,structure", "--json")
+    def test_standalone_contract_population_is_complete(self):
+        expected = {
+            "plugins/alexandria/skills/alexandria/SKILL.md": {
+                "alexandria-raw-release",
+                "alexandria-derived-view",
+                "alexandria-address-query",
+                "alexandria-compound-method-proof",
+            },
+            "plugins/ariadne/skills/ariadne/SKILL.md": {
+                "ariadne-capture-statement",
+                "ariadne-inspect-statement",
+                "ariadne-verify-statement",
+                "ariadne-replay-command",
+            },
+            "plugins/berean/skills/berean/SKILL.md": {
+                "berean-corpus-binding",
+                "berean-answer-evidence",
+                "berean-evaluation-report",
+                "berean-release-promotion",
+            },
+            "plugins/brevitas/skills/brevitas/SKILL.md": {
+                "brevitas-structure-check",
+                "brevitas-evidence-preservation",
+            },
+            "plugins/hermes/skills/hermes/SKILL.md": {
+                "hermes-sealed-baseline",
+                "hermes-candidate-acceptance",
+                "hermes-baseline-promotion",
+            },
+            "plugins/horos/skills/horos/SKILL.md": {
+                "horos-boundary-scan",
+                "horos-boundary-check",
+                "horos-census",
+                "horos-skeleton-map",
+            },
+            "plugins/janus/skills/janus/SKILL.md": {
+                "janus-manifest-validation",
+                "janus-bounded-conformance",
+                "janus-report-rendering",
+            },
+            "plugins/lazarus/skills/lazarus/SKILL.md": {
+                "lazarus-fixture-capture",
+                "lazarus-fixture-verification",
+                "lazarus-exact-replay",
+                "lazarus-preservation-release",
+            },
+            "plugins/lemma/skills/chunk/SKILL.md": {
+                "lemma-solidity-chunks",
+                "lemma-markdown-chunks",
+                "lemma-chunk-validation",
+            },
+            "plugins/pandects/skills/pandects/SKILL.md": {
+                "pandects-law-contract",
+                "pandects-broken-specimen",
+                "pandects-search-record",
+            },
+            "plugins/probitas/skills/probitas/SKILL.md": {
+                "probitas-evidence-collection",
+                "probitas-dossier-rendering",
+                "probitas-dossier-verification",
+            },
+            "plugins/sapheneia/skills/sapheneia/SKILL.md": {
+                "sapheneia-session-shape",
+                "sapheneia-deactivation",
+            },
+            "plugins/tabularium/skills/tabularium/SKILL.md": {
+                "tabularium-release-build",
+                "tabularium-release-verification",
+                "tabularium-compound-witness",
+            },
+        }
+        for path, promise_ids in expected.items():
+            with self.subTest(path=path):
+                text = (ROOT / path).read_text(encoding="utf-8")
+                self.assertEqual(text.splitlines().count("## Promise Machine contract"), 1)
+                self.assertEqual(
+                    {
+                        line.removeprefix("### ")
+                        for line in text.splitlines()
+                        if line.startswith("### ")
+                        and line.removeprefix("### ") in promise_ids
+                    },
+                    promise_ids,
+                )
+
+        completed = run_cli("check", "--only", "structure,contracts", "--json")
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["promises"], 0)
+        self.assertEqual(report["counts"]["promises"], 42)
 
     def test_missing_contract_fixture_is_refused(self):
         completed = run_cli(

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -369,6 +369,7 @@ class PromiseStructureTests(unittest.TestCase):
             },
             "plugins/pandects/skills/pandects/SKILL.md": {
                 "pandects-law-contract",
+                "pandects-catalogue-render",
                 "pandects-broken-specimen",
                 "pandects-search-record",
             },
@@ -391,12 +392,13 @@ class PromiseStructureTests(unittest.TestCase):
             with self.subTest(path=path):
                 text = (ROOT / path).read_text(encoding="utf-8")
                 self.assertEqual(text.splitlines().count("## Promise Machine contract"), 1)
+                contract = text.split("## Promise Machine contract", 1)[1]
+                contract = contract.split("\n## ", 1)[0]
                 self.assertEqual(
                     {
                         line.removeprefix("### ")
-                        for line in text.splitlines()
+                        for line in contract.splitlines()
                         if line.startswith("### ")
-                        and line.removeprefix("### ") in promise_ids
                     },
                     promise_ids,
                 )
@@ -405,7 +407,23 @@ class PromiseStructureTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["promises"], 42)
+        self.assertEqual(report["counts"]["promises"], 43)
+
+    def test_contract_component_refuses_an_absent_section(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            plugin = make_plugin(target)
+            skill = write_skill(plugin)
+            (skill / "SKILL.md").write_text(
+                "---\nname: example\ndescription: A fixture skill.\n---\n\n# Example\n",
+                encoding="utf-8",
+            )
+            completed = run_cli(
+                "check", "--root", target, "--only", "contracts", "--json"
+            )
+        report = json.loads(completed.stdout)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM031", [item["code"] for item in report["findings"]])
 
     def test_missing_contract_fixture_is_refused(self):
         completed = run_cli(


### PR DESCRIPTION
# Declare Hexaemeron Promise Machine contracts

## What changed

- Added 18 stable Promise Machine declarations to the ten first-party
  Hexaemeron skills.
- Added five Wildcat-authored overlays for vendored Fizz, Fizz Convert, Fizz
  Sync, X-Ray and Solidity Auditor instructions without changing upstream
  bytes.
- Bound every overlay to one canonical path and its exact SHA-256, so upstream
  drift blocks the Wildcat promise until it is reviewed.
- Added repository checks for complete first-party coverage, complete vendored
  coverage, suite-wide identifiers, confined paths, bounded reads and digest
  drift.
- Recorded the overlay design and its rejected alternatives in ADR-003.

## Audit

The audit is appended to `audit/AUDIT.md`. Round 1 was clean after reviewing
all 18 first-party declarations against their instructions and all five
overlays against unchanged vendored bytes. Behavioural conformance remains
the explicit work of the next two stacked steps.

## Proof

```bash
python3 scripts/promise_machine.py check --only contracts,overlays
python3 -m unittest tests.test_promise_machine_contract
python3 -m unittest discover -s tests
python3 plugins/hexaemeron/tests/run_tests.py plugins/hexaemeron
```

The checker reports 61 canonical first-party promises plus five vendored
overlays. The 44 focused tests, 80 root tests and 451 Hexaemeron tests pass. A
one-byte vendored mutation is refused with `PM057`, the five vendored
instruction files have no diff, and the Imprimatur, Brevitas, Phylax, Ephoros,
Hypomnema and Horos gates are clean.

This pull request stacks on the standalone Promise Machine contract step.

<!-- wildcat-origin: shoggoth -->
