### PR TITLE
Classify prompt and vendored Promise Machine evidence

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5435,3 +5435,29 @@ parity and its labelled evidence is `inferred`, not `recorded` or `proved`.
 Labelled cases describe expected decisions and do not establish that a future
 model will follow them. The coverage rows name `not-run` wherever no model,
 campaign, conversion, sync, pre-audit or audit was executed.
+
+## Promise Machine, step 7, round 2 -- 2026-08-20
+
+### Review scope
+
+The corrected gate derives every accepted evidence class from the owning
+canonical declaration, requires explicit classes for prompt and vendored
+references, and confines evaluation corpora to resolving repository-relative
+paths. All 16 selected rows retain model, prompt, corpus and disposition
+records with status limited to `recorded` or `unknown`.
+
+### Findings
+
+Zero findings.
+
+### Evidence
+
+All 17 focused coverage checks, 21 Brevitas tests, 60 Imprimatur checks, nine
+Sapheneia tests, 474 Hexaemeron tests and 97 root tests pass. The Phylax,
+Ephoros, Hypomnema and Horos gates are clean. The five vendored instruction
+files remain unchanged.
+
+### Leads not pursued
+
+The forward-testing and no-execution limits recorded in round 1 remain
+unchanged.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5359,3 +5359,26 @@ Recorded review cases establish that each decision path has been named and kept
 inside its boundary; they do not turn a human review judgement into runtime
 proof. The remaining prompt, transformation and vendored rows stay visibly
 pending for runbook step 8.
+
+## Promise Machine, step 6, round 2 -- 2026-08-20
+
+### Review scope
+
+The corrected coverage map keeps executable tests, recorded review cases and
+inapplicability reasons distinct. All exact references resolve; incompatible
+P/M/S/O/R paths remain separate; the required preservation and handoff records
+remain explicit; and the full law, copy and executable-coverage checks are clean.
+
+### Findings
+
+Zero findings.
+
+### Evidence
+
+All 90 root tests and all 467 Hexaemeron tests pass. The Phylax, Ephoros and
+Hypomnema gates are clean.
+
+### Leads not pursued
+
+The recorded-judgement and later-runbook boundaries from round 1 remain
+unchanged.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5327,3 +5327,35 @@ The declarations state evidence contracts but do not yet prove every skill's
 runtime implementation conforms to them. Executable, prompt, transformation
 and vendored conformance are the explicit subjects of the next two runbook
 steps, so treating that work as a finding here would duplicate their scope.
+
+## Promise Machine, step 6, round 1 -- 2026-08-20
+
+### Review scope
+
+The Solidity suite remained waived because this step changes a standard-library
+checker, JSON coverage records and Python tests. The review traced every selected
+P/M/S/O/R/X reference to its exact selector, checked evidence reuse and
+inapplicability rules, inspected the Berean and Janus preservation boundaries and
+the Lazarus-to-Berean-to-Ariadne handoffs, and compared judgement-held promises
+with the narrower mechanical gates beside them.
+
+### Findings
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S6-R1-01 | high | `tests/promise_machine_coverage.json` | The Ephoros observability review, Phylax boundary review and Protasis study-readiness promises cited mechanical parser tests, so the coverage map overstated what those tests established | fixed with 15 distinct labelled review cases that record positive, missing, subject-mismatch, overclaim and recovery judgements without presenting them as checked runtime proof |
+| S6-R1-02 | medium | `scripts/promise_machine.py` | Evidence references could not state their base evidence class, leaving recorded judgement cases indistinguishable from executable checks | fixed with an optional, validated `evidence_class` field and refusal tests for unsupported classes |
+
+### Evidence
+
+The executable coverage gate reports 50 selected promises out of 66 discovered,
+with no finding. The 25 focused coverage and labelled-case checks, all 90 root
+tests and all 467 Hexaemeron tests pass. The Phylax, Ephoros and Hypomnema gates
+are clean.
+
+### Leads not pursued
+
+Recorded review cases establish that each decision path has been named and kept
+inside its boundary; they do not turn a human review judgement into runtime
+proof. The remaining prompt, transformation and vendored rows stay visibly
+pending for runbook step 8.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5341,10 +5341,21 @@ with the narrower mechanical gates beside them.
 
 ### Findings
 
-| id | severity | file | finding | status |
-| --- | --- | --- | --- | --- |
-| S6-R1-01 | high | `tests/promise_machine_coverage.json` | The Ephoros observability review, Phylax boundary review and Protasis study-readiness promises cited mechanical parser tests, so the coverage map overstated what those tests established | fixed with 15 distinct labelled review cases that record positive, missing, subject-mismatch, overclaim and recovery judgements without presenting them as checked runtime proof |
-| S6-R1-02 | medium | `scripts/promise_machine.py` | Evidence references could not state their base evidence class, leaving recorded judgement cases indistinguishable from executable checks | fixed with an optional, validated `evidence_class` field and refusal tests for unsupported classes |
+FINDING
+[High] S6-R1-01: Three judgement-held promises cited mechanical parser tests.
+Location: `tests/promise_machine_coverage.json`
+Mechanism: The Ephoros, Phylax and Protasis review rows borrowed evidence from narrower mechanical gates.
+Impact: The coverage map overstated what those tests established.
+Fix: Added 15 labelled review cases that record P/M/S/O/R judgements without presenting them as checked runtime proof.
+END
+
+FINDING
+[Medium] S6-R1-02: Evidence references could not state their base class.
+Location: `scripts/promise_machine.py`
+Mechanism: The schema accepted only a path, selector and claim.
+Impact: Recorded judgement cases were indistinguishable from executable checks.
+Fix: Added a validated optional `evidence_class` field and refusal tests for unsupported classes.
+END
 
 ### Evidence
 

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5393,3 +5393,45 @@ Hypomnema gates are clean.
 
 The recorded-judgement and later-runbook boundaries from round 1 remain
 unchanged.
+
+## Promise Machine, step 7, round 1 -- 2026-08-20
+
+### Review scope
+
+The Solidity suite remained waived because this step changes Python and JSON
+coverage records and tests, not Solidity. The review compared all 16 prompt,
+transformation and vendored rows with their canonical evidence classes, traced
+each P/M/S/O/R/X reference to its owning test or labelled corpus, checked
+evaluation provenance and confirmed that the five vendored instructions remain
+byte-exact.
+
+### Findings
+
+FINDING
+[High] S7-R1-01: Vulgate cases used an evidence class its promise does not accept.
+Location: `tests/promise_machine_coverage.json`
+Mechanism: Generic Hexaemeron cases were marked `recorded`, while Vulgate declares only `checked` and `inferred` evidence.
+Impact: A recognised class could pass even when the owning promise excluded it.
+Fix: Added Vulgate-specific inferred references and made the gate reject explicit classes absent from the canonical declaration.
+END
+
+FINDING
+[Medium] S7-R1-02: Evaluation corpora could use checkout-specific absolute paths.
+Location: `scripts/promise_machine.py`
+Mechanism: Confinement accepted an absolute path when it happened to resolve inside the current checkout.
+Impact: A locally clean record could fail to identify the same corpus in another checkout.
+Fix: Required confined repository-relative corpus paths and added missing, absolute and overclaimed-provenance refusal cases.
+END
+
+### Evidence
+
+The prompt and vendored coverage gate reports all 16 selected promises with no
+finding. The 17 focused coverage checks pass, including evidence-class and
+evaluation-corpus mutations. Vulgate stays `unknown` for cross-model content
+parity and its labelled evidence is `inferred`, not `recorded` or `proved`.
+
+### Leads not pursued
+
+Labelled cases describe expected decisions and do not establish that a future
+model will follow them. The coverage rows name `not-run` wherever no model,
+campaign, conversion, sync, pre-audit or audit was executed.

--- a/plugins/brevitas/tests/test_brevitas.py
+++ b/plugins/brevitas/tests/test_brevitas.py
@@ -91,6 +91,33 @@ class BrevitasTests(unittest.TestCase):
         codes = self.codes("The path is unsafe.\n", source_text=source)
         self.assertIn("B030", codes)
 
