### PR TITLE
Enforce executable Promise Machine coverage

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5296,3 +5296,34 @@ Zero findings.
 ### Leads not pursued
 
 The behavioural-conformance boundary recorded in round 1 remains unchanged.
+
+## Promise Machine, step 5, round 1 -- 2026-08-20
+
+### Review scope
+
+The Solidity suite remained waived because this step changes first-party
+Markdown contracts, a standard-library checker and its Python tests. The
+review compared all 18 Hexaemeron declarations with their canonical
+instructions and checked the five vendored overlays against their unchanged
+upstream bytes. It also inspected overlay discovery, confinement, bounded
+reads, suite-wide identifier uniqueness, exact coverage, digest drift,
+first-party rejection and the runtime digest-check instruction.
+
+### Findings
+
+Zero findings.
+
+### Evidence
+
+The checker reports 61 canonical first-party promises and five digest-bound
+vendored overlays. All 44 focused Promise Machine tests, 80 root tests and 451
+Hexaemeron tests pass. A one-byte mutation of a vendored instruction is
+refused with `PM057`; the five vendored instruction paths have no diff.
+Imprimatur, Brevitas, Phylax, Ephoros, Hypomnema and Horos are clean.
+
+### Leads not pursued
+
+The declarations state evidence contracts but do not yet prove every skill's
+runtime implementation conforms to them. Executable, prompt, transformation
+and vendored conformance are the explicit subjects of the next two runbook
+steps, so treating that work as a finding here would duplicate their scope.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5359,3 +5359,26 @@ Recorded review cases establish that each decision path has been named and kept
 inside its boundary; they do not turn a human review judgement into runtime
 proof. The remaining prompt, transformation and vendored rows stay visibly
 pending for runbook step 8.
+
+## Promise Machine, step 6, round 2 -- 2026-08-20
+
+### Review scope
+
+The corrected coverage map keeps executable tests, recorded review cases and
+inapplicability reasons distinct. All exact references resolve; incompatible
+P/M/S/O/R paths remain separate; the required preservation and handoff records
+remain explicit; and the full law, copy and executable-coverage checks are clean.
+
+### Findings
+
+Zero findings.
+
+### Evidence
+
+All 90 root tests and all 467 Hexaemeron tests pass. The Phylax, Ephoros and
+Hypomnema gates are clean.
+
+### Leads not pursued
+
+The recorded-judgement and later-runbook boundaries from round 1 remain
+unchanged.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5327,3 +5327,35 @@ The declarations state evidence contracts but do not yet prove every skill's
 runtime implementation conforms to them. Executable, prompt, transformation
 and vendored conformance are the explicit subjects of the next two runbook
 steps, so treating that work as a finding here would duplicate their scope.
+
+## Promise Machine, step 6, round 1 -- 2026-08-20
+
+### Review scope
+
+The Solidity suite remained waived because this step changes a standard-library
+checker, JSON coverage records and Python tests. The review traced every selected
+P/M/S/O/R/X reference to its exact selector, checked evidence reuse and
+inapplicability rules, inspected the Berean and Janus preservation boundaries and
+the Lazarus-to-Berean-to-Ariadne handoffs, and compared judgement-held promises
+with the narrower mechanical gates beside them.
+
+### Findings
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S6-R1-01 | high | `tests/promise_machine_coverage.json` | The Ephoros observability review, Phylax boundary review and Protasis study-readiness promises cited mechanical parser tests, so the coverage map overstated what those tests established | fixed with 15 distinct labelled review cases that record positive, missing, subject-mismatch, overclaim and recovery judgements without presenting them as checked runtime proof |
+| S6-R1-02 | medium | `scripts/promise_machine.py` | Evidence references could not state their base evidence class, leaving recorded judgement cases indistinguishable from executable checks | fixed with an optional, validated `evidence_class` field and refusal tests for unsupported classes |
+
+### Evidence
+
+The executable coverage gate reports 50 selected promises out of 66 discovered,
+with no finding. The 25 focused coverage and labelled-case checks, all 90 root
+tests and all 467 Hexaemeron tests pass. The Phylax, Ephoros and Hypomnema gates
+are clean.
+
+### Leads not pursued
+
+Recorded review cases establish that each decision path has been named and kept
+inside its boundary; they do not turn a human review judgement into runtime
+proof. The remaining prompt, transformation and vendored rows stay visibly
+pending for runbook step 8.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5341,10 +5341,21 @@ with the narrower mechanical gates beside them.
 
 ### Findings
 
-| id | severity | file | finding | status |
-| --- | --- | --- | --- | --- |
-| S6-R1-01 | high | `tests/promise_machine_coverage.json` | The Ephoros observability review, Phylax boundary review and Protasis study-readiness promises cited mechanical parser tests, so the coverage map overstated what those tests established | fixed with 15 distinct labelled review cases that record positive, missing, subject-mismatch, overclaim and recovery judgements without presenting them as checked runtime proof |
-| S6-R1-02 | medium | `scripts/promise_machine.py` | Evidence references could not state their base evidence class, leaving recorded judgement cases indistinguishable from executable checks | fixed with an optional, validated `evidence_class` field and refusal tests for unsupported classes |
+FINDING
+[High] S6-R1-01: Three judgement-held promises cited mechanical parser tests.
+Location: `tests/promise_machine_coverage.json`
+Mechanism: The Ephoros, Phylax and Protasis review rows borrowed evidence from narrower mechanical gates.
+Impact: The coverage map overstated what those tests established.
+Fix: Added 15 labelled review cases that record P/M/S/O/R judgements without presenting them as checked runtime proof.
+END
+
+FINDING
+[Medium] S6-R1-02: Evidence references could not state their base class.
+Location: `scripts/promise_machine.py`
+Mechanism: The schema accepted only a path, selector and claim.
+Impact: Recorded judgement cases were indistinguishable from executable checks.
+Fix: Added a validated optional `evidence_class` field and refusal tests for unsupported classes.
+END
 
 ### Evidence
 

--- a/docs/decisions/ADR-003-bind-vendored-promises-with-digests.md
+++ b/docs/decisions/ADR-003-bind-vendored-promises-with-digests.md
@@ -1,0 +1,49 @@
+# ADR-003: Bind vendored promises with digests
+
+- Status: Accepted
+- Date: 2026-08-20
+- Promise Machine contract: `promise-machine/v1`
+
+## Context
+
+Five Hexaemeron skills are vendored from an upstream source. Their instruction
+files must remain attributable and byte-exact, but the Wildcat suite still
+needs to state what evidence it accepts from those operations and what each
+result authorises. Writing the suite contract into a vendored instruction
+would silently fork the upstream work. An unbound note elsewhere could survive
+an upstream change while describing behaviour the new bytes no longer have.
+
+## Decision
+
+Keep each upstream `SKILL.md` unchanged. Hold the Wildcat declarations in the
+single first-party file `plugins/hexaemeron/PROMISES.md`. Every declaration
+names one discovered vendored canonical path and the SHA-256 of that file's
+exact bytes, followed by the nine Promise Machine fields.
+
+The repository checker recomputes each digest and rejects a missing overlay,
+an extra overlay location, an unsafe or absent path, a first-party target, a
+duplicate path or promise identifier, incomplete fields, uncovered vendored
+skills and byte drift. A runtime that selects a vendored skill reads its block
+and compares the recorded digest before relying on the overlay. Digest drift
+blocks the Wildcat promise; it does not authorise editing the upstream file.
+
+## Alternatives rejected
+
+- Editing vendored instructions would create an unattributed local fork and
+  make upstream comparison unreliable.
+- A notice without a digest would not show whether the declaration still
+  described the instruction actually installed.
+- Separate overlay files beside each vendored skill would widen discovery and
+  make omission and duplicate ownership harder to check.
+
+## Consequences
+
+An upstream update now fails closed until its changed instruction is reviewed
+and the corresponding declaration and digest are deliberately updated. The
+overlay remains Wildcat-authored; the upstream instruction and attribution
+remain intact. The digest binds bytes, not truth: executable and review
+evidence must still satisfy the declaration before it authorises anything.
+
+Rollback is all-or-nothing. Remove the overlay, its runtime binding, checker
+component and tests together; do not leave an unchecked promise beside
+vendored instructions.

--- a/plugins/hexaemeron/AGENTS.md
+++ b/plugins/hexaemeron/AGENTS.md
@@ -35,6 +35,26 @@ Hexaemeron skill matches a task.
 | `metron` | `skills/metron/SKILL.md` | Baseline something slow, change one thing, re-measure, and keep or revert on the numbers |
 | `hypomnema` | `skills/hypomnema/SKILL.md` | Record the reason behind a decision, and put each kind of record where it will be found |
 
+## Vendored Promise Machine overlays
+
+Before selecting `fizz`, `fizz-convert`, `fizz-sync`, `x-ray` or
+`solidity-auditor`, read its declaration in [PROMISES.md](PROMISES.md) and
+recompute the SHA-256 of the exact canonical `SKILL.md`. The path and digest
+must match before the Wildcat promise is available. A mismatch blocks the
+overlay and requires review of the upstream change; it never authorises an
+edit to the vendored instruction.
+
+From this distribution repository, check the complete binding with:
+
+```bash
+python3 scripts/promise_machine.py check --only contracts,overlays
+```
+
+A standalone installation without the repository checker performs the same
+local path and digest comparison before it relies on an overlay. The overlay
+states what the Wildcat suite accepts from the vendored operation; the
+unchanged upstream file still controls how that operation runs.
+
 The first-party `fiat`, `imprimatur`, `vulgate`, and `kronos` directories each
 carry an `EVOLUTION.md` ledger governed by `skills/VERSIONING.md`. Read the
 selected skill's ledger before proposing a frontier run. A `mature` frontier

--- a/plugins/hexaemeron/PROMISES.md
+++ b/plugins/hexaemeron/PROMISES.md
@@ -1,0 +1,77 @@
+# Hexaemeron Promise Machine overlays
+
+This first-party file declares the promises Hexaemeron makes around vendored
+instructions. Each declaration is bound to one canonical path and the SHA-256
+of its exact bytes. The overlay is unavailable when that digest changes; the
+upstream instruction remains unchanged and must be reviewed before this file
+is updated.
+
+### hexaemeron-fizz-harness-campaign
+
+- Path: `plugins/hexaemeron/skills/fizz/SKILL.md`
+- SHA-256: `62a60df4cec160511b8ef36433eef7c8805d0b4a398491293eb4542ab73539bd`
+- Promise: A completed Fizz run establishes that the generated Echidna or Medusa harness builds and that the named campaign actually ran against it with its preserved configuration and results.
+- Evidence: The digest-matched instruction, source snapshot, generated harness and manifest, build result, named engine command, campaign configuration, bounded raw output and machine-readable result where the engine supplies one.
+- Evidence classes: checked, recorded
+- Boundary: The result covers the generated harness and campaign that ran; it does not establish exhaustive property discovery, semantic adequacy of every property, absence of vulnerabilities or a security sign-off.
+- Authorises: Using the generated harness and recorded campaign result as evidence for the properties and target boundary explicitly exercised.
+- Consequence: 3
+- Refuses: A stale overlay digest, a harness that does not build, a campaign inferred from generated files but never run, missing configuration, narrowed bounds used to hide a failure or a claim broader than the exercised properties.
+- Recovery: Reconcile the upstream instruction digest, regenerate the harness from the named source, restore the campaign configuration, run the selected engine and retain its actual result.
+- Exceptions: none
+
+### hexaemeron-fizz-convert-properties
+
+- Path: `plugins/hexaemeron/skills/fizz/skills/fizz-convert/SKILL.md`
+- SHA-256: `59cd4b4ef5dc56315782a7d25222afb286a24e63e438530cbd0044293ea54af7`
+- Promise: A completed Fizz Convert run establishes that the selected pending property was translated into wired Solidity assertion code, the harness builds and the corresponding source checklist entry was updated.
+- Evidence: The digest-matched instruction, selected property text and identifier, generated assertion and handler wiring, build output, changed checkbox and bounded diff.
+- Evidence classes: checked, recorded
+- Boundary: The result proves mechanical conversion and buildability of the selected property; it does not establish that the property is semantically correct, reachable, complete or adequate for security review.
+- Authorises: Treating the selected checklist entry as implemented in the named harness and passing it to a real fuzz campaign.
+- Consequence: 2
+- Refuses: A stale overlay digest, an ambiguous property, unwired assertion, failed build, unchecked source update or a semantic-completeness claim unsupported by execution.
+- Recovery: Reconcile the upstream instruction digest, clarify one property, repair its assertion and wiring, rebuild the harness and update only the matching checklist entry.
+- Exceptions: none
+
+### hexaemeron-fizz-sync-drift
+
+- Path: `plugins/hexaemeron/skills/fizz/skills/fizz-sync/SKILL.md`
+- SHA-256: `e969cd8a447941989715840e24aa6a915c0fd795effabd912b3c627598a95e16`
+- Promise: A completed Fizz Sync run establishes that bounded source-interface drift was reconciled into the existing harness, stale properties were quarantined, generated stubs were refreshed and the updated harness builds.
+- Evidence: The digest-matched instruction, prior and current source snapshots, ABI drift report, quarantined-property record, regenerated stubs, refreshed snapshot, bounded diff and build result.
+- Evidence classes: checked, recorded
+- Boundary: The result covers syntactic and declared interface reconciliation within the inspected source boundary; it does not prove semantic equivalence, preserve unstated assumptions or validate property adequacy.
+- Authorises: Running the reconciled harness against the current named source while treating quarantined properties as unresolved.
+- Consequence: 2
+- Refuses: A stale overlay digest, unbounded or unidentified source drift, silently deleted properties, a failed build, an unrefreshed snapshot or any claim that ABI agreement proves semantic agreement.
+- Recovery: Reconcile the upstream instruction digest, restore the before and after snapshots, classify every drift item, quarantine rather than erase stale properties, regenerate the affected stubs and rebuild.
+- Exceptions: none
+
+### hexaemeron-x-ray-preaudit
+
+- Path: `plugins/hexaemeron/skills/x-ray/SKILL.md`
+- SHA-256: `b23bb94517805c1b8ce717d0e1e0282b0b5c14c7b16f4c32e73940292d3d4a41`
+- Promise: A completed X-Ray run establishes that the required pre-audit views were produced for the named repository snapshot with their source boundary and unresolved gaps visible.
+- Evidence: The digest-matched instruction, repository commit, scoped source inventory and the four required pre-audit artefacts with their cited inputs and generation records.
+- Evidence classes: recorded, inferred
+- Boundary: The artefacts are preparation and analysis aids; they are not an audit, do not establish exploitability or absence of defects and inherit every omission in the inspected repository boundary.
+- Authorises: Beginning a human or agent audit with the four named pre-audit views as scoped orientation material.
+- Consequence: 1
+- Refuses: A stale overlay digest, an unnamed repository snapshot, a missing required artefact, uncited conclusions, hidden exclusions or language that presents pre-audit analysis as security sign-off.
+- Recovery: Reconcile the upstream instruction digest, fix the source boundary, regenerate the missing or stale views and leave every unresolved gap explicit.
+- Exceptions: none
+
+### hexaemeron-solidity-audit-report
+
+- Path: `plugins/hexaemeron/skills/solidity-auditor/SKILL.md`
+- SHA-256: `1c1cf4e99d042e7aadc56b622d97a07d3286f4786838a05510697c814d1e983f`
+- Promise: A completed Solidity Auditor run establishes that all twelve prescribed audit roles inspected the named Solidity scope, their raw results crossed the required wait barrier and the final report deduplicated, completeness-checked and judged the submitted findings.
+- Evidence: The digest-matched instruction, repository commit and Solidity scope, twelve role prompts and raw outputs, completion barrier, deduplication record, completeness pass, judgement record and final report.
+- Evidence classes: checked, recorded, inferred
+- Boundary: The report establishes performance of the prescribed review process over the named scope; findings remain judgements and a clean report does not prove the absence of vulnerabilities or replace independent review.
+- Authorises: Using the scoped report as one security-review input and advancing only according to its explicit findings, uncertainties and unresolved coverage.
+- Consequence: 3
+- Refuses: A stale overlay digest, fewer than twelve isolated role results, synthesis before the wait barrier, missing raw outputs, hidden scope exclusions, undeduplicated findings or a claim of defect absence.
+- Recovery: Reconcile the upstream instruction digest, restore the exact scope, rerun every missing or compromised role independently, wait for all raw results and repeat deduplication, completeness checking and judgement.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/elenchus/SKILL.md
+++ b/plugins/hexaemeron/skills/elenchus/SKILL.md
@@ -269,3 +269,17 @@ saying so costs nothing while claiming otherwise costs the next person's day.
 
 End with one action: the command to rerun, the question that unblocks you, or
 the review the fix now needs.