+    def test_source_evidence_survives(self) -> None:
+        source = "At `src/Foo.sol:42`, 17 calls reach 0x1111111111111111111111111111111111111111."
+        self.assertNotIn("B030", self.codes(source, source_text=source))
+
+    def test_source_subject_mismatch_is_refused(self) -> None:
+        source = "At `src/Foo.sol:42`, 17 calls reach the boundary."
+        draft = "At `src/Foo.sol:42`, 18 calls reach the boundary."
+        self.assertIn("B030", self.codes(draft, source_text=source))
+
+    def test_token_survival_does_not_establish_semantic_equivalence(self) -> None:
+        source = "The 17 calls are safe."
+        draft = "The 17 calls are unsafe."
+        self.assertNotIn("B030", self.codes(draft, source_text=source))
+
+    def test_missing_source_evidence_recovers_when_restored(self) -> None:
+        source = "At `src/Foo.sol:42`, 17 calls reach the boundary."
+        self.assertIn("B030", self.codes("The path is unsafe.\n", source_text=source))
+        self.assertNotIn("B030", self.codes(source, source_text=source))
+
+    def test_clean_structure_does_not_establish_factual_accuracy(self) -> None:
+        draft = VALID_FINDING.replace("Claim.", "The Moon is made of cheese.")
+        self.assertEqual(self.codes(draft), set())
+
+    def test_over_budget_finding_recovers_after_compression(self) -> None:
+        self.assertIn("B002", self.codes(VALID_FINDING + "Evidence: extra.\n"))
+        self.assertNotIn("B002", self.codes(VALID_FINDING))
+
     def test_host_descriptions_remain_identical(self) -> None:
         claude = json.loads(
             (PLUGIN / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")

--- a/plugins/hexaemeron/skills/imprimatur/tests/run_tests.py
+++ b/plugins/hexaemeron/skills/imprimatur/tests/run_tests.py
@@ -135,6 +135,59 @@ for label, text in FALSE_POSITIVES:
 
 # ------------------------------------------------------------------- behaviour
 
+def test_promise_machine_licensed_scope_qualifier_is_preserved() -> bool:
+    text = (
+        "Broadly, the Borrower may not vary the terms; clause 7.3 permits "
+        "variation on 30 days' notice."
+    )
+    return build(text)["defects"] == 0 and text.startswith("Broadly,")
+
+
+def test_promise_machine_missing_gate_evidence_is_refused() -> bool:
+    return "mathematical" in families("This approach is orthogonal to the framing.")
+
+
+def test_promise_machine_subject_mode_mismatch_is_refused() -> bool:
+    text = 'He said "load-bearing" again.'
+    return build(text)["defects"] == 0 and build(text, strict=True)["defects"] > 0
+
+
+def test_promise_machine_clean_lint_does_not_establish_truth() -> bool:
+    report = build("The Moon is made of cheese.")
+    return report["defects"] == 0 and "factual_accuracy" not in report
+
+
+def test_promise_machine_failure_recovers_without_erasing_the_term() -> bool:
+    bad = "This approach is orthogonal to the framing."
+    repaired = "The two libraries are orthogonal in the sense that neither imports the other."
+    return (
+        build(bad)["defects"] > 0
+        and build(repaired)["defects"] == 0
+        and "orthogonal" in repaired
+    )
+
+
+check(
+    "promise-machine/licensed scope qualifier is preserved",
+    test_promise_machine_licensed_scope_qualifier_is_preserved(),
+)
+check(
+    "promise-machine/missing gate evidence is refused",
+    test_promise_machine_missing_gate_evidence_is_refused(),
+)
+check(
+    "promise-machine/subject mode mismatch is refused",
+    test_promise_machine_subject_mode_mismatch_is_refused(),
+)
+check(
+    "promise-machine/clean lint does not establish truth",
+    test_promise_machine_clean_lint_does_not_establish_truth(),
+)
+check(
+    "promise-machine/failure recovers without erasing the term",
+    test_promise_machine_failure_recovers_without_erasing_the_term(),
+)
+
 # Evidence must not bleed across sentences.
 bleed = "This approach is orthogonal to the framing. The `verifyToken` helper is fine."
 check("gate/no cross-sentence bleed", "mathematical" in families(bleed))

--- a/plugins/hexaemeron/tests/fixtures/promise-machine/evaluation-cases.json
+++ b/plugins/hexaemeron/tests/fixtures/promise-machine/evaluation-cases.json
@@ -1,0 +1,69 @@
+{
+  "schema": "promise-machine-labelled-cases/v1",
+  "cases": {
+    "hypomnema-record-placement": {
+      "evaluation": {"model": "not-run", "prompt": "Review record placement against the canonical Hypomnema contract.", "corpus": "this labelled fixture", "disposition": "Expected P/M/S/O/R decisions recorded; forward model behaviour not tested."},
+      "P": {"disposition": "accept", "scenario": "The step inventory names every expensive decision and each has an established record with rejected alternatives and resolving pointers.", "boundary": "Acceptance covers the decisions identified in the named step."},
+      "M": {"disposition": "refuse", "scenario": "A durable interface is introduced without a reasoned record or rejected alternatives.", "boundary": "An expensive unidentified choice cannot be treated as settled."},
+      "S": {"disposition": "refuse", "scenario": "The cited decision record belongs to another step and repository revision.", "boundary": "A record for another subject does not establish this step's decision."},
+      "O": {"disposition": "refuse", "scenario": "A clean pointer lint is presented as proof that every decision was found and every record is correct.", "boundary": "Pointer resolution is narrower than record-placement judgement."},
+      "R": {"disposition": "recover", "scenario": "Inventory the missing choice, record its reason and alternatives, repair every pointer and repeat the review.", "boundary": "Recovery supplies a new record without rewriting the refused review."}
+    },
+    "kronos-fiat-dispatch": {
+      "evaluation": {"model": "not-run", "prompt": "Decide whether a ranked Kronos job may enter Fiat under the canonical authority boundary.", "corpus": "this labelled fixture", "disposition": "Expected P/M/S/O/R decisions recorded; user authority remains external evidence."},
+      "P": {"disposition": "accept", "scenario": "The user explicitly authorised Kronos execution, the selected job remains current and unparked, and Fiat returned a new init receipt.", "boundary": "Acceptance authorises one dispatch, not completion or global optimality."},
+      "M": {"disposition": "refuse", "scenario": "A valid ranking exists but no explicit user instruction authorises Kronos execution.", "boundary": "Ranking evidence cannot supply user authority."},
+      "S": {"disposition": "refuse", "scenario": "The selected ledger or held-job digest changed after ranking and before dispatch.", "boundary": "A stale selection cannot authorise a new Fiat run."},
+      "O": {"disposition": "refuse", "scenario": "A successful dispatch is presented as proof that the job is complete or the ranking was globally optimal.", "boundary": "Dispatch explains entry into Fiat and nothing later."},
+      "R": {"disposition": "recover", "scenario": "Return to rank-only output, refresh scope and eligibility, obtain explicit authority or park the blocker, then rerank.", "boundary": "Recovery creates a fresh selection and authority record."}
+    },
+    "vulgate-register-rewrite": {
+      "evaluation": {"model": "not-run", "prompt": "Rewrite a source passage under Vulgate while holding all content constant.", "corpus": "this labelled fixture", "disposition": "Expected P/M/S/O/R decisions recorded; cross-model content parity remains unknown."},
+      "P": {"disposition": "accept", "scenario": "The source and rewrite are compared line by line and every fact, qualifier, uncertainty, relation and required structure survives in the selected register.", "boundary": "Acceptance covers content parity for the named pair of texts."},
+      "M": {"disposition": "refuse", "scenario": "The rewrite is supplied without its source or without a completed parity comparison.", "boundary": "A pleasant register cannot substitute for source evidence."},
+      "S": {"disposition": "refuse", "scenario": "The source bytes belong to another draft than the rewrite under review.", "boundary": "Parity requires the exact source subject."},
+      "O": {"disposition": "refuse", "scenario": "A content-preserving rewrite is presented as factual verification, authorship diagnosis or an improved argument.", "boundary": "The mask changes register only."},
+      "R": {"disposition": "recover", "scenario": "Restore the lost caveat or relation, redo only the affected sentence and repeat the complete source comparison.", "boundary": "Recovery preserves the earlier refusal and supplies a corrected rewrite."}
+    },
+    "hexaemeron-fizz-harness-campaign": {
+      "evaluation": {"model": "not-run", "prompt": "Classify a Fizz harness and campaign record under the digest-bound overlay.", "corpus": "this labelled fixture", "disposition": "Expected P/M/S/O/R decisions recorded; no campaign was run by this fixture."},
+      "P": {"disposition": "accept", "scenario": "The digest matches, the generated harness builds and the named engine campaign ran with preserved configuration and retained results.", "boundary": "Acceptance covers only the exercised harness, properties and campaign."},
+      "M": {"disposition": "refuse", "scenario": "A harness was generated but no campaign command or actual result was retained.", "boundary": "Generated files are not evidence that a campaign ran."},
+      "S": {"disposition": "refuse", "scenario": "The overlay digest or source snapshot differs from the harness and campaign record.", "boundary": "Evidence from another instruction or source subject cannot satisfy the overlay."},
+      "O": {"disposition": "refuse", "scenario": "A passing campaign is presented as invariant completeness, absence of vulnerabilities or security sign-off.", "boundary": "A bounded campaign cannot establish those claims."},
+      "R": {"disposition": "recover", "scenario": "Reconcile the digest, regenerate from the named source, restore the configuration, run the engine and retain its result.", "boundary": "Recovery requires a real campaign rather than an inferred one."}
+    },
+    "hexaemeron-fizz-convert-properties": {
+      "evaluation": {"model": "not-run", "prompt": "Classify a Fizz Convert result under the digest-bound overlay.", "corpus": "this labelled fixture", "disposition": "Expected P/M/S/O/R decisions recorded; no conversion was run by this fixture."},
+      "P": {"disposition": "accept", "scenario": "One selected property is translated into a wired assertion, the harness builds and only its checklist entry changes.", "boundary": "Acceptance proves mechanical conversion and buildability for that property."},
+      "M": {"disposition": "refuse", "scenario": "The assertion is unwired, the build fails or the matching checklist entry is unchanged.", "boundary": "An incomplete mechanical conversion cannot be marked implemented."},
+      "S": {"disposition": "refuse", "scenario": "The overlay digest, selected property or harness differs from the conversion record.", "boundary": "Evidence must name the exact instruction, property and target harness."},
+      "O": {"disposition": "refuse", "scenario": "A built assertion is presented as semantically correct, reachable, complete or adequate for security review.", "boundary": "Mechanical conversion does not establish semantic adequacy."},
+      "R": {"disposition": "recover", "scenario": "Clarify one property, repair its assertion and wiring, rebuild and update only the matching checklist entry.", "boundary": "Recovery does not broaden the selected property."}
+    },
+    "hexaemeron-fizz-sync-drift": {
+      "evaluation": {"model": "not-run", "prompt": "Classify a Fizz Sync result under the digest-bound overlay.", "corpus": "this labelled fixture", "disposition": "Expected P/M/S/O/R decisions recorded; no sync was run by this fixture."},
+      "P": {"disposition": "accept", "scenario": "Before and after snapshots bound the drift, every item is classified, stale properties are quarantined, stubs and snapshot are refreshed and the harness builds.", "boundary": "Acceptance covers bounded interface reconciliation."},
+      "M": {"disposition": "refuse", "scenario": "A snapshot is missing, drift is unclassified, stale properties disappear or the refreshed harness does not build.", "boundary": "Incomplete drift evidence blocks reconciliation."},
+      "S": {"disposition": "refuse", "scenario": "The overlay digest or either source snapshot belongs to another harness revision.", "boundary": "The reconciliation record is subject-bound."},
+      "O": {"disposition": "refuse", "scenario": "ABI agreement is presented as semantic equivalence, preservation of unstated assumptions or property adequacy.", "boundary": "Syntactic reconciliation cannot establish semantics."},
+      "R": {"disposition": "recover", "scenario": "Restore both snapshots, classify every drift item, quarantine stale properties, regenerate affected stubs and rebuild.", "boundary": "Recovery keeps unresolved properties visible."}
+    },
+    "hexaemeron-x-ray-preaudit": {
+      "evaluation": {"model": "not-run", "prompt": "Classify an X-Ray result under the digest-bound overlay.", "corpus": "this labelled fixture", "disposition": "Expected P/M/S/O/R decisions recorded; no pre-audit was run by this fixture."},
+      "P": {"disposition": "accept", "scenario": "The digest, repository snapshot and source inventory bind all four required pre-audit artefacts and their unresolved gaps.", "boundary": "Acceptance makes the artefacts scoped orientation material."},
+      "M": {"disposition": "refuse", "scenario": "A required artefact, source boundary, citation or unresolved-gap record is absent.", "boundary": "Incomplete preparation cannot be presented as the prescribed result."},
+      "S": {"disposition": "refuse", "scenario": "The overlay digest or repository snapshot differs from the artefacts.", "boundary": "Pre-audit evidence applies only to its named source subject."},
+      "O": {"disposition": "refuse", "scenario": "The pre-audit views are presented as an audit, an exploitability judgement or security sign-off.", "boundary": "Preparation does not establish security conclusions."},
+      "R": {"disposition": "recover", "scenario": "Reconcile the digest and source boundary, regenerate missing or stale views and keep every gap explicit.", "boundary": "Recovery produces new scoped orientation material."}
+    },
+    "hexaemeron-solidity-audit-report": {
+      "evaluation": {"model": "not-run", "prompt": "Classify a Solidity Auditor result under the digest-bound overlay.", "corpus": "this labelled fixture", "disposition": "Expected P/M/S/O/R decisions recorded; no audit was run by this fixture."},
+      "P": {"disposition": "accept", "scenario": "All twelve roles inspect the exact scope, every raw result crosses the wait barrier and the final report records deduplication, completeness and judgement.", "boundary": "Acceptance establishes performance of the prescribed scoped review process."},
+      "M": {"disposition": "refuse", "scenario": "Fewer than twelve role results exist, raw output is missing or synthesis begins before the wait barrier.", "boundary": "An incomplete role set cannot satisfy the report promise."},
+      "S": {"disposition": "refuse", "scenario": "The overlay digest, repository revision or Solidity scope differs from the role outputs and final report.", "boundary": "The report is bound to the exact reviewed subject."},
+      "O": {"disposition": "refuse", "scenario": "A clean report is presented as proof that no vulnerability exists or as a replacement for independent review.", "boundary": "Review findings remain judgements and absence is not proved."},
+      "R": {"disposition": "recover", "scenario": "Restore the scope, rerun every missing or compromised role, wait for all results and repeat deduplication, completeness and judgement.", "boundary": "Recovery cannot synthesize around missing evidence."}
+    }
+  }
+}

--- a/plugins/hexaemeron/tests/fixtures/promise-machine/executable-cases.json
+++ b/plugins/hexaemeron/tests/fixtures/promise-machine/executable-cases.json
@@ -1,0 +1,23 @@
+{
+  "ephoros-observability-review": {
+    "P": {"disposition": "accept", "scenario": "Every on-call question has a bounded signal, exercised alert, runbook and reviewed output sample.", "boundary": "The result applies only to the named step and exercised signals."},
+    "M": {"disposition": "refuse", "scenario": "A new external call has no error or duration signal and no alert evidence.", "boundary": "Absent operational evidence cannot authorise unattended operation."},
+    "S": {"disposition": "refuse", "scenario": "The output sample and alert exercise came from an older build than the reviewed step.", "boundary": "Evidence from another subject does not establish the current step."},
+    "O": {"disposition": "refuse", "scenario": "The mechanical lint is clean and is presented as proof that observability is useful and complete.", "boundary": "Three parser rules do not establish the judgement-held review."},
+    "R": {"disposition": "recover", "scenario": "Add the missing bounded signal, exercise its alert, inspect current output and repeat the review.", "boundary": "Recovery produces new evidence; it does not rewrite the refused result."}
+  },
+  "phylax-boundary-review": {
+    "P": {"disposition": "accept", "scenario": "Every boundary introduced by the step is named, controlled and classified as verified or asserted.", "boundary": "The review covers only the introduced boundaries and available hostile-input evidence."},
+    "M": {"disposition": "refuse", "scenario": "External data reaches a generated path without a named confinement control or hostile-input test.", "boundary": "An unnamed or uncontrolled boundary blocks the step."},
+    "S": {"disposition": "refuse", "scenario": "The dependency review and lockfile evidence belong to the parent revision rather than the changed dependency.", "boundary": "A review of another subject cannot authorise this dependency transition."},
+    "O": {"disposition": "refuse", "scenario": "A clean mechanical lint is presented as whole-system security evidence.", "boundary": "Parser coverage is not a security review or proof that a control works."},
+    "R": {"disposition": "recover", "scenario": "Name the boundary, add and exercise its control, review the affected dependency or data path and repeat the review.", "boundary": "Recovery leaves the earlier refusal intact and supplies new evidence."}
+  },
+  "protasis-study-readiness": {
+    "P": {"disposition": "accept", "scenario": "The study states the problem, assumptions, current state, chosen design, rejected trade, boundaries, recovery and testable criteria.", "boundary": "Readiness authorises runbook derivation, not an implementation or proof that the design is correct."},
+    "M": {"disposition": "refuse", "scenario": "The study relies on an unstated environment assumption and gives no evidence-bearing success criterion.", "boundary": "Hidden assumptions and untestable success language block runbook derivation."},
+    "S": {"disposition": "refuse", "scenario": "The source inventory and current-state evidence name a different repository revision than the study entry ref.", "boundary": "A mismatched subject cannot establish current-state readiness."},
+    "O": {"disposition": "refuse", "scenario": "An accepted study is presented as proof that the selected design is correct and its future tests pass.", "boundary": "Content readiness is not implementation or correctness evidence."},
+    "R": {"disposition": "recover", "scenario": "Name the missing question, gather current evidence, amend the study and repeat the complete review.", "boundary": "Recovery supplies a new reviewed study without strengthening the refused draft."}
+  }
+}

--- a/plugins/hexaemeron/tests/test_hexctl.py
+++ b/plugins/hexaemeron/tests/test_hexctl.py
@@ -716,6 +716,24 @@ class TestControls(HexctlCase):
         proc = self.run_ctl("verify", expect=1)
         self.assertIn("chain broken", proc.stderr)
 
+    def test_verify_preserves_receipt_assertions_without_proving_them(self):
+        self.to_steps(("One",))
+        assertion = "all dragons defeated"
+        self.run_ctl(
+            "done",
+            "implement",
+            "--branch",
+            self.step_branch(1),
+            "--commit",
+            "abc123",
+            "--tests",
+            assertion,
+        )
+        self.run_ctl("verify")
+        state = json.loads(self.run_ctl("status", "--json").stdout)
+        receipt = state["steps"][0]["receipts"]["implement"]
+        self.assertEqual(receipt["tests"], assertion)
+
     def test_record_and_status_json(self):
         self.init()
         self.run_ctl("record", "note", '"local run"')

--- a/plugins/hexaemeron/tests/test_hypomnema_checker.py
+++ b/plugins/hexaemeron/tests/test_hypomnema_checker.py
@@ -50,6 +50,20 @@ class Links(unittest.TestCase):
     def test_it_ignores_an_image(self):
         self.assertEqual([], codes("![diagram](missing.png)"))
 
+    def test_clean_pointer_check_does_not_establish_record_correctness(self):
+        self.assertEqual(
+            [],
+            codes(
+                "See [the decision](decision.md).",
+                siblings=("decision.md",),
+            ),
+        )
+
+    def test_missing_pointer_recovers_when_target_is_restored(self):
+        source = "See [the decision](decision.md)."
+        self.assertIn("H001", codes(source))
+        self.assertEqual([], codes(source, siblings=("decision.md",)))
+
 
 class Superseding(unittest.TestCase):
     def test_it_flags_a_successor_that_does_not_exist(self):

--- a/plugins/hexaemeron/tests/test_promise_cases.py
+++ b/plugins/hexaemeron/tests/test_promise_cases.py
@@ -1,0 +1,67 @@
+import json
+from pathlib import Path
+import unittest
+
+
+CASES = Path(__file__).parent / "fixtures" / "promise-machine" / "executable-cases.json"
+
+
+class PromiseExecutableCaseTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cases = json.loads(CASES.read_text(encoding="utf-8"))
+
+    def assert_case(self, promise_id, code, disposition):
+        case = self.cases[promise_id][code]
+        self.assertEqual(case["disposition"], disposition)
+        self.assertTrue(case["scenario"].strip())
+        self.assertTrue(case["boundary"].strip())
+
+    def test_ephoros_review_positive(self):
+        self.assert_case("ephoros-observability-review", "P", "accept")
+
+    def test_ephoros_review_missing(self):
+        self.assert_case("ephoros-observability-review", "M", "refuse")
+
+    def test_ephoros_review_subject_mismatch(self):
+        self.assert_case("ephoros-observability-review", "S", "refuse")
+
+    def test_ephoros_review_overclaim(self):
+        self.assert_case("ephoros-observability-review", "O", "refuse")
+
+    def test_ephoros_review_recovery(self):
+        self.assert_case("ephoros-observability-review", "R", "recover")
+
+    def test_phylax_review_positive(self):
+        self.assert_case("phylax-boundary-review", "P", "accept")
+
+    def test_phylax_review_missing(self):
+        self.assert_case("phylax-boundary-review", "M", "refuse")
+
+    def test_phylax_review_subject_mismatch(self):
+        self.assert_case("phylax-boundary-review", "S", "refuse")
+
+    def test_phylax_review_overclaim(self):
+        self.assert_case("phylax-boundary-review", "O", "refuse")
+
+    def test_phylax_review_recovery(self):
+        self.assert_case("phylax-boundary-review", "R", "recover")
+
+    def test_protasis_study_positive(self):
+        self.assert_case("protasis-study-readiness", "P", "accept")
+
+    def test_protasis_study_missing(self):
+        self.assert_case("protasis-study-readiness", "M", "refuse")
+
+    def test_protasis_study_subject_mismatch(self):
+        self.assert_case("protasis-study-readiness", "S", "refuse")
+
+    def test_protasis_study_overclaim(self):
+        self.assert_case("protasis-study-readiness", "O", "refuse")
+
+    def test_protasis_study_recovery(self):
+        self.assert_case("protasis-study-readiness", "R", "recover")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/hexaemeron/tests/test_promise_evaluation_cases.py
+++ b/plugins/hexaemeron/tests/test_promise_evaluation_cases.py
@@ -1,0 +1,65 @@
+import json
+from pathlib import Path
+import unittest
+
+
+CASES = (
+    Path(__file__).parent
+    / "fixtures"
+    / "promise-machine"
+    / "evaluation-cases.json"
+)
+EXPECTED = {
+    "hypomnema-record-placement",
+    "kronos-fiat-dispatch",
+    "vulgate-register-rewrite",
+    "hexaemeron-fizz-harness-campaign",
+    "hexaemeron-fizz-convert-properties",
+    "hexaemeron-fizz-sync-drift",
+    "hexaemeron-x-ray-preaudit",
+    "hexaemeron-solidity-audit-report",
+}
+
+
+class PromptAndVendoredCaseTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        document = json.loads(CASES.read_text(encoding="utf-8"))
+        if document["schema"] != "promise-machine-labelled-cases/v1":
+            raise AssertionError("unsupported labelled-case schema")
+        cls.cases = document["cases"]
+        if set(cls.cases) != EXPECTED:
+            raise AssertionError("labelled-case promise set does not match the held set")
+
+    def assert_category(self, code, disposition):
+        for promise_id, record in self.cases.items():
+            with self.subTest(promise_id=promise_id, code=code):
+                self.assertEqual(set(record), {"evaluation", "P", "M", "S", "O", "R"})
+                self.assertEqual(
+                    set(record["evaluation"]),
+                    {"model", "prompt", "corpus", "disposition"},
+                )
+                self.assertTrue(all(value.strip() for value in record["evaluation"].values()))
+                case = record[code]
+                self.assertEqual(case["disposition"], disposition)
+                self.assertTrue(case["scenario"].strip())
+                self.assertTrue(case["boundary"].strip())
+
+    def test_labelled_positive_cases(self):
+        self.assert_category("P", "accept")
+
+    def test_labelled_missing_evidence_cases(self):
+        self.assert_category("M", "refuse")
+
+    def test_labelled_subject_mismatch_cases(self):
+        self.assert_category("S", "refuse")
+
+    def test_labelled_overclaim_cases(self):
+        self.assert_category("O", "refuse")
+
+    def test_labelled_recovery_cases(self):
+        self.assert_category("R", "recover")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/sapheneia/tests/fixtures/promise-machine/cases.json
+++ b/plugins/sapheneia/tests/fixtures/promise-machine/cases.json
@@ -1,0 +1,21 @@
+{
+  "schema": "promise-machine-labelled-cases/v1",
+  "cases": {
+    "sapheneia-session-shape": {
+      "evaluation": {"model": "not-run", "prompt": "Shape an active Sapheneia reply under the canonical interaction contract.", "corpus": "this labelled fixture", "disposition": "Expected P/M/S/O/R decisions recorded; cross-model behaviour remains unknown."},
+      "P": {"disposition": "accept", "scenario": "The reply names the immediate action, literal ask, boundary, working state, evidence and one next action while respecting the reader's stated preference.", "boundary": "Acceptance covers the exact reply and active session state."},
+      "M": {"disposition": "refuse", "scenario": "The reply hides the working state or leaves an implied obligation and no next action while work remains.", "boundary": "Missing interaction-state evidence blocks the shaped reply."},
+      "S": {"disposition": "refuse", "scenario": "The activation and preference record belongs to another user session.", "boundary": "Sapheneia state does not transfer between subjects."},
+      "O": {"disposition": "refuse", "scenario": "The reply shape is presented as a diagnosis or as a format that works for every AuDHD reader.", "boundary": "Interaction structure supplies no diagnostic evidence and preference wins."},
+      "R": {"disposition": "recover", "scenario": "Restate the action, boundary, evidence and next step, apply the reader's correction and check the revised reply.", "boundary": "Recovery revises the exact reply without changing another skill's facts."}
+    },
+    "sapheneia-deactivation": {
+      "evaluation": {"model": "not-run", "prompt": "Decide whether Sapheneia may deactivate under its canonical stop contract.", "corpus": "this labelled fixture", "disposition": "Expected P/M/S/O/R decisions recorded; cross-model behaviour remains unknown."},
+      "P": {"disposition": "accept", "scenario": "The user gives an explicit recognised stop instruction and the agent confirms that default response shape has resumed.", "boundary": "Acceptance changes only Sapheneia's response shape for later replies."},
+      "M": {"disposition": "refuse", "scenario": "A topic change or terse reply is treated as deactivation without an explicit stop instruction.", "boundary": "Behavioural inference cannot supply the missing instruction."},
+      "S": {"disposition": "refuse", "scenario": "The stop phrase belongs to another user or an earlier session.", "boundary": "Deactivation authority is bound to the active session subject."},
+      "O": {"disposition": "refuse", "scenario": "A delay, terse message or stop instruction is used to infer diagnosis, mood or intent.", "boundary": "Deactivation carries no diagnostic meaning."},
+      "R": {"disposition": "recover", "scenario": "Keep Sapheneia active until the current user gives an explicit stop instruction, then confirm the change once.", "boundary": "Recovery does not remove another active skill contract."}
+    }
+  }
+}

--- a/plugins/sapheneia/tests/test_promise_machine_cases.py
+++ b/plugins/sapheneia/tests/test_promise_machine_cases.py
@@ -1,0 +1,51 @@
+import json
+from pathlib import Path
+import unittest
+
+
+CASES = Path(__file__).parent / "fixtures" / "promise-machine" / "cases.json"
+EXPECTED = {"sapheneia-session-shape", "sapheneia-deactivation"}
+
+
+class SapheneiaPromiseCaseTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        document = json.loads(CASES.read_text(encoding="utf-8"))
+        if document["schema"] != "promise-machine-labelled-cases/v1":
+            raise AssertionError("unsupported labelled-case schema")
+        cls.cases = document["cases"]
+        if set(cls.cases) != EXPECTED:
+            raise AssertionError("labelled-case promise set does not match Sapheneia")
+
+    def assert_category(self, code, disposition):
+        for promise_id, record in self.cases.items():
+            with self.subTest(promise_id=promise_id, code=code):
+                self.assertEqual(set(record), {"evaluation", "P", "M", "S", "O", "R"})
+                self.assertEqual(
+                    set(record["evaluation"]),
+                    {"model", "prompt", "corpus", "disposition"},
+                )
+                self.assertTrue(all(value.strip() for value in record["evaluation"].values()))
+                case = record[code]
+                self.assertEqual(case["disposition"], disposition)
+                self.assertTrue(case["scenario"].strip())
+                self.assertTrue(case["boundary"].strip())
+
+    def test_labelled_positive_cases(self):
+        self.assert_category("P", "accept")
+
+    def test_labelled_missing_evidence_cases(self):
+        self.assert_category("M", "refuse")
+
+    def test_labelled_subject_mismatch_cases(self):
+        self.assert_category("S", "refuse")
+
+    def test_labelled_overclaim_cases(self):
+        self.assert_category("O", "refuse")
+
+    def test_labelled_recovery_cases(self):
+        self.assert_category("R", "recover")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/promise_machine.py
+++ b/scripts/promise_machine.py
@@ -167,6 +167,7 @@ class PromiseRecord:
     promise_id: str
     skill_path: str
     group: str
+    evidence_classes: frozenset[str]
 
 
 def relative(path: Path, root: Path) -> str:
@@ -854,6 +855,7 @@ def parse_contract(skill: SkillRecord, root: Path, *, required: bool = False):
                     )
                 )
         evidence_values = fields.get("Evidence classes", [])
+        classes: list[str] = []
         if len(evidence_values) == 1:
             classes = [
                 item.strip().strip("`").split(":", 1)[0].strip()
@@ -908,7 +910,7 @@ def parse_contract(skill: SkillRecord, root: Path, *, required: bool = False):
                         promise_id=promise_id or None,
                     )
                 )
-        promises.append((promise_id, skill.path))
+        promises.append((promise_id, skill.path, frozenset(classes)))
     return promises, findings
 
 
@@ -920,7 +922,7 @@ def check_structure(
     require_hexaemeron_contracts: bool = False,
 ):
     findings: list[Finding] = []