+
+## Promise Machine contract
+
+### elenchus-fixed-and-guarded
+
+- Promise: A fixed-and-guarded result establishes that the reported failure was reproduced, localised to a causal mechanism, repaired at that mechanism and covered by a regression test observed to fail on the unfixed parent and pass on the fixed tree.
+- Evidence: The reproduction command and output, causal account, minimal case where useful, fix diff, detached-parent guard report, fixed-tree report and both relevant suite results.
+- Evidence classes: checked, inferred
+- Boundary: The result covers the reproduced failure and named guard; it does not prove the surrounding system defect-free or turn an inconclusive, zero-test or infrastructure-failed comparison into a guard.
+- Authorises: Closing the named failure and relying on the regression test for that mechanism within the tested environment.
+- Consequence: 2
+- Refuses: A symptom-only patch, an unreproduced cause, a guard that never failed without the fix, narrowed fuzz bounds, unrelated changes or a stale, malformed, oversized, mixed or empty report.
+- Recovery: Preserve the failure, restore a faithful reproducer, isolate the mechanism, add or repair the guard report and rerun both the unfixed-parent and fixed-tree suites.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/ephoros/SKILL.md
+++ b/plugins/hexaemeron/skills/ephoros/SKILL.md
@@ -242,3 +242,29 @@ asserted, and saying which is which costs a sentence.
 
 End with one action: the alert still needing a threshold, the question with no
 signal behind it, or the sampled output someone should read.
+
+## Promise Machine contract
+
+### ephoros-mechanical-gate
+
+- Promise: A zero-exit Ephoros lint establishes that the bounded parser found none of its specified formatted-log, unbounded-metric-label or mean-duration patterns in the selected Python paths.
+- Evidence: The exact lint version, arguments, selected paths, structured findings and zero exit status.
+- Evidence classes: checked
+- Boundary: A clean lint covers only the three implemented Python rules; it does not prove useful observability, safe output, correct alerting or conformance of another language.
+- Authorises: Passing the mechanical Ephoros gate for the exact paths and checker version recorded.
+- Consequence: 1
+- Refuses: Unreadable or oversized input, an unexplained suppression, a non-zero result or any broader observability claim.
+- Recovery: Repair the offending signal or add a narrowly reasoned suppression when the rule is inapplicable, then rerun the same bounded lint.
+- Exceptions: none
+
+### ephoros-observability-review
+
+- Promise: A completed observability review establishes that the step's on-call questions have bounded signals, correlation and user-symptom alerts, and that emitted samples were checked for sensitive or unbounded data.
+- Evidence: The question-to-signal map, event and metric definitions, trace correlation, alert test, sampled output, staleness signal for long jobs and unresolved-gap list.
+- Evidence classes: checked, inferred, recorded
+- Boundary: The review covers the named step and exercised signals; it does not prove future telemetry availability, alert thresholds under every workload or absence of sensitive data outside the samples reviewed.
+- Authorises: Operating the reviewed step with the recorded signals and escalating through the named runbooks.
+- Consequence: 2
+- Refuses: A new unattended path with no signal, unbounded labels, mean-only duration, missing correlation, untested alerts, absent runbooks or sensitive values in emitted output.
+- Recovery: Write the unanswered on-call question, add or bound the missing signal, exercise the alert, inspect real output and repeat the review.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/fiat/SKILL.md
+++ b/plugins/hexaemeron/skills/fiat/SKILL.md
@@ -407,3 +407,29 @@ hand over: topic, the run branch and the base it landed on, the step list with
 each stacked PR URL and the order the stack merged in, the integration PR and
 its merge SHA, audit rounds per step with the closing state of each, and where
 the study and runbook live.
+
+## Promise Machine contract
+
+### fiat-receipted-delivery
+
+- Promise: A successful `hexctl verify` establishes that the controller state and append-only ledger agree and that every recorded phase transition occurred in the required order with the required receipt shape.
+- Evidence: The exact study and runbook receipts, step branches and commits, audit rounds, prose and push receipts, hash-chained ledger, controller version and zero-exit verification result.
+- Evidence classes: checked, recorded
+- Boundary: Controller verification proves receipt order and integrity, not the truth of a test summary, audit judgement, external check, implementation claim or user authority merely written into a receipt.
+- Authorises: Advancing only to the single next controller directive and reporting the recorded workflow state without strengthening any underlying receipt.
+- Consequence: 2
+- Refuses: Skipping a phase, reconstructing progress from chat, accepting a malformed or missing receipt, or describing an unrun check as complete.
+- Recovery: Inspect `hexctl status`, repair the current phase's real evidence without editing ledger history, submit the required receipt and rerun `hexctl verify`.
+- Exceptions: none
+
+### fiat-final-integration
+
+- Promise: A successful integration receipt establishes that every stacked step was merged in controller order, the run branch passed its required gates and exactly one recorded merge landed the run on the named base under the user's delivery authority.
+- Evidence: The user's explicit Fiat request, green step and integration checks, stacked PR URLs and head commits, merge-step receipts, integration PR and merge commit, final controller state and verified ledger.
+- Evidence classes: checked, recorded
+- Boundary: Integration establishes the recorded repository transition; it does not prove the software defect-free, make audit judgements independent or authorise a deployment, financial action or another repository.
+- Authorises: Publication of the complete run to the named base and a final report limited to the merged artefacts and recorded evidence.
+- Consequence: 3
+- Refuses: Direct step merges to the base, bypassed gates, a second base merge, deletion that closes a stacked PR prematurely or integration without explicit delivery authority.
+- Recovery: Leave the stack open, restore the required branch or check, retarget and merge in controller order, or halt with the exact blocker before any base mutation.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/hypomnema/SKILL.md
+++ b/plugins/hexaemeron/skills/hypomnema/SKILL.md
@@ -198,3 +198,29 @@ diff suggests, and saying which is which is the whole point of the record.
 
 End with one action: the decision still needing a record, the convention
 conflict somebody has to resolve, or the runbook an alert is waiting on.
+
+## Promise Machine contract
+
+### hypomnema-pointer-gate
+
+- Promise: A zero-exit Hypomnema lint establishes that the bounded checker found no unresolved relative links, absent superseding records or missing alert runbooks in the selected first-party documents.
+- Evidence: The exact lint version, arguments, selected paths, structured findings and zero exit status.
+- Evidence classes: checked
+- Boundary: A clean lint proves only that the recognised pointers resolve at check time; it does not prove that records are correct, complete, current or placed well.
+- Authorises: Passing the mechanical record-pointer gate for the exact paths and checker version recorded.
+- Consequence: 1
+- Refuses: Unsafe, unreadable or oversized paths, unresolved recognised pointers, an unexplained suppression or a claim about documents excluded from the run.
+- Recovery: Restore or correct the target, mark supersession accurately, add the missing runbook and rerun the same bounded lint.
+- Exceptions: none
+
+### hypomnema-record-placement
+
+- Promise: A completed record-placement review establishes that each expensive-to-reverse decision introduced by the step has a reasoned record in the repository's established location, with rejected alternatives and resolvable pointers.
+- Evidence: The step diff, decision inventory, authored or superseded records, alternatives and reasons, pointer-gate result and unresolved-decision list.
+- Evidence classes: checked, inferred, recorded
+- Boundary: The review covers the decisions identified in the named step; it does not prove that every future reader agrees with them or that an unidentified decision was documented.
+- Authorises: Treating the recorded choices as the current project decisions until superseded through the same convention.
+- Consequence: 2
+- Refuses: A costly choice with no reason, a second record scheme, deletion of superseded history, an absent target or a decision placed where the repository's readers will not find it.
+- Recovery: Identify the missing choice, write the reason and rejected alternatives in the established location, repair its pointers and repeat the review.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/imprimatur/SKILL.md
+++ b/plugins/hexaemeron/skills/imprimatur/SKILL.md
@@ -111,3 +111,17 @@ Attribution, licence, and the list of deviations are in `NOTICE.md`.
 - Never claim a draft is undetectable, human-passing, or clean because the score is high. The score counts known markers and nothing else.
 - Never let the lint's own vocabulary leak into prose. Words like "defect", "gated", and "pass" belong in reports, not in the writing being fixed.
 - Do not report the lint as run when it was not.
+
+## Promise Machine contract
+
+### imprimatur-prose-gate
+
+- Promise: A successful Imprimatur run establishes that the exact prose crossed the configured hard, gated and structural pattern thresholds and that every reported defect was cleared or evidenced under the checker rules.
+- Evidence: The exact input bytes, lexicon and allowlist, selected mode and threshold, defect and signal output, labelled-corpus provenance and zero exit status.
+- Evidence classes: checked, recorded
+- Boundary: The gate does not establish human authorship, factual accuracy, sound reasoning, an intended voice or absence of every machine-writing pattern.
+- Authorises: Presentation or hand-off of the checked prose as Imprimatur-clean at the named checker version and threshold.
+- Consequence: 0
+- Refuses: Calling prose clean when the gate did not run or failed, hiding a hard hit with a synonym, treating a cadence signal as a defect or deleting a scope-bearing qualifier to clear a word.
+- Recovery: Read the named defect, rewrite the sentence without weakening evidence or uncertainty and rerun the exact gate.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/kronos/SKILL.md
+++ b/plugins/hexaemeron/skills/kronos/SKILL.md
@@ -238,3 +238,41 @@ what it says.
 - Never summarise, shorten or reword a halt reason on the way into a park.
 - Never release a park on the loop's own judgement, and never call the loop
   complete while one stands.
+
+## Promise Machine contract
+
+### kronos-frontier-ranking
+
+- Promise: A successful scoreboard `record` establishes that all eligible in-scope ledgers were represented, each total matches its four declared axes, the recorded selection follows the tie-break and held-job digests came from disk.
+- Evidence: The selected scope and mode, current evolution ledgers, candidate scores and bases, recomputed totals and held-job hashes, append-only scoreboard line and successful `show` result.
+- Evidence classes: checked, recorded, inferred
+- Boundary: The checker validates the ranking record and arithmetic; it does not make subjective scores objective, rank mature, vendored, parked or out-of-scope work, or establish global priority.
+- Authorises: Selection of the recorded highest eligible held job for rank-only hand-off or a separately authorised Fiat dispatch.
+- Consequence: 1
+- Refuses: A changed or unreadable held job, inconsistent total, wrong tie-break, incomplete candidate universe, parked selection or rank-only record naming a run.
+- Recovery: Rescan the complete allowed scope, correct the score or basis, reread the scoreboard drift and record a new pass without rewriting history.
+- Exceptions: none
+
+### kronos-fiat-dispatch
+
+- Promise: A full or phase-only loop dispatches the selected held job to Fiat only when the user explicitly authorised Kronos execution and the candidate remains eligible and unparked at dispatch.
+- Evidence: The user's explicit Kronos request, current ranking record, selected ledger and held-job digest, empty standing park for that job and the newly initialised Fiat run receipt.
+- Evidence classes: checked, recorded, inferred
+- Boundary: Dispatch establishes why this eligible job entered Fiat; it does not prove the ranking globally optimal, the job complete or Fiat's later receipts true.
+- Authorises: Starting one Fiat delivery for the selected held job and reranking from disk only after that run reaches a terminal recorded state.
+- Consequence: 3
+- Refuses: Implicit activation, self-selection, a mature or vendored frontier, a standing park, a lower-ranked skip with no park or continuation after no eligible frontier remains.
+- Recovery: Return to rank-only output, correct scope or eligibility, obtain explicit authority, or park the exact Fiat blocker and rerank the remaining candidates.
+- Exceptions: none
+
+### kronos-parked-lane
+
+- Promise: A successful `park` or `unpark` append records the exact held-job digest and human-supplied reason while `parked` reports the current standing state without rewriting history.
+- Evidence: The readable skill ledger, recomputed held-job hash, exact halt or release reason, append-only parked record and `parked` exit status.
+- Evidence classes: checked, recorded
+- Boundary: A park records a person's blocking claim; it does not judge the claim, expire itself, follow a changed held job automatically or prove the blocker cleared.
+- Authorises: Excluding a standing parked job from selection, or restoring it only after a human-authored unpark record.
+- Consequence: 2
+- Refuses: Selecting a parked job, paraphrasing its halt reason, auto-expiry, autonomous release or declaring the loop complete while any park stands.
+- Recovery: Preserve the park, ask the responsible person whether stale or unknown state still applies and append an explicit unpark record only on their direction.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/metron/SKILL.md
+++ b/plugins/hexaemeron/skills/metron/SKILL.md
@@ -209,3 +209,29 @@ believe rather than profiled gets named as a belief.
 
 End with one action: the next thing worth measuring, the budget that needs a
 threshold, or the reverted idea somebody should stop suggesting.
+
+## Promise Machine contract
+
+### metron-budget-verdict
+
+- Promise: A budget verdict establishes that a named workload was measured against a stated threshold with a fixed command, environment, inputs, repetitions and aggregation rule.
+- Evidence: The benchmark identity, environment, input fixture, warm-up and repetition policy, raw or preserved measurements, aggregation method, variance and threshold comparison.
+- Evidence classes: measured, recorded
+- Boundary: The verdict applies only to the recorded workload and measurement method; it does not generalise to other machines, inputs, workloads or correctness.
+- Authorises: Accepting or refusing the measured subject against the named budget without strengthening the result beyond its measurement boundary.
+- Consequence: 1
+- Refuses: A missing baseline, changed method, mean-only latency, result inside unexplained noise, unbounded workload or comparison across unlike environments.
+- Recovery: Freeze one reproducible method, establish the baseline and variance, rerun the exact workload and compare it to the stated threshold.
+- Exceptions: none
+
+### metron-change-decision
+
+- Promise: A keep decision establishes that one isolated change improved the named measurement beyond variance while the correctness gates remained green; otherwise the attempted change is reverted and recorded.
+- Evidence: Before and after measurements taken the same way, isolated change diff, variance, correctness-suite results, budget results and the attempt-ledger verdict.
+- Evidence classes: measured, checked, recorded
+- Boundary: The decision proves the measured effect of the isolated change on the named workload, not its effect on unmeasured workloads or the reason for the movement unless separately isolated.
+- Authorises: Keeping the change only when both the measured improvement and correctness gates pass, or recording and abandoning it otherwise.
+- Consequence: 2
+- Refuses: Several unisolated edits, an unmeasured optimisation, a neutral or noisy result, a red or weakened correctness gate, or a speed gain bought by removing a guarantee.
+- Recovery: Revert the candidate, restore the baseline, isolate one hypothesis, repeat the same measurement and record the new verdict whether kept or rejected.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/phylax/SKILL.md
+++ b/plugins/hexaemeron/skills/phylax/SKILL.md
@@ -367,3 +367,29 @@ Name what you could not check and why.
 
 End with one action: the boundary that still needs a control, the review a
 dependency needs, or the approval a widened trust boundary is waiting on.
+
+## Promise Machine contract
+
+### phylax-mechanical-gate
+
+- Promise: A zero-exit Phylax lint establishes that the bounded parser found none of its specified external-input, subprocess, fetch, secret, path and model-output patterns in the selected first-party paths.
+- Evidence: The exact lint version, arguments, selected paths, structured findings and zero exit status.
+- Evidence classes: checked
+- Boundary: A clean lint covers only the rules and languages implemented by the parser; it is not a security review, a dependency audit, a privacy assessment or evidence that a control works against hostile input.
+- Authorises: Passing the mechanical Phylax gate for the exact paths and checker version recorded.
+- Consequence: 1
+- Refuses: Unsafe paths, unreadable or oversized input, an unexplained suppression, a non-zero result or any claim about a rule the parser does not implement.
+- Recovery: Correct the input or control, add a narrowly reasoned suppression only when the rule is inapplicable and rerun the same bounded lint.
+- Exceptions: none
+
+### phylax-boundary-review
+
+- Promise: A completed boundary review establishes that every trust boundary introduced by the step is named, paired with a control and classified as verified or merely asserted, with unresolved exposure left visible.
+- Evidence: The step diff, boundary inventory, hostile-input tests where available, dependency and lockfile review, sample output review, unresolved-gap list and reviewer conclusion.
+- Evidence classes: checked, inferred, recorded
+- Boundary: The review is scoped to the introduced boundaries and available evidence; it does not establish whole-system security or convert an asserted control into a verified one.
+- Authorises: Proceeding with the reviewed step only to the consequence level supported by its verified controls and explicitly accepted open gaps.
+- Consequence: 2
+- Refuses: An unnamed boundary, unvalidated external data, data-built shell strings, unsafe host or path handling, exposed credentials, unreviewed dependency drift or model output used directly as authority.
+- Recovery: Name the missing boundary, add and exercise its control, review the affected dependency or data path and repeat the boundary review.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/protasis/SKILL.md
+++ b/plugins/hexaemeron/skills/protasis/SKILL.md
@@ -299,3 +299,29 @@ End with one action, and make it something the reader can do in a couple of
 minutes: confirm an assumption, answer one question, or approve the runbook.
 Name the open question rather than closing it with a guess. Corrected here, an
 assumption costs a sentence. Found in the audit loop, it costs a step.
+
+## Promise Machine contract
+
+### protasis-study-readiness
+
+- Promise: A study accepted by Protasis states the problem, assumptions, current state, chosen design and rejected trade, boundaries, failure and recovery model, affected versions and evidence-bearing success criteria needed to derive a runbook.
+- Evidence: The exact study, source inventory, explicit unknowns and exclusions, answered discipline questions, design comparison and completed study checklist.
+- Evidence classes: checked, inferred, recorded
+- Boundary: Readiness means the study contains material required to plan; it does not establish that the design is correct, implementation exists, tests pass or later receipts are true.
+- Authorises: Derivation of a discrete runbook from the accepted study without silently adding a new design decision.
+- Consequence: 1
+- Refuses: Hidden assumptions, an unstated boundary, solution-first prose, missing trade, untestable success language or a topic still containing several independent deliveries.
+- Recovery: Name the missing question or decision, gather the required evidence, amend the study and repeat the complete Protasis review.
+- Exceptions: none
+
+### protasis-runbook-readiness
+
+- Promise: A runbook accepted by Protasis decomposes the study into ordered steps whose entry, modules, exit commands, files, tests and discipline effects are discrete and provable.
+- Evidence: The accepted study, exact runbook, `protasis.py` structural result, per-step commands and files, dependency order, version boundary and completed pre-receipt checklist.
+- Evidence classes: checked, inferred, recorded
+- Boundary: Runbook readiness establishes buildable specification content, not correct implementation, command success, audit closure or delivery completion.
+- Authorises: Starting implementation at the first step while using the study and runbook as the change-control boundary.
+- Consequence: 1
+- Refuses: A step with no executable exit, mixed independent outcomes, missing affected files or tests, forward references to an undecided design or receipt language with no evidence command.
+- Recovery: Split or reorder the failing step, supply its exact evidence and rerun both the mechanical check and the full content review.
+- Exceptions: none

--- a/plugins/hexaemeron/skills/vulgate/SKILL.md
+++ b/plugins/hexaemeron/skills/vulgate/SKILL.md
@@ -114,3 +114,17 @@ Before returning rewritten text, verify:
    tone changed.
 6. Read it aloud: would a person say this sentence to a colleague? If a
    sentence would embarrass its speaker out loud, rewrite it.
+
+## Promise Machine contract
+
+### vulgate-register-rewrite
+
+- Promise: A completed Vulgate pass rewrites the named prose into the selected plain register while preserving its claims, evidence, uncertainty, scope, logical relations and required structure.
+- Evidence: The exact source and rewritten bytes, selected register, protected facts and structure, line-by-line content comparison and completed rewrite checklist.
+- Evidence classes: checked, inferred
+- Boundary: The pass changes register only; it does not establish truth, improve the underlying argument, supply missing evidence, diagnose authorship or override another skill's required format.
+- Authorises: Presentation of the rewritten prose with its substantive content and evidence boundary unchanged.
+- Consequence: 0
+- Refuses: Added facts, deleted caveats, changed severity, softened refusal, invented quotation, moved attribution or a voice change that alters meaning.
+- Recovery: Restore the source claim and protected evidence, redo only the affected sentence and compare the complete rewrite with the original before hand-off.
+- Exceptions: none

--- a/plugins/hexaemeron/tests/fixtures/promise-machine/executable-cases.json
+++ b/plugins/hexaemeron/tests/fixtures/promise-machine/executable-cases.json
@@ -1,0 +1,23 @@
+{
+  "ephoros-observability-review": {
+    "P": {"disposition": "accept", "scenario": "Every on-call question has a bounded signal, exercised alert, runbook and reviewed output sample.", "boundary": "The result applies only to the named step and exercised signals."},
+    "M": {"disposition": "refuse", "scenario": "A new external call has no error or duration signal and no alert evidence.", "boundary": "Absent operational evidence cannot authorise unattended operation."},
+    "S": {"disposition": "refuse", "scenario": "The output sample and alert exercise came from an older build than the reviewed step.", "boundary": "Evidence from another subject does not establish the current step."},
+    "O": {"disposition": "refuse", "scenario": "The mechanical lint is clean and is presented as proof that observability is useful and complete.", "boundary": "Three parser rules do not establish the judgement-held review."},
+    "R": {"disposition": "recover", "scenario": "Add the missing bounded signal, exercise its alert, inspect current output and repeat the review.", "boundary": "Recovery produces new evidence; it does not rewrite the refused result."}
+  },
+  "phylax-boundary-review": {
+    "P": {"disposition": "accept", "scenario": "Every boundary introduced by the step is named, controlled and classified as verified or asserted.", "boundary": "The review covers only the introduced boundaries and available hostile-input evidence."},
+    "M": {"disposition": "refuse", "scenario": "External data reaches a generated path without a named confinement control or hostile-input test.", "boundary": "An unnamed or uncontrolled boundary blocks the step."},
+    "S": {"disposition": "refuse", "scenario": "The dependency review and lockfile evidence belong to the parent revision rather than the changed dependency.", "boundary": "A review of another subject cannot authorise this dependency transition."},
+    "O": {"disposition": "refuse", "scenario": "A clean mechanical lint is presented as whole-system security evidence.", "boundary": "Parser coverage is not a security review or proof that a control works."},
+    "R": {"disposition": "recover", "scenario": "Name the boundary, add and exercise its control, review the affected dependency or data path and repeat the review.", "boundary": "Recovery leaves the earlier refusal intact and supplies new evidence."}
+  },
+  "protasis-study-readiness": {
+    "P": {"disposition": "accept", "scenario": "The study states the problem, assumptions, current state, chosen design, rejected trade, boundaries, recovery and testable criteria.", "boundary": "Readiness authorises runbook derivation, not an implementation or proof that the design is correct."},
+    "M": {"disposition": "refuse", "scenario": "The study relies on an unstated environment assumption and gives no evidence-bearing success criterion.", "boundary": "Hidden assumptions and untestable success language block runbook derivation."},
+    "S": {"disposition": "refuse", "scenario": "The source inventory and current-state evidence name a different repository revision than the study entry ref.", "boundary": "A mismatched subject cannot establish current-state readiness."},
+    "O": {"disposition": "refuse", "scenario": "An accepted study is presented as proof that the selected design is correct and its future tests pass.", "boundary": "Content readiness is not implementation or correctness evidence."},
+    "R": {"disposition": "recover", "scenario": "Name the missing question, gather current evidence, amend the study and repeat the complete review.", "boundary": "Recovery supplies a new reviewed study without strengthening the refused draft."}
+  }
+}

--- a/plugins/hexaemeron/tests/test_hexctl.py
+++ b/plugins/hexaemeron/tests/test_hexctl.py
@@ -716,6 +716,24 @@ class TestControls(HexctlCase):
         proc = self.run_ctl("verify", expect=1)
         self.assertIn("chain broken", proc.stderr)
 
+    def test_verify_preserves_receipt_assertions_without_proving_them(self):
+        self.to_steps(("One",))
+        assertion = "all dragons defeated"
+        self.run_ctl(
+            "done",
+            "implement",
+            "--branch",
+            self.step_branch(1),
+            "--commit",
+            "abc123",
+            "--tests",
+            assertion,
+        )
+        self.run_ctl("verify")
+        state = json.loads(self.run_ctl("status", "--json").stdout)
+        receipt = state["steps"][0]["receipts"]["implement"]
+        self.assertEqual(receipt["tests"], assertion)
+
     def test_record_and_status_json(self):
         self.init()
         self.run_ctl("record", "note", '"local run"')

--- a/plugins/hexaemeron/tests/test_promise_cases.py
+++ b/plugins/hexaemeron/tests/test_promise_cases.py
@@ -1,0 +1,67 @@
+import json
+from pathlib import Path
+import unittest
+
+
+CASES = Path(__file__).parent / "fixtures" / "promise-machine" / "executable-cases.json"
+
+
+class PromiseExecutableCaseTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cases = json.loads(CASES.read_text(encoding="utf-8"))
+
+    def assert_case(self, promise_id, code, disposition):
+        case = self.cases[promise_id][code]
+        self.assertEqual(case["disposition"], disposition)
+        self.assertTrue(case["scenario"].strip())
+        self.assertTrue(case["boundary"].strip())
+
+    def test_ephoros_review_positive(self):
+        self.assert_case("ephoros-observability-review", "P", "accept")
+
+    def test_ephoros_review_missing(self):
+        self.assert_case("ephoros-observability-review", "M", "refuse")
+
+    def test_ephoros_review_subject_mismatch(self):
+        self.assert_case("ephoros-observability-review", "S", "refuse")
+
+    def test_ephoros_review_overclaim(self):
+        self.assert_case("ephoros-observability-review", "O", "refuse")
+
+    def test_ephoros_review_recovery(self):
+        self.assert_case("ephoros-observability-review", "R", "recover")
+
+    def test_phylax_review_positive(self):
+        self.assert_case("phylax-boundary-review", "P", "accept")
+
+    def test_phylax_review_missing(self):
+        self.assert_case("phylax-boundary-review", "M", "refuse")
+
+    def test_phylax_review_subject_mismatch(self):
+        self.assert_case("phylax-boundary-review", "S", "refuse")
+
+    def test_phylax_review_overclaim(self):
+        self.assert_case("phylax-boundary-review", "O", "refuse")
+
+    def test_phylax_review_recovery(self):
+        self.assert_case("phylax-boundary-review", "R", "recover")
+
+    def test_protasis_study_positive(self):
+        self.assert_case("protasis-study-readiness", "P", "accept")
+
+    def test_protasis_study_missing(self):
+        self.assert_case("protasis-study-readiness", "M", "refuse")
+
+    def test_protasis_study_subject_mismatch(self):
+        self.assert_case("protasis-study-readiness", "S", "refuse")
+
+    def test_protasis_study_overclaim(self):
+        self.assert_case("protasis-study-readiness", "O", "refuse")
+
+    def test_protasis_study_recovery(self):
+        self.assert_case("protasis-study-readiness", "R", "recover")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/promise_machine.py
+++ b/scripts/promise_machine.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 from dataclasses import asdict, dataclass
@@ -61,6 +62,9 @@ SUPPORTED_EVIDENCE_CLASSES = {
     "unknown",
 }
 PROMISE_ID = re.compile(r"[a-z][a-z0-9]*(?:-[a-z0-9]+)*")
+OVERLAY_PATH = Path("plugins/hexaemeron/PROMISES.md")
+OVERLAY_HEADING = "# Hexaemeron Promise Machine overlays"
+OVERLAY_FIELDS = ("Path", "SHA-256", *REQUIRED_FIELDS)
 
 
 @dataclass(frozen=True)
@@ -821,6 +825,7 @@ def check_structure(
     inventory: Inventory,
     *,
     require_standalone_contracts: bool = False,
+    require_hexaemeron_contracts: bool = False,
 ):
     findings: list[Finding] = []
     promises: list[tuple[str, str]] = []
@@ -849,7 +854,12 @@ def check_structure(
         parsed, parsed_findings = parse_contract(
             skill,
             root,
-            required=require_standalone_contracts and skill.plugin != "hexaemeron",
+            required=(
+                require_standalone_contracts and skill.plugin != "hexaemeron"
+            )
+            or (
+                require_hexaemeron_contracts and skill.plugin == "hexaemeron"
+            ),
         )
         promises.extend(parsed)
         findings.extend(parsed_findings)
@@ -870,6 +880,324 @@ def check_structure(
                     )
                 )
     return len(promises), findings
+
+
+def check_overlays(root: Path, inventory: Inventory):
+    findings: list[Finding] = []
+    expected_overlay = OVERLAY_PATH.as_posix()
+    discovered = set(inventory.overlays)
+    if expected_overlay not in discovered:
+        findings.append(
+            Finding(
+                "PM050",
+                "structural",
+                expected_overlay,
+                "required Hexaemeron vendored-promise overlay is absent",
+                "add the fixed first-party overlay for every vendored skill",
+            )
+        )
+    for unexpected in sorted(discovered - {expected_overlay}):
+        findings.append(
+            Finding(
+                "PM051",
+                "identity",
+                unexpected,
+                "promise overlay exists outside the fixed Hexaemeron boundary",
+                "remove the unexpected overlay or record a new first-party boundary in the law",
+            )
+        )
+
+    if expected_overlay not in discovered:
+        return 0, findings
+
+    path = root / OVERLAY_PATH
+    loaded, read_findings = read_markdown(
+        path, root, missing_code="PM050", unsafe_code="PM025"
+    )
+    findings.extend(read_findings)
+    if loaded is None:
+        return 0, findings
+    _, text = loaded
+    lines = text.splitlines()
+    if lines.count(OVERLAY_HEADING) != 1:
+        findings.append(
+            Finding(
+                "PM052",
+                "structural",
+                expected_overlay,
+                f"overlay heading must occur once: {OVERLAY_HEADING}",
+                "restore the single Hexaemeron overlay heading",
+            )
+        )
+
+    heading_index = lines.index(OVERLAY_HEADING) if OVERLAY_HEADING in lines else 0
+    section_end = next(
+        (
+            index
+            for index in range(heading_index + 1, len(lines))
+            if lines[index].startswith("# ") or lines[index].startswith("## ")
+        ),
+        len(lines),
+    )
+    blocks = [
+        index
+        for index in range(heading_index + 1, section_end)
+        if lines[index].startswith("### ")
+    ]
+    if not blocks:
+        findings.append(
+            Finding(
+                "PM052",
+                "structural",
+                expected_overlay,
+                "overlay contains no vendored promise block",
+                "add one digest-bound block for every vendored skill",
+            )
+        )
+        return 0, findings
+
+    skills = {item.path: item for item in inventory.skills}
+    vendored = {item.path for item in inventory.skills if item.governance == "vendored"}
+    canonical_ids: set[str] = set()
+    for skill in inventory.skills:
+        if skill.governance != "first-party":
+            continue
+        parsed, _ = parse_contract(skill, root)
+        canonical_ids.update(promise_id for promise_id, _ in parsed)
+    seen_paths: dict[str, list[str]] = {}
+    seen_ids: set[str] = set()
+    for offset, block_start in enumerate(blocks):
+        block_end = blocks[offset + 1] if offset + 1 < len(blocks) else len(lines)
+        promise_id = lines[block_start][4:].strip()
+        if not PROMISE_ID.fullmatch(promise_id):
+            findings.append(
+                Finding(
+                    "PM032",
+                    "structural",
+                    expected_overlay,
+                    "overlay promise id is not a stable lowercase hyphenated identifier",
+                    "use a lowercase identifier made of letters, digits and hyphens",
+                    promise_id=promise_id or None,
+                )
+            )
+        if promise_id in seen_ids or promise_id in canonical_ids:
+            findings.append(
+                Finding(
+                    "PM035",
+                    "identity",
+                    expected_overlay,
+                    "overlay promise id is duplicated across the suite",
+                    "give every suite promise one unique stable promise id",
+                    promise_id=promise_id or None,
+                )
+            )
+        seen_ids.add(promise_id)
+
+        fields: dict[str, list[str]] = {}
+        for line in lines[block_start + 1 : block_end]:
+            match = re.fullmatch(r"- \*\*([^*]+):\*\*\s*(.*)", line)
+            if match is None:
+                match = re.fullmatch(r"- ([^:]+):\s*(.*)", line)
+            if match is not None:
+                fields.setdefault(match.group(1).strip(), []).append(match.group(2).strip())
+        unknown = sorted(set(fields) - set(OVERLAY_FIELDS))
+        if unknown:
+            findings.append(
+                Finding(
+                    "PM053",
+                    "structural",
+                    expected_overlay,
+                    f"overlay declaration contains unknown fields: {unknown!r}",
+                    "use only Path, SHA-256 and the nine promise fields",
+                    promise_id=promise_id or None,
+                )
+            )
+        for field in OVERLAY_FIELDS:
+            values = fields.get(field, [])
+            if len(values) != 1 or not values[0]:
+                findings.append(
+                    Finding(
+                        "PM054",
+                        "structural",
+                        expected_overlay,
+                        f"overlay field must occur once and be non-empty: {field}",
+                        f"provide exactly one non-empty {field} field",
+                        promise_id=promise_id or None,
+                    )
+                )
+
+        declared_paths = fields.get("Path", [])
+        if len(declared_paths) == 1:
+            declared = declared_paths[0].strip("`")
+            seen_paths.setdefault(declared, []).append(promise_id)
+            skill = skills.get(declared)
+            if skill is None:
+                findings.append(
+                    Finding(
+                        "PM055",
+                        "identity",
+                        expected_overlay,
+                        f"overlay path is not a discovered canonical skill: {declared!r}",
+                        "bind the block to one discovered vendored SKILL.md path",
+                        promise_id=promise_id or None,
+                    )
+                )
+            elif skill.governance != "vendored":
+                findings.append(
+                    Finding(
+                        "PM055",
+                        "identity",
+                        expected_overlay,
+                        f"overlay path belongs to a {skill.governance} skill: {declared!r}",
+                        "put first-party promises in the canonical SKILL.md itself",
+                        promise_id=promise_id or None,
+                    )
+                )
+            target = root / declared
+            if (
+                Path(declared).is_absolute()
+                or ".." in Path(declared).parts
+                or target.is_symlink()
+                or not confined(target, root)
+                or not target.is_file()
+            ):
+                findings.append(
+                    Finding(
+                        "PM055",
+                        "identity",
+                        expected_overlay,
+                        f"overlay path is unsafe or absent: {declared!r}",
+                        "use the confined regular path of the vendored SKILL.md",
+                        promise_id=promise_id or None,
+                    )
+                )
+            digests = fields.get("SHA-256", [])
+            if len(digests) == 1:
+                digest = digests[0].strip("`")
+                if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+                    findings.append(
+                        Finding(
+                            "PM056",
+                            "structural",
+                            expected_overlay,
+                            "overlay SHA-256 is not 64 lowercase hexadecimal characters",
+                            "record the full lowercase SHA-256 of the vendored instruction bytes",
+                            promise_id=promise_id or None,
+                        )
+                    )
+                elif target.is_file() and not target.is_symlink() and confined(target, root):
+                    target_loaded, target_findings = read_markdown(
+                        target, root, missing_code="PM055", unsafe_code="PM055"
+                    )
+                    findings.extend(target_findings)
+                    actual = (
+                        hashlib.sha256(target_loaded[0]).hexdigest()
+                        if target_loaded is not None
+                        else ""
+                    )
+                    if actual != digest:
+                        findings.append(
+                            Finding(
+                                "PM057",
+                                "drift",
+                                declared,
+                                f"vendored instruction digest is {actual}; overlay records {digest}",
+                                "review the upstream change and update the first-party overlay deliberately",
+                                promise_id=promise_id or None,
+                            )
+                        )
+
+        evidence_values = fields.get("Evidence classes", [])
+        if len(evidence_values) == 1:
+            classes = [
+                item.strip().strip("`").split(":", 1)[0].strip()
+                for item in re.split(r"[,;]", evidence_values[0])
+                if item.strip()
+            ]
+            unsupported = sorted(set(classes) - SUPPORTED_EVIDENCE_CLASSES)
+            if not classes or unsupported:
+                findings.append(
+                    Finding(
+                        "PM036",
+                        "structural",
+                        expected_overlay,
+                        f"unsupported evidence classes: {unsupported or ['<empty>']!r}",
+                        "use a recognised base evidence class from the law",
+                        promise_id=promise_id or None,
+                    )
+                )
+        consequences = fields.get("Consequence", [])
+        if len(consequences) == 1 and consequences[0] not in {"0", "1", "2", "3"}:
+            findings.append(
+                Finding(
+                    "PM037",
+                    "structural",
+                    expected_overlay,
+                    f"unsupported consequence level: {consequences[0]!r}",
+                    "use consequence level 0, 1, 2 or 3",
+                    promise_id=promise_id or None,
+                )
+            )
+        exceptions = fields.get("Exceptions", [])
+        if len(exceptions) == 1 and exceptions[0].lower() != "none":
+            required = ("authority", "scope", "record", "expiry")
+            absent = [
+                item
+                for item in required
+                if re.search(
+                    rf"(?:^|;)\s*{item}\s*(?::|=)\s*[^;\s].*?(?=;|$)",
+                    exceptions[0],
+                    re.IGNORECASE,
+                )
+                is None
+            ]
+            if absent:
+                findings.append(
+                    Finding(
+                        "PM038",
+                        "structural",
+                        expected_overlay,
+                        f"exception omits required attribution: {absent!r}",
+                        "name authority, scope, record and expiry, or declare none",
+                        promise_id=promise_id or None,
+                    )
+                )
+
+    for declared, owners in sorted(seen_paths.items()):
+        if len(owners) > 1:
+            findings.append(
+                Finding(
+                    "PM058",
+                    "identity",
+                    expected_overlay,
+                    f"vendored path has multiple overlays: {declared!r} -> {owners!r}",
+                    "retain exactly one promise block for each vendored path",
+                )
+            )
+    declared_set = set(seen_paths)
+    for missing in sorted(vendored - declared_set):
+        findings.append(
+            Finding(
+                "PM059",
+                "structural",
+                missing,
+                "vendored skill has no digest-bound Promise Machine overlay",
+                "add one first-party overlay block for the vendored path",
+            )
+        )
+    for extra in sorted(declared_set - vendored):
+        if extra in skills:
+            continue
+        findings.append(
+            Finding(
+                "PM055",
+                "identity",
+                expected_overlay,
+                f"overlay does not belong to the vendored inventory: {extra!r}",
+                "remove the block or correct its path to a discovered vendored skill",
+            )
+        )
+    return len(blocks), findings
 
 
 def check_identity(inventory: Inventory):