-    promises: list[tuple[str, str]] = []
+    promises: list[tuple[str, str, frozenset[str]]] = []
     for skill in inventory.skills:
         if skill.governance == "vendored":
             loaded, read_findings = read_markdown(
@@ -956,7 +958,7 @@ def check_structure(
         promises.extend(parsed)
         findings.extend(parsed_findings)
     owners: dict[str, list[str]] = {}
-    for promise_id, path in promises:
+    for promise_id, path, _ in promises:
         owners.setdefault(promise_id, []).append(path)
     for promise_id, paths in sorted(owners.items()):
         if len(paths) > 1:
@@ -1055,7 +1057,7 @@ def check_overlays(root: Path, inventory: Inventory):
         if skill.governance != "first-party":
             continue
         parsed, _ = parse_contract(skill, root)
-        canonical_ids.update(promise_id for promise_id, _ in parsed)
+        canonical_ids.update(promise_id for promise_id, _, _ in parsed)
     seen_paths: dict[str, list[str]] = {}
     seen_ids: set[str] = set()
     for offset, block_start in enumerate(blocks):
@@ -1300,8 +1302,8 @@ def promise_records(root: Path, inventory: Inventory):
         parsed, _ = parse_contract(skill, root)
         group = "prompt" if skill.name in PROMPT_SKILLS else "executable"
         records.extend(
-            PromiseRecord(promise_id, skill.path, group)
-            for promise_id, _ in parsed
+            PromiseRecord(promise_id, skill.path, group, evidence_classes)
+            for promise_id, _, evidence_classes in parsed
         )
 
     loaded, _ = read_markdown(
@@ -1327,12 +1329,21 @@ def promise_records(root: Path, inventory: Inventory):
             block_end = blocks[offset + 1] if offset + 1 < len(blocks) else len(lines)
             promise_id = lines[block_start][4:].strip()
             declared = ""
+            evidence_classes: frozenset[str] = frozenset()
             for line in lines[block_start + 1 : block_end]:
                 match = re.fullmatch(r"- Path:\s*`?([^`]+?)`?\s*", line)
                 if match is not None:
                     declared = match.group(1).strip()
-                    break
-            records.append(PromiseRecord(promise_id, declared, "vendored"))
+                evidence_match = re.fullmatch(r"- Evidence classes:\s*(.+)", line)
+                if evidence_match is not None:
+                    evidence_classes = frozenset(
+                        item.strip().strip("`").split(":", 1)[0].strip()
+                        for item in re.split(r"[,;]", evidence_match.group(1))
+                        if item.strip()
+                    )
+            records.append(
+                PromiseRecord(promise_id, declared, "vendored", evidence_classes)
+            )
     return tuple(sorted(records, key=lambda item: item.promise_id))
 
 
@@ -1655,7 +1666,9 @@ def check_coverage(root: Path, inventory: Inventory, selected_groups: set[str]):
                 corpus_path = Path(evaluation["corpus"])
                 corpus_target = root / corpus_path
                 if (
-                    corpus_target.is_symlink()
+                    corpus_path.is_absolute()
+                    or ".." in corpus_path.parts
+                    or corpus_target.is_symlink()
                     or not confined(corpus_target, root)
                     or not corpus_target.exists()
                     or not (corpus_target.is_file() or corpus_target.is_dir())
@@ -1781,6 +1794,30 @@ def check_coverage(root: Path, inventory: Inventory, selected_groups: set[str]):
                         case_path,
                         f"coverage evidence class is unsupported: {case['evidence_class']!r}",
                         "use one base evidence class from the Promise Machine law",
+                        promise_id=promise_id,
+                    )
+                )
+                continue
+            if "evidence_class" in case and case["evidence_class"] not in record.evidence_classes:
+                findings.append(
+                    Finding(
+                        "PM064",
+                        "coverage",
+                        case_path,
+                        f"coverage evidence class {case['evidence_class']!r} is not accepted by the promise",
+                        f"use one of the promise's declared classes: {sorted(record.evidence_classes)!r}",
+                        promise_id=promise_id,
+                    )
+                )
+                continue
+            if record.group in {"prompt", "vendored"} and "evidence_class" not in case:
+                findings.append(
+                    Finding(
+                        "PM064",
+                        "coverage",
+                        case_path,
+                        "prompt or vendored evidence omits its base evidence class",
+                        "state one class accepted by the canonical promise declaration",
                         promise_id=promise_id,
                     )
                 )

--- a/scripts/promise_machine.py
+++ b/scripts/promise_machine.py
@@ -1675,7 +1675,12 @@ def check_coverage(root: Path, inventory: Inventory, selected_groups: set[str]):
                         )
                     )
                 continue
-            if set(case) != {"path", "selector", "claim"} or not all(
+            evidence_keys = {"path", "selector", "claim"}
+            allowed_evidence_keys = (
+                frozenset(evidence_keys),
+                frozenset(evidence_keys | {"evidence_class"}),
+            )
+            if set(case) not in allowed_evidence_keys or not all(
                 isinstance(case.get(key), str) and case[key].strip()
                 for key in ("path", "selector", "claim")
             ):
@@ -1684,8 +1689,23 @@ def check_coverage(root: Path, inventory: Inventory, selected_groups: set[str]):
                         "PM064",
                         "coverage",
                         case_path,
-                        "evidence reference must contain only non-empty path, selector and claim",
-                        "cite one exact existing test selector and its bounded interpretation",
+                        "evidence reference must contain non-empty path, selector and claim, with at most one evidence class",
+                        "cite one exact existing selector, its bounded interpretation and an optional base evidence class",
+                        promise_id=promise_id,
+                    )
+                )
+                continue
+            if "evidence_class" in case and (
+                not isinstance(case["evidence_class"], str)
+                or case["evidence_class"] not in SUPPORTED_EVIDENCE_CLASSES
+            ):
+                findings.append(
+                    Finding(
+                        "PM064",
+                        "coverage",
+                        case_path,
+                        f"coverage evidence class is unsupported: {case['evidence_class']!r}",
+                        "use one base evidence class from the Promise Machine law",
                         promise_id=promise_id,
                     )
                 )

--- a/scripts/promise_machine.py
+++ b/scripts/promise_machine.py
@@ -69,6 +69,7 @@ OVERLAY_FIELDS = ("Path", "SHA-256", *REQUIRED_FIELDS)
 COVERAGE_PATH = Path("tests/promise_machine_coverage.json")
 COVERAGE_SCHEMA = "promise-machine-coverage/v1"
 COVERAGE_CODES = ("P", "M", "S", "O", "R", "X")
+EVALUATION_KEYS = {"status", "model", "prompt", "corpus", "disposition"}
 PROMPT_SKILLS = {
     "brevitas",
     "hypomnema",
@@ -1570,6 +1571,28 @@ def check_coverage(root: Path, inventory: Inventory, selected_groups: set[str]):
                 )
             )
 
+        allowed_row_keys = {
+            "promise_id",
+            "skill_path",
+            "group",
+            "cases",
+            "pending",
+            "preserves",
+            "evaluation",
+        }
+        unknown_row_keys = sorted(set(row) - allowed_row_keys)
+        if unknown_row_keys:
+            findings.append(
+                Finding(
+                    "PM061",
+                    "structural",
+                    row_path,
+                    f"coverage row contains unknown fields: {unknown_row_keys!r}",
+                    "use only the coverage-row fields defined by the checked schema",
+                    promise_id=promise_id,
+                )
+            )
+
         required_preservation = PRESERVATION_REQUIREMENTS.get(promise_id)
         if required_preservation is not None:
             preserves = row.get("preserves")
@@ -1606,6 +1629,47 @@ def check_coverage(root: Path, inventory: Inventory, selected_groups: set[str]):
             continue
 
         selected += 1
+        if record.group in {"prompt", "vendored"}:
+            evaluation = row.get("evaluation")
+            if (
+                not isinstance(evaluation, dict)
+                or set(evaluation) != EVALUATION_KEYS
+                or evaluation.get("status") not in {"recorded", "unknown"}
+                or any(
+                    not isinstance(evaluation.get(key), str)
+                    or not evaluation[key].strip()
+                    for key in EVALUATION_KEYS - {"status"}
+                )
+            ):
+                findings.append(
+                    Finding(
+                        "PM069",
+                        "coverage",
+                        row_path,
+                        "prompt or vendored evaluation provenance is absent, incomplete or overclaimed",
+                        "record status as recorded or unknown and name model, prompt, corpus and disposition",
+                        promise_id=promise_id,
+                    )
+                )
+            else:
+                corpus_path = Path(evaluation["corpus"])
+                corpus_target = root / corpus_path
+                if (
+                    corpus_target.is_symlink()
+                    or not confined(corpus_target, root)
+                    or not corpus_target.exists()
+                    or not (corpus_target.is_file() or corpus_target.is_dir())
+                ):
+                    findings.append(
+                        Finding(
+                            "PM069",
+                            "coverage",
+                            row_path,
+                            f"evaluation corpus does not resolve inside the repository: {evaluation['corpus']!r}",
+                            "name the exact first-party file or directory that carries the evaluation cases",
+                            promise_id=promise_id,
+                        )
+                    )
         if not isinstance(cases, dict) or set(cases) != set(COVERAGE_CODES):
             findings.append(
                 Finding(
@@ -1618,6 +1682,17 @@ def check_coverage(root: Path, inventory: Inventory, selected_groups: set[str]):
                 )
             )
             continue
+        if "pending" in row:
+            findings.append(
+                Finding(
+                    "PM066",
+                    "coverage",
+                    row_path,
+                    "completed coverage row still carries a pending reason",
+                    "remove the stale pending field once every case is classified",
+                    promise_id=promise_id,
+                )
+            )
 
         references: dict[tuple[str, str], str] = {}
         for code in COVERAGE_CODES:

--- a/scripts/promise_machine.py
+++ b/scripts/promise_machine.py
@@ -21,6 +21,7 @@ MARKER = (
 )
 MAX_MARKDOWN_BYTES = 256 * 1024
 MAX_JSON_BYTES = 64 * 1024