@@ -1424,6 +1752,7 @@ def parse_only(raw: str):
         "inventory",
         "structure",
         "contracts",
+        "overlays",
         "identity",
         "routers",
         "versions",
@@ -1496,6 +1825,7 @@ def main(argv=None):
             "inventory",
             "structure",
             "contracts",
+            "overlays",
             "identity",
             "routers",
             "versions",
@@ -1505,13 +1835,18 @@ def main(argv=None):
             inventory, inventory_findings = discover_inventory(root)
             findings.extend(inventory_findings)
             plugins = [root / path for path in inventory.plugins]
-        if only & {"structure", "contracts"} and inventory is not None:
+        if only & {"structure", "contracts", "overlays"} and inventory is not None:
             promises, structure_findings = check_structure(
                 root,
                 inventory,
                 require_standalone_contracts="contracts" in only,
+                require_hexaemeron_contracts="overlays" in only,
             )
             findings.extend(structure_findings)
+        if "overlays" in only and inventory is not None:
+            overlay_promises, overlay_findings = check_overlays(root, inventory)
+            promises += overlay_promises
+            findings.extend(overlay_findings)
         if "identity" in only and inventory is not None:
             findings.extend(check_identity(inventory))
         if "routers" in only and inventory is not None:

--- a/scripts/promise_machine.py
+++ b/scripts/promise_machine.py
@@ -1675,7 +1675,12 @@ def check_coverage(root: Path, inventory: Inventory, selected_groups: set[str]):
                         )
                     )
                 continue
-            if set(case) != {"path", "selector", "claim"} or not all(
+            evidence_keys = {"path", "selector", "claim"}
+            allowed_evidence_keys = (
+                frozenset(evidence_keys),
+                frozenset(evidence_keys | {"evidence_class"}),
+            )
+            if set(case) not in allowed_evidence_keys or not all(
                 isinstance(case.get(key), str) and case[key].strip()
                 for key in ("path", "selector", "claim")
             ):
@@ -1684,8 +1689,23 @@ def check_coverage(root: Path, inventory: Inventory, selected_groups: set[str]):
                         "PM064",
                         "coverage",
                         case_path,
-                        "evidence reference must contain only non-empty path, selector and claim",
-                        "cite one exact existing test selector and its bounded interpretation",
+                        "evidence reference must contain non-empty path, selector and claim, with at most one evidence class",
+                        "cite one exact existing selector, its bounded interpretation and an optional base evidence class",
+                        promise_id=promise_id,
+                    )
+                )
+                continue
+            if "evidence_class" in case and (
+                not isinstance(case["evidence_class"], str)
+                or case["evidence_class"] not in SUPPORTED_EVIDENCE_CLASSES
+            ):
+                findings.append(
+                    Finding(
+                        "PM064",
+                        "coverage",
+                        case_path,
+                        f"coverage evidence class is unsupported: {case['evidence_class']!r}",
+                        "use one base evidence class from the Promise Machine law",
                         promise_id=promise_id,
                     )
                 )

--- a/scripts/promise_machine.py
+++ b/scripts/promise_machine.py
@@ -21,6 +21,7 @@ MARKER = (
 )
 MAX_MARKDOWN_BYTES = 256 * 1024
 MAX_JSON_BYTES = 64 * 1024