+MAX_COVERAGE_BYTES = 512 * 1024
 REQUIRED_HEADINGS = (
     "# Promise Machine contract",
     "## Contract identity",
@@ -65,6 +66,72 @@ PROMISE_ID = re.compile(r"[a-z][a-z0-9]*(?:-[a-z0-9]+)*")
 OVERLAY_PATH = Path("plugins/hexaemeron/PROMISES.md")
 OVERLAY_HEADING = "# Hexaemeron Promise Machine overlays"
 OVERLAY_FIELDS = ("Path", "SHA-256", *REQUIRED_FIELDS)
+COVERAGE_PATH = Path("tests/promise_machine_coverage.json")
+COVERAGE_SCHEMA = "promise-machine-coverage/v1"
+COVERAGE_CODES = ("P", "M", "S", "O", "R", "X")
+PROMPT_SKILLS = {
+    "brevitas",
+    "hypomnema",
+    "imprimatur",
+    "kronos",
+    "sapheneia",
+    "vulgate",
+}
+PRESERVATION_REQUIREMENTS = {
+    "berean-corpus-binding": {"corpus-digest", "source-class", "subject"},
+    "berean-answer-evidence": {
+        "answer-truth-refused",
+        "read-class",
+        "source-class",
+        "subject",
+        "time-domain",
+    },
+    "berean-evaluation-report": {
+        "answer-digest",
+        "answer-truth-refused",
+        "corpus-digest",
+        "time-domain",
+    },
+    "berean-release-promotion": {
+        "answer-digest",
+        "answer-truth-refused",
+        "corpus-digest",
+        "evaluation-digest",
+    },
+    "janus-manifest-validation": {"adapter", "manifest"},
+    "janus-bounded-conformance": {
+        "adapter",
+        "bounded-search",
+        "cross-host-refused",
+        "manifest",
+        "recorder",
+        "safety-refused",
+        "unknown-effect-refused",
+    },
+    "janus-report-rendering": {
+        "adapter",
+        "bounded-search",
+        "manifest",
+        "recorder",
+        "safety-refused",
+    },
+}
+REQUIRED_HANDOFFS = {
+    ("lazarus-fixture-verification", "berean-answer-evidence"),
+    ("berean-release-promotion", "ariadne-capture-statement"),
+}
+HANDOFF_PRESERVES = {
+    ("lazarus-fixture-verification", "berean-answer-evidence"): {
+        "block",
+        "evidence-class",
+        "subject",
+    },
+    ("berean-release-promotion", "ariadne-capture-statement"): {
+        "answer-digest",
+        "evidence-class",
+        "subject",
+    },
+}
 
 
 @dataclass(frozen=True)
@@ -92,6 +159,13 @@ class Inventory:
     skills: tuple[SkillRecord, ...]
     routers: tuple[str, ...]
     overlays: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PromiseRecord:
+    promise_id: str
+    skill_path: str
+    group: str
 
 
 def relative(path: Path, root: Path) -> str:
@@ -174,26 +248,35 @@ def read_markdown(path: Path, root: Path, *, missing_code: str, unsafe_code: str
     return (payload, text), findings
 
 
-def read_json(path: Path, root: Path):
+def read_json(
+    path: Path,
+    root: Path,
+    *,
+    max_bytes: int = MAX_JSON_BYTES,
+    missing_code: str = "PM021",
+    unsafe_code: str = "PM021",
+    malformed_code: str = "PM022",
+    noun: str = "plugin manifest",
+):
     shown = relative(path, root)
     if path.is_symlink() or not confined(path, root):
         return None, [
             Finding(
-                "PM021",
+                unsafe_code,
                 "identity",
                 shown,
-                "plugin manifest is a symlink or resolves outside the repository",
-                "restore a regular manifest at the fixed plugin path",
+                f"{noun} is a symlink or resolves outside the repository",
+                f"restore a regular {noun} at the fixed path",
             )
         ]
     if not path.is_file():
         return None, [
             Finding(
-                "PM021",
+                missing_code,
                 "structural",
                 shown,
-                "paired plugin manifest is absent",
-                "restore both host manifests for the plugin",
+                f"{noun} is absent",
+                f"restore the required {noun}",
             )
         ]
     try:
@@ -201,43 +284,51 @@ def read_json(path: Path, root: Path):
     except OSError as exc:
         return None, [
             Finding(
-                "PM021",
+                unsafe_code,
                 "identity",
                 shown,
-                f"plugin manifest could not be read: {exc}",
-                "restore a readable manifest inside the repository",
+                f"{noun} could not be read: {exc}",
+                f"restore a readable {noun} inside the repository",
             )
         ]
-    if len(payload) > MAX_JSON_BYTES:
+    if len(payload) > max_bytes:
         return None, [
             Finding(
-                "PM022",
+                malformed_code,
                 "structural",
                 shown,
-                f"plugin manifest is {len(payload)} bytes; limit is {MAX_JSON_BYTES}",
-                "reduce the manifest below the bounded-read limit",
+                f"JSON document is {len(payload)} bytes; limit is {max_bytes}",
+                "reduce the document below the bounded-read limit",
             )
         ]
+    def reject_duplicate_keys(pairs):
+        document = {}
+        for key, value in pairs:
+            if key in document:
+                raise ValueError(f"duplicate object key: {key!r}")
+            document[key] = value
+        return document
+
     try:
-        document = json.loads(payload)
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        document = json.loads(payload, object_pairs_hook=reject_duplicate_keys)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
         return None, [
             Finding(
-                "PM022",
+                malformed_code,
                 "structural",
                 shown,
-                f"plugin manifest is not valid UTF-8 JSON: {exc}",
-                "restore a valid plugin manifest",
+                f"{noun} is not valid UTF-8 JSON: {exc}",
+                f"restore a valid {noun}",
             )
         ]
     if not isinstance(document, dict):
         return None, [
             Finding(
-                "PM022",
+                malformed_code,
                 "structural",
                 shown,
-                "plugin manifest root is not an object",
-                "restore the manifest object",
+                f"{noun} root is not an object",
+                f"restore the {noun} object",
             )
         ]
     return document, []
@@ -1200,6 +1291,465 @@ def check_overlays(root: Path, inventory: Inventory):
     return len(blocks), findings
 
 
+def promise_records(root: Path, inventory: Inventory):
+    records: list[PromiseRecord] = []
+    for skill in inventory.skills:
+        if skill.governance != "first-party":
+            continue
+        parsed, _ = parse_contract(skill, root)
+        group = "prompt" if skill.name in PROMPT_SKILLS else "executable"
+        records.extend(
+            PromiseRecord(promise_id, skill.path, group)
+            for promise_id, _ in parsed
+        )
+
+    loaded, _ = read_markdown(
+        root / OVERLAY_PATH, root, missing_code="PM060", unsafe_code="PM060"
+    )
+    if loaded is not None:
+        lines = loaded[1].splitlines()
+        heading_index = lines.index(OVERLAY_HEADING) if OVERLAY_HEADING in lines else 0
+        section_end = next(
+            (
+                index
+                for index in range(heading_index + 1, len(lines))
+                if lines[index].startswith("# ") or lines[index].startswith("## ")
+            ),
+            len(lines),
+        )
+        blocks = [
+            index
+            for index in range(heading_index + 1, section_end)
+            if lines[index].startswith("### ")
+        ]
+        for offset, block_start in enumerate(blocks):
+            block_end = blocks[offset + 1] if offset + 1 < len(blocks) else len(lines)
+            promise_id = lines[block_start][4:].strip()
+            declared = ""
+            for line in lines[block_start + 1 : block_end]:
+                match = re.fullmatch(r"- Path:\s*`?([^`]+?)`?\s*", line)
+                if match is not None:
+                    declared = match.group(1).strip()
+                    break
+            records.append(PromiseRecord(promise_id, declared, "vendored"))
+    return tuple(sorted(records, key=lambda item: item.promise_id))
+
+
+def parse_groups(raw: str):
+    groups = {item.strip() for item in raw.split(",") if item.strip()}
+    unknown = sorted(groups - {"executable", "prompt", "vendored"})
+    if unknown or not groups:
+        raise ValueError(f"unsupported --group value(s): {unknown or ['<empty>']}")
+    return groups
+
+
+def selector_resolves(path: Path, text: str, selector: str):
+    if path.suffix == ".py":
+        pattern = rf"^\s*def\s+{re.escape(selector)}\s*\("
+    elif path.suffix == ".sol":
+        pattern = rf"^\s*function\s+{re.escape(selector)}\s*\("
+    else:
+        return False
+    return re.search(pattern, text, re.MULTILINE) is not None
+
+
+def check_coverage(root: Path, inventory: Inventory, selected_groups: set[str]):
+    findings: list[Finding] = []
+    expected_records = promise_records(root, inventory)
+    expected = {item.promise_id: item for item in expected_records}
+    required_handoffs = {
+        pair for pair in REQUIRED_HANDOFFS if pair[0] in expected and pair[1] in expected
+    }
+    document, read_findings = read_json(
+        root / COVERAGE_PATH,
+        root,
+        max_bytes=MAX_COVERAGE_BYTES,
+        missing_code="PM060",
+        unsafe_code="PM060",
+        malformed_code="PM061",
+        noun="coverage file",
+    )
+    findings.extend(read_findings)
+    if document is None:
+        return 0, 0, findings
+    if document.get("contract") != CONTRACT_ID or document.get("schema") != COVERAGE_SCHEMA:
+        findings.append(
+            Finding(
+                "PM061",
+                "structural",
+                COVERAGE_PATH.as_posix(),
+                "coverage contract or schema identity is absent or unsupported",
+                f"use contract {CONTRACT_ID!r} and schema {COVERAGE_SCHEMA!r}",
+            )
+        )
+    handoffs = document.get("handoffs")
+    seen_handoffs: set[tuple[str, str]] = set()
+    if not isinstance(handoffs, list):
+        findings.append(
+            Finding(
+                "PM068",
+                "composition",
+                COVERAGE_PATH.as_posix(),
+                "coverage handoffs are not an array",
+                "record the required producer-to-consumer evidence boundaries",
+            )
+        )
+        handoffs = []
+    for index, handoff in enumerate(handoffs):
+        handoff_path = f"{COVERAGE_PATH.as_posix()}#handoffs[{index}]"
+        required_keys = {"producer", "consumer", "path", "selector", "preserves", "refuses"}
+        if not isinstance(handoff, dict) or set(handoff) != required_keys:
+            findings.append(
+                Finding(
+                    "PM068",
+                    "composition",
+                    handoff_path,
+                    "handoff does not have the required evidence-bound shape",
+                    "name producer, consumer, exact test, preserved fields and refused overclaim",
+                )
+            )
+            continue
+        if not all(
+            isinstance(handoff[key], str) and handoff[key].strip()
+            for key in ("producer", "consumer", "path", "selector", "refuses")
+        ):
+            findings.append(
+                Finding(
+                    "PM068",
+                    "composition",
+                    handoff_path,
+                    "handoff identities and test reference are not non-empty strings",
+                    "state concrete producer, consumer, path, selector and refused overclaim",
+                )
+            )
+            continue
+        pair = (handoff["producer"], handoff["consumer"])
+        seen_handoffs.add(pair)
+        preserves = handoff["preserves"]
+        if (
+            pair not in required_handoffs
+            or not isinstance(preserves, list)
+            or not preserves
+            or any(not isinstance(item, str) or not item for item in preserves)
+            or not HANDOFF_PRESERVES.get(pair, set()).issubset(
+                set(item for item in preserves if isinstance(item, str))
+            )
+            or handoff["refuses"] != "answer-truth"
+        ):
+            findings.append(
+                Finding(
+                    "PM068",
+                    "composition",
+                    handoff_path,
+                    "handoff does not preserve its declared evidence boundary or refusal",
+                    "preserve subject and evidence class without promoting answer truth",
+                )
+            )
+        target = root / handoff["path"]
+        loaded, target_findings = read_markdown(
+            target, root, missing_code="PM065", unsafe_code="PM065"
+        )
+        findings.extend(target_findings)
+        if loaded is not None and not selector_resolves(
+            target, loaded[1], handoff["selector"]
+        ):
+            findings.append(
+                Finding(
+                    "PM065",
+                    "composition",
+                    handoff["path"],
+                    f"handoff test selector does not resolve: {handoff['selector']!r}",
+                    "cite the exact existing cross-skill test selector",
+                )
+            )
+    for pair in sorted(required_handoffs - seen_handoffs):
+        findings.append(
+            Finding(
+                "PM068",
+                "composition",
+                COVERAGE_PATH.as_posix(),
+                f"required evidence handoff is absent: {pair!r}",
+                "add its exact subject, evidence-class and answer-truth guard",
+            )
+        )
+    handoff_counts: dict[tuple[str, str], int] = {}
+    for handoff in handoffs:
+        if not isinstance(handoff, dict):
+            continue
+        producer = handoff.get("producer")
+        consumer = handoff.get("consumer")
+        if isinstance(producer, str) and isinstance(consumer, str):
+            pair = (producer, consumer)
+            handoff_counts[pair] = handoff_counts.get(pair, 0) + 1
+    for pair, count in sorted(handoff_counts.items()):
+        if count > 1:
+            findings.append(
+                Finding(
+                    "PM068",
+                    "composition",
+                    COVERAGE_PATH.as_posix(),
+                    f"evidence handoff is repeated {count} times: {pair!r}",
+                    "retain one exact record for each required handoff",
+                )
+            )
+    rows = document.get("rows")
+    evidence_catalog = document.get("evidence")
+    if not isinstance(evidence_catalog, dict):
+        findings.append(
+            Finding(
+                "PM061",
+                "structural",
+                COVERAGE_PATH.as_posix(),
+                "coverage evidence catalogue is not an object",
+                "provide named exact test references for coverage rows",
+            )
+        )
+        evidence_catalog = {}
+    if not isinstance(rows, list):
+        findings.append(
+            Finding(
+                "PM061",
+                "structural",
+                COVERAGE_PATH.as_posix(),
+                "coverage rows are not an array",
+                "provide one row object for every discovered promise",
+            )
+        )
+        return 0, 0, findings
+
+    seen: dict[str, int] = {}
+    selected = 0
+    for index, row in enumerate(rows):
+        row_path = f"{COVERAGE_PATH.as_posix()}#rows[{index}]"
+        if not isinstance(row, dict):
+            findings.append(
+                Finding(
+                    "PM061",
+                    "structural",
+                    row_path,
+                    "coverage row is not an object",
+                    "replace it with a typed coverage row",
+                )
+            )
+            continue
+        promise_id = row.get("promise_id")
+        if not isinstance(promise_id, str):
+            findings.append(
+                Finding(
+                    "PM061",
+                    "structural",
+                    row_path,
+                    "coverage row has no string promise_id",
+                    "name the discovered stable promise id",
+                )
+            )
+            continue
+        seen[promise_id] = seen.get(promise_id, 0) + 1
+        record = expected.get(promise_id)
+        if record is None:
+            findings.append(
+                Finding(
+                    "PM062",
+                    "identity",
+                    row_path,
+                    "coverage row names no discovered promise",
+                    "remove the stale row or restore its canonical declaration",
+                    promise_id=promise_id,
+                )
+            )
+            continue
+        if row.get("skill_path") != record.skill_path or row.get("group") != record.group:
+            findings.append(
+                Finding(
+                    "PM063",
+                    "identity",
+                    row_path,
+                    f"coverage owner or group disagrees with discovery: expected {record.skill_path!r} in {record.group!r}",
+                    "derive the owner and group from the canonical declaration",
+                    promise_id=promise_id,
+                )
+            )
+
+        required_preservation = PRESERVATION_REQUIREMENTS.get(promise_id)
+        if required_preservation is not None:
+            preserves = row.get("preserves")
+            if not isinstance(preserves, list) or not required_preservation.issubset(
+                set(item for item in preserves if isinstance(item, str))
+            ):
+                findings.append(
+                    Finding(
+                        "PM068",
+                        "composition",
+                        row_path,
+                        f"coverage row omits required preserved boundaries: {sorted(required_preservation)!r}",
+                        "retain the producer evidence class, subject and refused overclaim",
+                        promise_id=promise_id,
+                    )
+                )
+
+        cases = row.get("cases")
+        if record.group not in selected_groups:
+            pending_reason = row.get("pending")
+            if cases is None and (
+                not isinstance(pending_reason, str) or not pending_reason.strip()
+            ):
+                findings.append(
+                    Finding(
+                        "PM066",
+                        "coverage",
+                        row_path,
+                        "unselected incomplete row has no visible pending reason",
+                        "state the later runbook step that will classify this row",
+                        promise_id=promise_id,
+                    )
+                )
+            continue
+
+        selected += 1
+        if not isinstance(cases, dict) or set(cases) != set(COVERAGE_CODES):
+            findings.append(
+                Finding(
+                    "PM066",
+                    "coverage",
+                    row_path,
+                    f"selected row must classify exactly {list(COVERAGE_CODES)!r}",
+                    "provide evidence or an explicit inapplicability reason for every class",
+                    promise_id=promise_id,
+                )
+            )
+            continue
+
+        references: dict[tuple[str, str], str] = {}
+        for code in COVERAGE_CODES:
+            raw_case = cases[code]
+            case_path = f"{row_path}.{code}"
+            if isinstance(raw_case, str):
+                case = evidence_catalog.get(raw_case)
+                if case is None:
+                    findings.append(
+                        Finding(
+                            "PM064",
+                            "coverage",
+                            case_path,
+                            f"coverage evidence id does not resolve: {raw_case!r}",
+                            "cite an existing evidence-catalogue entry",
+                            promise_id=promise_id,
+                        )
+                    )
+                    continue
+            else:
+                case = raw_case
+            if not isinstance(case, dict):
+                findings.append(
+                    Finding(
+                        "PM064",
+                        "coverage",
+                        case_path,
+                        "coverage case is not an object",
+                        "provide one evidence reference or inapplicability reason",
+                        promise_id=promise_id,
+                    )
+                )
+                continue
+            if "not_applicable" in case:
+                if set(case) != {"not_applicable", "reason"} or case.get("not_applicable") is not True or not isinstance(case.get("reason"), str) or not case["reason"].strip():
+                    findings.append(
+                        Finding(
+                            "PM064",
+                            "coverage",
+                            case_path,
+                            "inapplicability is not an attributed non-empty reason",
+                            "set not_applicable true and state why the class cannot apply",
+                            promise_id=promise_id,
+                        )
+                    )
+                elif code in {"P", "M", "O", "R"}:
+                    findings.append(
+                        Finding(
+                            "PM066",
+                            "coverage",
+                            case_path,
+                            f"material {code} evidence may not be inapplicable",
+                            "cite a distinct positive, missing, overclaim or recovery case",
+                            promise_id=promise_id,
+                        )
+                    )
+                continue
+            if set(case) != {"path", "selector", "claim"} or not all(
+                isinstance(case.get(key), str) and case[key].strip()
+                for key in ("path", "selector", "claim")
+            ):
+                findings.append(
+                    Finding(
+                        "PM064",
+                        "coverage",
+                        case_path,
+                        "evidence reference must contain only non-empty path, selector and claim",
+                        "cite one exact existing test selector and its bounded interpretation",
+                        promise_id=promise_id,
+                    )
+                )
+                continue
+            evidence_path = Path(case["path"])
+            target = root / evidence_path
+            loaded, target_findings = read_markdown(
+                target, root, missing_code="PM065", unsafe_code="PM065"
+            )
+            findings.extend(target_findings)
+            if loaded is not None and not selector_resolves(
+                target, loaded[1], case["selector"]
+            ):
+                findings.append(
+                    Finding(
+                        "PM065",
+                        "coverage",
+                        case["path"],
+                        f"test selector does not resolve: {case['selector']!r}",
+                        "cite an exact function or test name present in the file",
+                        promise_id=promise_id,
+                    )
+                )
+            reference = (case["path"], case["selector"])
+            if reference in references:
+                findings.append(
+                    Finding(
+                        "PM067",
+                        "coverage",
+                        case_path,
+                        f"one test selector is reused for incompatible {references[reference]} and {code} cases",
+                        "cite distinct evidence for each incompatible class",
+                        promise_id=promise_id,
+                    )
+                )
+            references[reference] = code
+
+    actual_ids = set(seen)
+    for promise_id in sorted(set(expected) - actual_ids):
+        findings.append(
+            Finding(
+                "PM062",
+                "coverage",
+                COVERAGE_PATH.as_posix(),
+                "discovered promise has no coverage row",
+                "add the promise without removing any discovered entry",
+                promise_id=promise_id,
+            )
+        )
+    for promise_id, count in sorted(seen.items()):
+        if count > 1:
+            findings.append(
+                Finding(
+                    "PM062",
+                    "identity",
+                    COVERAGE_PATH.as_posix(),
+                    f"promise has {count} coverage rows",
+                    "retain exactly one row for each discovered promise",
+                    promise_id=promise_id,
+                )
+            )
+    return len(rows), selected, findings
+
+
 def check_identity(inventory: Inventory):
     findings: list[Finding] = []
     owners: dict[str, list[str]] = {}
@@ -1716,20 +2266,22 @@ def report(
                 f"{item.message}; repair: {item.remedy}"
             )
         print(f"refused: {len(findings)} finding(s)")
-    elif command == "inventory":
+    elif command in {"inventory", "coverage"}:
+        keys = (
+            (
+                "plugins",
+                "canonical_skills",
+                "governed_skills",
+                "vendored_skills",
+                "routers",
+                "overlays",
+            )
+            if command == "inventory"
+            else ("promises", "coverage_rows", "coverage_selected")
+        )
         print(
             "clean: "
-            + " ".join(
-                f"{key}={counts[key]}"
-                for key in (
-                    "plugins",
-                    "canonical_skills",
-                    "governed_skills",
-                    "vendored_skills",
-                    "routers",
-                    "overlays",
-                )
-            )
+            + " ".join(f"{key}={counts[key]}" for key in keys)
         )
     else:
         suffix = f"; wrote {written}" if command == "sync" else ""
@@ -1785,6 +2337,16 @@ def main(argv=None):
     inventory_parser.add_argument("--root", help=argparse.SUPPRESS)
     inventory_parser.add_argument("--json", action="store_true", help="emit canonical JSON")
 
+    coverage_parser = subparsers.add_parser(
+        "coverage", help="check promise-to-evidence classifications"
+    )
+    coverage_parser.add_argument("--check", action="store_true")
+    coverage_parser.add_argument(
+        "--group", default="executable,prompt,vendored", help="comma-separated groups"
+    )
+    coverage_parser.add_argument("--root", help=argparse.SUPPRESS)
+    coverage_parser.add_argument("--json", action="store_true", help="emit canonical JSON")
+
     args = parser.parse_args(argv)
     try:
         root = repository_root(args.root)
@@ -1801,6 +2363,40 @@ def main(argv=None):
             findings,
             as_json=args.json,
             inventory=inventory,
+        )
+
+    if args.command == "coverage":
+        try:
+            selected_groups = parse_groups(args.group)
+        except ValueError as exc:
+            parser.error(str(exc))
+        inventory, findings = discover_inventory(root)
+        plugins = [root / path for path in inventory.plugins]
+        canonical_promises, structure_findings = check_structure(
+            root,
+            inventory,
+            require_standalone_contracts=True,
+            require_hexaemeron_contracts=True,
+        )
+        overlay_promises, overlay_findings = check_overlays(root, inventory)
+        coverage_rows, coverage_selected, coverage_findings = check_coverage(
+            root, inventory, selected_groups
+        )
+        findings.extend(structure_findings)
+        findings.extend(overlay_findings)
+        findings.extend(coverage_findings)
+        return report(
+            "coverage",
+            root,
+            plugins,
+            findings,
+            as_json=args.json,
+            inventory=inventory,
+            promises=canonical_promises + overlay_promises,
+            stats={
+                "coverage_rows": coverage_rows,
+                "coverage_selected": coverage_selected,
+            },
         )
 
     if args.command == "check":

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -684,6 +684,246 @@
       "path": "plugins/berean/tests/test_promote.py",
       "selector": "test_an_active_release_rolls_back_by_record",
       "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "brevitas-structure-p": {
+      "path": "plugins/brevitas/tests/test_brevitas.py",
+      "selector": "test_valid_finding",
+      "claim": "A valid finding satisfies the mechanical structure budget.",
+      "evidence_class": "checked"
+    },
+    "brevitas-structure-m": {
+      "path": "plugins/brevitas/tests/test_brevitas.py",
+      "selector": "test_over_budget_finding",
+      "claim": "An over-budget finding is refused.",
+      "evidence_class": "checked"
+    },
+    "brevitas-structure-s": {
+      "path": "plugins/brevitas/tests/test_brevitas.py",
+      "selector": "test_two_sections",
+      "claim": "A report whose structure disagrees with the selected mode is refused.",
+      "evidence_class": "checked"
+    },
+    "brevitas-structure-o": {
+      "path": "plugins/brevitas/tests/test_brevitas.py",
+      "selector": "test_clean_structure_does_not_establish_factual_accuracy",
+      "claim": "A structurally clean draft does not establish factual accuracy.",
+      "evidence_class": "checked"
+    },
+    "brevitas-structure-r": {
+      "path": "plugins/brevitas/tests/test_brevitas.py",
+      "selector": "test_over_budget_finding_recovers_after_compression",
+      "claim": "Removing the excess connective line clears the same structure check.",
+      "evidence_class": "checked"
+    },
+    "brevitas-evidence-p": {
+      "path": "plugins/brevitas/tests/test_brevitas.py",
+      "selector": "test_source_evidence_survives",
+      "claim": "Protected source tokens survive the checked draft.",
+      "evidence_class": "checked"
+    },
+    "brevitas-evidence-m": {
+      "path": "plugins/brevitas/tests/test_brevitas.py",
+      "selector": "test_missing_source_evidence",
+      "claim": "A draft missing protected source evidence is refused.",
+      "evidence_class": "checked"
+    },
+    "brevitas-evidence-s": {
+      "path": "plugins/brevitas/tests/test_brevitas.py",
+      "selector": "test_source_subject_mismatch_is_refused",
+      "claim": "A draft whose numeric subject differs from the source is refused.",
+      "evidence_class": "checked"
+    },
+    "brevitas-evidence-o": {
+      "path": "plugins/brevitas/tests/test_brevitas.py",
+      "selector": "test_token_survival_does_not_establish_semantic_equivalence",
+      "claim": "Protected-token survival is kept narrower than semantic equivalence.",
+      "evidence_class": "checked"
+    },
+    "brevitas-evidence-r": {
+      "path": "plugins/brevitas/tests/test_brevitas.py",
+      "selector": "test_missing_source_evidence_recovers_when_restored",
+      "claim": "Restoring the exact missing source evidence clears the preservation check.",
+      "evidence_class": "checked"
+    },
+    "hypomnema-pointer-p": {
+      "path": "plugins/hexaemeron/tests/test_hypomnema_checker.py",
+      "selector": "test_it_allows_a_link_that_resolves",
+      "claim": "A recognised relative pointer to an existing target passes.",
+      "evidence_class": "checked"
+    },
+    "hypomnema-pointer-m": {
+      "path": "plugins/hexaemeron/tests/test_hypomnema_checker.py",
+      "selector": "test_it_flags_a_link_to_nothing",
+      "claim": "A recognised pointer to an absent target is refused.",
+      "evidence_class": "checked"
+    },
+    "hypomnema-pointer-s": {
+      "path": "plugins/hexaemeron/tests/test_hypomnema_checker.py",
+      "selector": "test_it_flags_a_successor_that_does_not_exist",
+      "claim": "A supersession record naming an absent successor is refused.",
+      "evidence_class": "checked"
+    },
+    "hypomnema-pointer-o": {
+      "path": "plugins/hexaemeron/tests/test_hypomnema_checker.py",
+      "selector": "test_clean_pointer_check_does_not_establish_record_correctness",
+      "claim": "Pointer resolution is kept narrower than record correctness.",
+      "evidence_class": "checked"
+    },
+    "hypomnema-pointer-r": {
+      "path": "plugins/hexaemeron/tests/test_hypomnema_checker.py",
+      "selector": "test_missing_pointer_recovers_when_target_is_restored",
+      "claim": "Restoring the named target clears the same pointer check.",
+      "evidence_class": "checked"
+    },
+    "hex-eval-p": {
+      "path": "plugins/hexaemeron/tests/test_promise_evaluation_cases.py",
+      "selector": "test_labelled_positive_cases",
+      "claim": "The owning plugin records bounded positive cases for each judgement-shaped promise.",
+      "evidence_class": "recorded"
+    },
+    "hex-eval-m": {
+      "path": "plugins/hexaemeron/tests/test_promise_evaluation_cases.py",
+      "selector": "test_labelled_missing_evidence_cases",
+      "claim": "The owning plugin records missing-evidence refusals for each judgement-shaped promise.",
+      "evidence_class": "recorded"
+    },
+    "hex-eval-s": {
+      "path": "plugins/hexaemeron/tests/test_promise_evaluation_cases.py",
+      "selector": "test_labelled_subject_mismatch_cases",
+      "claim": "The owning plugin records subject-mismatch refusals for each judgement-shaped promise.",
+      "evidence_class": "recorded"
+    },
+    "hex-eval-o": {
+      "path": "plugins/hexaemeron/tests/test_promise_evaluation_cases.py",
+      "selector": "test_labelled_overclaim_cases",
+      "claim": "The owning plugin records the nearest tempting overclaim for each judgement-shaped promise.",
+      "evidence_class": "recorded"
+    },
+    "hex-eval-r": {
+      "path": "plugins/hexaemeron/tests/test_promise_evaluation_cases.py",
+      "selector": "test_labelled_recovery_cases",
+      "claim": "The owning plugin records bounded recovery for each judgement-shaped promise.",
+      "evidence_class": "recorded"
+    },
+    "imprimatur-p": {
+      "path": "plugins/hexaemeron/skills/imprimatur/tests/run_tests.py",
+      "selector": "test_promise_machine_licensed_scope_qualifier_is_preserved",
+      "claim": "A licensed legal scope qualifier remains present in clean exact input.",
+      "evidence_class": "checked"
+    },
+    "imprimatur-m": {
+      "path": "plugins/hexaemeron/skills/imprimatur/tests/run_tests.py",
+      "selector": "test_promise_machine_missing_gate_evidence_is_refused",
+      "claim": "A gated term without its required referent is refused.",
+      "evidence_class": "checked"
+    },
+    "imprimatur-s": {
+      "path": "plugins/hexaemeron/skills/imprimatur/tests/run_tests.py",
+      "selector": "test_promise_machine_subject_mode_mismatch_is_refused",
+      "claim": "The same text is not silently reclassified across different selected modes.",
+      "evidence_class": "checked"
+    },
+    "imprimatur-o": {
+      "path": "plugins/hexaemeron/skills/imprimatur/tests/run_tests.py",
+      "selector": "test_promise_machine_clean_lint_does_not_establish_truth",
+      "claim": "A clean lint remains narrower than factual verification.",
+      "evidence_class": "checked"
+    },
+    "imprimatur-r": {
+      "path": "plugins/hexaemeron/skills/imprimatur/tests/run_tests.py",
+      "selector": "test_promise_machine_failure_recovers_without_erasing_the_term",
+      "claim": "Supplying the referent clears the gate without deleting the licensed term.",
+      "evidence_class": "checked"
+    },
+    "kronos-rank-p": {
+      "path": "plugins/hexaemeron/tests/test_kronos_scoreboard.py",
+      "selector": "test_a_valid_pass_appends_exactly_one_line",
+      "claim": "A valid complete ranking appends one pass record.",
+      "evidence_class": "checked"
+    },
+    "kronos-rank-m": {
+      "path": "plugins/hexaemeron/tests/test_kronos_scoreboard.py",
+      "selector": "test_a_missing_field_is_refused",
+      "claim": "A ranking record missing required evidence is refused.",
+      "evidence_class": "checked"
+    },
+    "kronos-rank-s": {
+      "path": "plugins/hexaemeron/tests/test_kronos_scoreboard.py",
+      "selector": "test_show_marks_an_axis_that_moved_under_an_unchanged_held_job",
+      "claim": "Score drift under an unchanged held job remains visible.",
+      "evidence_class": "checked"
+    },
+    "kronos-rank-o": {
+      "path": "plugins/hexaemeron/tests/test_kronos_scoreboard.py",
+      "selector": "test_a_rank_only_pass_is_recorded_with_no_run",
+      "claim": "Rank-only output cannot silently claim a Fiat dispatch.",
+      "evidence_class": "checked"
+    },
+    "kronos-rank-r": {
+      "path": "plugins/hexaemeron/tests/test_kronos_scoreboard.py",
+      "selector": "test_show_reports_no_drift_when_the_held_job_changed_too",
+      "claim": "A refreshed held job and score are reported as a new subject rather than stale drift.",
+      "evidence_class": "checked"
+    },
+    "kronos-park-p": {
+      "path": "plugins/hexaemeron/tests/test_kronos_scoreboard.py",
+      "selector": "test_a_park_stores_the_reason_byte_for_byte",
+      "claim": "A park records its human-supplied reason without paraphrase.",
+      "evidence_class": "checked"
+    },
+    "kronos-park-m": {
+      "path": "plugins/hexaemeron/tests/test_kronos_scoreboard.py",
+      "selector": "test_an_empty_reason_is_refused",
+      "claim": "A park with no human-supplied reason is refused.",
+      "evidence_class": "checked"
+    },
+    "kronos-park-s": {
+      "path": "plugins/hexaemeron/tests/test_kronos_scoreboard.py",
+      "selector": "test_a_moved_held_job_is_reported_stale_rather_than_cleared",
+      "claim": "A park bound to an earlier held job remains visibly stale rather than clearing itself.",
+      "evidence_class": "checked"
+    },
+    "kronos-park-o": {
+      "path": "plugins/hexaemeron/tests/test_kronos_scoreboard.py",
+      "selector": "test_a_deleted_ledger_reads_as_unknown_not_resolved",
+      "claim": "Unreadable state remains unknown and is not promoted to resolved.",
+      "evidence_class": "checked"
+    },
+    "kronos-park-r": {
+      "path": "plugins/hexaemeron/tests/test_kronos_scoreboard.py",
+      "selector": "test_park_unpark_park_replays_to_one_standing_park",
+      "claim": "Explicit unpark and later park records replay to one current standing state.",
+      "evidence_class": "checked"
+    },
+    "sapheneia-eval-p": {
+      "path": "plugins/sapheneia/tests/test_promise_machine_cases.py",
+      "selector": "test_labelled_positive_cases",
+      "claim": "Sapheneia records bounded positive interaction cases without diagnosing the reader.",
+      "evidence_class": "recorded"
+    },
+    "sapheneia-eval-m": {
+      "path": "plugins/sapheneia/tests/test_promise_machine_cases.py",
+      "selector": "test_labelled_missing_evidence_cases",
+      "claim": "Sapheneia records refusal when activation, state or an explicit stop instruction is missing.",
+      "evidence_class": "recorded"
+    },
+    "sapheneia-eval-s": {
+      "path": "plugins/sapheneia/tests/test_promise_machine_cases.py",
+      "selector": "test_labelled_subject_mismatch_cases",
+      "claim": "Sapheneia records refusal when activation or deactivation evidence belongs to another session.",
+      "evidence_class": "recorded"
+    },
+    "sapheneia-eval-o": {
+      "path": "plugins/sapheneia/tests/test_promise_machine_cases.py",
+      "selector": "test_labelled_overclaim_cases",
+      "claim": "Sapheneia records diagnostic and universal-format overclaims as refusals.",
+      "evidence_class": "recorded"
+    },
+    "sapheneia-eval-r": {
+      "path": "plugins/sapheneia/tests/test_promise_machine_cases.py",
+      "selector": "test_labelled_recovery_cases",
+      "claim": "Sapheneia records bounded correction and explicit deactivation recovery paths.",
+      "evidence_class": "recorded"
     }
   },
   "rows": [
@@ -887,15 +1127,41 @@
       "promise_id": "brevitas-evidence-preservation",
       "skill_path": "plugins/brevitas/skills/brevitas/SKILL.md",
       "group": "prompt",
-      "cases": null,
-      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+      "evaluation": {
+        "status": "recorded",
+        "model": "not-applicable: deterministic checker",
+        "prompt": "Check protected source evidence with the selected Brevitas mode.",
+        "corpus": "plugins/brevitas/tests/test_brevitas.py",
+        "disposition": "Checked P/M/S/O/R cases; X is unsupported by the canonical declaration."
+      },
+      "cases": {
+        "P": "brevitas-evidence-p",
+        "M": "brevitas-evidence-m",
+        "S": "brevitas-evidence-s",
+        "O": "brevitas-evidence-o",
+        "R": "brevitas-evidence-r",
+        "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
+      }
     },
     {
       "promise_id": "brevitas-structure-check",
       "skill_path": "plugins/brevitas/skills/brevitas/SKILL.md",
       "group": "prompt",
-      "cases": null,
-      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+      "evaluation": {
+        "status": "recorded",
+        "model": "not-applicable: deterministic checker",
+        "prompt": "Check a draft against the selected Brevitas structure mode.",
+        "corpus": "plugins/brevitas/tests/test_brevitas.py",
+        "disposition": "Checked P/M/S/O/R cases; X is unsupported by the canonical declaration."
+      },
+      "cases": {
+        "P": "brevitas-structure-p",
+        "M": "brevitas-structure-m",
+        "S": "brevitas-structure-s",
+        "O": "brevitas-structure-o",
+        "R": "brevitas-structure-r",
+        "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
+      }
     },
     {
       "promise_id": "elenchus-fixed-and-guarded",
@@ -1029,36 +1295,81 @@
       "promise_id": "hexaemeron-fizz-convert-properties",
       "skill_path": "plugins/hexaemeron/skills/fizz/skills/fizz-convert/SKILL.md",
       "group": "vendored",
-      "cases": null,
-      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+      "evaluation": {
+        "status": "recorded",
+        "model": "not-run",
+        "prompt": "Classify a Fizz Convert result under its digest-bound overlay.",
+        "corpus": "plugins/hexaemeron/tests/fixtures/promise-machine/evaluation-cases.json",
+        "disposition": "Labelled P/M/S/O/R cases recorded; no conversion result is claimed."
+      },
+      "cases": {
+        "P": "hex-eval-p", "M": "hex-eval-m", "S": "hex-eval-s", "O": "hex-eval-o", "R": "hex-eval-r",
+        "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
+      }
     },
     {
       "promise_id": "hexaemeron-fizz-harness-campaign",
       "skill_path": "plugins/hexaemeron/skills/fizz/SKILL.md",
       "group": "vendored",
-      "cases": null,
-      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+      "evaluation": {
+        "status": "recorded",
+        "model": "not-run",
+        "prompt": "Classify a Fizz harness and campaign result under its digest-bound overlay.",
+        "corpus": "plugins/hexaemeron/tests/fixtures/promise-machine/evaluation-cases.json",
+        "disposition": "Labelled P/M/S/O/R cases recorded; no harness campaign is claimed."
+      },
+      "cases": {
+        "P": "hex-eval-p", "M": "hex-eval-m", "S": "hex-eval-s", "O": "hex-eval-o", "R": "hex-eval-r",
+        "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
+      }
     },
     {
       "promise_id": "hexaemeron-fizz-sync-drift",
       "skill_path": "plugins/hexaemeron/skills/fizz/skills/fizz-sync/SKILL.md",
       "group": "vendored",
-      "cases": null,
-      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+      "evaluation": {
+        "status": "recorded",
+        "model": "not-run",
+        "prompt": "Classify a Fizz Sync result under its digest-bound overlay.",
+        "corpus": "plugins/hexaemeron/tests/fixtures/promise-machine/evaluation-cases.json",
+        "disposition": "Labelled P/M/S/O/R cases recorded; no harness sync is claimed."
+      },
+      "cases": {
+        "P": "hex-eval-p", "M": "hex-eval-m", "S": "hex-eval-s", "O": "hex-eval-o", "R": "hex-eval-r",
+        "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
+      }
     },
     {
       "promise_id": "hexaemeron-solidity-audit-report",
       "skill_path": "plugins/hexaemeron/skills/solidity-auditor/SKILL.md",
       "group": "vendored",
-      "cases": null,
-      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+      "evaluation": {
+        "status": "recorded",
+        "model": "not-run",
+        "prompt": "Classify a Solidity Auditor result under its digest-bound overlay.",
+        "corpus": "plugins/hexaemeron/tests/fixtures/promise-machine/evaluation-cases.json",
+        "disposition": "Labelled P/M/S/O/R cases recorded; no audit report is claimed."
+      },
+      "cases": {
+        "P": "hex-eval-p", "M": "hex-eval-m", "S": "hex-eval-s", "O": "hex-eval-o", "R": "hex-eval-r",
+        "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
+      }
     },
     {
       "promise_id": "hexaemeron-x-ray-preaudit",
       "skill_path": "plugins/hexaemeron/skills/x-ray/SKILL.md",
       "group": "vendored",
-      "cases": null,
-      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+      "evaluation": {
+        "status": "recorded",
+        "model": "not-run",
+        "prompt": "Classify an X-Ray result under its digest-bound overlay.",
+        "corpus": "plugins/hexaemeron/tests/fixtures/promise-machine/evaluation-cases.json",
+        "disposition": "Labelled P/M/S/O/R cases recorded; no pre-audit result is claimed."
+      },
+      "cases": {
+        "P": "hex-eval-p", "M": "hex-eval-m", "S": "hex-eval-s", "O": "hex-eval-o", "R": "hex-eval-r",
+        "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
+      }
     },
     {
       "promise_id": "horos-boundary-check",
@@ -1128,22 +1439,57 @@
       "promise_id": "hypomnema-pointer-gate",
       "skill_path": "plugins/hexaemeron/skills/hypomnema/SKILL.md",
       "group": "prompt",
-      "cases": null,
-      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+      "evaluation": {
+        "status": "recorded",
+        "model": "not-applicable: deterministic checker",
+        "prompt": "Check first-party record pointers under the Hypomnema parser boundary.",
+        "corpus": "plugins/hexaemeron/tests/test_hypomnema_checker.py",
+        "disposition": "Checked P/M/S/O/R cases; X is unsupported by the canonical declaration."
+      },
+      "cases": {
+        "P": "hypomnema-pointer-p",
+        "M": "hypomnema-pointer-m",
+        "S": "hypomnema-pointer-s",
+        "O": "hypomnema-pointer-o",
+        "R": "hypomnema-pointer-r",
+        "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
+      }
     },
     {
       "promise_id": "hypomnema-record-placement",
       "skill_path": "plugins/hexaemeron/skills/hypomnema/SKILL.md",
       "group": "prompt",
-      "cases": null,
-      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+      "evaluation": {
+        "status": "recorded",
+        "model": "not-run",
+        "prompt": "Review record placement against the canonical Hypomnema contract.",
+        "corpus": "plugins/hexaemeron/tests/fixtures/promise-machine/evaluation-cases.json",
+        "disposition": "Labelled P/M/S/O/R cases recorded; forward model behaviour remains unknown."
+      },
+      "cases": {
+        "P": "hex-eval-p", "M": "hex-eval-m", "S": "hex-eval-s", "O": "hex-eval-o", "R": "hex-eval-r",
+        "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
+      }
     },
     {
       "promise_id": "imprimatur-prose-gate",
       "skill_path": "plugins/hexaemeron/skills/imprimatur/SKILL.md",
       "group": "prompt",
-      "cases": null,
-      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+      "evaluation": {
+        "status": "recorded",
+        "model": "labelled-prose-v1 mixed human and model-assisted corpus",
+        "prompt": "Run the exact prose through the selected Imprimatur mode and thresholds.",
+        "corpus": "plugins/hexaemeron/skills/imprimatur/evals/labelled-prose-v1",
+        "disposition": "Mechanical cases pass; the provisional holdout failed its recorded agreement and structural-coverage gates."
+      },
+      "cases": {
+        "P": "imprimatur-p",
+        "M": "imprimatur-m",
+        "S": "imprimatur-s",
+        "O": "imprimatur-o",
+        "R": "imprimatur-r",
+        "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
+      }
     },
     {
       "promise_id": "janus-bounded-conformance",
@@ -1200,22 +1546,57 @@
       "promise_id": "kronos-fiat-dispatch",
       "skill_path": "plugins/hexaemeron/skills/kronos/SKILL.md",
       "group": "prompt",
-      "cases": null,
-      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+      "evaluation": {
+        "status": "recorded",
+        "model": "not-run",
+        "prompt": "Decide whether a ranked Kronos job may enter Fiat under the authority boundary.",
+        "corpus": "plugins/hexaemeron/tests/fixtures/promise-machine/evaluation-cases.json",
+        "disposition": "Labelled P/M/S/O/R cases recorded; user authority remains external evidence."
+      },
+      "cases": {
+        "P": "hex-eval-p", "M": "hex-eval-m", "S": "hex-eval-s", "O": "hex-eval-o", "R": "hex-eval-r",
+        "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
+      }
     },
     {
       "promise_id": "kronos-frontier-ranking",
       "skill_path": "plugins/hexaemeron/skills/kronos/SKILL.md",
       "group": "prompt",
-      "cases": null,
-      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+      "evaluation": {
+        "status": "recorded",
+        "model": "not-applicable: deterministic scoreboard checker",
+        "prompt": "Record and inspect a complete Kronos ranking pass.",
+        "corpus": "plugins/hexaemeron/tests/test_kronos_scoreboard.py",
+        "disposition": "Checked P/M/S/O/R cases; X is unsupported by the canonical declaration."
+      },
+      "cases": {
+        "P": "kronos-rank-p",
+        "M": "kronos-rank-m",
+        "S": "kronos-rank-s",
+        "O": "kronos-rank-o",
+        "R": "kronos-rank-r",
+        "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
+      }
     },
     {
       "promise_id": "kronos-parked-lane",
       "skill_path": "plugins/hexaemeron/skills/kronos/SKILL.md",
       "group": "prompt",
-      "cases": null,
-      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+      "evaluation": {
+        "status": "recorded",
+        "model": "not-applicable: deterministic parked-state checker",
+        "prompt": "Record and replay a Kronos park or unpark event.",
+        "corpus": "plugins/hexaemeron/tests/test_kronos_scoreboard.py",
+        "disposition": "Checked P/M/S/O/R cases; X is unsupported by the canonical declaration."
+      },
+      "cases": {
+        "P": "kronos-park-p",
+        "M": "kronos-park-m",
+        "S": "kronos-park-s",
+        "O": "kronos-park-o",
+        "R": "kronos-park-r",
+        "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
+      }
     },
     {
       "promise_id": "lazarus-exact-replay",
@@ -1541,15 +1922,33 @@
       "promise_id": "sapheneia-deactivation",
       "skill_path": "plugins/sapheneia/skills/sapheneia/SKILL.md",
       "group": "prompt",
-      "cases": null,
-      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+      "evaluation": {
+        "status": "unknown",
+        "model": "not-run",
+        "prompt": "Decide whether Sapheneia may deactivate under its canonical stop contract.",
+        "corpus": "plugins/sapheneia/tests/fixtures/promise-machine/cases.json",
+        "disposition": "Labelled P/M/S/O/R expectations recorded; cross-model behaviour remains unknown."
+      },
+      "cases": {
+        "P": "sapheneia-eval-p", "M": "sapheneia-eval-m", "S": "sapheneia-eval-s", "O": "sapheneia-eval-o", "R": "sapheneia-eval-r",
+        "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
+      }
     },
     {
       "promise_id": "sapheneia-session-shape",
       "skill_path": "plugins/sapheneia/skills/sapheneia/SKILL.md",
       "group": "prompt",
-      "cases": null,
-      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+      "evaluation": {
+        "status": "unknown",
+        "model": "not-run",
+        "prompt": "Shape an active Sapheneia reply under the canonical interaction contract.",
+        "corpus": "plugins/sapheneia/tests/fixtures/promise-machine/cases.json",
+        "disposition": "Labelled P/M/S/O/R expectations recorded; cross-model behaviour remains unknown."
+      },
+      "cases": {
+        "P": "sapheneia-eval-p", "M": "sapheneia-eval-m", "S": "sapheneia-eval-s", "O": "sapheneia-eval-o", "R": "sapheneia-eval-r",
+        "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
+      }
     },
     {
       "promise_id": "tabularium-compound-witness",
@@ -1603,8 +2002,17 @@
       "promise_id": "vulgate-register-rewrite",
       "skill_path": "plugins/hexaemeron/skills/vulgate/SKILL.md",
       "group": "prompt",
-      "cases": null,
-      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+      "evaluation": {
+        "status": "unknown",
+        "model": "not-run",
+        "prompt": "Rewrite a source passage under Vulgate while holding all content constant.",
+        "corpus": "plugins/hexaemeron/tests/fixtures/promise-machine/evaluation-cases.json",
+        "disposition": "Labelled P/M/S/O/R expectations recorded; cross-model content parity remains unknown."
+      },
+      "cases": {
+        "P": "hex-eval-p", "M": "hex-eval-m", "S": "hex-eval-s", "O": "hex-eval-o", "R": "hex-eval-r",
+        "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
+      }
     }
   ]
 }

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -1,0 +1,1520 @@
+{
+  "contract": "promise-machine/v1",
+  "schema": "promise-machine-coverage/v1",
+  "handoffs": [
+    {
+      "producer": "lazarus-fixture-verification",
+      "consumer": "berean-answer-evidence",
+      "path": "plugins/berean/tests/test_examples.py",
+      "selector": "test_the_copied_reads_match_the_lazarus_fixture_byte_for_byte",
+      "preserves": ["block", "evidence-class", "subject"],
+      "refuses": "answer-truth"
+    },
+    {
+      "producer": "berean-release-promotion",
+      "consumer": "ariadne-capture-statement",
+      "path": "plugins/ariadne/tests/test_gates.py",
+      "selector": "test_a_payload_asserting_its_own_verification_fails",
+      "preserves": ["answer-digest", "evidence-class", "subject"],
+      "refuses": "answer-truth"
+    }
+  ],
+  "evidence": {
+    "alexandria-p": {
+      "path": "plugins/alexandria/tests/test_demo.py",
+      "selector": "test_documented_build_and_verify_commands_run_exactly",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "alexandria-m": {
+      "path": "plugins/alexandria/tests/test_demo.py",
+      "selector": "test_build_refuses_existing_output",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "alexandria-s": {
+      "path": "plugins/alexandria/tests/test_demo.py",
+      "selector": "test_source_pin_tamper_fails_before_ingest",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "alexandria-o": {
+      "path": "plugins/alexandria/tests/test_demo.py",
+      "selector": "test_compound_plan_does_not_treat_logs_as_complete_credit_history",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "alexandria-r": {
+      "path": "plugins/alexandria/tests/test_demo.py",
+      "selector": "test_cli_failure_is_controlled",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "ariadne-p": {
+      "path": "plugins/ariadne/tests/test_examples.py",
+      "selector": "test_both_examples_verify_with_nothing_unchecked",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "ariadne-m": {
+      "path": "plugins/ariadne/tests/test_gates.py",
+      "selector": "test_a_missing_claims_block_fails",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "ariadne-s": {
+      "path": "plugins/ariadne/tests/test_examples.py",
+      "selector": "test_the_unhappy_example_says_its_audit_covered_another_revision",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "ariadne-o": {
+      "path": "plugins/ariadne/tests/test_examples.py",
+      "selector": "test_every_example_records_its_deployment_as_unconfirmed",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "ariadne-r": {
+      "path": "plugins/ariadne/tests/test_examples.py",
+      "selector": "test_every_tampered_copy_fails_the_gate_it_is_meant_to",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "hermes-p": {
+      "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
+      "selector": "test_accepts_and_promotes_a_fully_verified_candidate",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "hermes-m": {
+      "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
+      "selector": "test_rejects_full_suite_failure_at_gate_four",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "hermes-s": {
+      "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
+      "selector": "test_rejects_changed_invariant_snapshot_rows",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "hermes-o": {
+      "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
+      "selector": "test_records_changed_fuzz_statistics_without_calling_them_a_regression",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "hermes-r": {
+      "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
+      "selector": "test_rejects_any_gas_regression_at_gate_three",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "elenchus-p": {
+      "path": "plugins/hexaemeron/tests/test_elenchus_checker.py",
+      "selector": "test_runner_categories_distinguish_all_three_outcomes",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "elenchus-m": {
+      "path": "plugins/hexaemeron/tests/test_elenchus_checker.py",
+      "selector": "test_legacy_no_report_is_inconclusive",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "elenchus-s": {
+      "path": "plugins/hexaemeron/tests/test_elenchus_checker.py",
+      "selector": "test_oversized_and_stale_reports_are_rejected_before_parsing",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "elenchus-o": {
+      "path": "plugins/hexaemeron/tests/test_elenchus_checker.py",
+      "selector": "test_diagnostic_poisoning_and_exit_code_do_not_change_the_report",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "elenchus-r": {
+      "path": "plugins/hexaemeron/tests/test_elenchus_checker.py",
+      "selector": "test_legacy_cli_is_nonfatal_by_default_and_fails_when_required",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "ephoros-p": {
+      "path": "plugins/hexaemeron/tests/test_ephoros_checker.py",
+      "selector": "test_it_allows_a_stable_name_with_fields",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "ephoros-m": {
+      "path": "plugins/hexaemeron/tests/test_ephoros_checker.py",
+      "selector": "test_it_flags_an_f_string_message",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "ephoros-s": {
+      "path": "plugins/hexaemeron/tests/test_ephoros_checker.py",
+      "selector": "test_a_bare_pragma_does_not_suppress",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "ephoros-o": {
+      "path": "plugins/hexaemeron/tests/test_ephoros_checker.py",
+      "selector": "test_it_ignores_print_which_is_not_telemetry",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "ephoros-r": {
+      "path": "plugins/hexaemeron/tests/test_ephoros_checker.py",
+      "selector": "test_a_stated_reason_suppresses",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "fiat-p": {
+      "path": "plugins/hexaemeron/tests/test_hexctl.py",
+      "selector": "test_push_advances_steps_then_the_stack_integrates",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "fiat-m": {
+      "path": "plugins/hexaemeron/tests/test_hexctl.py",
+      "selector": "test_done_out_of_order_rejected",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "fiat-s": {
+      "path": "plugins/hexaemeron/tests/test_hexctl.py",
+      "selector": "test_state_edit_detected_by_verify",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "fiat-o": {
+      "path": "plugins/hexaemeron/tests/test_hexctl.py",
+      "selector": "test_verify_preserves_receipt_assertions_without_proving_them",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "fiat-r": {
+      "path": "plugins/hexaemeron/tests/test_hexctl.py",
+      "selector": "test_halt_blocks_progress_and_resume_restores",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "horos-p": {
+      "path": "plugins/horos/tests/test_boundary.py",
+      "selector": "test_check_passes_on_a_fresh_boundary",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "horos-m": {
+      "path": "plugins/horos/tests/test_boundary.py",
+      "selector": "test_a_missing_boundary_is_a_distinct_failure",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "horos-s": {
+      "path": "plugins/horos/tests/test_boundary.py",
+      "selector": "test_a_changed_entry_drifts_and_is_named",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "horos-o": {
+      "path": "plugins/horos/tests/test_boundary.py",
+      "selector": "test_the_boundary_file_never_classifies_itself",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "horos-r": {
+      "path": "plugins/horos/tests/test_boundary.py",
+      "selector": "test_write_creates_the_boundary_and_leaves_no_temporary",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "lazarus-p": {
+      "path": "plugins/lazarus/tests/test_goldfinch.py",
+      "selector": "test_fixture_verifies_with_expected_evidence_and_provenance",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "lazarus-m": {
+      "path": "plugins/lazarus/tests/test_verifier.py",
+      "selector": "test_missing_or_extra_proof_targets_fail",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "lazarus-s": {
+      "path": "plugins/lazarus/tests/test_verifier.py",
+      "selector": "test_proved_rpc_selector_must_name_the_fixture_block",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "lazarus-o": {
+      "path": "plugins/lazarus/tests/test_preservation_release.py",
+      "selector": "test_it_claims_nothing_about_the_canonical_chain",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "lazarus-r": {
+      "path": "plugins/lazarus/tests/test_goldfinch.py",
+      "selector": "test_demo_command_runs_the_complete_application_check",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "metron-p": {
+      "path": "plugins/hexaemeron/tests/test_metron_check.py",
+      "selector": "test_an_improvement_past_the_variance_is_reported_and_passes",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "metron-m": {
+      "path": "plugins/hexaemeron/tests/test_metron_check.py",
+      "selector": "test_a_run_reporting_only_one_budget_fails_on_the_rest",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "metron-s": {
+      "path": "plugins/hexaemeron/tests/test_metron_check.py",
+      "selector": "test_a_move_inside_the_variance_is_another_sample",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "metron-o": {
+      "path": "plugins/hexaemeron/tests/test_metron_check.py",
+      "selector": "test_no_baseline_entry_is_neutral_rather_than_a_failure",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "metron-r": {
+      "path": "plugins/hexaemeron/tests/test_metron_check.py",
+      "selector": "test_the_ledger_keeps_the_reverted_attempt",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "pandects-p": {
+      "path": "plugins/pandects/tests/test_checker.py",
+      "selector": "test_a_law_with_every_part_passes",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "pandects-m": {
+      "path": "plugins/pandects/tests/test_checker.py",
+      "selector": "test_a_missing_component_fails",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "pandects-s": {
+      "path": "plugins/pandects/tests/test_checker.py",
+      "selector": "test_a_component_whose_id_disagrees_with_the_catalogue_fails",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "pandects-o": {
+      "path": "plugins/pandects/tests/test_checker.py",
+      "selector": "test_a_law_reverting_to_signal_a_violation_fails",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "pandects-r": {
+      "path": "plugins/pandects/tests/test_search_record.py",
+      "selector": "test_a_timed_out_campaign_is_recorded_rather_than_dropped",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "phylax-p": {
+      "path": "plugins/hexaemeron/tests/test_phylax_checker.py",
+      "selector": "test_it_allows_an_argument_list",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "phylax-m": {
+      "path": "plugins/hexaemeron/tests/test_phylax_checker.py",
+      "selector": "test_it_flags_a_shell_invocation",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "phylax-s": {
+      "path": "plugins/hexaemeron/tests/test_phylax_checker.py",
+      "selector": "test_a_bare_pragma_without_a_reason_does_not_suppress",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "phylax-o": {
+      "path": "plugins/hexaemeron/tests/test_phylax_checker.py",
+      "selector": "test_findings_do_not_repeat_secret_material_in_text_or_json",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "phylax-r": {
+      "path": "plugins/hexaemeron/tests/test_phylax_checker.py",
+      "selector": "test_a_stated_reason_suppresses_the_finding",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "probitas-p": {
+      "path": "plugins/probitas/tests/test_demo.py",
+      "selector": "test_it_exits_zero",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "probitas-m": {
+      "path": "plugins/probitas/tests/test_evidence.py",
+      "selector": "test_missing_source_raises",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "probitas-s": {
+      "path": "plugins/probitas/tests/test_gates.py",
+      "selector": "test_an_invented_transaction_hash_fails",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "probitas-o": {
+      "path": "plugins/probitas/tests/test_gates.py",
+      "selector": "test_a_rating_with_no_rubric_fails",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "probitas-r": {
+      "path": "plugins/probitas/tests/test_registry.py",
+      "selector": "test_an_adapter_returning_no_coverage_is_a_bug_not_a_silence",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "protasis-p": {
+      "path": "plugins/hexaemeron/tests/test_protasis_checker.py",
+      "selector": "test_a_complete_step_is_clean",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "protasis-m": {
+      "path": "plugins/hexaemeron/tests/test_protasis_checker.py",
+      "selector": "test_each_required_field_is_required",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "protasis-s": {
+      "path": "plugins/hexaemeron/tests/test_protasis_checker.py",
+      "selector": "test_a_fenced_block_under_a_later_field_does_not_count",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "protasis-o": {
+      "path": "plugins/hexaemeron/tests/test_protasis_checker.py",
+      "selector": "test_an_exit_with_no_command_is_a_finding",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "protasis-r": {
+      "path": "plugins/hexaemeron/tests/test_protasis_checker.py",
+      "selector": "test_this_runs_own_runbook_is_clean",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "tabularium-p": {
+      "path": "plugins/tabularium/tests/test_release.py",
+      "selector": "test_committed_release_verifies_offline_and_without_rewrites",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "tabularium-m": {
+      "path": "plugins/tabularium/tests/test_verify.py",
+      "selector": "test_missing_artifact_fails",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "tabularium-s": {
+      "path": "plugins/tabularium/tests/test_verify.py",
+      "selector": "test_altered_source_bytes_fail_the_declared_digest",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "tabularium-o": {
+      "path": "plugins/tabularium/tests/test_verify.py",
+      "selector": "test_indexed_block_must_match_source_metadata",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "tabularium-r": {
+      "path": "plugins/tabularium/tests/test_release.py",
+      "selector": "test_documented_demo_rebuilds_and_compares_in_a_fresh_directory",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "chunk-markdown-p": {
+      "path": "plugins/lemma/tests/test_markdown.py",
+      "selector": "test_byte_exact",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "chunk-markdown-m": {
+      "path": "plugins/lemma/tests/test_markdown.py",
+      "selector": "test_summary_fail_loud",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "chunk-markdown-s": {
+      "path": "plugins/lemma/tests/test_markdown.py",
+      "selector": "test_heading_path",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "chunk-markdown-o": {
+      "path": "plugins/lemma/tests/test_markdown.py",
+      "selector": "test_exclusions",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "chunk-markdown-r": {
+      "path": "plugins/lemma/tests/test_markdown.py",
+      "selector": "test_short_document_survives",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "chunk-solidity-p": {
+      "path": "plugins/lemma/tests/test_solidity.py",
+      "selector": "test_chunks",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "chunk-solidity-m": {
+      "path": "plugins/lemma/tests/test_solidity.py",
+      "selector": "test_compile_errors_raise",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "chunk-solidity-s": {
+      "path": "plugins/lemma/tests/test_solidity.py",
+      "selector": "test_source_path_canonicality",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "chunk-solidity-o": {
+      "path": "plugins/lemma/tests/test_solidity.py",
+      "selector": "test_empty_selection",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "chunk-solidity-r": {
+      "path": "plugins/lemma/tests/test_solidity.py",
+      "selector": "test_cli_integration",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "janus-manifest-p": {
+      "path": "plugins/janus/tests/test_validator.py",
+      "selector": "test_the_honest_manifest_validates",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "janus-manifest-m": {
+      "path": "plugins/janus/tests/test_validator.py",
+      "selector": "test_each_fixture_fails_with_its_named_code",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "janus-manifest-s": {
+      "path": "plugins/janus/tests/test_reporter.py",
+      "selector": "test_markdown_names_each_gate_and_hook",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "janus-manifest-o": {
+      "path": "plugins/janus/tests/test_validator.py",
+      "selector": "test_wildcard_is_rejected_everywhere_it_could_hide",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "janus-manifest-r": {
+      "path": "plugins/janus/tests/test_validator.py",
+      "selector": "test_validate_command_exit_code",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "janus-bounded-p": {
+      "path": "plugins/janus/harness/test/WildcatConformance.t.sol",
+      "selector": "test_gate1_and_gate2_honest_deposit",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "janus-bounded-m": {
+      "path": "plugins/janus/harness/test/StateDeltaRecorder.t.sol",
+      "selector": "test_ending_without_beginning_reverts",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "janus-bounded-s": {
+      "path": "plugins/janus/harness/test/WildcatConformance.t.sol",
+      "selector": "test_gate7_adapter_names_its_scope",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "janus-bounded-o": {
+      "path": "plugins/janus/tests/test_reporter.py",
+      "selector": "test_empty_findings_report_states_context_not_safety",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "janus-bounded-r": {
+      "path": "plugins/janus/harness/test/HostileHooks.t.sol",
+      "selector": "test_storage_mutation_hook_caught_by_gate1",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "janus-report-p": {
+      "path": "plugins/janus/tests/test_reporter.py",
+      "selector": "test_report_command_writes_both_outputs",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "janus-report-m": {
+      "path": "plugins/janus/tests/test_reporter.py",
+      "selector": "test_the_sample_findings_load",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "janus-report-s": {
+      "path": "plugins/janus/tests/test_reporter.py",
+      "selector": "test_markdown_cells_survive_a_pipe_or_newline",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "janus-report-o": {
+      "path": "plugins/janus/tests/test_reporter.py",
+      "selector": "test_empty_findings_report_states_context_not_safety",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "janus-report-r": {
+      "path": "plugins/janus/tests/test_reporter.py",
+      "selector": "test_sarif_round_trips_as_json",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "berean-corpus-p": {
+      "path": "plugins/berean/tests/test_corpus.py",
+      "selector": "test_build_then_verify_is_clean",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "berean-corpus-m": {
+      "path": "plugins/berean/tests/test_corpus.py",
+      "selector": "test_an_empty_tree_is_refused",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "berean-corpus-s": {
+      "path": "plugins/berean/tests/test_corpus.py",
+      "selector": "test_a_one_byte_edit_fails_corpus_bytes",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "berean-corpus-o": {
+      "path": "plugins/berean/tests/test_corpus.py",
+      "selector": "test_an_unpinned_extra_file_fails_corpus_complete",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "berean-corpus-r": {
+      "path": "plugins/berean/tests/test_corpus.py",
+      "selector": "test_write_stages_and_lands_whole",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "berean-answer-p": {
+      "path": "plugins/berean/tests/test_answers.py",
+      "selector": "test_a_classified_answer_passes",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "berean-answer-m": {
+      "path": "plugins/berean/tests/test_answers.py",
+      "selector": "test_an_evidence_free_document_sentence_fails",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "berean-answer-s": {
+      "path": "plugins/berean/tests/test_answers.py",
+      "selector": "test_a_mismatched_span_fails_answer_citations",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "berean-answer-o": {
+      "path": "plugins/berean/tests/test_answers.py",
+      "selector": "test_a_user_supplied_fact_carries_no_evidence",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "berean-answer-r": {
+      "path": "plugins/berean/tests/test_answers.py",
+      "selector": "test_a_clean_refusal_passes",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "berean-evaluation-p": {
+      "path": "plugins/berean/tests/test_evals.py",
+      "selector": "test_the_fixture_corpus_grades_clean_and_reproduces_its_report",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "berean-evaluation-m": {
+      "path": "plugins/berean/tests/test_evals.py",
+      "selector": "test_a_release_without_evals_refuses",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "berean-evaluation-s": {
+      "path": "plugins/berean/tests/test_evals.py",
+      "selector": "test_a_cases_digest_mismatch_refuses_to_grade",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "berean-evaluation-o": {
+      "path": "plugins/berean/tests/test_evals.py",
+      "selector": "test_an_accepted_answer_fails_a_rejected_case",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "berean-evaluation-r": {
+      "path": "plugins/berean/tests/test_evals.py",
+      "selector": "test_a_drifted_corpus_refuses_to_grade",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "berean-promotion-p": {
+      "path": "plugins/berean/tests/test_promote.py",
+      "selector": "test_a_clean_report_promotes_and_the_release_is_active",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "berean-promotion-m": {
+      "path": "plugins/berean/tests/test_promote.py",
+      "selector": "test_a_failed_report_does_not_promote",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "berean-promotion-s": {
+      "path": "plugins/berean/tests/test_promote.py",
+      "selector": "test_a_report_for_another_corpus_does_not_promote",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "berean-promotion-o": {
+      "path": "plugins/berean/tests/test_promote.py",
+      "selector": "test_a_pinned_pass_over_a_failing_case_does_not_promote",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "berean-promotion-r": {
+      "path": "plugins/berean/tests/test_promote.py",
+      "selector": "test_an_active_release_rolls_back_by_record",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    }
+  },
+  "rows": [
+    {
+      "promise_id": "alexandria-address-query",
+      "skill_path": "plugins/alexandria/skills/alexandria/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "alexandria-p",
+        "M": "alexandria-m",
+        "S": "alexandria-s",
+        "O": "alexandria-o",
+        "R": "alexandria-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "alexandria-compound-method-proof",
+      "skill_path": "plugins/alexandria/skills/alexandria/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "alexandria-p",
+        "M": "alexandria-m",
+        "S": "alexandria-s",
+        "O": "alexandria-o",
+        "R": "alexandria-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "alexandria-derived-view",
+      "skill_path": "plugins/alexandria/skills/alexandria/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "alexandria-p",
+        "M": "alexandria-m",
+        "S": "alexandria-s",
+        "O": "alexandria-o",
+        "R": "alexandria-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "alexandria-raw-release",
+      "skill_path": "plugins/alexandria/skills/alexandria/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "alexandria-p",
+        "M": "alexandria-m",
+        "S": "alexandria-s",
+        "O": "alexandria-o",
+        "R": "alexandria-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "ariadne-capture-statement",
+      "skill_path": "plugins/ariadne/skills/ariadne/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "ariadne-p",
+        "M": "ariadne-m",
+        "S": "ariadne-s",
+        "O": "ariadne-o",
+        "R": "ariadne-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "ariadne-inspect-statement",
+      "skill_path": "plugins/ariadne/skills/ariadne/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "ariadne-p",
+        "M": "ariadne-m",
+        "S": "ariadne-s",
+        "O": "ariadne-o",
+        "R": "ariadne-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "ariadne-replay-command",
+      "skill_path": "plugins/ariadne/skills/ariadne/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "ariadne-p",
+        "M": "ariadne-m",
+        "S": "ariadne-s",
+        "O": "ariadne-o",
+        "R": "ariadne-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "ariadne-verify-statement",
+      "skill_path": "plugins/ariadne/skills/ariadne/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "ariadne-p",
+        "M": "ariadne-m",
+        "S": "ariadne-s",
+        "O": "ariadne-o",
+        "R": "ariadne-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "berean-answer-evidence",
+      "skill_path": "plugins/berean/skills/berean/SKILL.md",
+      "group": "executable",
+      "preserves": ["answer-truth-refused", "read-class", "source-class", "subject", "time-domain"],
+      "cases": {
+        "P": "berean-answer-p",
+        "M": "berean-answer-m",
+        "S": "berean-answer-s",
+        "O": "berean-answer-o",
+        "R": "berean-answer-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "berean-corpus-binding",
+      "skill_path": "plugins/berean/skills/berean/SKILL.md",
+      "group": "executable",
+      "preserves": ["corpus-digest", "source-class", "subject"],
+      "cases": {
+        "P": "berean-corpus-p",
+        "M": "berean-corpus-m",
+        "S": "berean-corpus-s",
+        "O": "berean-corpus-o",
+        "R": "berean-corpus-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "berean-evaluation-report",
+      "skill_path": "plugins/berean/skills/berean/SKILL.md",
+      "group": "executable",
+      "preserves": ["answer-digest", "answer-truth-refused", "corpus-digest", "time-domain"],
+      "cases": {
+        "P": "berean-evaluation-p",
+        "M": "berean-evaluation-m",
+        "S": "berean-evaluation-s",
+        "O": "berean-evaluation-o",
+        "R": "berean-evaluation-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "berean-release-promotion",
+      "skill_path": "plugins/berean/skills/berean/SKILL.md",
+      "group": "executable",
+      "preserves": ["answer-digest", "answer-truth-refused", "corpus-digest", "evaluation-digest"],
+      "cases": {
+        "P": "berean-promotion-p",
+        "M": "berean-promotion-m",
+        "S": "berean-promotion-s",
+        "O": "berean-promotion-o",
+        "R": "berean-promotion-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "brevitas-evidence-preservation",
+      "skill_path": "plugins/brevitas/skills/brevitas/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "brevitas-structure-check",
+      "skill_path": "plugins/brevitas/skills/brevitas/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "elenchus-fixed-and-guarded",
+      "skill_path": "plugins/hexaemeron/skills/elenchus/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "elenchus-p",
+        "M": "elenchus-m",
+        "S": "elenchus-s",
+        "O": "elenchus-o",
+        "R": "elenchus-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "ephoros-mechanical-gate",
+      "skill_path": "plugins/hexaemeron/skills/ephoros/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "ephoros-p",
+        "M": "ephoros-m",
+        "S": "ephoros-s",
+        "O": "ephoros-o",
+        "R": "ephoros-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "ephoros-observability-review",
+      "skill_path": "plugins/hexaemeron/skills/ephoros/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "ephoros-p",
+        "M": "ephoros-m",
+        "S": "ephoros-s",
+        "O": "ephoros-o",
+        "R": "ephoros-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "fiat-final-integration",
+      "skill_path": "plugins/hexaemeron/skills/fiat/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "fiat-p",
+        "M": "fiat-m",
+        "S": "fiat-s",
+        "O": "fiat-o",
+        "R": "fiat-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "fiat-receipted-delivery",
+      "skill_path": "plugins/hexaemeron/skills/fiat/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "fiat-p",
+        "M": "fiat-m",
+        "S": "fiat-s",
+        "O": "fiat-o",
+        "R": "fiat-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "hermes-baseline-promotion",
+      "skill_path": "plugins/hermes/skills/hermes/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "hermes-p",
+        "M": "hermes-m",
+        "S": "hermes-s",
+        "O": "hermes-o",
+        "R": "hermes-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "hermes-candidate-acceptance",
+      "skill_path": "plugins/hermes/skills/hermes/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "hermes-p",
+        "M": "hermes-m",
+        "S": "hermes-s",
+        "O": "hermes-o",
+        "R": "hermes-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "hermes-sealed-baseline",
+      "skill_path": "plugins/hermes/skills/hermes/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "hermes-p",
+        "M": "hermes-m",
+        "S": "hermes-s",
+        "O": "hermes-o",
+        "R": "hermes-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "hexaemeron-fizz-convert-properties",
+      "skill_path": "plugins/hexaemeron/skills/fizz/skills/fizz-convert/SKILL.md",
+      "group": "vendored",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "hexaemeron-fizz-harness-campaign",
+      "skill_path": "plugins/hexaemeron/skills/fizz/SKILL.md",
+      "group": "vendored",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "hexaemeron-fizz-sync-drift",
+      "skill_path": "plugins/hexaemeron/skills/fizz/skills/fizz-sync/SKILL.md",
+      "group": "vendored",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "hexaemeron-solidity-audit-report",
+      "skill_path": "plugins/hexaemeron/skills/solidity-auditor/SKILL.md",
+      "group": "vendored",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "hexaemeron-x-ray-preaudit",
+      "skill_path": "plugins/hexaemeron/skills/x-ray/SKILL.md",
+      "group": "vendored",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "horos-boundary-check",
+      "skill_path": "plugins/horos/skills/horos/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "horos-p",
+        "M": "horos-m",
+        "S": "horos-s",
+        "O": "horos-o",
+        "R": "horos-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "horos-boundary-scan",
+      "skill_path": "plugins/horos/skills/horos/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "horos-p",
+        "M": "horos-m",
+        "S": "horos-s",
+        "O": "horos-o",
+        "R": "horos-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "horos-census",
+      "skill_path": "plugins/horos/skills/horos/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "horos-p",
+        "M": "horos-m",
+        "S": "horos-s",
+        "O": "horos-o",
+        "R": "horos-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "horos-skeleton-map",
+      "skill_path": "plugins/horos/skills/horos/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "horos-p",
+        "M": "horos-m",
+        "S": "horos-s",
+        "O": "horos-o",
+        "R": "horos-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "hypomnema-pointer-gate",
+      "skill_path": "plugins/hexaemeron/skills/hypomnema/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "hypomnema-record-placement",
+      "skill_path": "plugins/hexaemeron/skills/hypomnema/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "imprimatur-prose-gate",
+      "skill_path": "plugins/hexaemeron/skills/imprimatur/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "janus-bounded-conformance",
+      "skill_path": "plugins/janus/skills/janus/SKILL.md",
+      "group": "executable",
+      "preserves": ["adapter", "bounded-search", "cross-host-refused", "manifest", "recorder", "safety-refused", "unknown-effect-refused"],
+      "cases": {
+        "P": "janus-bounded-p",
+        "M": "janus-bounded-m",
+        "S": "janus-bounded-s",
+        "O": "janus-bounded-o",
+        "R": "janus-bounded-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "janus-manifest-validation",
+      "skill_path": "plugins/janus/skills/janus/SKILL.md",
+      "group": "executable",
+      "preserves": ["adapter", "manifest"],
+      "cases": {
+        "P": "janus-manifest-p",
+        "M": "janus-manifest-m",
+        "S": "janus-manifest-s",
+        "O": "janus-manifest-o",
+        "R": "janus-manifest-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "janus-report-rendering",
+      "skill_path": "plugins/janus/skills/janus/SKILL.md",
+      "group": "executable",
+      "preserves": ["adapter", "bounded-search", "manifest", "recorder", "safety-refused"],
+      "cases": {
+        "P": "janus-report-p",
+        "M": "janus-report-m",
+        "S": "janus-report-s",
+        "O": "janus-report-o",
+        "R": "janus-report-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "kronos-fiat-dispatch",
+      "skill_path": "plugins/hexaemeron/skills/kronos/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "kronos-frontier-ranking",
+      "skill_path": "plugins/hexaemeron/skills/kronos/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "kronos-parked-lane",
+      "skill_path": "plugins/hexaemeron/skills/kronos/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "lazarus-exact-replay",
+      "skill_path": "plugins/lazarus/skills/lazarus/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "lazarus-p",
+        "M": "lazarus-m",
+        "S": "lazarus-s",
+        "O": "lazarus-o",
+        "R": "lazarus-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "lazarus-fixture-capture",
+      "skill_path": "plugins/lazarus/skills/lazarus/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "lazarus-p",
+        "M": "lazarus-m",
+        "S": "lazarus-s",
+        "O": "lazarus-o",
+        "R": "lazarus-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "lazarus-fixture-verification",
+      "skill_path": "plugins/lazarus/skills/lazarus/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "lazarus-p",
+        "M": "lazarus-m",
+        "S": "lazarus-s",
+        "O": "lazarus-o",
+        "R": "lazarus-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "lazarus-preservation-release",
+      "skill_path": "plugins/lazarus/skills/lazarus/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "lazarus-p",
+        "M": "lazarus-m",
+        "S": "lazarus-s",
+        "O": "lazarus-o",
+        "R": "lazarus-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "lemma-chunk-validation",
+      "skill_path": "plugins/lemma/skills/chunk/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "chunk-solidity-p",
+        "M": "chunk-solidity-m",
+        "S": "chunk-solidity-s",
+        "O": "chunk-solidity-o",
+        "R": "chunk-solidity-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "lemma-markdown-chunks",
+      "skill_path": "plugins/lemma/skills/chunk/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "chunk-markdown-p",
+        "M": "chunk-markdown-m",
+        "S": "chunk-markdown-s",
+        "O": "chunk-markdown-o",
+        "R": "chunk-markdown-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "lemma-solidity-chunks",
+      "skill_path": "plugins/lemma/skills/chunk/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "chunk-solidity-p",
+        "M": "chunk-solidity-m",
+        "S": "chunk-solidity-s",
+        "O": "chunk-solidity-o",
+        "R": "chunk-solidity-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "metron-budget-verdict",
+      "skill_path": "plugins/hexaemeron/skills/metron/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "metron-p",
+        "M": "metron-m",
+        "S": "metron-s",
+        "O": "metron-o",
+        "R": "metron-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "metron-change-decision",
+      "skill_path": "plugins/hexaemeron/skills/metron/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "metron-p",
+        "M": "metron-m",
+        "S": "metron-s",
+        "O": "metron-o",
+        "R": "metron-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "pandects-broken-specimen",
+      "skill_path": "plugins/pandects/skills/pandects/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "pandects-p",
+        "M": "pandects-m",
+        "S": "pandects-s",
+        "O": "pandects-o",
+        "R": "pandects-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "pandects-catalogue-render",
+      "skill_path": "plugins/pandects/skills/pandects/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "pandects-p",
+        "M": "pandects-m",
+        "S": "pandects-s",
+        "O": "pandects-o",
+        "R": "pandects-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "pandects-law-contract",
+      "skill_path": "plugins/pandects/skills/pandects/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "pandects-p",
+        "M": "pandects-m",
+        "S": "pandects-s",
+        "O": "pandects-o",
+        "R": "pandects-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "pandects-search-record",
+      "skill_path": "plugins/pandects/skills/pandects/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "pandects-p",
+        "M": "pandects-m",
+        "S": "pandects-s",
+        "O": "pandects-o",
+        "R": "pandects-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "phylax-boundary-review",
+      "skill_path": "plugins/hexaemeron/skills/phylax/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "phylax-p",
+        "M": "phylax-m",
+        "S": "phylax-s",
+        "O": "phylax-o",
+        "R": "phylax-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "phylax-mechanical-gate",
+      "skill_path": "plugins/hexaemeron/skills/phylax/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "phylax-p",
+        "M": "phylax-m",
+        "S": "phylax-s",
+        "O": "phylax-o",
+        "R": "phylax-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "probitas-dossier-rendering",
+      "skill_path": "plugins/probitas/skills/probitas/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "probitas-p",
+        "M": "probitas-m",
+        "S": "probitas-s",
+        "O": "probitas-o",
+        "R": "probitas-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "probitas-dossier-verification",
+      "skill_path": "plugins/probitas/skills/probitas/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "probitas-p",
+        "M": "probitas-m",
+        "S": "probitas-s",
+        "O": "probitas-o",
+        "R": "probitas-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "probitas-evidence-collection",
+      "skill_path": "plugins/probitas/skills/probitas/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "probitas-p",
+        "M": "probitas-m",
+        "S": "probitas-s",
+        "O": "probitas-o",
+        "R": "probitas-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "protasis-runbook-readiness",
+      "skill_path": "plugins/hexaemeron/skills/protasis/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "protasis-p",
+        "M": "protasis-m",
+        "S": "protasis-s",
+        "O": "protasis-o",
+        "R": "protasis-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "protasis-study-readiness",
+      "skill_path": "plugins/hexaemeron/skills/protasis/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "protasis-p",
+        "M": "protasis-m",
+        "S": "protasis-s",
+        "O": "protasis-o",
+        "R": "protasis-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "sapheneia-deactivation",
+      "skill_path": "plugins/sapheneia/skills/sapheneia/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "sapheneia-session-shape",
+      "skill_path": "plugins/sapheneia/skills/sapheneia/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    },
+    {
+      "promise_id": "tabularium-compound-witness",
+      "skill_path": "plugins/tabularium/skills/tabularium/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "tabularium-p",
+        "M": "tabularium-m",
+        "S": "tabularium-s",
+        "O": "tabularium-o",
+        "R": "tabularium-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "tabularium-release-build",
+      "skill_path": "plugins/tabularium/skills/tabularium/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "tabularium-p",
+        "M": "tabularium-m",
+        "S": "tabularium-s",
+        "O": "tabularium-o",
+        "R": "tabularium-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "tabularium-release-verification",
+      "skill_path": "plugins/tabularium/skills/tabularium/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "tabularium-p",
+        "M": "tabularium-m",
+        "S": "tabularium-s",
+        "O": "tabularium-o",
+        "R": "tabularium-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "vulgate-register-rewrite",
+      "skill_path": "plugins/hexaemeron/skills/vulgate/SKILL.md",
+      "group": "prompt",
+      "cases": null,
+      "pending": "Runbook Step 8 classifies prompt, transformation and vendored evidence."
+    }
+  ]
+}

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -805,6 +805,36 @@
       "claim": "The owning plugin records bounded recovery for each judgement-shaped promise.",
       "evidence_class": "recorded"
     },
+    "vulgate-eval-p": {
+      "path": "plugins/hexaemeron/tests/test_promise_evaluation_cases.py",
+      "selector": "test_labelled_positive_cases",
+      "claim": "The labelled positive case supports an inferred content-parity judgement without claiming truth.",
+      "evidence_class": "inferred"
+    },
+    "vulgate-eval-m": {
+      "path": "plugins/hexaemeron/tests/test_promise_evaluation_cases.py",
+      "selector": "test_labelled_missing_evidence_cases",
+      "claim": "The labelled case refuses a rewrite with no exact source or parity comparison.",
+      "evidence_class": "inferred"
+    },
+    "vulgate-eval-s": {
+      "path": "plugins/hexaemeron/tests/test_promise_evaluation_cases.py",
+      "selector": "test_labelled_subject_mismatch_cases",
+      "claim": "The labelled case refuses source bytes from a different draft.",
+      "evidence_class": "inferred"
+    },
+    "vulgate-eval-o": {
+      "path": "plugins/hexaemeron/tests/test_promise_evaluation_cases.py",
+      "selector": "test_labelled_overclaim_cases",
+      "claim": "The labelled case keeps register rewriting narrower than truth, authorship or argument improvement.",
+      "evidence_class": "inferred"
+    },
+    "vulgate-eval-r": {
+      "path": "plugins/hexaemeron/tests/test_promise_evaluation_cases.py",
+      "selector": "test_labelled_recovery_cases",
+      "claim": "The labelled recovery restores lost content and repeats the complete comparison.",
+      "evidence_class": "inferred"
+    },
     "imprimatur-p": {
       "path": "plugins/hexaemeron/skills/imprimatur/tests/run_tests.py",
       "selector": "test_promise_machine_licensed_scope_qualifier_is_preserved",
@@ -2010,7 +2040,7 @@
         "disposition": "Labelled P/M/S/O/R expectations recorded; cross-model content parity remains unknown."
       },
       "cases": {
-        "P": "hex-eval-p", "M": "hex-eval-m", "S": "hex-eval-s", "O": "hex-eval-o", "R": "hex-eval-r",
+        "P": "vulgate-eval-p", "M": "vulgate-eval-m", "S": "vulgate-eval-s", "O": "vulgate-eval-o", "R": "vulgate-eval-r",
         "X": {"not_applicable": true, "reason": "The canonical declaration supports no exception for this promise."}
       }
     }

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -145,6 +145,36 @@
       "selector": "test_a_stated_reason_suppresses",
       "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
     },
+    "ephoros-review-p": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_ephoros_review_positive",
+      "claim": "The named review case records acceptance only when every on-call question has bounded, exercised and reviewed evidence.",
+      "evidence_class": "recorded"
+    },
+    "ephoros-review-m": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_ephoros_review_missing",
+      "claim": "The named review case refuses unattended operation when an introduced external call lacks operational evidence.",
+      "evidence_class": "recorded"
+    },
+    "ephoros-review-s": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_ephoros_review_subject_mismatch",
+      "claim": "The named review case refuses observability evidence from a different build.",
+      "evidence_class": "recorded"
+    },
+    "ephoros-review-o": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_ephoros_review_overclaim",
+      "claim": "The named review case refuses to promote a clean mechanical lint into a complete observability judgement.",
+      "evidence_class": "recorded"
+    },
+    "ephoros-review-r": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_ephoros_review_recovery",
+      "claim": "The named review case records a recovery that supplies new operational evidence before review repeats.",
+      "evidence_class": "recorded"
+    },
     "fiat-p": {
       "path": "plugins/hexaemeron/tests/test_hexctl.py",
       "selector": "test_push_advances_steps_then_the_stack_integrates",
@@ -295,6 +325,36 @@
       "selector": "test_a_stated_reason_suppresses_the_finding",
       "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
     },
+    "phylax-review-p": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_phylax_review_positive",
+      "claim": "The named review case records acceptance only when each introduced boundary is named, controlled and evidence-classified.",
+      "evidence_class": "recorded"
+    },
+    "phylax-review-m": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_phylax_review_missing",
+      "claim": "The named review case refuses an external-data boundary without a confinement control or hostile-input evidence.",
+      "evidence_class": "recorded"
+    },
+    "phylax-review-s": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_phylax_review_subject_mismatch",
+      "claim": "The named review case refuses dependency evidence from a different revision.",
+      "evidence_class": "recorded"
+    },
+    "phylax-review-o": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_phylax_review_overclaim",
+      "claim": "The named review case refuses to promote a clean mechanical lint into whole-system security evidence.",
+      "evidence_class": "recorded"
+    },
+    "phylax-review-r": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_phylax_review_recovery",
+      "claim": "The named review case records recovery through a newly named and exercised boundary control.",
+      "evidence_class": "recorded"
+    },
     "probitas-p": {
       "path": "plugins/probitas/tests/test_demo.py",
       "selector": "test_it_exits_zero",
@@ -344,6 +404,36 @@
       "path": "plugins/hexaemeron/tests/test_protasis_checker.py",
       "selector": "test_this_runs_own_runbook_is_clean",
       "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
+    "protasis-study-p": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_protasis_study_positive",
+      "claim": "The named study case records readiness only after the full content contract and evidence-bearing criteria are present.",
+      "evidence_class": "recorded"
+    },
+    "protasis-study-m": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_protasis_study_missing",
+      "claim": "The named study case refuses hidden assumptions and untestable success language.",
+      "evidence_class": "recorded"
+    },
+    "protasis-study-s": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_protasis_study_subject_mismatch",
+      "claim": "The named study case refuses current-state evidence from a different repository revision.",
+      "evidence_class": "recorded"
+    },
+    "protasis-study-o": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_protasis_study_overclaim",
+      "claim": "The named study case refuses to present content readiness as implementation or correctness evidence.",
+      "evidence_class": "recorded"
+    },
+    "protasis-study-r": {
+      "path": "plugins/hexaemeron/tests/test_promise_cases.py",
+      "selector": "test_protasis_study_recovery",
+      "claim": "The named study case records recovery by gathering current evidence and repeating the complete review.",
+      "evidence_class": "recorded"
     },
     "tabularium-p": {
       "path": "plugins/tabularium/tests/test_release.py",
@@ -844,11 +934,11 @@
       "skill_path": "plugins/hexaemeron/skills/ephoros/SKILL.md",
       "group": "executable",
       "cases": {
-        "P": "ephoros-p",
-        "M": "ephoros-m",
-        "S": "ephoros-s",
-        "O": "ephoros-o",
-        "R": "ephoros-r",
+        "P": "ephoros-review-p",
+        "M": "ephoros-review-m",
+        "S": "ephoros-review-s",
+        "O": "ephoros-review-o",
+        "R": "ephoros-review-r",
         "X": {
           "not_applicable": true,
           "reason": "The canonical declaration supports no exception for this promise."
@@ -1340,11 +1430,11 @@
       "skill_path": "plugins/hexaemeron/skills/phylax/SKILL.md",
       "group": "executable",
       "cases": {
-        "P": "phylax-p",
-        "M": "phylax-m",
-        "S": "phylax-s",
-        "O": "phylax-o",
-        "R": "phylax-r",
+        "P": "phylax-review-p",
+        "M": "phylax-review-m",
+        "S": "phylax-review-s",
+        "O": "phylax-review-o",
+        "R": "phylax-review-r",
         "X": {
           "not_applicable": true,
           "reason": "The canonical declaration supports no exception for this promise."
@@ -1436,11 +1526,11 @@
       "skill_path": "plugins/hexaemeron/skills/protasis/SKILL.md",
       "group": "executable",
       "cases": {
-        "P": "protasis-p",
-        "M": "protasis-m",
-        "S": "protasis-s",
-        "O": "protasis-o",
-        "R": "protasis-r",
+        "P": "protasis-study-p",
+        "M": "protasis-study-m",
+        "S": "protasis-study-s",
+        "O": "protasis-study-o",
+        "R": "protasis-study-r",
         "X": {
           "not_applicable": true,
           "reason": "The canonical declaration supports no exception for this promise."

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -1057,6 +1057,36 @@ class PromiseCoverageTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 1)
         self.assertIn("PM064", [item["code"] for item in report["findings"]])
 
+    def test_unsupported_evidence_class_is_refused(self):
+        def mutate(document):
+            document["evidence"]["p"]["evidence_class"] = "anecdotal"
+
+        completed, report = self.run_mutation(mutate)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM064", [item["code"] for item in report["findings"]])
+
+    def test_duplicate_json_key_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            coverage_path, _ = write_coverage_fixture(target)
+            coverage_path.write_text(
+                '{"contract":"promise-machine/v1",'
+                '"contract":"promise-machine/v1"}',
+                encoding="utf-8",
+            )
+            completed = run_cli(
+                "coverage",
+                "--check",
+                "--root",
+                target,
+                "--group",
+                "executable",
+                "--json",
+            )
+        report = json.loads(completed.stdout)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM061", [item["code"] for item in report["findings"]])
+
     def test_selected_pending_row_is_refused(self):
         def mutate(document):
             document["rows"][0]["cases"] = None

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -1045,6 +1045,8 @@ class PromiseCoverageTests(unittest.TestCase):
             row = document["rows"][1]
             row["cases"] = dict(document["rows"][0]["cases"])
             row.pop("pending")
+            for evidence in document["evidence"].values():
+                evidence["evidence_class"] = "checked"
             row["evaluation"] = {
                 "status": "recorded",
                 "model": "not-run",
@@ -1120,6 +1122,14 @@ class PromiseCoverageTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 1)
         self.assertIn("PM064", [item["code"] for item in report["findings"]])
 
+    def test_evidence_class_must_be_accepted_by_the_promise(self):
+        def mutate(document):
+            document["evidence"]["p"]["evidence_class"] = "recorded"
+
+        completed, report = self.run_mutation(mutate)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM064", [item["code"] for item in report["findings"]])
+
     def test_duplicate_json_key_is_refused(self):
         with tempfile.TemporaryDirectory() as directory:
             target = Path(directory)
@@ -1171,6 +1181,36 @@ class PromiseCoverageTests(unittest.TestCase):
             document["rows"][1]["evaluation"]["corpus"] = "tests/missing.json"
 
         completed, report = self.run_vendored_mutation(mutate)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM069", [item["code"] for item in report["findings"]])
+
+    def test_prompt_or_vendored_evaluation_corpus_must_be_repository_relative(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            coverage_path, document = write_coverage_fixture(target)
+            row = document["rows"][1]
+            row["cases"] = dict(document["rows"][0]["cases"])
+            row.pop("pending")
+            for evidence in document["evidence"].values():
+                evidence["evidence_class"] = "checked"
+            row["evaluation"] = {
+                "status": "recorded",
+                "model": "not-run",
+                "prompt": "Fixture prompt.",
+                "corpus": str((target / "tests" / "evidence.py").resolve()),
+                "disposition": "Fixture classifications recorded.",
+            }
+            coverage_path.write_text(json.dumps(document), encoding="utf-8")
+            completed = run_cli(
+                "coverage",
+                "--check",
+                "--root",
+                target,
+                "--group",
+                "vendored",
+                "--json",
+            )
+        report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 1)
         self.assertIn("PM069", [item["code"] for item in report["findings"]])
 

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -128,6 +128,68 @@ def write_overlay(root, skill, *, promise_id="hexaemeron-upstream-run", digest=N
     return overlay
 
 
+def write_coverage_fixture(root):
+    plugin = make_plugin(root, "hexaemeron")
+    write_skill(plugin, "elenchus")
+    vendored = write_vendored_skill(plugin)
+    write_overlay(root, vendored)
+    evidence_path = root / "tests" / "evidence.py"
+    evidence_path.parent.mkdir(parents=True)
+    selectors = {
+        "p": "test_positive",
+        "m": "test_missing",
+        "s": "test_subject_mismatch",
+        "o": "test_overclaim",
+        "r": "test_recovery",
+    }
+    evidence_path.write_text(
+        "\n".join(f"def {selector}():\n    pass\n" for selector in selectors.values()),
+        encoding="utf-8",
+    )
+    evidence = {
+        key: {
+            "path": "tests/evidence.py",
+            "selector": selector,
+            "claim": f"Fixture {key} evidence.",
+        }
+        for key, selector in selectors.items()
+    }
+    document = {
+        "contract": "promise-machine/v1",
+        "schema": "promise-machine-coverage/v1",
+        "handoffs": [],
+        "evidence": evidence,
+        "rows": [
+            {
+                "promise_id": "example-check",
+                "skill_path": "plugins/hexaemeron/skills/elenchus/SKILL.md",
+                "group": "executable",
+                "cases": {
+                    "P": "p",
+                    "M": "m",
+                    "S": "s",
+                    "O": "o",
+                    "R": "r",
+                    "X": {
+                        "not_applicable": True,
+                        "reason": "The fixture supports no exceptions.",
+                    },
+                },
+            },
+            {
+                "promise_id": "hexaemeron-upstream-run",
+                "skill_path": "plugins/hexaemeron/skills/upstream/SKILL.md",
+                "group": "vendored",
+                "cases": None,
+                "pending": "Runbook Step 8 classifies vendored evidence.",
+            },
+        ],
+    }
+    coverage = root / "tests" / "promise_machine_coverage.json"
+    coverage.write_text(json.dumps(document), encoding="utf-8")
+    return coverage, document
+
+
 class PromiseLawTests(unittest.TestCase):
     def test_repository_law_and_copies_are_clean(self):
         completed = run_cli("check", "--only", "law,copies")
@@ -883,6 +945,126 @@ class PromiseIdentityTests(unittest.TestCase):
                 "check", "--root", target, "--only", "routers", "--json"
             )
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+
+
+class PromiseCoverageTests(unittest.TestCase):
+    def test_repository_executable_coverage_is_complete(self):
+        completed = run_cli(
+            "coverage", "--check", "--group", "executable", "--json"
+        )
+        report = json.loads(completed.stdout)
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["counts"]["coverage_rows"], 66)
+        self.assertEqual(report["counts"]["coverage_selected"], 50)
+
+    def test_berean_and_janus_boundaries_are_explicit(self):
+        coverage = json.loads(
+            (ROOT / "tests" / "promise_machine_coverage.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        rows = {row["promise_id"]: row for row in coverage["rows"]}
+        self.assertEqual(
+            set(rows["berean-answer-evidence"]["preserves"]),
+            {
+                "answer-truth-refused",
+                "read-class",
+                "source-class",
+                "subject",
+                "time-domain",
+            },
+        )
+        self.assertEqual(
+            set(rows["janus-bounded-conformance"]["preserves"]),
+            {
+                "adapter",
+                "bounded-search",
+                "cross-host-refused",
+                "manifest",
+                "recorder",
+                "safety-refused",
+                "unknown-effect-refused",
+            },
+        )
+        self.assertEqual(
+            {
+                (handoff["producer"], handoff["consumer"])
+                for handoff in coverage["handoffs"]
+            },
+            {
+                ("lazarus-fixture-verification", "berean-answer-evidence"),
+                ("berean-release-promotion", "ariadne-capture-statement"),
+            },
+        )
+
+    def run_mutation(self, mutate):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            coverage_path, document = write_coverage_fixture(target)
+            mutate(document)
+            coverage_path.write_text(json.dumps(document), encoding="utf-8")
+            completed = run_cli(
+                "coverage",
+                "--check",
+                "--root",
+                target,
+                "--group",
+                "executable",
+                "--json",
+            )
+        return completed, json.loads(completed.stdout)
+
+    def test_missing_coverage_row_is_refused(self):
+        completed, report = self.run_mutation(
+            lambda document: document["rows"].pop(0)
+        )
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM062", [item["code"] for item in report["findings"]])
+
+    def test_unresolved_test_selector_is_refused(self):
+        def mutate(document):
+            document["evidence"]["p"]["selector"] = "test_absent"
+
+        completed, report = self.run_mutation(mutate)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM065", [item["code"] for item in report["findings"]])
+
+    def test_one_selector_cannot_satisfy_incompatible_cases(self):
+        def mutate(document):
+            document["rows"][0]["cases"]["M"] = "p"
+
+        completed, report = self.run_mutation(mutate)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM067", [item["code"] for item in report["findings"]])
+
+    def test_material_missing_case_cannot_be_inapplicable(self):
+        def mutate(document):
+            document["rows"][0]["cases"]["M"] = {
+                "not_applicable": True,
+                "reason": "Fixture claim.",
+            }
+
+        completed, report = self.run_mutation(mutate)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM066", [item["code"] for item in report["findings"]])
+
+    def test_inapplicability_requires_a_reason(self):
+        def mutate(document):
+            document["rows"][0]["cases"]["X"] = {"not_applicable": True}
+
+        completed, report = self.run_mutation(mutate)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM064", [item["code"] for item in report["findings"]])
+
+    def test_selected_pending_row_is_refused(self):
+        def mutate(document):
+            document["rows"][0]["cases"] = None
+            document["rows"][0]["pending"] = "Later."
+
+        completed, report = self.run_mutation(mutate)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM066", [item["code"] for item in report["findings"]])
 
 
 if __name__ == "__main__":

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -998,6 +998,31 @@ class PromiseCoverageTests(unittest.TestCase):
             },
         )
 
+    def test_repository_prompt_and_vendored_coverage_is_complete(self):
+        completed = run_cli(
+            "coverage", "--check", "--group", "prompt,vendored", "--json"
+        )
+        report = json.loads(completed.stdout)
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["counts"]["coverage_rows"], 66)
+        self.assertEqual(report["counts"]["coverage_selected"], 16)
+
+    def test_prompt_and_vendored_evaluations_never_claim_proof(self):
+        coverage = json.loads(
+            (ROOT / "tests" / "promise_machine_coverage.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        selected = [
+            row for row in coverage["rows"] if row["group"] in {"prompt", "vendored"}
+        ]
+        self.assertEqual(len(selected), 16)
+        self.assertTrue(all("pending" not in row for row in selected))
+        self.assertTrue(
+            all(row["evaluation"]["status"] in {"recorded", "unknown"} for row in selected)
+        )
+
     def run_mutation(self, mutate):
         with tempfile.TemporaryDirectory() as directory:
             target = Path(directory)
@@ -1011,6 +1036,36 @@ class PromiseCoverageTests(unittest.TestCase):
                 target,
                 "--group",
                 "executable",
+                "--json",
+            )
+        return completed, json.loads(completed.stdout)
+
+    def run_vendored_mutation(self, mutate):
+        def complete(document):
+            row = document["rows"][1]
+            row["cases"] = dict(document["rows"][0]["cases"])
+            row.pop("pending")
+            row["evaluation"] = {
+                "status": "recorded",
+                "model": "not-run",
+                "prompt": "Fixture prompt.",
+                "corpus": "tests/evidence.py",
+                "disposition": "Fixture classifications recorded.",
+            }
+            mutate(document)
+
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            coverage_path, document = write_coverage_fixture(target)
+            complete(document)
+            coverage_path.write_text(json.dumps(document), encoding="utf-8")
+            completed = run_cli(
+                "coverage",
+                "--check",
+                "--root",
+                target,
+                "--group",
+                "vendored",
                 "--json",
             )
         return completed, json.loads(completed.stdout)
@@ -1095,6 +1150,29 @@ class PromiseCoverageTests(unittest.TestCase):
         completed, report = self.run_mutation(mutate)
         self.assertEqual(completed.returncode, 1)
         self.assertIn("PM066", [item["code"] for item in report["findings"]])
+
+    def test_prompt_or_vendored_evaluation_provenance_is_required(self):
+        completed, report = self.run_vendored_mutation(
+            lambda document: document["rows"][1].pop("evaluation")
+        )
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM069", [item["code"] for item in report["findings"]])
+
+    def test_prompt_or_vendored_evaluation_may_not_claim_proof(self):
+        def mutate(document):
+            document["rows"][1]["evaluation"]["status"] = "proved"
+
+        completed, report = self.run_vendored_mutation(mutate)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM069", [item["code"] for item in report["findings"]])
+
+    def test_prompt_or_vendored_evaluation_corpus_must_resolve(self):
+        def mutate(document):
+            document["rows"][1]["evaluation"]["corpus"] = "tests/missing.json"
+
+        completed, report = self.run_vendored_mutation(mutate)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM069", [item["code"] for item in report["findings"]])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Classify prompt and vendored Promise Machine evidence

## What changed

- Completed P/M/S/O/R/X coverage for all 11 prompt or transformation promises
  and all five digest-bound vendored overlays.
- Bound every evaluation row to a repository-relative corpus and recorded its
  model, prompt, disposition and `recorded` or `unknown` status.
- Added deterministic checks for Brevitas evidence preservation and structure,
  Hypomnema pointers, Imprimatur qualification, and Kronos ranking and parking.
- Added owning-plugin labelled cases for Hypomnema record placement, Kronos
  dispatch, Vulgate, Sapheneia and all five vendored overlays.
- Kept Vulgate and Sapheneia cross-model behaviour `unknown`, and stated
  `not-run` wherever no model, Fizz campaign, conversion, sync, X-Ray pass or
  Solidity audit ran.
- Made the coverage gate reject missing evaluation provenance, non-resolving or
  checkout-specific corpus paths, and evidence classes the owning promise does
  not accept.

## Audit

The audit is appended to `audit/AUDIT.md`. Round 1 found that Vulgate cases
used an inadmissible evidence class and that absolute corpus paths could make a
local record non-portable. Both findings are fixed and guarded. Round 2 was
clean.

## Proof

```bash
python3 scripts/promise_machine.py coverage --check --group prompt,vendored
python3 -m unittest tests.test_promise_machine_contract.PromiseCoverageTests
python3 -m unittest discover -s plugins/brevitas/tests -t plugins/brevitas
python3 plugins/hexaemeron/skills/imprimatur/tests/run_tests.py
python3 -m unittest discover -s plugins/sapheneia/tests -t plugins/sapheneia
python3 plugins/hexaemeron/tests/run_tests.py
python3 -m unittest discover -s tests
```

The coverage command reports all 16 selected promises with no finding. The 17
focused coverage checks, 21 Brevitas tests, 60 Imprimatur checks, nine
Sapheneia tests, 474 Hexaemeron tests and 97 root tests pass. The Phylax,
Ephoros, Hypomnema and Horos gates are clean, and the five vendored instruction
files remain unchanged.

This pull request stacks on the executable Promise Machine coverage step.

<!-- wildcat-origin: shoggoth -->