+MAX_COVERAGE_BYTES = 512 * 1024
 REQUIRED_HEADINGS = (
     "# Promise Machine contract",
     "## Contract identity",
@@ -65,6 +66,72 @@ PROMISE_ID = re.compile(r"[a-z][a-z0-9]*(?:-[a-z0-9]+)*")
 OVERLAY_PATH = Path("plugins/hexaemeron/PROMISES.md")
 OVERLAY_HEADING = "# Hexaemeron Promise Machine overlays"
 OVERLAY_FIELDS = ("Path", "SHA-256", *REQUIRED_FIELDS)
+COVERAGE_PATH = Path("tests/promise_machine_coverage.json")
+COVERAGE_SCHEMA = "promise-machine-coverage/v1"
+COVERAGE_CODES = ("P", "M", "S", "O", "R", "X")
+PROMPT_SKILLS = {
+    "brevitas",
+    "hypomnema",
+    "imprimatur",
+    "kronos",
+    "sapheneia",
+    "vulgate",
+}
+PRESERVATION_REQUIREMENTS = {
+    "berean-corpus-binding": {"corpus-digest", "source-class", "subject"},
+    "berean-answer-evidence": {
+        "answer-truth-refused",
+        "read-class",
+        "source-class",
+        "subject",
+        "time-domain",
+    },
+    "berean-evaluation-report": {
+        "answer-digest",
+        "answer-truth-refused",
+        "corpus-digest",
+        "time-domain",
+    },
+    "berean-release-promotion": {
+        "answer-digest",
+        "answer-truth-refused",
+        "corpus-digest",
+        "evaluation-digest",
+    },
+    "janus-manifest-validation": {"adapter", "manifest"},
+    "janus-bounded-conformance": {
+        "adapter",
+        "bounded-search",
+        "cross-host-refused",
+        "manifest",
+        "recorder",
+        "safety-refused",
+        "unknown-effect-refused",
+    },
+    "janus-report-rendering": {
+        "adapter",
+        "bounded-search",
+        "manifest",
+        "recorder",
+        "safety-refused",
+    },
+}
+REQUIRED_HANDOFFS = {
+    ("lazarus-fixture-verification", "berean-answer-evidence"),
+    ("berean-release-promotion", "ariadne-capture-statement"),
+}
+HANDOFF_PRESERVES = {
+    ("lazarus-fixture-verification", "berean-answer-evidence"): {
+        "block",
+        "evidence-class",
+        "subject",
+    },
+    ("berean-release-promotion", "ariadne-capture-statement"): {
+        "answer-digest",
+        "evidence-class",
+        "subject",
+    },
+}
 
 
 @dataclass(frozen=True)
@@ -92,6 +159,13 @@ class Inventory:
     skills: tuple[SkillRecord, ...]
     routers: tuple[str, ...]
     overlays: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PromiseRecord:
+    promise_id: str
+    skill_path: str
+    group: str
 
 
 def relative(path: Path, root: Path) -> str:
@@ -174,26 +248,35 @@ def read_markdown(path: Path, root: Path, *, missing_code: str, unsafe_code: str
     return (payload, text), findings
 
 
-def read_json(path: Path, root: Path):
+def read_json(
+    path: Path,
+    root: Path,
+    *,
+    max_bytes: int = MAX_JSON_BYTES,
+    missing_code: str = "PM021",
+    unsafe_code: str = "PM021",
+    malformed_code: str = "PM022",
+    noun: str = "plugin manifest",
+):
     shown = relative(path, root)
     if path.is_symlink() or not confined(path, root):
         return None, [
             Finding(
-                "PM021",
+                unsafe_code,
                 "identity",
                 shown,
-                "plugin manifest is a symlink or resolves outside the repository",
-                "restore a regular manifest at the fixed plugin path",
+                f"{noun} is a symlink or resolves outside the repository",
+                f"restore a regular {noun} at the fixed path",
             )
         ]
     if not path.is_file():
         return None, [
             Finding(
-                "PM021",
+                missing_code,
                 "structural",
                 shown,
-                "paired plugin manifest is absent",
-                "restore both host manifests for the plugin",
+                f"{noun} is absent",
+                f"restore the required {noun}",
             )
         ]
     try:
@@ -201,43 +284,51 @@ def read_json(path: Path, root: Path):
     except OSError as exc:
         return None, [
             Finding(
-                "PM021",
+                unsafe_code,
                 "identity",
                 shown,
-                f"plugin manifest could not be read: {exc}",
-                "restore a readable manifest inside the repository",
+                f"{noun} could not be read: {exc}",
+                f"restore a readable {noun} inside the repository",
             )
         ]
-    if len(payload) > MAX_JSON_BYTES:
+    if len(payload) > max_bytes:
         return None, [
             Finding(
-                "PM022",
+                malformed_code,
                 "structural",
                 shown,
-                f"plugin manifest is {len(payload)} bytes; limit is {MAX_JSON_BYTES}",
-                "reduce the manifest below the bounded-read limit",
+                f"JSON document is {len(payload)} bytes; limit is {max_bytes}",
+                "reduce the document below the bounded-read limit",
             )
         ]
+    def reject_duplicate_keys(pairs):
+        document = {}
+        for key, value in pairs:
+            if key in document:
+                raise ValueError(f"duplicate object key: {key!r}")
+            document[key] = value
+        return document
+
     try:
-        document = json.loads(payload)
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        document = json.loads(payload, object_pairs_hook=reject_duplicate_keys)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
         return None, [
             Finding(
-                "PM022",
+                malformed_code,
                 "structural",
                 shown,
-                f"plugin manifest is not valid UTF-8 JSON: {exc}",
-                "restore a valid plugin manifest",
+                f"{noun} is not valid UTF-8 JSON: {exc}",
+                f"restore a valid {noun}",
             )
         ]
     if not isinstance(document, dict):
         return None, [
             Finding(
-                "PM022",
+                malformed_code,
                 "structural",
                 shown,
-                "plugin manifest root is not an object",
-                "restore the manifest object",
+                f"{noun} root is not an object",
+                f"restore the {noun} object",
             )
         ]
     return document, []
@@ -1200,6 +1291,465 @@ def check_overlays(root: Path, inventory: Inventory):
     return len(blocks), findings
 
 
+def promise_records(root: Path, inventory: Inventory):
+    records: list[PromiseRecord] = []
+    for skill in inventory.skills:
+        if skill.governance != "first-party":
+            continue
+        parsed, _ = parse_contract(skill, root)
+        group = "prompt" if skill.name in PROMPT_SKILLS else "executable"
+        records.extend(
+            PromiseRecord(promise_id, skill.path, group)
+            for promise_id, _ in parsed
+        )
+
+    loaded, _ = read_markdown(
+        root / OVERLAY_PATH, root, missing_code="PM060", unsafe_code="PM060"
+    )
+    if loaded is not None:
+        lines = loaded[1].splitlines()
+        heading_index = lines.index(OVERLAY_HEADING) if OVERLAY_HEADING in lines else 0
+        section_end = next(
+            (
+                index
+                for index in range(heading_index + 1, len(lines))
+                if lines[index].startswith("# ") or lines[index].startswith("## ")
+            ),
+            len(lines),
+        )
+        blocks = [
+            index
+            for index in range(heading_index + 1, section_end)
+            if lines[index].startswith("### ")
+        ]
+        for offset, block_start in enumerate(blocks):
+            block_end = blocks[offset + 1] if offset + 1 < len(blocks) else len(lines)
+            promise_id = lines[block_start][4:].strip()
+            declared = ""
+            for line in lines[block_start + 1 : block_end]:
+                match = re.fullmatch(r"- Path:\s*`?([^`]+?)`?\s*", line)
+                if match is not None:
+                    declared = match.group(1).strip()
+                    break
+            records.append(PromiseRecord(promise_id, declared, "vendored"))
+    return tuple(sorted(records, key=lambda item: item.promise_id))
+
+
+def parse_groups(raw: str):
+    groups = {item.strip() for item in raw.split(",") if item.strip()}
+    unknown = sorted(groups - {"executable", "prompt", "vendored"})
+    if unknown or not groups:
+        raise ValueError(f"unsupported --group value(s): {unknown or ['<empty>']}")
+    return groups
+
+
+def selector_resolves(path: Path, text: str, selector: str):
+    if path.suffix == ".py":
+        pattern = rf"^\s*def\s+{re.escape(selector)}\s*\("
+    elif path.suffix == ".sol":
+        pattern = rf"^\s*function\s+{re.escape(selector)}\s*\("
+    else:
+        return False
+    return re.search(pattern, text, re.MULTILINE) is not None
+
+
+def check_coverage(root: Path, inventory: Inventory, selected_groups: set[str]):
+    findings: list[Finding] = []
+    expected_records = promise_records(root, inventory)
+    expected = {item.promise_id: item for item in expected_records}
+    required_handoffs = {
+        pair for pair in REQUIRED_HANDOFFS if pair[0] in expected and pair[1] in expected
+    }
+    document, read_findings = read_json(
+        root / COVERAGE_PATH,
+        root,
+        max_bytes=MAX_COVERAGE_BYTES,
+        missing_code="PM060",
+        unsafe_code="PM060",
+        malformed_code="PM061",
+        noun="coverage file",
+    )
+    findings.extend(read_findings)
+    if document is None:
+        return 0, 0, findings
+    if document.get("contract") != CONTRACT_ID or document.get("schema") != COVERAGE_SCHEMA:
+        findings.append(
+            Finding(
+                "PM061",
+                "structural",
+                COVERAGE_PATH.as_posix(),
+                "coverage contract or schema identity is absent or unsupported",
+                f"use contract {CONTRACT_ID!r} and schema {COVERAGE_SCHEMA!r}",
+            )
+        )
+    handoffs = document.get("handoffs")
+    seen_handoffs: set[tuple[str, str]] = set()
+    if not isinstance(handoffs, list):
+        findings.append(
+            Finding(
+                "PM068",
+                "composition",
+                COVERAGE_PATH.as_posix(),
+                "coverage handoffs are not an array",
+                "record the required producer-to-consumer evidence boundaries",
+            )
+        )
+        handoffs = []
+    for index, handoff in enumerate(handoffs):
+        handoff_path = f"{COVERAGE_PATH.as_posix()}#handoffs[{index}]"
+        required_keys = {"producer", "consumer", "path", "selector", "preserves", "refuses"}
+        if not isinstance(handoff, dict) or set(handoff) != required_keys:
+            findings.append(
+                Finding(
+                    "PM068",
+                    "composition",
+                    handoff_path,
+                    "handoff does not have the required evidence-bound shape",
+                    "name producer, consumer, exact test, preserved fields and refused overclaim",
+                )
+            )
+            continue
+        if not all(
+            isinstance(handoff[key], str) and handoff[key].strip()
+            for key in ("producer", "consumer", "path", "selector", "refuses")
+        ):
+            findings.append(
+                Finding(
+                    "PM068",
+                    "composition",
+                    handoff_path,
+                    "handoff identities and test reference are not non-empty strings",
+                    "state concrete producer, consumer, path, selector and refused overclaim",
+                )
+            )
+            continue
+        pair = (handoff["producer"], handoff["consumer"])
+        seen_handoffs.add(pair)
+        preserves = handoff["preserves"]
+        if (
+            pair not in required_handoffs
+            or not isinstance(preserves, list)
+            or not preserves
+            or any(not isinstance(item, str) or not item for item in preserves)
+            or not HANDOFF_PRESERVES.get(pair, set()).issubset(
+                set(item for item in preserves if isinstance(item, str))
+            )
+            or handoff["refuses"] != "answer-truth"
+        ):
+            findings.append(
+                Finding(
+                    "PM068",
+                    "composition",
+                    handoff_path,
+                    "handoff does not preserve its declared evidence boundary or refusal",
+                    "preserve subject and evidence class without promoting answer truth",
+                )
+            )
+        target = root / handoff["path"]
+        loaded, target_findings = read_markdown(
+            target, root, missing_code="PM065", unsafe_code="PM065"
+        )
+        findings.extend(target_findings)
+        if loaded is not None and not selector_resolves(
+            target, loaded[1], handoff["selector"]
+        ):
+            findings.append(
+                Finding(
+                    "PM065",
+                    "composition",
+                    handoff["path"],
+                    f"handoff test selector does not resolve: {handoff['selector']!r}",
+                    "cite the exact existing cross-skill test selector",
+                )
+            )
+    for pair in sorted(required_handoffs - seen_handoffs):
+        findings.append(
+            Finding(
+                "PM068",
+                "composition",
+                COVERAGE_PATH.as_posix(),
+                f"required evidence handoff is absent: {pair!r}",
+                "add its exact subject, evidence-class and answer-truth guard",
+            )
+        )
+    handoff_counts: dict[tuple[str, str], int] = {}
+    for handoff in handoffs:
+        if not isinstance(handoff, dict):
+            continue
+        producer = handoff.get("producer")
+        consumer = handoff.get("consumer")
+        if isinstance(producer, str) and isinstance(consumer, str):
+            pair = (producer, consumer)
+            handoff_counts[pair] = handoff_counts.get(pair, 0) + 1
+    for pair, count in sorted(handoff_counts.items()):
+        if count > 1:
+            findings.append(
+                Finding(
+                    "PM068",
+                    "composition",
+                    COVERAGE_PATH.as_posix(),
+                    f"evidence handoff is repeated {count} times: {pair!r}",
+                    "retain one exact record for each required handoff",
+                )
+            )
+    rows = document.get("rows")
+    evidence_catalog = document.get("evidence")
+    if not isinstance(evidence_catalog, dict):
+        findings.append(
+            Finding(
+                "PM061",
+                "structural",
+                COVERAGE_PATH.as_posix(),
+                "coverage evidence catalogue is not an object",
+                "provide named exact test references for coverage rows",
+            )
+        )
+        evidence_catalog = {}
+    if not isinstance(rows, list):
+        findings.append(
+            Finding(
+                "PM061",
+                "structural",
+                COVERAGE_PATH.as_posix(),
+                "coverage rows are not an array",
+                "provide one row object for every discovered promise",
+            )
+        )
+        return 0, 0, findings
+
+    seen: dict[str, int] = {}
+    selected = 0
+    for index, row in enumerate(rows):
+        row_path = f"{COVERAGE_PATH.as_posix()}#rows[{index}]"
+        if not isinstance(row, dict):
+            findings.append(
+                Finding(
+                    "PM061",
+                    "structural",
+                    row_path,
+                    "coverage row is not an object",
+                    "replace it with a typed coverage row",
+                )
+            )
+            continue
+        promise_id = row.get("promise_id")
+        if not isinstance(promise_id, str):
+            findings.append(
+                Finding(
+                    "PM061",
+                    "structural",
+                    row_path,
+                    "coverage row has no string promise_id",
+                    "name the discovered stable promise id",
+                )
+            )
+            continue
+        seen[promise_id] = seen.get(promise_id, 0) + 1
+        record = expected.get(promise_id)
+        if record is None:
+            findings.append(
+                Finding(
+                    "PM062",
+                    "identity",
+                    row_path,
+                    "coverage row names no discovered promise",
+                    "remove the stale row or restore its canonical declaration",
+                    promise_id=promise_id,
+                )
+            )
+            continue
+        if row.get("skill_path") != record.skill_path or row.get("group") != record.group:
+            findings.append(
+                Finding(
+                    "PM063",
+                    "identity",
+                    row_path,
+                    f"coverage owner or group disagrees with discovery: expected {record.skill_path!r} in {record.group!r}",
+                    "derive the owner and group from the canonical declaration",
+                    promise_id=promise_id,
+                )
+            )
+
+        required_preservation = PRESERVATION_REQUIREMENTS.get(promise_id)
+        if required_preservation is not None:
+            preserves = row.get("preserves")
+            if not isinstance(preserves, list) or not required_preservation.issubset(
+                set(item for item in preserves if isinstance(item, str))
+            ):
+                findings.append(
+                    Finding(
+                        "PM068",
+                        "composition",
+                        row_path,
+                        f"coverage row omits required preserved boundaries: {sorted(required_preservation)!r}",
+                        "retain the producer evidence class, subject and refused overclaim",
+                        promise_id=promise_id,
+                    )
+                )
+
+        cases = row.get("cases")
+        if record.group not in selected_groups:
+            pending_reason = row.get("pending")
+            if cases is None and (
+                not isinstance(pending_reason, str) or not pending_reason.strip()
+            ):
+                findings.append(
+                    Finding(
+                        "PM066",
+                        "coverage",
+                        row_path,
+                        "unselected incomplete row has no visible pending reason",
+                        "state the later runbook step that will classify this row",
+                        promise_id=promise_id,
+                    )
+                )
+            continue
+
+        selected += 1
+        if not isinstance(cases, dict) or set(cases) != set(COVERAGE_CODES):
+            findings.append(
+                Finding(
+                    "PM066",
+                    "coverage",
+                    row_path,
+                    f"selected row must classify exactly {list(COVERAGE_CODES)!r}",
+                    "provide evidence or an explicit inapplicability reason for every class",
+                    promise_id=promise_id,
+                )
+            )
+            continue
+
+        references: dict[tuple[str, str], str] = {}
+        for code in COVERAGE_CODES:
+            raw_case = cases[code]
+            case_path = f"{row_path}.{code}"
+            if isinstance(raw_case, str):
+                case = evidence_catalog.get(raw_case)
+                if case is None:
+                    findings.append(
+                        Finding(
+                            "PM064",
+                            "coverage",
+                            case_path,
+                            f"coverage evidence id does not resolve: {raw_case!r}",
+                            "cite an existing evidence-catalogue entry",
+                            promise_id=promise_id,
+                        )
+                    )
+                    continue
+            else:
+                case = raw_case
+            if not isinstance(case, dict):
+                findings.append(
+                    Finding(
+                        "PM064",
+                        "coverage",
+                        case_path,
+                        "coverage case is not an object",
+                        "provide one evidence reference or inapplicability reason",
+                        promise_id=promise_id,
+                    )
+                )
+                continue
+            if "not_applicable" in case:
+                if set(case) != {"not_applicable", "reason"} or case.get("not_applicable") is not True or not isinstance(case.get("reason"), str) or not case["reason"].strip():
+                    findings.append(
+                        Finding(
+                            "PM064",
+                            "coverage",
+                            case_path,
+                            "inapplicability is not an attributed non-empty reason",
+                            "set not_applicable true and state why the class cannot apply",
+                            promise_id=promise_id,
+                        )
+                    )
+                elif code in {"P", "M", "O", "R"}:
+                    findings.append(
+                        Finding(
+                            "PM066",
+                            "coverage",
+                            case_path,
+                            f"material {code} evidence may not be inapplicable",
+                            "cite a distinct positive, missing, overclaim or recovery case",
+                            promise_id=promise_id,
+                        )
+                    )
+                continue
+            if set(case) != {"path", "selector", "claim"} or not all(
+                isinstance(case.get(key), str) and case[key].strip()
+                for key in ("path", "selector", "claim")
+            ):
+                findings.append(
+                    Finding(
+                        "PM064",
+                        "coverage",
+                        case_path,
+                        "evidence reference must contain only non-empty path, selector and claim",
+                        "cite one exact existing test selector and its bounded interpretation",
+                        promise_id=promise_id,
+                    )
+                )
+                continue
+            evidence_path = Path(case["path"])
+            target = root / evidence_path
+            loaded, target_findings = read_markdown(
+                target, root, missing_code="PM065", unsafe_code="PM065"
+            )
+            findings.extend(target_findings)
+            if loaded is not None and not selector_resolves(
+                target, loaded[1], case["selector"]
+            ):
+                findings.append(
+                    Finding(
+                        "PM065",
+                        "coverage",
+                        case["path"],
+                        f"test selector does not resolve: {case['selector']!r}",
+                        "cite an exact function or test name present in the file",
+                        promise_id=promise_id,
+                    )
+                )
+            reference = (case["path"], case["selector"])
+            if reference in references:
+                findings.append(
+                    Finding(
+                        "PM067",
+                        "coverage",
+                        case_path,
+                        f"one test selector is reused for incompatible {references[reference]} and {code} cases",
+                        "cite distinct evidence for each incompatible class",
+                        promise_id=promise_id,
+                    )
+                )
+            references[reference] = code
+
+    actual_ids = set(seen)
+    for promise_id in sorted(set(expected) - actual_ids):
+        findings.append(
+            Finding(
+                "PM062",
+                "coverage",
+                COVERAGE_PATH.as_posix(),
+                "discovered promise has no coverage row",
+                "add the promise without removing any discovered entry",
+                promise_id=promise_id,
+            )
+        )
+    for promise_id, count in sorted(seen.items()):
+        if count > 1:
+            findings.append(
+                Finding(
+                    "PM062",
+                    "identity",
+                    COVERAGE_PATH.as_posix(),
+                    f"promise has {count} coverage rows",
+                    "retain exactly one row for each discovered promise",
+                    promise_id=promise_id,
+                )
+            )
+    return len(rows), selected, findings
+
+
 def check_identity(inventory: Inventory):
     findings: list[Finding] = []
     owners: dict[str, list[str]] = {}
@@ -1716,20 +2266,22 @@ def report(
                 f"{item.message}; repair: {item.remedy}"
             )
         print(f"refused: {len(findings)} finding(s)")
-    elif command == "inventory":
+    elif command in {"inventory", "coverage"}:
+        keys = (
+            (
+                "plugins",
+                "canonical_skills",
+                "governed_skills",
+                "vendored_skills",
+                "routers",
+                "overlays",
+            )
+            if command == "inventory"
+            else ("promises", "coverage_rows", "coverage_selected")
+        )
         print(
             "clean: "
-            + " ".join(
-                f"{key}={counts[key]}"
-                for key in (
-                    "plugins",
-                    "canonical_skills",
-                    "governed_skills",
-                    "vendored_skills",
-                    "routers",
-                    "overlays",
-                )
-            )
+            + " ".join(f"{key}={counts[key]}" for key in keys)
         )
     else:
         suffix = f"; wrote {written}" if command == "sync" else ""
@@ -1785,6 +2337,16 @@ def main(argv=None):
     inventory_parser.add_argument("--root", help=argparse.SUPPRESS)
     inventory_parser.add_argument("--json", action="store_true", help="emit canonical JSON")
 
+    coverage_parser = subparsers.add_parser(
+        "coverage", help="check promise-to-evidence classifications"
+    )
+    coverage_parser.add_argument("--check", action="store_true")
+    coverage_parser.add_argument(
+        "--group", default="executable,prompt,vendored", help="comma-separated groups"
+    )
+    coverage_parser.add_argument("--root", help=argparse.SUPPRESS)
+    coverage_parser.add_argument("--json", action="store_true", help="emit canonical JSON")
+
     args = parser.parse_args(argv)
     try:
         root = repository_root(args.root)
@@ -1801,6 +2363,40 @@ def main(argv=None):
             findings,
             as_json=args.json,
             inventory=inventory,
+        )
+
+    if args.command == "coverage":
+        try:
+            selected_groups = parse_groups(args.group)
+        except ValueError as exc:
+            parser.error(str(exc))
+        inventory, findings = discover_inventory(root)
+        plugins = [root / path for path in inventory.plugins]
+        canonical_promises, structure_findings = check_structure(
+            root,
+            inventory,
+            require_standalone_contracts=True,
+            require_hexaemeron_contracts=True,
+        )
+        overlay_promises, overlay_findings = check_overlays(root, inventory)
+        coverage_rows, coverage_selected, coverage_findings = check_coverage(
+            root, inventory, selected_groups
+        )
+        findings.extend(structure_findings)
+        findings.extend(overlay_findings)
+        findings.extend(coverage_findings)
+        return report(
+            "coverage",
+            root,
+            plugins,
+            findings,
+            as_json=args.json,
+            inventory=inventory,
+            promises=canonical_promises + overlay_promises,
+            stats={
+                "coverage_rows": coverage_rows,
+                "coverage_selected": coverage_selected,
+            },
         )
 
     if args.command == "check":

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -1,0 +1,1520 @@
+{
+  "contract": "promise-machine/v1",
+  "schema": "promise-machine-coverage/v1",
+  "handoffs": [
+    {
+      "producer": "lazarus-fixture-verification",
+      "consumer": "berean-answer-evidence",
+      "path": "plugins/berean/tests/test_examples.py",
+      "selector": "test_the_copied_reads_match_the_lazarus_fixture_byte_for_byte",
+      "preserves": ["block", "evidence-class", "subject"],
+      "refuses": "answer-truth"
+    },
+    {
+      "producer": "berean-release-promotion",
+      "consumer": "ariadne-capture-statement",
+      "path": "plugins/ariadne/tests/test_gates.py",
+      "selector": "test_a_payload_asserting_its_own_verification_fails",
+      "preserves": ["answer-digest", "evidence-class", "subject"],
+      "refuses": "answer-truth"
+    }
+  ],
+  "evidence": {
+    "alexandria-p": {
+      "path": "plugins/alexandria/tests/test_demo.py",
+      "selector": "test_documented_build_and_verify_commands_run_exactly",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "alexandria-m": {
+      "path": "plugins/alexandria/tests/test_demo.py",
+      "selector": "test_build_refuses_existing_output",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "alexandria-s": {
+      "path": "plugins/alexandria/tests/test_demo.py",
+      "selector": "test_source_pin_tamper_fails_before_ingest",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "alexandria-o": {
+      "path": "plugins/alexandria/tests/test_demo.py",
+      "selector": "test_compound_plan_does_not_treat_logs_as_complete_credit_history",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "alexandria-r": {
+      "path": "plugins/alexandria/tests/test_demo.py",
+      "selector": "test_cli_failure_is_controlled",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "ariadne-p": {
+      "path": "plugins/ariadne/tests/test_examples.py",
+      "selector": "test_both_examples_verify_with_nothing_unchecked",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "ariadne-m": {
+      "path": "plugins/ariadne/tests/test_gates.py",
+      "selector": "test_a_missing_claims_block_fails",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "ariadne-s": {
+      "path": "plugins/ariadne/tests/test_examples.py",
+      "selector": "test_the_unhappy_example_says_its_audit_covered_another_revision",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "ariadne-o": {
+      "path": "plugins/ariadne/tests/test_examples.py",
+      "selector": "test_every_example_records_its_deployment_as_unconfirmed",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "ariadne-r": {
+      "path": "plugins/ariadne/tests/test_examples.py",
+      "selector": "test_every_tampered_copy_fails_the_gate_it_is_meant_to",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "hermes-p": {
+      "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
+      "selector": "test_accepts_and_promotes_a_fully_verified_candidate",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "hermes-m": {
+      "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
+      "selector": "test_rejects_full_suite_failure_at_gate_four",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "hermes-s": {
+      "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
+      "selector": "test_rejects_changed_invariant_snapshot_rows",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "hermes-o": {
+      "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
+      "selector": "test_records_changed_fuzz_statistics_without_calling_them_a_regression",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "hermes-r": {
+      "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
+      "selector": "test_rejects_any_gas_regression_at_gate_three",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "elenchus-p": {
+      "path": "plugins/hexaemeron/tests/test_elenchus_checker.py",
+      "selector": "test_runner_categories_distinguish_all_three_outcomes",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "elenchus-m": {
+      "path": "plugins/hexaemeron/tests/test_elenchus_checker.py",
+      "selector": "test_legacy_no_report_is_inconclusive",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "elenchus-s": {
+      "path": "plugins/hexaemeron/tests/test_elenchus_checker.py",
+      "selector": "test_oversized_and_stale_reports_are_rejected_before_parsing",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "elenchus-o": {
+      "path": "plugins/hexaemeron/tests/test_elenchus_checker.py",
+      "selector": "test_diagnostic_poisoning_and_exit_code_do_not_change_the_report",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "elenchus-r": {
+      "path": "plugins/hexaemeron/tests/test_elenchus_checker.py",
+      "selector": "test_legacy_cli_is_nonfatal_by_default_and_fails_when_required",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "ephoros-p": {
+      "path": "plugins/hexaemeron/tests/test_ephoros_checker.py",
+      "selector": "test_it_allows_a_stable_name_with_fields",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "ephoros-m": {
+      "path": "plugins/hexaemeron/tests/test_ephoros_checker.py",
+      "selector": "test_it_flags_an_f_string_message",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "ephoros-s": {
+      "path": "plugins/hexaemeron/tests/test_ephoros_checker.py",
+      "selector": "test_a_bare_pragma_does_not_suppress",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "ephoros-o": {
+      "path": "plugins/hexaemeron/tests/test_ephoros_checker.py",
+      "selector": "test_it_ignores_print_which_is_not_telemetry",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "ephoros-r": {
+      "path": "plugins/hexaemeron/tests/test_ephoros_checker.py",
+      "selector": "test_a_stated_reason_suppresses",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "fiat-p": {
+      "path": "plugins/hexaemeron/tests/test_hexctl.py",
+      "selector": "test_push_advances_steps_then_the_stack_integrates",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "fiat-m": {
+      "path": "plugins/hexaemeron/tests/test_hexctl.py",
+      "selector": "test_done_out_of_order_rejected",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "fiat-s": {
+      "path": "plugins/hexaemeron/tests/test_hexctl.py",
+      "selector": "test_state_edit_detected_by_verify",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "fiat-o": {
+      "path": "plugins/hexaemeron/tests/test_hexctl.py",
+      "selector": "test_verify_preserves_receipt_assertions_without_proving_them",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "fiat-r": {
+      "path": "plugins/hexaemeron/tests/test_hexctl.py",
+      "selector": "test_halt_blocks_progress_and_resume_restores",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "horos-p": {
+      "path": "plugins/horos/tests/test_boundary.py",
+      "selector": "test_check_passes_on_a_fresh_boundary",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "horos-m": {
+      "path": "plugins/horos/tests/test_boundary.py",
+      "selector": "test_a_missing_boundary_is_a_distinct_failure",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "horos-s": {
+      "path": "plugins/horos/tests/test_boundary.py",
+      "selector": "test_a_changed_entry_drifts_and_is_named",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "horos-o": {
+      "path": "plugins/horos/tests/test_boundary.py",
+      "selector": "test_the_boundary_file_never_classifies_itself",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "horos-r": {
+      "path": "plugins/horos/tests/test_boundary.py",
+      "selector": "test_write_creates_the_boundary_and_leaves_no_temporary",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "lazarus-p": {
+      "path": "plugins/lazarus/tests/test_goldfinch.py",
+      "selector": "test_fixture_verifies_with_expected_evidence_and_provenance",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "lazarus-m": {
+      "path": "plugins/lazarus/tests/test_verifier.py",
+      "selector": "test_missing_or_extra_proof_targets_fail",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "lazarus-s": {
+      "path": "plugins/lazarus/tests/test_verifier.py",
+      "selector": "test_proved_rpc_selector_must_name_the_fixture_block",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "lazarus-o": {
+      "path": "plugins/lazarus/tests/test_preservation_release.py",
+      "selector": "test_it_claims_nothing_about_the_canonical_chain",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "lazarus-r": {
+      "path": "plugins/lazarus/tests/test_goldfinch.py",
+      "selector": "test_demo_command_runs_the_complete_application_check",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "metron-p": {
+      "path": "plugins/hexaemeron/tests/test_metron_check.py",
+      "selector": "test_an_improvement_past_the_variance_is_reported_and_passes",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "metron-m": {
+      "path": "plugins/hexaemeron/tests/test_metron_check.py",
+      "selector": "test_a_run_reporting_only_one_budget_fails_on_the_rest",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "metron-s": {
+      "path": "plugins/hexaemeron/tests/test_metron_check.py",
+      "selector": "test_a_move_inside_the_variance_is_another_sample",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "metron-o": {
+      "path": "plugins/hexaemeron/tests/test_metron_check.py",
+      "selector": "test_no_baseline_entry_is_neutral_rather_than_a_failure",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "metron-r": {
+      "path": "plugins/hexaemeron/tests/test_metron_check.py",
+      "selector": "test_the_ledger_keeps_the_reverted_attempt",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "pandects-p": {
+      "path": "plugins/pandects/tests/test_checker.py",
+      "selector": "test_a_law_with_every_part_passes",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "pandects-m": {
+      "path": "plugins/pandects/tests/test_checker.py",
+      "selector": "test_a_missing_component_fails",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "pandects-s": {
+      "path": "plugins/pandects/tests/test_checker.py",
+      "selector": "test_a_component_whose_id_disagrees_with_the_catalogue_fails",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "pandects-o": {
+      "path": "plugins/pandects/tests/test_checker.py",
+      "selector": "test_a_law_reverting_to_signal_a_violation_fails",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "pandects-r": {
+      "path": "plugins/pandects/tests/test_search_record.py",
+      "selector": "test_a_timed_out_campaign_is_recorded_rather_than_dropped",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "phylax-p": {
+      "path": "plugins/hexaemeron/tests/test_phylax_checker.py",
+      "selector": "test_it_allows_an_argument_list",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "phylax-m": {
+      "path": "plugins/hexaemeron/tests/test_phylax_checker.py",
+      "selector": "test_it_flags_a_shell_invocation",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "phylax-s": {
+      "path": "plugins/hexaemeron/tests/test_phylax_checker.py",
+      "selector": "test_a_bare_pragma_without_a_reason_does_not_suppress",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "phylax-o": {
+      "path": "plugins/hexaemeron/tests/test_phylax_checker.py",
+      "selector": "test_findings_do_not_repeat_secret_material_in_text_or_json",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "phylax-r": {
+      "path": "plugins/hexaemeron/tests/test_phylax_checker.py",
+      "selector": "test_a_stated_reason_suppresses_the_finding",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "probitas-p": {
+      "path": "plugins/probitas/tests/test_demo.py",
+      "selector": "test_it_exits_zero",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "probitas-m": {
+      "path": "plugins/probitas/tests/test_evidence.py",
+      "selector": "test_missing_source_raises",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "probitas-s": {
+      "path": "plugins/probitas/tests/test_gates.py",
+      "selector": "test_an_invented_transaction_hash_fails",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "probitas-o": {
+      "path": "plugins/probitas/tests/test_gates.py",
+      "selector": "test_a_rating_with_no_rubric_fails",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "probitas-r": {
+      "path": "plugins/probitas/tests/test_registry.py",
+      "selector": "test_an_adapter_returning_no_coverage_is_a_bug_not_a_silence",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "protasis-p": {
+      "path": "plugins/hexaemeron/tests/test_protasis_checker.py",
+      "selector": "test_a_complete_step_is_clean",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "protasis-m": {
+      "path": "plugins/hexaemeron/tests/test_protasis_checker.py",
+      "selector": "test_each_required_field_is_required",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "protasis-s": {
+      "path": "plugins/hexaemeron/tests/test_protasis_checker.py",
+      "selector": "test_a_fenced_block_under_a_later_field_does_not_count",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "protasis-o": {
+      "path": "plugins/hexaemeron/tests/test_protasis_checker.py",
+      "selector": "test_an_exit_with_no_command_is_a_finding",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "protasis-r": {
+      "path": "plugins/hexaemeron/tests/test_protasis_checker.py",
+      "selector": "test_this_runs_own_runbook_is_clean",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "tabularium-p": {
+      "path": "plugins/tabularium/tests/test_release.py",
+      "selector": "test_committed_release_verifies_offline_and_without_rewrites",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "tabularium-m": {
+      "path": "plugins/tabularium/tests/test_verify.py",
+      "selector": "test_missing_artifact_fails",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "tabularium-s": {
+      "path": "plugins/tabularium/tests/test_verify.py",
+      "selector": "test_altered_source_bytes_fail_the_declared_digest",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "tabularium-o": {
+      "path": "plugins/tabularium/tests/test_verify.py",
+      "selector": "test_indexed_block_must_match_source_metadata",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "tabularium-r": {
+      "path": "plugins/tabularium/tests/test_release.py",
+      "selector": "test_documented_demo_rebuilds_and_compares_in_a_fresh_directory",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "chunk-markdown-p": {
+      "path": "plugins/lemma/tests/test_markdown.py",
+      "selector": "test_byte_exact",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "chunk-markdown-m": {
+      "path": "plugins/lemma/tests/test_markdown.py",
+      "selector": "test_summary_fail_loud",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "chunk-markdown-s": {
+      "path": "plugins/lemma/tests/test_markdown.py",
+      "selector": "test_heading_path",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "chunk-markdown-o": {
+      "path": "plugins/lemma/tests/test_markdown.py",
+      "selector": "test_exclusions",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "chunk-markdown-r": {
+      "path": "plugins/lemma/tests/test_markdown.py",
+      "selector": "test_short_document_survives",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "chunk-solidity-p": {
+      "path": "plugins/lemma/tests/test_solidity.py",
+      "selector": "test_chunks",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "chunk-solidity-m": {
+      "path": "plugins/lemma/tests/test_solidity.py",
+      "selector": "test_compile_errors_raise",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "chunk-solidity-s": {
+      "path": "plugins/lemma/tests/test_solidity.py",
+      "selector": "test_source_path_canonicality",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "chunk-solidity-o": {
+      "path": "plugins/lemma/tests/test_solidity.py",
+      "selector": "test_empty_selection",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "chunk-solidity-r": {
+      "path": "plugins/lemma/tests/test_solidity.py",
+      "selector": "test_cli_integration",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "janus-manifest-p": {
+      "path": "plugins/janus/tests/test_validator.py",
+      "selector": "test_the_honest_manifest_validates",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "janus-manifest-m": {
+      "path": "plugins/janus/tests/test_validator.py",
+      "selector": "test_each_fixture_fails_with_its_named_code",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "janus-manifest-s": {
+      "path": "plugins/janus/tests/test_reporter.py",
+      "selector": "test_markdown_names_each_gate_and_hook",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "janus-manifest-o": {
+      "path": "plugins/janus/tests/test_validator.py",
+      "selector": "test_wildcard_is_rejected_everywhere_it_could_hide",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "janus-manifest-r": {
+      "path": "plugins/janus/tests/test_validator.py",
+      "selector": "test_validate_command_exit_code",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "janus-bounded-p": {
+      "path": "plugins/janus/harness/test/WildcatConformance.t.sol",
+      "selector": "test_gate1_and_gate2_honest_deposit",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "janus-bounded-m": {
+      "path": "plugins/janus/harness/test/StateDeltaRecorder.t.sol",
+      "selector": "test_ending_without_beginning_reverts",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "janus-bounded-s": {
+      "path": "plugins/janus/harness/test/WildcatConformance.t.sol",
+      "selector": "test_gate7_adapter_names_its_scope",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "janus-bounded-o": {
+      "path": "plugins/janus/tests/test_reporter.py",
+      "selector": "test_empty_findings_report_states_context_not_safety",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "janus-bounded-r": {
+      "path": "plugins/janus/harness/test/HostileHooks.t.sol",
+      "selector": "test_storage_mutation_hook_caught_by_gate1",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "janus-report-p": {
+      "path": "plugins/janus/tests/test_reporter.py",
+      "selector": "test_report_command_writes_both_outputs",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "janus-report-m": {
+      "path": "plugins/janus/tests/test_reporter.py",
+      "selector": "test_the_sample_findings_load",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "janus-report-s": {
+      "path": "plugins/janus/tests/test_reporter.py",
+      "selector": "test_markdown_cells_survive_a_pipe_or_newline",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "janus-report-o": {
+      "path": "plugins/janus/tests/test_reporter.py",
+      "selector": "test_empty_findings_report_states_context_not_safety",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "janus-report-r": {
+      "path": "plugins/janus/tests/test_reporter.py",
+      "selector": "test_sarif_round_trips_as_json",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "berean-corpus-p": {
+      "path": "plugins/berean/tests/test_corpus.py",
+      "selector": "test_build_then_verify_is_clean",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "berean-corpus-m": {
+      "path": "plugins/berean/tests/test_corpus.py",
+      "selector": "test_an_empty_tree_is_refused",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "berean-corpus-s": {
+      "path": "plugins/berean/tests/test_corpus.py",
+      "selector": "test_a_one_byte_edit_fails_corpus_bytes",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "berean-corpus-o": {
+      "path": "plugins/berean/tests/test_corpus.py",
+      "selector": "test_an_unpinned_extra_file_fails_corpus_complete",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "berean-corpus-r": {
+      "path": "plugins/berean/tests/test_corpus.py",
+      "selector": "test_write_stages_and_lands_whole",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "berean-answer-p": {
+      "path": "plugins/berean/tests/test_answers.py",
+      "selector": "test_a_classified_answer_passes",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "berean-answer-m": {
+      "path": "plugins/berean/tests/test_answers.py",
+      "selector": "test_an_evidence_free_document_sentence_fails",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "berean-answer-s": {
+      "path": "plugins/berean/tests/test_answers.py",
+      "selector": "test_a_mismatched_span_fails_answer_citations",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "berean-answer-o": {
+      "path": "plugins/berean/tests/test_answers.py",
+      "selector": "test_a_user_supplied_fact_carries_no_evidence",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "berean-answer-r": {
+      "path": "plugins/berean/tests/test_answers.py",
+      "selector": "test_a_clean_refusal_passes",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "berean-evaluation-p": {
+      "path": "plugins/berean/tests/test_evals.py",
+      "selector": "test_the_fixture_corpus_grades_clean_and_reproduces_its_report",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "berean-evaluation-m": {
+      "path": "plugins/berean/tests/test_evals.py",
+      "selector": "test_a_release_without_evals_refuses",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "berean-evaluation-s": {
+      "path": "plugins/berean/tests/test_evals.py",
+      "selector": "test_a_cases_digest_mismatch_refuses_to_grade",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "berean-evaluation-o": {
+      "path": "plugins/berean/tests/test_evals.py",
+      "selector": "test_an_accepted_answer_fails_a_rejected_case",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "berean-evaluation-r": {
+      "path": "plugins/berean/tests/test_evals.py",
+      "selector": "test_a_drifted_corpus_refuses_to_grade",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "berean-promotion-p": {
+      "path": "plugins/berean/tests/test_promote.py",
+      "selector": "test_a_clean_report_promotes_and_the_release_is_active",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "berean-promotion-m": {
+      "path": "plugins/berean/tests/test_promote.py",
+      "selector": "test_a_failed_report_does_not_promote",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "berean-promotion-s": {
+      "path": "plugins/berean/tests/test_promote.py",
+      "selector": "test_a_report_for_another_corpus_does_not_promote",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "berean-promotion-o": {
+      "path": "plugins/berean/tests/test_promote.py",
+      "selector": "test_a_pinned_pass_over_a_failing_case_does_not_promote",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "berean-promotion-r": {
+      "path": "plugins/berean/tests/test_promote.py",
+      "selector": "test_an_active_release_rolls_back_by_record",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    }
+  },
+  "rows": [
+    {
+      "promise_id": "alexandria-address-query",
+      "skill_path": "plugins/alexandria/skills/alexandria/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "alexandria-p",
+        "M": "alexandria-m",
+        "S": "alexandria-s",
+        "O": "alexandria-o",
+        "R": "alexandria-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "alexandria-compound-method-proof",
+      "skill_path": "plugins/alexandria/skills/alexandria/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "alexandria-p",
+        "M": "alexandria-m",
+        "S": "alexandria-s",
+        "O": "alexandria-o",
+        "R": "alexandria-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "alexandria-derived-view",
+      "skill_path": "plugins/alexandria/skills/alexandria/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "alexandria-p",
+        "M": "alexandria-m",
+        "S": "alexandria-s",
+        "O": "alexandria-o",
+        "R": "alexandria-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "alexandria-raw-release",
+      "skill_path": "plugins/alexandria/skills/alexandria/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "alexandria-p",
+        "M": "alexandria-m",
+        "S": "alexandria-s",
+        "O": "alexandria-o",
+        "R": "alexandria-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "ariadne-capture-statement",
+      "skill_path": "plugins/ariadne/skills/ariadne/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "ariadne-p",
+        "M": "ariadne-m",
+        "S": "ariadne-s",
+        "O": "ariadne-o",
+        "R": "ariadne-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "ariadne-inspect-statement",
+      "skill_path": "plugins/ariadne/skills/ariadne/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "ariadne-p",
+        "M": "ariadne-m",
+        "S": "ariadne-s",
+        "O": "ariadne-o",
+        "R": "ariadne-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "ariadne-replay-command",
+      "skill_path": "plugins/ariadne/skills/ariadne/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "ariadne-p",
+        "M": "ariadne-m",
+        "S": "ariadne-s",
+        "O": "ariadne-o",
+        "R": "ariadne-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "ariadne-verify-statement",
+      "skill_path": "plugins/ariadne/skills/ariadne/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "ariadne-p",
+        "M": "ariadne-m",
+        "S": "ariadne-s",
+        "O": "ariadne-o",
+        "R": "ariadne-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "berean-answer-evidence",
+      "skill_path": "plugins/berean/skills/berean/SKILL.md",
+      "group": "executable",
+      "preserves": ["answer-truth-refused", "read-class", "source-class", "subject", "time-domain"],
+      "cases": {
+        "P": "berean-answer-p",
+        "M": "berean-answer-m",
+        "S": "berean-answer-s",
+        "O": "berean-answer-o",
+        "R": "berean-answer-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "berean-corpus-binding",
+      "skill_path": "plugins/berean/skills/berean/SKILL.md",
+      "group": "executable",
+      "preserves": ["corpus-digest", "source-class", "subject"],
+      "cases": {
+        "P": "berean-corpus-p",
+        "M": "berean-corpus-m",
+        "S": "berean-corpus-s",
+        "O": "berean-corpus-o",
+        "R": "berean-corpus-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "berean-evaluation-report",
+      "skill_path": "plugins/berean/skills/berean/SKILL.md",
+      "group": "executable",
+      "preserves": ["answer-digest", "answer-truth-refused", "corpus-digest", "time-domain"],
+      "cases": {
+        "P": "berean-evaluation-p",
+        "M": "berean-evaluation-m",
+        "S": "berean-evaluation-s",
+        "O": "berean-evaluation-o",
+        "R": "berean-evaluation-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "berean-release-promotion",
+      "skill_path": "plugins/berean/skills/berean/SKILL.md",
+      "group": "executable",
+      "preserves": ["answer-digest", "answer-truth-refused", "corpus-digest", "evaluation-digest"],
+      "cases": {
+        "P": "berean-promotion-p",
+        "M": "berean-promotion-m",
+        "S": "berean-promotion-s",
+        "O": "berean-promotion-o",
+        "R": "berean-promotion-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "brevitas-evidence-preservation",
+      "skill_path": "plugins/brevitas/skills/brevitas/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "brevitas-structure-check",
+      "skill_path": "plugins/brevitas/skills/brevitas/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "elenchus-fixed-and-guarded",
+      "skill_path": "plugins/hexaemeron/skills/elenchus/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "elenchus-p",
+        "M": "elenchus-m",
+        "S": "elenchus-s",
+        "O": "elenchus-o",
+        "R": "elenchus-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "ephoros-mechanical-gate",
+      "skill_path": "plugins/hexaemeron/skills/ephoros/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "ephoros-p",
+        "M": "ephoros-m",
+        "S": "ephoros-s",
+        "O": "ephoros-o",
+        "R": "ephoros-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "ephoros-observability-review",
+      "skill_path": "plugins/hexaemeron/skills/ephoros/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "ephoros-p",
+        "M": "ephoros-m",
+        "S": "ephoros-s",
+        "O": "ephoros-o",
+        "R": "ephoros-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "fiat-final-integration",
+      "skill_path": "plugins/hexaemeron/skills/fiat/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "fiat-p",
+        "M": "fiat-m",
+        "S": "fiat-s",
+        "O": "fiat-o",
+        "R": "fiat-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "fiat-receipted-delivery",
+      "skill_path": "plugins/hexaemeron/skills/fiat/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "fiat-p",
+        "M": "fiat-m",
+        "S": "fiat-s",
+        "O": "fiat-o",
+        "R": "fiat-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "hermes-baseline-promotion",
+      "skill_path": "plugins/hermes/skills/hermes/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "hermes-p",
+        "M": "hermes-m",
+        "S": "hermes-s",
+        "O": "hermes-o",
+        "R": "hermes-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "hermes-candidate-acceptance",
+      "skill_path": "plugins/hermes/skills/hermes/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "hermes-p",
+        "M": "hermes-m",
+        "S": "hermes-s",
+        "O": "hermes-o",
+        "R": "hermes-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "hermes-sealed-baseline",
+      "skill_path": "plugins/hermes/skills/hermes/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "hermes-p",
+        "M": "hermes-m",
+        "S": "hermes-s",
+        "O": "hermes-o",
+        "R": "hermes-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "hexaemeron-fizz-convert-properties",
+      "skill_path": "plugins/hexaemeron/skills/fizz/skills/fizz-convert/SKILL.md",
+      "group": "vendored",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "hexaemeron-fizz-harness-campaign",
+      "skill_path": "plugins/hexaemeron/skills/fizz/SKILL.md",
+      "group": "vendored",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "hexaemeron-fizz-sync-drift",
+      "skill_path": "plugins/hexaemeron/skills/fizz/skills/fizz-sync/SKILL.md",
+      "group": "vendored",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "hexaemeron-solidity-audit-report",
+      "skill_path": "plugins/hexaemeron/skills/solidity-auditor/SKILL.md",
+      "group": "vendored",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "hexaemeron-x-ray-preaudit",
+      "skill_path": "plugins/hexaemeron/skills/x-ray/SKILL.md",
+      "group": "vendored",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "horos-boundary-check",
+      "skill_path": "plugins/horos/skills/horos/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "horos-p",
+        "M": "horos-m",
+        "S": "horos-s",
+        "O": "horos-o",
+        "R": "horos-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "horos-boundary-scan",
+      "skill_path": "plugins/horos/skills/horos/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "horos-p",
+        "M": "horos-m",
+        "S": "horos-s",
+        "O": "horos-o",
+        "R": "horos-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "horos-census",
+      "skill_path": "plugins/horos/skills/horos/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "horos-p",
+        "M": "horos-m",
+        "S": "horos-s",
+        "O": "horos-o",
+        "R": "horos-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "horos-skeleton-map",
+      "skill_path": "plugins/horos/skills/horos/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "horos-p",
+        "M": "horos-m",
+        "S": "horos-s",
+        "O": "horos-o",
+        "R": "horos-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "hypomnema-pointer-gate",
+      "skill_path": "plugins/hexaemeron/skills/hypomnema/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "hypomnema-record-placement",
+      "skill_path": "plugins/hexaemeron/skills/hypomnema/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "imprimatur-prose-gate",
+      "skill_path": "plugins/hexaemeron/skills/imprimatur/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "janus-bounded-conformance",
+      "skill_path": "plugins/janus/skills/janus/SKILL.md",
+      "group": "executable",
+      "preserves": ["adapter", "bounded-search", "cross-host-refused", "manifest", "recorder", "safety-refused", "unknown-effect-refused"],
+      "cases": {
+        "P": "janus-bounded-p",
+        "M": "janus-bounded-m",
+        "S": "janus-bounded-s",
+        "O": "janus-bounded-o",
+        "R": "janus-bounded-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "janus-manifest-validation",
+      "skill_path": "plugins/janus/skills/janus/SKILL.md",
+      "group": "executable",
+      "preserves": ["adapter", "manifest"],
+      "cases": {
+        "P": "janus-manifest-p",
+        "M": "janus-manifest-m",
+        "S": "janus-manifest-s",
+        "O": "janus-manifest-o",
+        "R": "janus-manifest-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "janus-report-rendering",
+      "skill_path": "plugins/janus/skills/janus/SKILL.md",
+      "group": "executable",
+      "preserves": ["adapter", "bounded-search", "manifest", "recorder", "safety-refused"],
+      "cases": {
+        "P": "janus-report-p",
+        "M": "janus-report-m",
+        "S": "janus-report-s",
+        "O": "janus-report-o",
+        "R": "janus-report-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "kronos-fiat-dispatch",
+      "skill_path": "plugins/hexaemeron/skills/kronos/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "kronos-frontier-ranking",
+      "skill_path": "plugins/hexaemeron/skills/kronos/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "kronos-parked-lane",
+      "skill_path": "plugins/hexaemeron/skills/kronos/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "lazarus-exact-replay",
+      "skill_path": "plugins/lazarus/skills/lazarus/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "lazarus-p",
+        "M": "lazarus-m",
+        "S": "lazarus-s",
+        "O": "lazarus-o",
+        "R": "lazarus-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "lazarus-fixture-capture",
+      "skill_path": "plugins/lazarus/skills/lazarus/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "lazarus-p",
+        "M": "lazarus-m",
+        "S": "lazarus-s",
+        "O": "lazarus-o",
+        "R": "lazarus-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "lazarus-fixture-verification",
+      "skill_path": "plugins/lazarus/skills/lazarus/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "lazarus-p",
+        "M": "lazarus-m",
+        "S": "lazarus-s",
+        "O": "lazarus-o",
+        "R": "lazarus-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "lazarus-preservation-release",
+      "skill_path": "plugins/lazarus/skills/lazarus/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "lazarus-p",
+        "M": "lazarus-m",
+        "S": "lazarus-s",
+        "O": "lazarus-o",
+        "R": "lazarus-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "lemma-chunk-validation",
+      "skill_path": "plugins/lemma/skills/chunk/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "chunk-solidity-p",
+        "M": "chunk-solidity-m",
+        "S": "chunk-solidity-s",
+        "O": "chunk-solidity-o",
+        "R": "chunk-solidity-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "lemma-markdown-chunks",
+      "skill_path": "plugins/lemma/skills/chunk/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "chunk-markdown-p",
+        "M": "chunk-markdown-m",
+        "S": "chunk-markdown-s",
+        "O": "chunk-markdown-o",
+        "R": "chunk-markdown-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "lemma-solidity-chunks",
+      "skill_path": "plugins/lemma/skills/chunk/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "chunk-solidity-p",
+        "M": "chunk-solidity-m",
+        "S": "chunk-solidity-s",
+        "O": "chunk-solidity-o",
+        "R": "chunk-solidity-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "metron-budget-verdict",
+      "skill_path": "plugins/hexaemeron/skills/metron/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "metron-p",
+        "M": "metron-m",
+        "S": "metron-s",
+        "O": "metron-o",
+        "R": "metron-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "metron-change-decision",
+      "skill_path": "plugins/hexaemeron/skills/metron/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "metron-p",
+        "M": "metron-m",
+        "S": "metron-s",
+        "O": "metron-o",
+        "R": "metron-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "pandects-broken-specimen",
+      "skill_path": "plugins/pandects/skills/pandects/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "pandects-p",
+        "M": "pandects-m",
+        "S": "pandects-s",
+        "O": "pandects-o",
+        "R": "pandects-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "pandects-catalogue-render",
+      "skill_path": "plugins/pandects/skills/pandects/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "pandects-p",
+        "M": "pandects-m",
+        "S": "pandects-s",
+        "O": "pandects-o",
+        "R": "pandects-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "pandects-law-contract",
+      "skill_path": "plugins/pandects/skills/pandects/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "pandects-p",
+        "M": "pandects-m",
+        "S": "pandects-s",
+        "O": "pandects-o",
+        "R": "pandects-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "pandects-search-record",
+      "skill_path": "plugins/pandects/skills/pandects/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "pandects-p",
+        "M": "pandects-m",
+        "S": "pandects-s",
+        "O": "pandects-o",
+        "R": "pandects-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "phylax-boundary-review",
+      "skill_path": "plugins/hexaemeron/skills/phylax/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "phylax-p",
+        "M": "phylax-m",
+        "S": "phylax-s",
+        "O": "phylax-o",
+        "R": "phylax-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "phylax-mechanical-gate",
+      "skill_path": "plugins/hexaemeron/skills/phylax/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "phylax-p",
+        "M": "phylax-m",
+        "S": "phylax-s",
+        "O": "phylax-o",
+        "R": "phylax-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "probitas-dossier-rendering",
+      "skill_path": "plugins/probitas/skills/probitas/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "probitas-p",
+        "M": "probitas-m",
+        "S": "probitas-s",
+        "O": "probitas-o",
+        "R": "probitas-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "probitas-dossier-verification",
+      "skill_path": "plugins/probitas/skills/probitas/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "probitas-p",
+        "M": "probitas-m",
+        "S": "probitas-s",
+        "O": "probitas-o",
+        "R": "probitas-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "probitas-evidence-collection",
+      "skill_path": "plugins/probitas/skills/probitas/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "probitas-p",
+        "M": "probitas-m",
+        "S": "probitas-s",
+        "O": "probitas-o",
+        "R": "probitas-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "protasis-runbook-readiness",
+      "skill_path": "plugins/hexaemeron/skills/protasis/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "protasis-p",
+        "M": "protasis-m",
+        "S": "protasis-s",
+        "O": "protasis-o",
+        "R": "protasis-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "protasis-study-readiness",
+      "skill_path": "plugins/hexaemeron/skills/protasis/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "protasis-p",
+        "M": "protasis-m",
+        "S": "protasis-s",
+        "O": "protasis-o",
+        "R": "protasis-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "sapheneia-deactivation",
+      "skill_path": "plugins/sapheneia/skills/sapheneia/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "sapheneia-session-shape",
+      "skill_path": "plugins/sapheneia/skills/sapheneia/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "tabularium-compound-witness",
+      "skill_path": "plugins/tabularium/skills/tabularium/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "tabularium-p",
+        "M": "tabularium-m",
+        "S": "tabularium-s",
+        "O": "tabularium-o",
+        "R": "tabularium-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "tabularium-release-build",
+      "skill_path": "plugins/tabularium/skills/tabularium/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "tabularium-p",
+        "M": "tabularium-m",
+        "S": "tabularium-s",
+        "O": "tabularium-o",
+        "R": "tabularium-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "tabularium-release-verification",
+      "skill_path": "plugins/tabularium/skills/tabularium/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "tabularium-p",
+        "M": "tabularium-m",
+        "S": "tabularium-s",
+        "O": "tabularium-o",
+        "R": "tabularium-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "vulgate-register-rewrite",
+      "skill_path": "plugins/hexaemeron/skills/vulgate/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    }
+  ]
+}

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -145,6 +145,36 @@
       "selector": "test_a_stated_reason_suppresses",
       "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
     },
+    "ephoros-review-p": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_ephoros_review_positive",
+      "claim": "The named review case records acceptance only when every on-call question has bounded, exercised and reviewed evidence.",
+      "evidence_class": "recorded"
+    },
+    "ephoros-review-m": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_ephoros_review_missing",
+      "claim": "The named review case refuses unattended operation when an introduced external call lacks operational evidence.",
+      "evidence_class": "recorded"
+    },
+    "ephoros-review-s": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_ephoros_review_subject_mismatch",
+      "claim": "The named review case refuses observability evidence from a different build.",
+      "evidence_class": "recorded"
+    },
+    "ephoros-review-o": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_ephoros_review_overclaim",
+      "claim": "The named review case refuses to promote a clean mechanical lint into a complete observability judgement.",
+      "evidence_class": "recorded"
+    },
+    "ephoros-review-r": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_ephoros_review_recovery",
+      "claim": "The named review case records a recovery that supplies new operational evidence before review repeats.",
+      "evidence_class": "recorded"
+    },
     "fiat-p": {
       "path": "plugins/hexaemeron/tests/test_hexctl.py",
       "selector": "test_push_advances_steps_then_the_stack_integrates",
@@ -295,6 +325,36 @@
       "selector": "test_a_stated_reason_suppresses_the_finding",
       "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
     },
+    "phylax-review-p": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_phylax_review_positive",
+      "claim": "The named review case records acceptance only when each introduced boundary is named, controlled and evidence-classified.",
+      "evidence_class": "recorded"
+    },
+    "phylax-review-m": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_phylax_review_missing",
+      "claim": "The named review case refuses an external-data boundary without a confinement control or hostile-input evidence.",
+      "evidence_class": "recorded"
+    },
+    "phylax-review-s": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_phylax_review_subject_mismatch",
+      "claim": "The named review case refuses dependency evidence from a different revision.",
+      "evidence_class": "recorded"
+    },
+    "phylax-review-o": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_phylax_review_overclaim",
+      "claim": "The named review case refuses to promote a clean mechanical lint into whole-system security evidence.",
+      "evidence_class": "recorded"
+    },
+    "phylax-review-r": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_phylax_review_recovery",
+      "claim": "The named review case records recovery through a newly named and exercised boundary control.",
+      "evidence_class": "recorded"
+    },
     "probitas-p": {
       "path": "plugins/probitas/tests/test_demo.py",
       "selector": "test_it_exits_zero",
@@ -344,6 +404,36 @@
       "path": "plugins/hexaemeron/tests/test_protasis_checker.py",
       "selector": "test_this_runs_own_runbook_is_clean",
       "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "protasis-study-p": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_protasis_study_positive",
+      "claim": "The named study case records readiness only after the full content contract and evidence-bearing criteria are present.",
+      "evidence_class": "recorded"
+    },
+    "protasis-study-m": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_protasis_study_missing",
+      "claim": "The named study case refuses hidden assumptions and untestable success language.",
+      "evidence_class": "recorded"
+    },
+    "protasis-study-s": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_protasis_study_subject_mismatch",
+      "claim": "The named study case refuses current-state evidence from a different repository revision.",
+      "evidence_class": "recorded"
+    },
+    "protasis-study-o": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_protasis_study_overclaim",
+      "claim": "The named study case refuses to present content readiness as implementation or correctness evidence.",
+      "evidence_class": "recorded"
+    },
+    "protasis-study-r": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_protasis_study_recovery",
+      "claim": "The named study case records recovery by gathering current evidence and repeating the complete review.",
+      "evidence_class": "recorded"
     },
     "tabularium-p": {
       "path": "plugins/tabularium/tests/test_release.py",
@@ -844,11 +934,11 @@
       "skill_path": "plugins/hexaemeron/skills/ephoros/SKILL.md",
       "group": "executable",
       "cases": {
-        "P": "ephoros-p",
-        "M": "ephoros-m",
-        "S": "ephoros-s",
-        "O": "ephoros-o",
-        "R": "ephoros-r",
+        "P": "ephoros-review-p",
+        "M": "ephoros-review-m",
+        "S": "ephoros-review-s",
+        "O": "ephoros-review-o",
+        "R": "ephoros-review-r",
         "X": {
           "not_applicable": true,
           "reason": "The canonical declaration supports no exception for this promise."
@@ -1340,11 +1430,11 @@
       "skill_path": "plugins/hexaemeron/skills/phylax/SKILL.md",
       "group": "executable",
       "cases": {
-        "P": "phylax-p",
-        "M": "phylax-m",
-        "S": "phylax-s",
-        "O": "phylax-o",
-        "R": "phylax-r",
+        "P": "phylax-review-p",
+        "M": "phylax-review-m",
+        "S": "phylax-review-s",
+        "O": "phylax-review-o",
+        "R": "phylax-review-r",
         "X": {
           "not_applicable": true,
           "reason": "The canonical declaration supports no exception for this promise."
@@ -1436,11 +1526,11 @@
       "skill_path": "plugins/hexaemeron/skills/protasis/SKILL.md",
       "group": "executable",
       "cases": {
-        "P": "protasis-p",
-        "M": "protasis-m",
-        "S": "protasis-s",
-        "O": "protasis-o",
-        "R": "protasis-r",
+        "P": "protasis-study-p",
+        "M": "protasis-study-m",
+        "S": "protasis-study-s",
+        "O": "protasis-study-o",
+        "R": "protasis-study-r",
         "X": {
           "not_applicable": true,
           "reason": "The canonical declaration supports no exception for this promise."

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -1,4 +1,5 @@
 import json
+import hashlib
 import os
 from pathlib import Path
 import shutil
@@ -78,6 +79,53 @@ def write_skill(plugin, name="example", *, promise_id="example-check", fields=No
     )
     (directory / "EVOLUTION.md").write_text("# Evolution\n", encoding="utf-8")
     return directory
+
+
+def write_vendored_skill(plugin, name="upstream"):
+    directory = plugin / "skills" / name
+    directory.mkdir(parents=True)
+    skill = directory / "SKILL.md"
+    skill.write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: A vendored fixture skill.\n"
+        "---\n\n"
+        f"# {name}\n",
+        encoding="utf-8",
+    )
+    (directory / "NOTICE.md").write_text(
+        "# Notice\n\n"
+        "This directory is vendored verbatim.\n\n"
+        "- Upstream: https://example.invalid/upstream\n"
+        "- Release tag: v0.0.0\n"
+        "- Vendored: 2026-08-20\n",
+        encoding="utf-8",
+    )
+    (directory / "LICENSE").write_text("Fixture licence.\n", encoding="utf-8")
+    return skill
+
+
+def write_overlay(root, skill, *, promise_id="hexaemeron-upstream-run", digest=None):
+    digest = digest or hashlib.sha256(skill.read_bytes()).hexdigest()
+    path = skill.relative_to(root).as_posix()
+    overlay = root / "plugins" / "hexaemeron" / "PROMISES.md"
+    overlay.write_text(
+        "# Hexaemeron Promise Machine overlays\n\n"
+        f"### {promise_id}\n\n"
+        f"- Path: `{path}`\n"
+        f"- SHA-256: `{digest}`\n"
+        "- Promise: The named vendored operation completed.\n"
+        "- Evidence: The digest-matched instruction and operation record.\n"
+        "- Evidence classes: checked, recorded\n"
+        "- Boundary: The result covers only the named operation.\n"
+        "- Authorises: Use of the recorded result inside its boundary.\n"
+        "- Consequence: 1\n"
+        "- Refuses: A stale digest or failed operation.\n"
+        "- Recovery: Reconcile the instruction and rerun the operation.\n"
+        "- Exceptions: none\n",
+        encoding="utf-8",
+    )
+    return overlay
 
 
 class PromiseLawTests(unittest.TestCase):
@@ -407,8 +455,114 @@ class PromiseStructureTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["promises"], 43)
+        self.assertEqual(report["counts"]["promises"], 61)
 
+    def test_hexaemeron_contract_population_is_complete(self):
+        expected = {
+            "elenchus": {"elenchus-fixed-and-guarded"},
+            "ephoros": {"ephoros-mechanical-gate", "ephoros-observability-review"},
+            "fiat": {"fiat-receipted-delivery", "fiat-final-integration"},
+            "hypomnema": {"hypomnema-pointer-gate", "hypomnema-record-placement"},
+            "imprimatur": {"imprimatur-prose-gate"},
+            "kronos": {
+                "kronos-frontier-ranking",
+                "kronos-fiat-dispatch",
+                "kronos-parked-lane",
+            },
+            "metron": {"metron-budget-verdict", "metron-change-decision"},
+            "phylax": {"phylax-mechanical-gate", "phylax-boundary-review"},
+            "protasis": {"protasis-study-readiness", "protasis-runbook-readiness"},
+            "vulgate": {"vulgate-register-rewrite"},
+        }
+        for skill, promise_ids in expected.items():
+            path = ROOT / "plugins" / "hexaemeron" / "skills" / skill / "SKILL.md"
+            with self.subTest(skill=skill):
+                text = path.read_text(encoding="utf-8")
+                self.assertEqual(text.splitlines().count("## Promise Machine contract"), 1)
+                contract = text.split("## Promise Machine contract", 1)[1]
+                contract = contract.split("\n## ", 1)[0]
+                self.assertEqual(
+                    {
+                        line.removeprefix("### ")
+                        for line in contract.splitlines()
+                        if line.startswith("### ")
+                    },
+                    promise_ids,
+                )
+
+
+class PromiseOverlayTests(unittest.TestCase):
+    def test_repository_overlay_population_is_complete_and_digest_bound(self):
+        expected = {
+            "plugins/hexaemeron/skills/fizz/SKILL.md":
+                "62a60df4cec160511b8ef36433eef7c8805d0b4a398491293eb4542ab73539bd",
+            "plugins/hexaemeron/skills/fizz/skills/fizz-convert/SKILL.md":
+                "59cd4b4ef5dc56315782a7d25222afb286a24e63e438530cbd0044293ea54af7",
+            "plugins/hexaemeron/skills/fizz/skills/fizz-sync/SKILL.md":
+                "e969cd8a447941989715840e24aa6a915c0fd795effabd912b3c627598a95e16",
+            "plugins/hexaemeron/skills/x-ray/SKILL.md":
+                "b23bb94517805c1b8ce717d0e1e0282b0b5c14c7b16f4c32e73940292d3d4a41",
+            "plugins/hexaemeron/skills/solidity-auditor/SKILL.md":
+                "1c1cf4e99d042e7aadc56b622d97a07d3286f4786838a05510697c814d1e983f",
+        }
+        text = (ROOT / "plugins" / "hexaemeron" / "PROMISES.md").read_text(
+            encoding="utf-8"
+        )
+        for path, digest in expected.items():
+            with self.subTest(path=path):
+                self.assertIn(f"- Path: `{path}`", text)
+                self.assertIn(f"- SHA-256: `{digest}`", text)
+
+        completed = run_cli("check", "--only", "contracts,overlays", "--json")
+        report = json.loads(completed.stdout)
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["counts"]["promises"], 66)
+        self.assertEqual(report["counts"]["overlays"], 1)
+
+    def test_one_byte_vendored_mutation_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            plugin = make_plugin(target, "hexaemeron")
+            skill = write_vendored_skill(plugin)
+            write_overlay(target, skill)
+            clean = run_cli("check", "--root", target, "--only", "overlays", "--json")
+            skill.write_bytes(skill.read_bytes() + b"x")
+            drifted = run_cli(
+                "check", "--root", target, "--only", "overlays", "--json"
+            )
+        self.assertEqual(clean.returncode, 0, clean.stdout + clean.stderr)
+        report = json.loads(drifted.stdout)
+        self.assertEqual(drifted.returncode, 1)
+        self.assertIn("PM057", [item["code"] for item in report["findings"]])
+
+    def test_missing_overlay_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            plugin = make_plugin(target, "hexaemeron")
+            write_vendored_skill(plugin)
+            completed = run_cli(
+                "check", "--root", target, "--only", "overlays", "--json"
+            )
+        report = json.loads(completed.stdout)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM050", [item["code"] for item in report["findings"]])
+
+    def test_overlay_cannot_bind_a_first_party_skill(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            plugin = make_plugin(target, "hexaemeron")
+            skill = write_skill(plugin) / "SKILL.md"
+            write_overlay(target, skill)
+            completed = run_cli(
+                "check", "--root", target, "--only", "overlays", "--json"
+            )
+        report = json.loads(completed.stdout)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM055", [item["code"] for item in report["findings"]])
+
+
+class PromiseStructureValidationTests(unittest.TestCase):
     def test_contract_component_refuses_an_absent_section(self):
         with tempfile.TemporaryDirectory() as directory:
             target = Path(directory)

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -1057,6 +1057,36 @@ class PromiseCoverageTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 1)
         self.assertIn("PM064", [item["code"] for item in report["findings"]])
 
+    def test_unsupported_evidence_class_is_refused(self):
+        def mutate(document):
+            document["evidence"]["p"]["evidence_class"] = "anecdotal"
+
+        completed, report = self.run_mutation(mutate)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM064", [item["code"] for item in report["findings"]])
+
+    def test_duplicate_json_key_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            coverage_path, _ = write_coverage_fixture(target)
+            coverage_path.write_text(
+                '{"contract":"promise-machine/v1",'
+                '"contract":"promise-machine/v1"}',
+                encoding="utf-8",
+            )
+            completed = run_cli(
+                "coverage",
+                "--check",
+                "--root",
+                target,
+                "--group",
+                "executable",
+                "--json",
+            )
+        report = json.loads(completed.stdout)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM061", [item["code"] for item in report["findings"]])
+
     def test_selected_pending_row_is_refused(self):
         def mutate(document):
             document["rows"][0]["cases"] = None

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -128,6 +128,68 @@ def write_overlay(root, skill, *, promise_id="hexaemeron-upstream-run", digest=N
     return overlay
 
 
+def write_coverage_fixture(root):
+    plugin = make_plugin(root, "hexaemeron")
+    write_skill(plugin, "elenchus")
+    vendored = write_vendored_skill(plugin)
+    write_overlay(root, vendored)
+    evidence_path = root / "tests" / "evidence.py"
+    evidence_path.parent.mkdir(parents=True)
+    selectors = {
+        "p": "test_positive",
+        "m": "test_missing",
+        "s": "test_subject_mismatch",
+        "o": "test_overclaim",
+        "r": "test_recovery",
+    }
+    evidence_path.write_text(
+        "\n".join(f"def {selector}():\n    pass\n" for selector in selectors.values()),
+        encoding="utf-8",
+    )
+    evidence = {
+        key: {
+            "path": "tests/evidence.py",
+            "selector": selector,
+            "claim": f"Fixture {key} evidence.",
+        }
+        for key, selector in selectors.items()
+    }
+    document = {
+        "contract": "promise-machine/v1",
+        "schema": "promise-machine-coverage/v1",
+        "handoffs": [],
+        "evidence": evidence,
+        "rows": [
+            {
+                "promise_id": "example-check",
+                "skill_path": "plugins/hexaemeron/skills/elenchus/SKILL.md",
+                "group": "executable",
+                "cases": {
+                    "P": "p",
+                    "M": "m",
+                    "S": "s",
+                    "O": "o",
+                    "R": "r",
+                    "X": {
+                        "not_applicable": True,
+                        "reason": "The fixture supports no exceptions.",
+                    },
+                },
+            },
+            {
+                "promise_id": "hexaemeron-upstream-run",
+                "skill_path": "plugins/hexaemeron/skills/upstream/SKILL.md",
+                "group": "vendored",
+                "cases": None,
+                "pending": "Runbook Step 8 classifies vendored evidence.",
+            },
+        ],
+    }
+    coverage = root / "tests" / "promise_machine_coverage.json"
+    coverage.write_text(json.dumps(document), encoding="utf-8")
+    return coverage, document
+
+
 class PromiseLawTests(unittest.TestCase):
     def test_repository_law_and_copies_are_clean(self):
         completed = run_cli("check", "--only", "law,copies")
@@ -883,6 +945,126 @@ class PromiseIdentityTests(unittest.TestCase):
                 "check", "--root", target, "--only", "routers", "--json"
             )
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+
+
+class PromiseCoverageTests(unittest.TestCase):
+    def test_repository_executable_coverage_is_complete(self):
+        completed = run_cli(
+            "coverage", "--check", "--group", "executable", "--json"
+        )
+        report = json.loads(completed.stdout)
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["counts"]["coverage_rows"], 66)
+        self.assertEqual(report["counts"]["coverage_selected"], 50)
+
+    def test_berean_and_janus_boundaries_are_explicit(self):
+        coverage = json.loads(
+            (ROOT / "tests" / "promise_machine_coverage.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        rows = {row["promise_id"]: row for row in coverage["rows"]}
+        self.assertEqual(
+            set(rows["berean-answer-evidence"]["preserves"]),
+            {
+                "answer-truth-refused",
+                "read-class",
+                "source-class",
+                "subject",
+                "time-domain",
+            },
+        )
+        self.assertEqual(
+            set(rows["janus-bounded-conformance"]["preserves"]),
+            {
+                "adapter",
+                "bounded-search",
+                "cross-host-refused",
+                "manifest",
+                "recorder",
+                "safety-refused",
+                "unknown-effect-refused",
+            },
+        )
+        self.assertEqual(
+            {
+                (handoff["producer"], handoff["consumer"])
+                for handoff in coverage["handoffs"]
+            },
+            {
+                ("lazarus-fixture-verification", "berean-answer-evidence"),
+                ("berean-release-promotion", "ariadne-capture-statement"),
+            },
+        )
+
+    def run_mutation(self, mutate):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            coverage_path, document = write_coverage_fixture(target)
+            mutate(document)
+            coverage_path.write_text(json.dumps(document), encoding="utf-8")
+            completed = run_cli(
+                "coverage",
+                "--check",
+                "--root",
+                target,
+                "--group",
+                "executable",
+                "--json",
+            )
+        return completed, json.loads(completed.stdout)
+
+    def test_missing_coverage_row_is_refused(self):
+        completed, report = self.run_mutation(
+            lambda document: document["rows"].pop(0)
+        )
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM062", [item["code"] for item in report["findings"]])
+
+    def test_unresolved_test_selector_is_refused(self):
+        def mutate(document):
+            document["evidence"]["p"]["selector"] = "test_absent"
+
+        completed, report = self.run_mutation(mutate)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM065", [item["code"] for item in report["findings"]])
+
+    def test_one_selector_cannot_satisfy_incompatible_cases(self):
+        def mutate(document):
+            document["rows"][0]["cases"]["M"] = "p"
+
+        completed, report = self.run_mutation(mutate)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM067", [item["code"] for item in report["findings"]])
+
+    def test_material_missing_case_cannot_be_inapplicable(self):
+        def mutate(document):
+            document["rows"][0]["cases"]["M"] = {
+                "not_applicable": True,
+                "reason": "Fixture claim.",
+            }
+
+        completed, report = self.run_mutation(mutate)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM066", [item["code"] for item in report["findings"]])
+
+    def test_inapplicability_requires_a_reason(self):
+        def mutate(document):
+            document["rows"][0]["cases"]["X"] = {"not_applicable": True}
+
+        completed, report = self.run_mutation(mutate)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM064", [item["code"] for item in report["findings"]])
+
+    def test_selected_pending_row_is_refused(self):
+        def mutate(document):
+            document["rows"][0]["cases"] = None
+            document["rows"][0]["pending"] = "Later."
+
+        completed, report = self.run_mutation(mutate)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM066", [item["code"] for item in report["findings"]])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Enforce executable Promise Machine coverage

## What changed

- Added one checked coverage row for each of the 66 discovered promises and
  completed the 50 executable rows.
- Added exact P/M/S/O/R/X evidence references, with attributed
  inapplicability where a class cannot apply.
- Added bounded coverage parsing, duplicate-key refusal, exact selector
  resolution, incompatible-case separation and evidence-class validation.
- Kept Berean's source, read, subject and time boundaries explicit through
  promotion and the Lazarus-to-Berean-to-Ariadne handoffs.
- Kept Janus evidence bound to its adapter, manifest, recorder and bounded
  search, including explicit refusal of unknown effects, cross-host results
  and safety claims.
- Added 15 recorded review cases so the Ephoros, Phylax and Protasis review
  promises do not borrow narrower mechanical-test evidence.

## Audit

The audit is appended to `audit/AUDIT.md`. Round 1 found that three
judgement-held promises cited mechanical parser tests and that evidence
references could not state their base class. Both findings are fixed and
guarded. Round 2 was clean.

## Proof

```bash
python3 scripts/promise_machine.py check
python3 scripts/promise_machine.py coverage --check --group executable
python3 -m unittest discover -s tests
python3 plugins/hexaemeron/tests/run_tests.py
```

The coverage command reports 50 selected executable promises out of 66
discovered. All 90 root tests, all 467 Hexaemeron tests, the named executable
plugin suites, both relevant Foundry suites, and the Phylax, Ephoros,
Hypomnema and Horos gates pass.

This pull request stacks on the Hexaemeron Promise Machine contract step.

<!-- wildcat-origin: shoggoth -->
