### PR TITLE
Demonstrate the Promise Machine against itself

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,14 +4,14 @@
     "name": "Wildcat Labs",
     "url": "https://wildcat.finance"
   },
-  "description": "Agent skills written and used by Wildcat Labs.",
+  "description": "Wildcat Labs Skills, governed by the Promise Machine evidence and transition contract.",
   "plugins": [
     {
       "name": "hermes",
       "displayName": "Hermes",
       "source": "./plugins/hermes",
       "description": "Fail-closed Solidity gas optimisation with measured Foundry evidence.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"
@@ -32,7 +32,7 @@
       "displayName": "Hexaemeron",
       "source": "./plugins/hexaemeron",
       "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose, specification, debugging, hardening, telemetry and measurement skills.",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"
@@ -54,7 +54,7 @@
       "displayName": "Horos",
       "source": "./plugins/horos",
       "description": "Classify a repository's token sinks with evidence and emit the reading boundary agents respect.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"
@@ -76,7 +76,7 @@
       "displayName": "Janus",
       "source": "./plugins/janus",
       "description": "A conformance suite for what a contract hook may observe and change before and after a host action.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"
@@ -97,7 +97,7 @@
       "displayName": "Sapheneia",
       "source": "./plugins/sapheneia",
       "description": "AuDHD-shaped replies with visible state and next actions.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"
@@ -118,7 +118,7 @@
       "displayName": "Probitas",
       "source": "./plugins/probitas",
       "description": "Sourced counterparty lending dossiers from declared addresses, with coverage gaps kept visible.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"
@@ -140,7 +140,7 @@
       "displayName": "Lemma",
       "source": "./plugins/lemma",
       "description": "Source-linked JSONL chunks from Solidity compiler inputs and Markdown documents.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"
@@ -161,7 +161,7 @@
       "displayName": "Lazarus",
       "source": "./plugins/lazarus",
       "description": "Proof-checked historical Ethereum fixtures with exact-request replay, no live fallback, and preservation releases a stranger can check.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"
@@ -183,7 +183,7 @@
       "displayName": "Pandects",
       "source": "./plugins/pandects",
       "description": "Executable credit laws with broken specimens and reduced counterexamples.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"
@@ -205,7 +205,7 @@
       "displayName": "Ariadne",
       "source": "./plugins/ariadne",
       "description": "Release evidence statements binding artefact digests to the record behind them.",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"
@@ -227,7 +227,7 @@
       "displayName": "Tabularium",
       "source": "./plugins/tabularium",
       "description": "Venue-qualified credit-event releases rebuilt from preserved source records.",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"
@@ -248,7 +248,7 @@
       "displayName": "Alexandria",
       "source": "./plugins/alexandria",
       "description": "Digest-bound lending-data releases with reviewed credit views and address queries.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"
@@ -270,7 +270,7 @@
       "displayName": "Brevitas",
       "source": "./plugins/brevitas",
       "description": "Evidence-preserving budgets for engineering prose.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"
@@ -292,7 +292,7 @@
       "displayName": "Berean",
       "source": "./plugins/berean",
       "description": "Digest-pinned agent releases with byte-exact citations, block-bound reads and evaluated refusals.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "Wildcat Labs",
         "url": "https://wildcat.finance"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-# Wildcat Labs skills
+# Wildcat Labs Skills
+
+## The Promise Machine
+
+Every skill in this suite is governed by the
+[Promise Machine](./PROMISE_MACHINE.md): no skill may claim more than its
+evidence establishes or authorise a more consequential transition than that
+evidence warrants. Each skill still owns its narrow job and its own evidence;
+the Promise Machine is the shared architecture that keeps those boundaries
+intact when skills, hosts and releases compose.
 
 Agent skills written and used by [Wildcat Labs](https://wildcat.finance).
 

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5578,3 +5578,34 @@ versions and evolution ledgers remain unchanged.
 
 This follow-up changes test expectations only. It does not change a command,
 result format, promise, canonical skill version, frontier digest or held job.
+
+## Promise Machine, step 9, round 1 -- 2026-08-20
+
+### Review scope
+
+The Solidity suite remained waived because Step 9 adds one Markdown evidence
+record and changes no executable or Solidity file. The review compared every
+recorded count with its command result, checked the installed package and skill
+versions independently, inspected the Codex resolver entries, and confirmed
+that both unavailable host observations were reported as unknowns.
+
+### Findings
+
+Zero findings.
+
+### Evidence
+
+The Promise Machine inventory and full check are clean, the checker completes
+in 0.10 seconds, and the root suite passes 104 tests. Every plugin suite named
+in the runbook passes, including Berean's 151 tests, Janus's 14 Python and 24
+Foundry tests, and Pandects's 116 Python and 79 Foundry tests. The Phylax,
+Ephoros and Hypomnema tree checks exit clean. The new evidence document passes
+Imprimatur and Brevitas.
+
+### Leads not pursued
+
+Codex computer control cannot inspect the Codex app, so the picker screenshot
+was not taken. Claude Code's expired OAuth token prevented the model-backed
+slash invocation. The evidence record names both limits and retains the
+resolver, package and host-neutral transcripts that did run; it does not infer
+either missing result.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5461,3 +5461,46 @@ files remain unchanged.
 
 The forward-testing and no-execution limits recorded in round 1 remain
 unchanged.
+
+## Promise Machine, step 8, round 1 -- 2026-08-20
+
+### Review scope
+
+The Solidity suite remained waived because this step changes the root Python
+checker, JSON inventories, package manifests, prose and Imprimatur's Markdown
+heading rule, not Solidity. The review compared all 29 level-2 and level-3
+bindings with their canonical declarations and result surfaces, checked package
+and skill version separation, recomputed the unchanged frontier digest for the
+Imprimatur generation, and inspected the new default full-check path.
+
+### Findings
+
+FINDING
+[High] S8-R1-01: A runtime field map was not bound to the result surface bytes.
+Location: `tests/promise_machine_coverage.json`
+Mechanism: The gate checked that each schema, writer or contract existed, but a later change to that source could leave its field map green.
+Impact: A stale map could misstate where a consequential result carries its subject, evidence, unknowns or transition.
+Fix: Added a required source SHA-256, recomputation in the root checker and a source-drift refusal test.
+END
+
+FINDING
+[Medium] S8-R1-02: Runtime source hashing had no read bound.
+Location: `scripts/promise_machine.py`
+Mechanism: A coverage entry could point the checker at any regular repository file and read all of it into memory.
+Impact: A malformed or hostile entry could turn the structural gate into an avoidable memory sink.
+Fix: Hash sources in 64 KiB chunks, stop above 1 MiB and guard the limit with an oversized-source test.
+END
+
+### Evidence
+
+The full checker reports 14 plugins, 28 canonical skills, 66 promises, 29
+digest-bound runtime bindings and zero findings. The focused runtime mutations
+refuse an absent binding, a repository escape, source drift and an oversized
+source.
+
+### Leads not pursued
+
+The inventory binds existing domain formats; it does not replace them with a
+generic result envelope or claim that a structural field map proves the domain
+result. Berean's Wildcat-grounded release and Janus's second adapter remain held
+frontier work.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5504,3 +5504,30 @@ The inventory binds existing domain formats; it does not replace them with a
 generic result envelope or claim that a structural field map proves the domain
 result. Berean's Wildcat-grounded release and Janus's second adapter remain held
 frontier work.
+
+## Promise Machine, step 8, round 2 -- 2026-08-20
+
+### Review scope
+
+The corrected checker now derives the high-consequence set from canonical
+declarations, requires exactly one complete runtime map for each member, confines
+its source, recomputes the reviewed source digest through a bounded read and
+refuses stale or extra entries. The package release still leaves every unrelated
+skill frontier untouched.
+
+### Findings
+
+Zero findings.
+
+### Evidence
+
+The Promise Machine full check is clean across all 66 promises. All 91 focused
+contract, evolution, version and marketplace tests, all 104 root tests, all 474
+Hexaemeron tests and all 62 Imprimatur checks pass. The Phylax, Ephoros,
+Hypomnema and Horos gates are clean.
+
+### Leads not pursued
+
+The digest proves which result surface the map reviewed, not that a domain
+operation ran or its assertion is true. Those claims remain with the exact
+command, gate or observation named by the owning promise.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5554,3 +5554,27 @@ passes on the full Lazarus suite and preserves the checked-in fixture's
 
 This repair changes no Lazarus command, result format, canonical skill version,
 frontier digest or held job. It corrects a stale test of the distribution layer.
+
+## Promise Machine, step 8, publication gate repair follow-up -- 2026-08-20
+
+### Failure
+
+FINDING
+[High] S8-PG-02: Four plugin suites retained the same package/skill version assumption.
+Location: `plugins/alexandria/tests/test_scaffold.py`, `plugins/berean/tests/test_scaffold.py`, `plugins/probitas/tests/test_manifests.py` and `plugins/tabularium/tests/test_scaffold.py`
+Mechanism: Three tests pinned the preceding package version and the Probitas test required package and canonical skill versions to be equal.
+Impact: The complete Step 10 demonstration stopped in Alexandria, while Probitas would have rejected the intended package-only release despite its held skill frontier.
+Fix: Bind package assertions to the release version and marketplace surfaces, and make Probitas's package-versus-skill independence explicit.
+END
+
+### Evidence
+
+The failure reproduced in Alexandria's full suite. The corrected Alexandria,
+Berean, Probitas and Tabularium suites pass 255, 151, 276 and 134 tests. Their
+host manifests carry the release package versions while their canonical skill
+versions and evolution ledgers remain unchanged.
+
+### Boundary
+
+This follow-up changes test expectations only. It does not change a command,
+result format, promise, canonical skill version, frontier digest or held job.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5531,3 +5531,26 @@ Hypomnema and Horos gates are clean.
 The digest proves which result surface the map reviewed, not that a domain
 operation ran or its assertion is true. Those claims remain with the exact
 command, gate or observation named by the owning promise.
+
+## Promise Machine, step 8, publication gate repair -- 2026-08-20
+
+### Failure
+
+FINDING
+[High] S8-PG-01: Lazarus's scaffold test still equated package and skill versions.
+Location: `plugins/lazarus/tests/test_scaffold.py`
+Mechanism: The test compared both host manifest versions with canonical skill metadata instead of the marketplace package entry.
+Impact: The planned `lazarus` package release failed on Python 3.11 and 3.13 despite preserving `lazarus-v1.1.0` correctly.
+Fix: Compare both host manifests with the marketplace package version and guard its independence from skill and writer versions.
+END
+
+### Evidence
+
+The failure reproduced with the exact Lazarus scaffold test. The corrected test
+passes on the full Lazarus suite and preserves the checked-in fixture's
+`tool_version` separately.
+
+### Boundary
+
+This repair changes no Lazarus command, result format, canonical skill version,
+frontier digest or held job. It corrects a stale test of the distribution layer.

--- a/docs/decisions/ADR-004-release-the-promise-machine-without-moving-skill-frontiers.md
+++ b/docs/decisions/ADR-004-release-the-promise-machine-without-moving-skill-frontiers.md
@@ -1,0 +1,46 @@
+# ADR-004: Release the Promise Machine without moving skill frontiers
+
+- Status: Accepted
+- Date: 2026-08-20
+- Contract: `promise-machine/v1`
+
+## Context
+
+The Promise Machine adds one generated law copy and runtime binding to every
+plugin. Installed hosts cache plugins by package version, while each canonical
+skill carries a separate behavioural version and a held frontier. Treating the
+suite release as a skill advance would say that frontier work happened when it
+did not. Leaving package versions unchanged would let a host retain the package
+from before the governing contract existed.
+
+Level-2 and level-3 promises also produce different durable records. Replacing
+those domain formats with one generic envelope would discard useful semantics
+and create a second authority beside their existing schemas and writers.
+
+## Decision
+
+Publish every plugin at the patch package version recorded in the Promise
+Machine study. The Claude manifest, Codex manifest and Claude marketplace entry
+for a plugin carry the same package version. Canonical skill versions,
+evolution histories, frontier revisions, frontier digests and `Next Fiat job`
+values do not move for this suite-wide release.
+
+Keep domain result formats authoritative. The checked coverage inventory joins
+every level-2 and level-3 promise to its existing result schema, writer or
+contract and names where promise id, subject, scope, evidence references and
+classes, unknowns, transition and exception are carried. The root checker
+refuses a missing, incomplete, stale or repository-escaping runtime binding.
+
+## Consequences
+
+Hosts receive the Promise Machine only after observing a new plugin package
+identity. A package update no longer implies a skill frontier advance. Reviewers
+can inspect consequential results through the domain format they already use
+and the checked join that limits what the result authorises.
+
+Future behavioural changes still update the affected canonical skill's
+evolution ledger on the axis required by `VERSIONING.md`. Future package-only
+changes update the three package surfaces without rewriting skill history.
+Rollback restores the prior package manifests, marketplace entries, runtime
+inventory, public prose and checker gate together; a partial rollback is not a
+valid release state.

--- a/docs/promise-machine/evidence/2026-08-20-self-demonstration.md
+++ b/docs/promise-machine/evidence/2026-08-20-self-demonstration.md
@@ -1,0 +1,147 @@
+# Promise Machine self-demonstration
+
+- Date: 2026-08-20
+- Candidate base: `f2b76d0cb1a8973c744bf879b38c6df72884f904`
+- Host: macOS, Python 3.14.6, Forge 1.7.1 and uv 0.12.5
+- Codex: `codex-cli 0.147.0`
+- Claude Code: 2.1.234
+- Evidence class: observed local command and resolver transcripts
+
+This record demonstrates repository conformance and the discovery state that
+the available host controls could inspect. It does not turn repository
+correctness into a claim about model judgement. The two unavailable manual
+surfaces remain named below.
+
+## Result
+
+| Surface | Observed result | Boundary |
+| --- | --- | --- |
+| Complete repository gate | Pass | 14 plugins, 28 canonical skills, 23 governed skills, five vendored skills, one router and one overlay |
+| Runtime coverage | Pass | 14 plugin copies and 29 level-2 or level-3 runtime bindings |
+| Checker timing | Pass | 0.11 seconds real time against a five-second budget |
+| Codex package and resolver state | Pass | 14 release-candidate packages installed; one qualified Protasis and one unversioned suite router in the model-visible registry |
+| Codex picker screenshot | Not observed | Computer control refused access to the Codex app; no screenshot is claimed |
+| Claude package state | Pass | 14 release-candidate packages installed and Hexaemeron exposes Protasis |
+| Claude slash invocation | Not observed | The invocation stopped at an expired OAuth token with HTTP 401; no model result is claimed |
+| Host-neutral discovery | Pass | The only `SKILL.md` below `.agents/skills/` is `promise-machine`; its routes resolve to the three tested runtime contracts |
+
+## Deterministic gates
+
+The following suites ran from their shipped boundaries and returned zero
+failures unless a skip is shown.
+
+| Gate | Result | Evidence boundary |
+| --- | --- | --- |
+| Root repository suite | 104 passed | `tests/` |
+| Alexandria | 255 passed | plugin Python suite |
+| Ariadne | 632 passed, six skipped | plugin Python suite |
+| Berean release verifier and evaluation suite | 151 passed | plugin Python suite and shipped fixtures |
+| Brevitas | 21 passed | plugin Python suite |
+| Hermes | 14 passed | shipped harness tests |
+| Hexaemeron | 474 passed | plugin test runner |
+| Imprimatur | 62 passed | skill test runner |
+| Horos | 212 passed | plugin Python suite |
+| Janus Python suite | 14 passed | plugin Python suite |
+| Janus Foundry harness | 24 passed | `plugins/janus/harness/` |
+| Lemma Markdown and Solidity harnesses | zero failures | two shipped script suites |
+| Lazarus | 364 passed in its pinned uv environment | plugin Python suite |
+| Pandects Python suite | 116 passed | plugin Python suite |
+| Pandects Foundry suite | 79 passed | `plugins/pandects/` |
+| Probitas | 276 passed | plugin Python suite |
+| Sapheneia | nine passed | plugin Python suite |
+| Tabularium | 134 passed | plugin Python suite |
+
+Janus and Pandects emitted their expected Foundry warnings and passed. No
+Solidity file differs from the preceding Step 8 branch, so the suite-wide
+Solidity audit remained waived. The two named Foundry suites still ran because
+their evidence contracts changed during this delivery.
+
+The timing transcript was:
+
+```text
+clean: 14 plugin(s), 14 copy/copies
+real 0.11
+user 0.08
+sys 0.03
+```
+
+## Codex observation
+
+The supported marketplace installer refreshed `wildcat-labs` from the
+published Step 8 branch. `codex plugin list` then reported all 14 packages as
+installed and enabled at the package versions declared by this release,
+including Hexaemeron 1.5.1, Berean 0.1.1 and Janus 0.1.1.
+
+The model-visible prompt resolver was inspected with:
+
+```bash
+codex debug prompt-input '/prot'
+```
+
+The relevant registry lines were:
+
+```text
+promise-machine: ... (file: r8/promise-machine/SKILL.md)
+berean:berean: ... (file: r6/berean/0.1.1/skills/berean/SKILL.md)
+hexaemeron:protasis: ... (file: r7/protasis/SKILL.md)
+janus:janus: ... (file: r6/janus/0.1.1/skills/janus/SKILL.md)
+```
+
+There was no bare `protasis`, `berean` or `janus` skill entry. The installed
+ledgers reported `protasis-v2.2.0`, `berean-v0.1.0` and `janus-v0.1.0`.
+The Promise Machine entry carried no version.
+
+Computer control returned `Computer Use is not allowed to use the app
+'com.openai.codex' for safety reasons.` The picker screenshot required by the
+runbook was therefore not observable from this task. The resolver transcript
+is evidence of the registry Codex sends to the model, not evidence of how the
+picker rendered it.
+
+## Claude Code observation
+
+The supported marketplace installer refreshed the local candidate and
+installed all 14 packages. `claude plugin details hexaemeron@wildcat-labs`
+reported Hexaemeron 1.5.1 and a 13-skill component inventory containing
+`protasis`. Its installed ledger reported `protasis-v2.2.0`.
+
+The exact command invocation was attempted:
+
+```text
+/hexaemeron:protasis Return only the current canonical Protasis version from
+the installed skill ledger, followed by the canonical SKILL.md path.
+```
+
+Claude Code stopped before resolving a model response:
+
+```text
+Failed to authenticate. API Error: 401 OAuth access token has expired.
+Re-authenticate to continue.
+```
+
+The package and component discovery are observed. Successful slash execution
+is not observed and is not inferred from installation.
+
+## Host-neutral observation
+
+Searching for `SKILL.md` exactly two levels below `.agents/skills/` returned:
+
+```text
+.agents/skills/promise-machine/SKILL.md
+```
+
+The router linked to the Hexaemeron, Berean and Janus runtime contracts. Those
+contracts selected `skills/protasis/SKILL.md`, `skills/berean/SKILL.md` and
+`skills/janus/SKILL.md`; their ledgers reported `protasis-v2.2.0`,
+`berean-v0.1.0` and `janus-v0.1.0`. No version field occurred in the router.
+
+## Remaining host evidence
+
+Two observations require a user-controlled host boundary:
+
+1. restart the Codex desktop app and capture the `/prot` picker after the final
+   `main` marketplace refresh;
+2. re-authenticate Claude Code and capture a successful
+   `/hexaemeron:protasis` invocation after the final refresh.
+
+Neither missing observation weakens the deterministic contract results above.
+Neither is represented as complete.

--- a/plugins/alexandria/.claude-plugin/plugin.json
+++ b/plugins/alexandria/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "alexandria",
   "displayName": "Alexandria",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Digest-bound lending-data releases with reviewed credit views and address queries.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/alexandria/.codex-plugin/plugin.json
+++ b/plugins/alexandria/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "alexandria",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Digest-bound lending-data releases with reviewed credit views and address queries.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/alexandria/tests/test_scaffold.py
+++ b/plugins/alexandria/tests/test_scaffold.py
@@ -89,8 +89,19 @@ class AlexandriaScaffoldTests(unittest.TestCase):
         for host in (".claude-plugin", ".codex-plugin"):
             path = PLUGIN_ROOT / host / "plugin.json"
             manifests.append(json.loads(path.read_text(encoding="utf-8")))
+        marketplace = json.loads(
+            (REPO_ROOT / ".claude-plugin" / "marketplace.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        package = next(
+            item["version"]
+            for item in marketplace["plugins"]
+            if item["name"] == "alexandria"
+        )
         self.assertEqual([item["name"] for item in manifests], ["alexandria"] * 2)
-        self.assertEqual([item["version"] for item in manifests], ["0.2.0"] * 2)
+        self.assertEqual([item["version"] for item in manifests], [package] * 2)
+        self.assertEqual(package, "0.2.1")
         self.assertEqual([item["skills"] for item in manifests], ["./skills/"] * 2)
         self.assertTrue(SKILL.is_file())
 

--- a/plugins/ariadne/.claude-plugin/plugin.json
+++ b/plugins/ariadne/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ariadne",
   "displayName": "Ariadne",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Release evidence statements binding artefact digests to the record behind them.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/ariadne/.codex-plugin/plugin.json
+++ b/plugins/ariadne/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ariadne",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Release evidence statements binding artefact digests to the record behind them.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/berean/.claude-plugin/plugin.json
+++ b/plugins/berean/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "berean",
   "displayName": "Berean",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Digest-pinned agent releases with byte-exact citations, block-bound reads and evaluated refusals.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/berean/.codex-plugin/plugin.json
+++ b/plugins/berean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "berean",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Digest-pinned agent releases with byte-exact citations, block-bound reads and evaluated refusals.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/berean/tests/test_scaffold.py
+++ b/plugins/berean/tests/test_scaffold.py
@@ -55,7 +55,7 @@ class ManifestTests(unittest.TestCase):
             read(REPO_ROOT / ".claude-plugin" / "marketplace.json")
         )
         entry = {p["name"]: p for p in marketplace["plugins"]}["berean"]
-        self.assertEqual(claude["version"], "0.1.0")
+        self.assertEqual(claude["version"], "0.1.1")
         self.assertEqual(codex["version"], claude["version"])
         self.assertEqual(entry["version"], claude["version"])
         self.assertEqual(codex["description"], claude["description"])

--- a/plugins/brevitas/.claude-plugin/plugin.json
+++ b/plugins/brevitas/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "brevitas",
   "displayName": "Brevitas",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Evidence-preserving budgets for engineering prose.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/brevitas/.codex-plugin/plugin.json
+++ b/plugins/brevitas/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brevitas",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Evidence-preserving budgets for engineering prose.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/hermes/.claude-plugin/plugin.json
+++ b/plugins/hermes/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hermes",
   "displayName": "Hermes",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Fail-closed Solidity gas optimisation with measured Foundry evidence.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/hermes/.codex-plugin/plugin.json
+++ b/plugins/hermes/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Fail-closed Solidity gas optimisation with measured Foundry evidence.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/hexaemeron/.claude-plugin/plugin.json
+++ b/plugins/hexaemeron/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hexaemeron",
   "displayName": "Hexaemeron",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose, specification, debugging, hardening, telemetry and measurement skills.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/hexaemeron/.codex-plugin/plugin.json
+++ b/plugins/hexaemeron/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hexaemeron",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Receipted delivery through merge and closure, with ranked frontier, audit, fuzzing, prose, specification, debugging, hardening, telemetry and measurement skills.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/hexaemeron/skills/imprimatur/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/imprimatur/EVOLUTION.md
@@ -2,7 +2,7 @@
 
 Policy: [../VERSIONING.md](../VERSIONING.md)
 
-- Current version: `imprimatur-v2.1.0`
+- Current version: `imprimatur-v2.2.0`
 - Frontier status: `open`
 - Frontier revision: `labelled-prose-v2`
 - Current frontier: Imprimatur has a provenance-bound 64-sample evaluation, but labelled-prose-v1 failed the pre-registered annotation-agreement and structural-holdout coverage gates; its holdout is spent and its provisional scores cannot support tuning.
@@ -14,3 +14,4 @@ Policy: [../VERSIONING.md](../VERSIONING.md)
 | --- | --- | --- | --- | --- | --- |
 | `imprimatur-v1.1.0` | baseline | `labelled-corpus-calibration` | `ed610953c08d982f939838315687b6672e19c2a20bdc0db6139fd4349e551535` | [skills#74](https://github.com/wildcat-finance/skills/issues/74) | Versioning starts here. Imprimatur has governed maturity handling and its own held frontier. |
 | `imprimatur-v2.1.0` | evolution | `labelled-prose-v2` | `092addc4bcae8cd93d34df41146b3a3bbd3fd24a529cd84b1d16e0399d7affb4` | [labelled-prose-v1](evals/labelled-prose-v1/README.md) | Published the provenance-bound corpus, independent raw labels, adjudication, deterministic evaluator, untouched baseline and single provisional holdout result. Agreement and structural holdout coverage failed, so the lint stayed unchanged and the frontier remains open. |
+| `imprimatur-v2.2.0` | generation | `labelled-prose-v2` | `092addc4bcae8cd93d34df41146b3a3bbd3fd24a529cd84b1d16e0399d7affb4` | [Promise Machine root identity](../../../../README.md) and [regression cases](tests/run_tests.py) | Permit the two fixed suite product-name headings without weakening the generic title-case-heading defect. |

--- a/plugins/hexaemeron/skills/imprimatur/SKILL.md
+++ b/plugins/hexaemeron/skills/imprimatur/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   any prose that ships, when checking whether a draft reads as
   machine-written, or when the user names a term to ban.
 metadata:
-  version: "2.1.0"
+  version: "2.2.0"
 ---
 
 # Imprimatur

--- a/plugins/hexaemeron/skills/imprimatur/lexicon/structural.json
+++ b/plugins/hexaemeron/skills/imprimatur/lexicon/structural.json
@@ -53,7 +53,11 @@
       "note": "Headings In Title Case Like This.",
       "severity": "medium",
       "regex": "^#{1,6}\\s+(?:[A-Z][a-z']+\\s+){2,}[A-Z][a-z']+\\s*$",
-      "case_sensitive": true
+      "case_sensitive": true,
+      "allow_exact": [
+        "# Wildcat Labs Skills",
+        "## The Promise Machine"
+      ]
     },
     "unrequested_tldr": {
       "note": "Only permitted when the user asked for one.",

--- a/plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py
+++ b/plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py
@@ -253,6 +253,8 @@ def scan_structural(text: str, lex: dict) -> list[dict]:
             sys.stderr.write(f"imprimatur: bad regex {name}: {exc}\n")
             continue
         for m in pattern.finditer(text):
+            if m.group(0).strip() in spec.get("allow_exact", []):
+                continue
             ln, cl = line_col(text, m.start())
             hits.append(
                 {

--- a/plugins/hexaemeron/skills/imprimatur/tests/run_tests.py
+++ b/plugins/hexaemeron/skills/imprimatur/tests/run_tests.py
@@ -54,6 +54,7 @@ TRUE_POSITIVES = [
     ("not because but", "Not because it failed, but because it never ran.", "not_x_but_y"),
     ("em dash", "The market cleared — eventually.", "em_dash"),
     ("apology theatre", "I apologise for the confusion in the last message.", "apology_theatre"),
+    ("generic title case", "## Evidence Changes Everything", "title_case_heading"),
     ("gated no referent", "This approach is orthogonal to the framing.", "mathematical"),
     ("intensifier no number", "The rate is materially different this quarter.", "intensifier"),
 ]
@@ -117,6 +118,10 @@ FALSE_POSITIVES = [
     (
         "sentence case heading",
         "## The three passes\n\nEach pass runs in order.",
+    ),
+    (
+        "suite product headings",
+        "# Wildcat Labs Skills\n\n## The Promise Machine\n",
     ),
     (
         "genuine enumeration",

--- a/plugins/horos/.claude-plugin/plugin.json
+++ b/plugins/horos/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "horos",
   "displayName": "Horos",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Classify a repository's token sinks with evidence and emit the reading boundary agents respect.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/horos/.codex-plugin/plugin.json
+++ b/plugins/horos/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "horos",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Classify a repository's token sinks with evidence and emit the reading boundary agents respect.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/janus/.claude-plugin/plugin.json
+++ b/plugins/janus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "janus",
   "displayName": "Janus",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A conformance suite for what a contract hook may observe and change before and after a host action.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/janus/.codex-plugin/plugin.json
+++ b/plugins/janus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "janus",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A conformance suite for what a contract hook may observe and change before and after a host action.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/lazarus/.claude-plugin/plugin.json
+++ b/plugins/lazarus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lazarus",
   "displayName": "Lazarus",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Proof-checked historical Ethereum fixtures with exact-request replay, no live fallback, and preservation releases a stranger can check.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/lazarus/.codex-plugin/plugin.json
+++ b/plugins/lazarus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lazarus",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Proof-checked historical Ethereum fixtures with exact-request replay, no live fallback, and preservation releases a stranger can check.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/lazarus/tests/test_scaffold.py
+++ b/plugins/lazarus/tests/test_scaffold.py
@@ -1,5 +1,6 @@
 """The Lazarus shell keeps every host and document on one contract."""
 
+import json
 import re
 import unittest
 
@@ -18,19 +19,27 @@ class ScaffoldTests(unittest.TestCase):
         self.assertEqual(claude["description"], codex["description"])
         self.assertEqual(claude["license"], "MIT")
 
-    def test_the_host_manifests_follow_the_skill_and_not_the_writer(self):
+    def test_the_host_manifests_follow_the_package_and_not_the_skill_or_writer(self):
         """Two axes, kept apart on purpose.
 
-        The host manifests carry the skill's version, which moves when the
-        frontier advances. `__version__` is what Lazarus stamps into a manifest
-        as `tool_version`, so moving it rewrites the provenance of every fixture
-        already captured. They were one number until the skill's first evolution
-        advance, and that advance is what showed they are not one thing.
+        The host manifests carry the installable package version. The skill
+        version moves under its evolution ledger, while `__version__` is what
+        Lazarus stamps into a fixture as `tool_version`. A release may move the
+        package without rewriting either behavioural history or old provenance.
         """
-        skill = support.skill_version()
+        marketplace = json.loads(
+            (support.REPO_ROOT / ".claude-plugin/marketplace.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        entries = [entry for entry in marketplace["plugins"] if entry["name"] == "lazarus"]
+        self.assertEqual(len(entries), 1)
+        package = entries[0]["version"]
         for host in (".claude-plugin/plugin.json", ".codex-plugin/plugin.json"):
             with self.subTest(host=host):
-                self.assertEqual(support.load_json(host)["version"], skill)
+                self.assertEqual(support.load_json(host)["version"], package)
+        self.assertNotEqual(package, support.skill_version())
+        self.assertNotEqual(package, __version__)
 
     def test_the_writer_version_is_the_one_the_fixture_records(self):
         """Pinned to the artefact it appears in rather than to a literal, so a

--- a/plugins/lemma/.claude-plugin/plugin.json
+++ b/plugins/lemma/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lemma",
   "displayName": "Lemma",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Source-linked JSONL chunks from Solidity compiler inputs and Markdown documents.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/lemma/.codex-plugin/plugin.json
+++ b/plugins/lemma/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lemma",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Source-linked JSONL chunks from Solidity compiler inputs and Markdown documents.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/pandects/.claude-plugin/plugin.json
+++ b/plugins/pandects/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pandects",
   "displayName": "Pandects",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Executable credit laws with broken specimens and reduced counterexamples.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/pandects/.codex-plugin/plugin.json
+++ b/plugins/pandects/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pandects",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Executable credit laws with broken specimens and reduced counterexamples.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/probitas/.claude-plugin/plugin.json
+++ b/plugins/probitas/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "probitas",
   "displayName": "Probitas",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Sourced counterparty lending dossiers from declared addresses, with coverage gaps kept visible.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/probitas/.codex-plugin/plugin.json
+++ b/plugins/probitas/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "probitas",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Sourced counterparty lending dossiers from declared addresses, with coverage gaps kept visible.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/probitas/tests/test_manifests.py
+++ b/plugins/probitas/tests/test_manifests.py
@@ -58,10 +58,12 @@ class TestManifests(unittest.TestCase):
         self.assertEqual(claude["name"], "probitas")
         self.assertEqual(codex["name"], "probitas")
 
-    def test_versions_agree_across_manifests_and_skill(self):
+    def test_package_versions_agree_without_moving_the_skill(self):
         claude, codex = load(CLAUDE_MANIFEST), load(CODEX_MANIFEST)
         self.assertEqual(claude["version"], codex["version"])
-        self.assertEqual(
+        self.assertEqual(claude["version"], "0.1.1")
+        self.assertEqual(skill_frontmatter()["metadata"]["version"], "0.1.0")
+        self.assertNotEqual(
             skill_frontmatter()["metadata"]["version"], claude["version"]
         )
 

--- a/plugins/sapheneia/.claude-plugin/plugin.json
+++ b/plugins/sapheneia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sapheneia",
   "displayName": "Sapheneia",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "AuDHD-shaped replies with visible state and next actions.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/sapheneia/.codex-plugin/plugin.json
+++ b/plugins/sapheneia/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sapheneia",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "AuDHD-shaped replies with visible state and next actions.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/tabularium/.claude-plugin/plugin.json
+++ b/plugins/tabularium/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tabularium",
   "displayName": "Tabularium",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Venue-qualified credit-event releases rebuilt from preserved source records.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/tabularium/.codex-plugin/plugin.json
+++ b/plugins/tabularium/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tabularium",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Venue-qualified credit-event releases rebuilt from preserved source records.",
   "author": {
     "name": "Wildcat Labs",

--- a/plugins/tabularium/tests/test_scaffold.py
+++ b/plugins/tabularium/tests/test_scaffold.py
@@ -48,8 +48,19 @@ class TabulariumPackagingTests(unittest.TestCase):
         for host in (".claude-plugin", ".codex-plugin"):
             path = PLUGIN_ROOT / host / "plugin.json"
             manifests.append(json.loads(path.read_text(encoding="utf-8")))
+        marketplace = json.loads(
+            (REPO_ROOT / ".claude-plugin" / "marketplace.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        package = next(
+            item["version"]
+            for item in marketplace["plugins"]
+            if item["name"] == "tabularium"
+        )
         self.assertEqual([item["name"] for item in manifests], ["tabularium"] * 2)
-        self.assertEqual([item["version"] for item in manifests], ["0.3.0"] * 2)
+        self.assertEqual([item["version"] for item in manifests], [package] * 2)
+        self.assertEqual(package, "0.3.1")
         self.assertEqual([item["skills"] for item in manifests], ["./skills/"] * 2)
         self.assertEqual(manifests[0]["description"], manifests[1]["description"])
         self.assertEqual(

--- a/scripts/promise_machine.py
+++ b/scripts/promise_machine.py
@@ -22,6 +22,7 @@ MARKER = (
 MAX_MARKDOWN_BYTES = 256 * 1024
 MAX_JSON_BYTES = 64 * 1024
 MAX_COVERAGE_BYTES = 512 * 1024
+MAX_RUNTIME_SOURCE_BYTES = 1024 * 1024
 REQUIRED_HEADINGS = (
     "# Promise Machine contract",
     "## Contract identity",
@@ -194,6 +195,21 @@ def confined(path: Path, root: Path) -> bool:
         return True
     except (OSError, ValueError):
         return False
+
+
+def bounded_sha256(path: Path, limit: int):
+    digest = hashlib.sha256()
+    total = 0
+    try:
+        with path.open("rb") as source:
+            while chunk := source.read(64 * 1024):
+                total += len(chunk)
+                if total > limit:
+                    return None, f"source exceeds the {limit}-byte limit"
+                digest.update(chunk)
+    except OSError as exc:
+        return None, f"source could not be read: {exc}"
+    return digest.hexdigest(), None
 
 
 def read_markdown(path: Path, root: Path, *, missing_code: str, unsafe_code: str):
@@ -1594,14 +1610,18 @@ def check_coverage(root: Path, inventory: Inventory, selected_groups: set[str]):
     for promise_id in sorted(required_runtime & actual_runtime):
         binding = runtime_catalog[promise_id]
         binding_path = f"{COVERAGE_PATH.as_posix()}#runtime.{promise_id}"
-        if not isinstance(binding, dict) or set(binding) != {"source", "bindings"}:
+        if not isinstance(binding, dict) or set(binding) != {
+            "source",
+            "sha256",
+            "bindings",
+        }:
             findings.append(
                 Finding(
                     "PM070",
                     "structural",
                     binding_path,
-                    "runtime binding must contain exactly source and bindings",
-                    "name one confined result schema, writer or contract and its field map",
+                    "runtime binding must contain exactly source, sha256 and bindings",
+                    "name one digest-bound result schema, writer or contract and its field map",
                     promise_id=promise_id,
                 )
             )
@@ -1638,6 +1658,45 @@ def check_coverage(root: Path, inventory: Inventory, selected_groups: set[str]):
                         promise_id=promise_id,
                     )
                 )
+            else:
+                digest = binding.get("sha256")
+                if not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+                    findings.append(
+                        Finding(
+                            "PM070",
+                            "structural",
+                            binding_path,
+                            "runtime binding source digest is absent or malformed",
+                            "record the full lowercase SHA-256 of the reviewed source bytes",
+                            promise_id=promise_id,
+                        )
+                    )
+                else:
+                    actual, digest_error = bounded_sha256(
+                        source_target, MAX_RUNTIME_SOURCE_BYTES
+                    )
+                    if digest_error is not None:
+                        findings.append(
+                            Finding(
+                                "PM070",
+                                "structural",
+                                binding_path,
+                                f"runtime binding {digest_error}",
+                                "name a bounded readable result surface inside the repository",
+                                promise_id=promise_id,
+                            )
+                        )
+                    elif actual != digest:
+                        findings.append(
+                            Finding(
+                                "PM071",
+                                "drift",
+                                binding_path,
+                                f"runtime binding source digest is {actual}; inventory records {digest}",
+                                "review the changed result surface and update its field map and digest together",
+                                promise_id=promise_id,
+                            )
+                        )
         fields = binding.get("bindings")
         if (
             not isinstance(fields, dict)

--- a/scripts/promise_machine.py
+++ b/scripts/promise_machine.py
@@ -70,6 +70,16 @@ COVERAGE_PATH = Path("tests/promise_machine_coverage.json")
 COVERAGE_SCHEMA = "promise-machine-coverage/v1"
 COVERAGE_CODES = ("P", "M", "S", "O", "R", "X")
 EVALUATION_KEYS = {"status", "model", "prompt", "corpus", "disposition"}
+RUNTIME_BINDING_KEYS = {
+    "promise_id",
+    "subject",
+    "scope",
+    "evidence_references",
+    "evidence_classes",
+    "unknowns",
+    "transition",
+    "exception",
+}
 PROMPT_SKILLS = {
     "brevitas",
     "hypomnema",
@@ -168,6 +178,7 @@ class PromiseRecord:
     skill_path: str
     group: str
     evidence_classes: frozenset[str]
+    consequence: int
 
 
 def relative(path: Path, root: Path) -> str:
@@ -910,7 +921,12 @@ def parse_contract(skill: SkillRecord, root: Path, *, required: bool = False):
                         promise_id=promise_id or None,
                     )
                 )
-        promises.append((promise_id, skill.path, frozenset(classes)))
+        consequence = (
+            int(consequences[0])
+            if len(consequences) == 1 and consequences[0] in {"0", "1", "2", "3"}
+            else -1
+        )
+        promises.append((promise_id, skill.path, frozenset(classes), consequence))
     return promises, findings
 
 
@@ -922,7 +938,7 @@ def check_structure(
     require_hexaemeron_contracts: bool = False,
 ):
     findings: list[Finding] = []
-    promises: list[tuple[str, str, frozenset[str]]] = []
+    promises: list[tuple[str, str, frozenset[str], int]] = []
     for skill in inventory.skills:
         if skill.governance == "vendored":
             loaded, read_findings = read_markdown(
@@ -958,7 +974,7 @@ def check_structure(
         promises.extend(parsed)
         findings.extend(parsed_findings)
     owners: dict[str, list[str]] = {}
-    for promise_id, path, _ in promises:
+    for promise_id, path, _, _ in promises:
         owners.setdefault(promise_id, []).append(path)
     for promise_id, paths in sorted(owners.items()):
         if len(paths) > 1:
@@ -1057,7 +1073,7 @@ def check_overlays(root: Path, inventory: Inventory):
         if skill.governance != "first-party":
             continue
         parsed, _ = parse_contract(skill, root)
-        canonical_ids.update(promise_id for promise_id, _, _ in parsed)
+        canonical_ids.update(promise_id for promise_id, _, _, _ in parsed)
     seen_paths: dict[str, list[str]] = {}
     seen_ids: set[str] = set()
     for offset, block_start in enumerate(blocks):
@@ -1302,8 +1318,10 @@ def promise_records(root: Path, inventory: Inventory):
         parsed, _ = parse_contract(skill, root)
         group = "prompt" if skill.name in PROMPT_SKILLS else "executable"
         records.extend(
-            PromiseRecord(promise_id, skill.path, group, evidence_classes)
-            for promise_id, _, evidence_classes in parsed
+            PromiseRecord(
+                promise_id, skill.path, group, evidence_classes, consequence
+            )
+            for promise_id, _, evidence_classes, consequence in parsed
         )
 
     loaded, _ = read_markdown(
@@ -1330,6 +1348,7 @@ def promise_records(root: Path, inventory: Inventory):
             promise_id = lines[block_start][4:].strip()
             declared = ""
             evidence_classes: frozenset[str] = frozenset()
+            consequence = -1
             for line in lines[block_start + 1 : block_end]:
                 match = re.fullmatch(r"- Path:\s*`?([^`]+?)`?\s*", line)
                 if match is not None:
@@ -1341,8 +1360,13 @@ def promise_records(root: Path, inventory: Inventory):
                         for item in re.split(r"[,;]", evidence_match.group(1))
                         if item.strip()
                     )
+                consequence_match = re.fullmatch(r"- Consequence:\s*([0-3])\s*", line)
+                if consequence_match is not None:
+                    consequence = int(consequence_match.group(1))
             records.append(
-                PromiseRecord(promise_id, declared, "vendored", evidence_classes)
+                PromiseRecord(
+                    promise_id, declared, "vendored", evidence_classes, consequence
+                )
             )
     return tuple(sorted(records, key=lambda item: item.promise_id))
 
@@ -1506,6 +1530,7 @@ def check_coverage(root: Path, inventory: Inventory, selected_groups: set[str]):
             )
     rows = document.get("rows")
     evidence_catalog = document.get("evidence")
+    runtime_catalog = document.get("runtime", {})
     if not isinstance(evidence_catalog, dict):
         findings.append(
             Finding(
@@ -1528,6 +1553,110 @@ def check_coverage(root: Path, inventory: Inventory, selected_groups: set[str]):
             )
         )
         return 0, 0, findings
+
+    required_runtime = {
+        record.promise_id for record in expected_records if record.consequence >= 2
+    }
+    if not isinstance(runtime_catalog, dict):
+        findings.append(
+            Finding(
+                "PM070",
+                "structural",
+                COVERAGE_PATH.as_posix(),
+                "runtime binding inventory is not an object",
+                "map every level-2 or level-3 promise to its result surface and binding fields",
+            )
+        )
+        runtime_catalog = {}
+    actual_runtime = set(runtime_catalog)
+    for promise_id in sorted(required_runtime - actual_runtime):
+        findings.append(
+            Finding(
+                "PM070",
+                "coverage",
+                COVERAGE_PATH.as_posix(),
+                "level-2 or level-3 promise has no runtime binding",
+                "name the existing result surface and all eight Promise Machine bindings",
+                promise_id=promise_id,
+            )
+        )
+    for promise_id in sorted(actual_runtime - required_runtime):
+        findings.append(
+            Finding(
+                "PM070",
+                "coverage",
+                COVERAGE_PATH.as_posix(),
+                "runtime binding does not belong to a discovered level-2 or level-3 promise",
+                "remove the stale binding or correct its promise id",
+                promise_id=promise_id,
+            )
+        )
+    for promise_id in sorted(required_runtime & actual_runtime):
+        binding = runtime_catalog[promise_id]
+        binding_path = f"{COVERAGE_PATH.as_posix()}#runtime.{promise_id}"
+        if not isinstance(binding, dict) or set(binding) != {"source", "bindings"}:
+            findings.append(
+                Finding(
+                    "PM070",
+                    "structural",
+                    binding_path,
+                    "runtime binding must contain exactly source and bindings",
+                    "name one confined result schema, writer or contract and its field map",
+                    promise_id=promise_id,
+                )
+            )
+            continue
+        source = binding.get("source")
+        if not isinstance(source, str) or not source.strip():
+            findings.append(
+                Finding(
+                    "PM070",
+                    "structural",
+                    binding_path,
+                    "runtime binding source is absent",
+                    "name the existing result schema, writer or contract",
+                    promise_id=promise_id,
+                )
+            )
+        else:
+            source_path = Path(source)
+            source_target = root / source_path
+            if (
+                source_path.is_absolute()
+                or ".." in source_path.parts
+                or source_target.is_symlink()
+                or not confined(source_target, root)
+                or not source_target.is_file()
+            ):
+                findings.append(
+                    Finding(
+                        "PM070",
+                        "identity",
+                        binding_path,
+                        f"runtime binding source does not resolve inside the repository: {source!r}",
+                        "name a confined existing result schema, writer or contract",
+                        promise_id=promise_id,
+                    )
+                )
+        fields = binding.get("bindings")
+        if (
+            not isinstance(fields, dict)
+            or set(fields) != RUNTIME_BINDING_KEYS
+            or any(
+                not isinstance(fields.get(key), str) or not fields[key].strip()
+                for key in RUNTIME_BINDING_KEYS
+            )
+        ):
+            findings.append(
+                Finding(
+                    "PM070",
+                    "structural",
+                    binding_path,
+                    "runtime field map is absent, incomplete or contains unknown fields",
+                    "bind promise id, subject, scope, evidence references and classes, unknowns, transition and exception",
+                    promise_id=promise_id,
+                )
+            )
 
     seen: dict[str, int] = {}
     selected = 0
@@ -2441,6 +2570,7 @@ def parse_only(raw: str):
         "routers",
         "versions",
         "hosts",
+        "coverage",
     }
     unknown = sorted(set(requested) - allowed)
     if unknown or not requested:
@@ -2458,7 +2588,13 @@ def main(argv=None):
     sync_parser.add_argument("--json", action="store_true", help="emit canonical JSON")
 
     check_parser = subparsers.add_parser("check", help="check the law and plugin copies")
-    check_parser.add_argument("--only", default="law,copies")
+    check_parser.add_argument(
+        "--only",
+        default=(
+            "law,copies,inventory,structure,contracts,overlays,identity,routers,"
+            "versions,hosts,coverage"
+        ),
+    )
     check_parser.add_argument("--root", help=argparse.SUPPRESS)
     check_parser.add_argument("--json", action="store_true", help="emit canonical JSON")
 
@@ -2558,6 +2694,7 @@ def main(argv=None):
             "routers",
             "versions",
             "hosts",
+            "coverage",
         }
         if only & inventory_components:
             inventory, inventory_findings = discover_inventory(root)
@@ -2591,6 +2728,13 @@ def main(argv=None):
             stats["claude_plugins"] = claude_plugins
             stats["codex_plugins"] = codex_plugins
             findings.extend(host_findings)
+        if "coverage" in only and inventory is not None:
+            coverage_rows, coverage_selected, coverage_findings = check_coverage(
+                root, inventory, {"executable", "prompt", "vendored"}
+            )
+            stats["coverage_rows"] = coverage_rows
+            stats["coverage_selected"] = coverage_selected
+            findings.extend(coverage_findings)
         return report(
             "check",
             root,

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -22,6 +22,7 @@
   "runtime": {
     "alexandria-derived-view": {
       "source": "plugins/alexandria/schemas/archive-manifest-v1.schema.json",
+      "sha256": "59e92f0716b34c18705069d1bca86d48df3bc3485b06f5c4a8c7dbaa2bc88947",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "release_id and kind",
@@ -35,6 +36,7 @@
     },
     "alexandria-raw-release": {
       "source": "plugins/alexandria/schemas/archive-manifest-v1.schema.json",
+      "sha256": "59e92f0716b34c18705069d1bca86d48df3bc3485b06f5c4a8c7dbaa2bc88947",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "release_id, source and chain",
@@ -48,6 +50,7 @@
     },
     "ariadne-replay-command": {
       "source": "plugins/ariadne/scripts/ariadne.py",
+      "sha256": "af69eb88dc6b927c6c715aa94baa2b09aa67a577ba75c0295f51711700d8132d",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "statement subject digest and replay project",
@@ -61,6 +64,7 @@
     },
     "ariadne-verify-statement": {
       "source": "plugins/ariadne/scripts/ariadne.py",
+      "sha256": "af69eb88dc6b927c6c715aa94baa2b09aa67a577ba75c0295f51711700d8132d",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "in-toto subject name and digest",
@@ -74,6 +78,7 @@
     },
     "berean-release-promotion": {
       "source": "plugins/berean/schemas/promotion-record-v1.json",
+      "sha256": "16ceae02a2f87bb44dcb718743708747e703ed254ddde85dc7c6135fbe11ecb7",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "release_digest",
@@ -87,6 +92,7 @@
     },
     "elenchus-fixed-and-guarded": {
       "source": "plugins/hexaemeron/skills/elenchus/scripts/elenchus.py",
+      "sha256": "9069e2a4266bf349c963aaad6e22cf2966d14bb34d05d025b72c9e77017d39c5",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "baseline and fixed commit identities",
@@ -100,6 +106,7 @@
     },
     "ephoros-observability-review": {
       "source": "plugins/hexaemeron/skills/ephoros/SKILL.md",
+      "sha256": "381440b736200a933464b18e2a99469b9bc80229951ea3e7b837a3986c5425e4",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "reviewed step and build identity",
@@ -113,6 +120,7 @@
     },
     "fiat-final-integration": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
+      "sha256": "25aed7debc2ff69842b8dbece31dff08afaab2649d57d69ede24a65c80ba1afc",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "run branch, base, integration head and merge commit",
@@ -126,6 +134,7 @@
     },
     "fiat-receipted-delivery": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
+      "sha256": "25aed7debc2ff69842b8dbece31dff08afaab2649d57d69ede24a65c80ba1afc",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "topic, run branch, step branch and head commit",
@@ -139,6 +148,7 @@
     },
     "hermes-baseline-promotion": {
       "source": "plugins/hermes/skills/hermes/scripts/hermes.py",
+      "sha256": "9c7cda0947024a36a10c40c798c554521b11b5d8ef40414b877d59c7003389ea",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "candidate commit, target set and sealed run directory",
@@ -152,6 +162,7 @@
     },
     "hermes-candidate-acceptance": {
       "source": "plugins/hermes/skills/hermes/scripts/hermes.py",
+      "sha256": "9c7cda0947024a36a10c40c798c554521b11b5d8ef40414b877d59c7003389ea",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "baseline commit, candidate commit and named targets",
@@ -165,6 +176,7 @@
     },
     "hexaemeron-fizz-convert-properties": {
       "source": "plugins/hexaemeron/skills/fizz/skills/fizz-convert/SKILL.md",
+      "sha256": "59cd4b4ef5dc56315782a7d25222afb286a24e63e438530cbd0044293ea54af7",
       "bindings": {
         "promise_id": "coverage key joined to the digest-bound vendored overlay",
         "subject": "target repository, PROPERTIES.md entry and harness assertion",
@@ -178,6 +190,7 @@
     },
     "hexaemeron-fizz-harness-campaign": {
       "source": "plugins/hexaemeron/skills/fizz/SKILL.md",
+      "sha256": "62a60df4cec160511b8ef36433eef7c8805d0b4a398491293eb4542ab73539bd",
       "bindings": {
         "promise_id": "coverage key joined to the digest-bound vendored overlay",
         "subject": "target repository revision, generated harness and campaign",
@@ -191,6 +204,7 @@
     },
     "hexaemeron-fizz-sync-drift": {
       "source": "plugins/hexaemeron/skills/fizz/skills/fizz-sync/SKILL.md",
+      "sha256": "e969cd8a447941989715840e24aa6a915c0fd795effabd912b3c627598a95e16",
       "bindings": {
         "promise_id": "coverage key joined to the digest-bound vendored overlay",
         "subject": "target source revision, prior snapshot and reconciled harness",
@@ -204,6 +218,7 @@
     },
     "hexaemeron-solidity-audit-report": {
       "source": "plugins/hexaemeron/skills/solidity-auditor/SKILL.md",
+      "sha256": "1c1cf4e99d042e7aadc56b622d97a07d3286f4786838a05510697c814d1e983f",
       "bindings": {
         "promise_id": "coverage key joined to the digest-bound vendored overlay",
         "subject": "audited repository revision and Solidity scope",
@@ -217,6 +232,7 @@
     },
     "horos-boundary-scan": {
       "source": "plugins/horos/skills/horos/scripts/horos.py",
+      "sha256": "8145f8b035b01f06c41cec470637e8670a0bd0caf4688bcd7cd4d490361d707c",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "repository root and tracked-tree identity",
@@ -230,6 +246,7 @@
     },
     "hypomnema-record-placement": {
       "source": "plugins/hexaemeron/skills/hypomnema/SKILL.md",
+      "sha256": "c62f0cce2534ea935ba85b26958f851c9e162de28729a0530c31d157726a7542",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "named decision and changed repository surface",
@@ -243,6 +260,7 @@
     },
     "janus-bounded-conformance": {
       "source": "plugins/janus/scripts/janus.py",
+      "sha256": "46f586289cf3def05130fb7870e1f60bb27b1b85a41c2f43630d74a45685d80d",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "hook, host adapter and manifest revision",
@@ -256,6 +274,7 @@
     },
     "kronos-fiat-dispatch": {
       "source": "plugins/hexaemeron/skills/kronos/scripts/kronos.py",
+      "sha256": "8b2a9a3eef62c506c7fecb2ca22268a7e4402d51576e69ee678ab926f47df8d5",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "selected plugin, skill and held job hash",
@@ -269,6 +288,7 @@
     },
     "kronos-parked-lane": {
       "source": "plugins/hexaemeron/skills/kronos/scripts/kronos.py",
+      "sha256": "8b2a9a3eef62c506c7fecb2ca22268a7e4402d51576e69ee678ab926f47df8d5",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "parked plugin, skill and held job hash",
@@ -282,6 +302,7 @@
     },
     "lazarus-exact-replay": {
       "source": "plugins/lazarus/scripts/lazarus.py",
+      "sha256": "0ae280084dd2934e902b11826c12aff8247989616126c1771ae6af65e38307b2",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "verified fixture identity and exact request key",
@@ -295,6 +316,7 @@
     },
     "lazarus-fixture-capture": {
       "source": "plugins/lazarus/schemas/manifest-v1.json",
+      "sha256": "53acaefd6ddaf5648dc9d16345fc13c64c3bd7786851271ef922b67b9f423c14",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "fixture digest, chain id, block number and block hash",
@@ -308,6 +330,7 @@
     },
     "lazarus-preservation-release": {
       "source": "plugins/lazarus/schemas/release-v1.json",
+      "sha256": "f7b8ce3eb37c40d79a23bdff1d88dd0e6e163c2d72ec67575b3b4e7023d5415d",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "release digest, fixture digest and statement digest",
@@ -321,6 +344,7 @@
     },
     "metron-change-decision": {
       "source": "plugins/hexaemeron/skills/metron/SKILL.md",
+      "sha256": "575ac79da8d176d1466942c30fde70b33f59fc6e8cb07cfb7666241cda461394",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "named workload, implementation and isolated change",
@@ -334,6 +358,7 @@
     },
     "pandects-search-record": {
       "source": "plugins/pandects/scripts/pandects.py",
+      "sha256": "33b3a2f58f986f8833aa7f89a75314ce6a4d4e46fa5032852feb8b70012fe15e",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "target revision, adapter and law identifiers",
@@ -347,6 +372,7 @@
     },
     "phylax-boundary-review": {
       "source": "plugins/hexaemeron/skills/phylax/SKILL.md",
+      "sha256": "abd7a080c09d22d64d1cc80f4299604f3678f35df507d9b60a3bc756bc5b1019",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "reviewed step, source tree and external-input boundary",
@@ -360,6 +386,7 @@
     },
     "probitas-dossier-verification": {
       "source": "plugins/probitas/scripts/probitas.py",
+      "sha256": "82679d551c7150e2dc2dd8bbc007662d6fc7f2dcc9a537cd3d359bd8aa53d41c",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "dossier bytes, evidence digest and declared entity addresses",
@@ -373,6 +400,7 @@
     },
     "tabularium-release-build": {
       "source": "plugins/tabularium/scripts/tabularium.py",
+      "sha256": "733c4c67e327fa5cf5818e50aa612d8bd8dc23a276a53d46cd5e5d037dc54d0f",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "release directory, source digest and adapter version",
@@ -386,6 +414,7 @@
     },
     "tabularium-release-verification": {
       "source": "plugins/tabularium/scripts/tabularium.py",
+      "sha256": "733c4c67e327fa5cf5818e50aa612d8bd8dc23a276a53d46cd5e5d037dc54d0f",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "release directory, source digest and adapter version",

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -19,6 +19,385 @@
       "refuses": "answer-truth"
     }
   ],
+  "runtime": {
+    "alexandria-derived-view": {
+      "source": "plugins/alexandria/schemas/archive-manifest-v1.schema.json",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "release_id and kind",
+        "scope": "coverage and components",
+        "evidence_references": "objects, sources and corrections",
+        "evidence_classes": "component evidence_class values joined to the canonical Evidence classes field",
+        "unknowns": "coverage gaps and unsupported components",
+        "transition": "successful derive and verify status joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "alexandria-raw-release": {
+      "source": "plugins/alexandria/schemas/archive-manifest-v1.schema.json",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "release_id, source and chain",
+        "scope": "coverage, capture and finality",
+        "evidence_references": "objects and components",
+        "evidence_classes": "component evidence_class values joined to the canonical Evidence classes field",
+        "unknowns": "coverage gaps, corrections and unsupported components",
+        "transition": "successful ingest and verify status joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "ariadne-replay-command": {
+      "source": "plugins/ariadne/scripts/ariadne.py",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "statement subject digest and replay project",
+        "scope": "recorded command, arguments and exact replay mode",
+        "evidence_references": "statement predicate command and produced artefact digest",
+        "evidence_classes": "replay disposition joined to the canonical Evidence classes field",
+        "unknowns": "redacted arguments, unchecked predicates and non-deterministic records",
+        "transition": "allow-execution authority and replay exit joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "ariadne-verify-statement": {
+      "source": "plugins/ariadne/scripts/ariadne.py",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "in-toto subject name and digest",
+        "scope": "predicate type and complete gate set",
+        "evidence_references": "predicate materials, claims and gate report",
+        "evidence_classes": "gate dispositions joined to the canonical Evidence classes field",
+        "unknowns": "unchecked predicates, unsigned status and skipped records",
+        "transition": "zero-exit gate result joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "berean-release-promotion": {
+      "source": "plugins/berean/schemas/promotion-record-v1.json",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "release_digest",
+        "scope": "action, previous_release_digest and thresholds",
+        "evidence_references": "evaluation_report_digest and record chain",
+        "evidence_classes": "evaluation disposition joined to the canonical Evidence classes field",
+        "unknowns": "failed cases, ungrounded questions and recorded refusal conditions",
+        "transition": "operator, action and result joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "elenchus-fixed-and-guarded": {
+      "source": "plugins/hexaemeron/skills/elenchus/scripts/elenchus.py",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "baseline and fixed commit identities",
+        "scope": "reproduction command and named regression guard",
+        "evidence_references": "detached-parent and fixed-tree reports",
+        "evidence_classes": "runner category joined to the canonical Evidence classes field",
+        "unknowns": "inconclusive, zero-test and infrastructure outcomes",
+        "transition": "fixed-and-guarded verdict joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "ephoros-observability-review": {
+      "source": "plugins/hexaemeron/skills/ephoros/SKILL.md",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "reviewed step and build identity",
+        "scope": "named on-call questions and unattended path",
+        "evidence_references": "structured events, metrics, correlations, exercises and review record",
+        "evidence_classes": "review disposition joined to the canonical Evidence classes field",
+        "unknowns": "unexercised failure modes and missing operational evidence",
+        "transition": "review acceptance joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "fiat-final-integration": {
+      "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
+      "bindings": {
+        "promise_id": "coverage key joined to controller phase and canonical promise heading",
+        "subject": "run branch, base, integration head and merge commit",
+        "scope": "ordered step PR stack and one base merge",
+        "evidence_references": "ledger receipts, green checks, PR URLs and commits",
+        "evidence_classes": "receipt kind joined to the canonical Evidence classes field",
+        "unknowns": "carried-forward work and any unrun external check",
+        "transition": "integration receipt and explicit user authority joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "fiat-receipted-delivery": {
+      "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
+      "bindings": {
+        "promise_id": "coverage key joined to controller phase and canonical promise heading",
+        "subject": "topic, run branch, step branch and head commit",
+        "scope": "current step and phase",
+        "evidence_references": "append-only ledger receipt payload and previous hash",
+        "evidence_classes": "receipt kind joined to the canonical Evidence classes field",
+        "unknowns": "unrun checks and receipt assertions not independently proved",
+        "transition": "single next controller directive joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "hermes-baseline-promotion": {
+      "source": "plugins/hermes/skills/hermes/scripts/hermes.py",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "candidate commit, target set and sealed run directory",
+        "scope": "declared optimisation class and promoted baseline",
+        "evidence_references": "accepted result.json, snapshots, layouts and selector maps",
+        "evidence_classes": "accepted status joined to the canonical Evidence classes field",
+        "unknowns": "unmeasured targets and recorded fuzz-statistic changes",
+        "transition": "promotion command and accepted status joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "hermes-candidate-acceptance": {
+      "source": "plugins/hermes/skills/hermes/scripts/hermes.py",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "baseline commit, candidate commit and named targets",
+        "scope": "one optimisation class and six gates",
+        "evidence_references": "result.json, command logs, snapshots, layouts, selectors and property report",
+        "evidence_classes": "gate statuses joined to the canonical Evidence classes field",
+        "unknowns": "unmeasured behaviour and non-regression-neutral fuzz statistics",
+        "transition": "accepted status and zero exit joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "hexaemeron-fizz-convert-properties": {
+      "source": "plugins/hexaemeron/skills/fizz/skills/fizz-convert/SKILL.md",
+      "bindings": {
+        "promise_id": "coverage key joined to the digest-bound vendored overlay",
+        "subject": "target repository, PROPERTIES.md entry and harness assertion",
+        "scope": "selected pending properties and unchanged harness boundary",
+        "evidence_references": "conversion record, compilation and named tests",
+        "evidence_classes": "vendored operation record joined to overlay Evidence classes",
+        "unknowns": "unconverted properties and unrun campaigns",
+        "transition": "successful conversion gates joined to overlay Authorises",
+        "exception": "overlay Exceptions field"
+      }
+    },
+    "hexaemeron-fizz-harness-campaign": {
+      "source": "plugins/hexaemeron/skills/fizz/SKILL.md",
+      "bindings": {
+        "promise_id": "coverage key joined to the digest-bound vendored overlay",
+        "subject": "target repository revision, generated harness and campaign",
+        "scope": "selected contracts, properties, engine settings and corpus",
+        "evidence_references": "generated files, compilation, campaign logs and violations",
+        "evidence_classes": "vendored operation record joined to overlay Evidence classes",
+        "unknowns": "unreached states, skipped engines and unresolved properties",
+        "transition": "successful generation and campaign gates joined to overlay Authorises",
+        "exception": "overlay Exceptions field"
+      }
+    },
+    "hexaemeron-fizz-sync-drift": {
+      "source": "plugins/hexaemeron/skills/fizz/skills/fizz-sync/SKILL.md",
+      "bindings": {
+        "promise_id": "coverage key joined to the digest-bound vendored overlay",
+        "subject": "target source revision, prior snapshot and reconciled harness",
+        "scope": "added, removed and changed callable surface",
+        "evidence_references": "drift report, quarantined properties, regenerated stubs and tests",
+        "evidence_classes": "vendored operation record joined to overlay Evidence classes",
+        "unknowns": "semantically stale properties and unrun campaigns",
+        "transition": "successful sync gates joined to overlay Authorises",
+        "exception": "overlay Exceptions field"
+      }
+    },
+    "hexaemeron-solidity-audit-report": {
+      "source": "plugins/hexaemeron/skills/solidity-auditor/SKILL.md",
+      "bindings": {
+        "promise_id": "coverage key joined to the digest-bound vendored overlay",
+        "subject": "audited repository revision and Solidity scope",
+        "scope": "enumerated source, threat model and review roles",
+        "evidence_references": "source citations, raw role results and final finding report",
+        "evidence_classes": "audit observations joined to overlay Evidence classes",
+        "unknowns": "unreviewed code, unavailable tools and inconclusive leads",
+        "transition": "completed audit report joined to overlay Authorises",
+        "exception": "overlay Exceptions field"
+      }
+    },
+    "horos-boundary-scan": {
+      "source": "plugins/horos/skills/horos/scripts/horos.py",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "repository root and tracked-tree identity",
+        "scope": "walked files and applied classification rules",
+        "evidence_references": "boundary entries and per-file evidence",
+        "evidence_classes": "classification rule joined to the canonical Evidence classes field",
+        "unknowns": "omitted paths and fail-open unproven classifications",
+        "transition": "atomic scan write and zero exit joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "hypomnema-record-placement": {
+      "source": "plugins/hexaemeron/skills/hypomnema/SKILL.md",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "named decision and changed repository surface",
+        "scope": "decision inventory and selected record homes",
+        "evidence_references": "authored records, alternatives, reasons and pointer-gate result",
+        "evidence_classes": "review disposition joined to the canonical Evidence classes field",
+        "unknowns": "unresolved decisions and intentionally absent records",
+        "transition": "accepted record placement joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "janus-bounded-conformance": {
+      "source": "plugins/janus/scripts/janus.py",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "hook, host adapter and manifest revision",
+        "scope": "recorder coverage, search settings and explored sequences",
+        "evidence_references": "complete deltas, hostile-hook guards and Foundry results",
+        "evidence_classes": "bounded conformance result joined to the canonical Evidence classes field",
+        "unknowns": "unrecorded effects, other hosts and executions outside the bounded search",
+        "transition": "conformance verdict joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "kronos-fiat-dispatch": {
+      "source": "plugins/hexaemeron/skills/kronos/scripts/kronos.py",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "selected plugin, skill and held job hash",
+        "scope": "eligible candidate set, mode and score inputs",
+        "evidence_references": "ledgers, recomputed scores and append-only scoreboard",
+        "evidence_classes": "selection record joined to the canonical Evidence classes field",
+        "unknowns": "excluded, mature, parked and unevidenced candidates",
+        "transition": "explicit Fiat dispatch joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "kronos-parked-lane": {
+      "source": "plugins/hexaemeron/skills/kronos/scripts/kronos.py",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "parked plugin, skill and held job hash",
+        "scope": "named lane, parking reason and review boundary",
+        "evidence_references": "current ledgers, score inputs and scoreboard record",
+        "evidence_classes": "parking record joined to the canonical Evidence classes field",
+        "unknowns": "unresolved blocker and future eligibility",
+        "transition": "park action joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "lazarus-exact-replay": {
+      "source": "plugins/lazarus/scripts/lazarus.py",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "verified fixture identity and exact request key",
+        "scope": "captured method and parameters with loopback-only service",
+        "evidence_references": "manifest, request-key table and response record",
+        "evidence_classes": "response evidence_class joined to the canonical Evidence classes field",
+        "unknowns": "uncaptured requests and recorded-only RPC relations",
+        "transition": "verified replay binding joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "lazarus-fixture-capture": {
+      "source": "plugins/lazarus/schemas/manifest-v1.json",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "fixture digest, chain id, block number and block hash",
+        "scope": "plan subjects, limits and opening and closing headers",
+        "evidence_references": "files, request records, proofs and manifest digests",
+        "evidence_classes": "record evidence classes joined to the canonical Evidence classes field",
+        "unknowns": "recorded-only RPC results and external canonical-chain provenance",
+        "transition": "in-process verification status joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "lazarus-preservation-release": {
+      "source": "plugins/lazarus/schemas/release-v1.json",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "release digest, fixture digest and statement digest",
+        "scope": "release member set and verified evidence counts",
+        "evidence_references": "fixture, Ariadne statement and binding document",
+        "evidence_classes": "fixture and statement relations joined to the canonical Evidence classes field",
+        "unknowns": "unsigned publisher identity and recorded-only RPC evidence",
+        "transition": "verify-release status joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "metron-change-decision": {
+      "source": "plugins/hexaemeron/skills/metron/SKILL.md",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "named workload, implementation and isolated change",
+        "scope": "measurement method, environment and budget",
+        "evidence_references": "before and after samples, variance and correctness results",
+        "evidence_classes": "measured verdict joined to the canonical Evidence classes field",
+        "unknowns": "noise, unmeasured workloads and unexplained environmental changes",
+        "transition": "keep or revert decision joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "pandects-search-record": {
+      "source": "plugins/pandects/scripts/pandects.py",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "target revision, adapter and law identifiers",
+        "scope": "engine, command, configuration, seed and sequence bounds",
+        "evidence_references": "captured search output and generated search-record JSON",
+        "evidence_classes": "campaign status joined to the canonical Evidence classes field",
+        "unknowns": "absent engines, unavailable values and timed-out campaigns",
+        "transition": "bounded campaign result joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "phylax-boundary-review": {
+      "source": "plugins/hexaemeron/skills/phylax/SKILL.md",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "reviewed step, source tree and external-input boundary",
+        "scope": "named inputs, subprocesses, hosts, secrets and output paths",
+        "evidence_references": "boundary inventory, controls, hostile cases and test results",
+        "evidence_classes": "review disposition joined to the canonical Evidence classes field",
+        "unknowns": "unreviewed capabilities and unavailable adversarial evidence",
+        "transition": "review acceptance joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "probitas-dossier-verification": {
+      "source": "plugins/probitas/scripts/probitas.py",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "dossier bytes, evidence digest and declared entity addresses",
+        "scope": "venue coverage rows and five verification gates",
+        "evidence_references": "evidence records, citations, figures and source hashes",
+        "evidence_classes": "provenance tier and gate result joined to the canonical Evidence classes field",
+        "unknowns": "unchecked venues, unsupported claims and explicit gaps",
+        "transition": "five passing gates and zero exit joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "tabularium-release-build": {
+      "source": "plugins/tabularium/scripts/tabularium.py",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "release directory, source digest and adapter version",
+        "scope": "venue, chain, capture boundary and mapped selectors",
+        "evidence_references": "source, capture, events and coverage manifest digests",
+        "evidence_classes": "source and mapping relations joined to the canonical Evidence classes field",
+        "unknowns": "unsupported entities, known gaps and unsigned publisher identity",
+        "transition": "atomic build and verification status joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
+    "tabularium-release-verification": {
+      "source": "plugins/tabularium/scripts/tabularium.py",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading",
+        "subject": "release directory, source digest and adapter version",
+        "scope": "venue, capture boundary, paths and one-to-one source selectors",
+        "evidence_references": "rebuilt event bytes, manifest digests and mapping provenance",
+        "evidence_classes": "verification result joined to the canonical Evidence classes field",
+        "unknowns": "publisher identity, chain proof and unmapped source entities",
+        "transition": "zero-exit verification joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    }
+  },
   "evidence": {
     "alexandria-p": {
       "path": "plugins/alexandria/tests/test_demo.py",

--- a/tests/test_marketplace_prose.py
+++ b/tests/test_marketplace_prose.py
@@ -94,6 +94,23 @@ def root_readme_frontier(name):
 
 
 class MarketplaceProseTests(unittest.TestCase):
+    def test_wildcat_labs_identity_contains_the_promise_machine_architecture(self):
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertTrue(readme.startswith("# Wildcat Labs Skills\n\n## The Promise Machine\n"))
+        self.assertIn("shared architecture", readme)
+        self.assertFalse(readme.startswith("# The Promise Machine"))
+
+        marketplace = json.loads(MARKETPLACE.read_text(encoding="utf-8"))
+        self.assertIn("Wildcat Labs Skills", marketplace["description"])
+        self.assertIn("Promise Machine", marketplace["description"])
+
+        for name in PLUGINS:
+            runtime = ROOT / "plugins" / name / "AGENTS.md"
+            with self.subTest(plugin=name):
+                text = runtime.read_text(encoding="utf-8")
+                self.assertIn("## Promise Machine binding", text)
+                self.assertIn("promise-machine/v1", text)
+
     def test_marketplace_names_exactly_the_shipped_plugins(self):
         self.assertEqual(set(marketplace_entries()), set(PLUGINS))
 

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -1017,7 +1017,7 @@ class PromiseCoverageTests(unittest.TestCase):
         self.assertEqual(len(coverage["runtime"]), 29)
         for promise_id, binding in coverage["runtime"].items():
             with self.subTest(promise_id=promise_id):
-                self.assertEqual(set(binding), {"source", "bindings"})
+                self.assertEqual(set(binding), {"source", "sha256", "bindings"})
                 self.assertEqual(set(binding["bindings"]), expected_fields)
                 self.assertTrue((ROOT / binding["source"]).is_file())
 
@@ -1054,6 +1054,79 @@ class PromiseCoverageTests(unittest.TestCase):
             document["runtime"] = {
                 "example-check": {
                     "source": "../outside.json",
+                    "sha256": "0" * 64,
+                    "bindings": {
+                        "promise_id": "promise id",
+                        "subject": "subject",
+                        "scope": "scope",
+                        "evidence_references": "evidence references",
+                        "evidence_classes": "evidence classes",
+                        "unknowns": "unknowns",
+                        "transition": "transition",
+                        "exception": "exception",
+                    },
+                }
+            }
+            coverage_path.write_text(json.dumps(document), encoding="utf-8")
+            completed = run_cli(
+                "coverage", "--check", "--root", target, "--group", "executable", "--json"
+            )
+        report = json.loads(completed.stdout)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM070", [item["code"] for item in report["findings"]])
+
+    def test_runtime_binding_source_digest_must_be_current(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            coverage_path, document = write_coverage_fixture(target)
+            skill = target / "plugins/hexaemeron/skills/elenchus/SKILL.md"
+            skill.write_text(
+                skill.read_text(encoding="utf-8").replace(
+                    "- Consequence: 1", "- Consequence: 2"
+                ),
+                encoding="utf-8",
+            )
+            document["runtime"] = {
+                "example-check": {
+                    "source": "tests/evidence.py",
+                    "sha256": "0" * 64,
+                    "bindings": {
+                        "promise_id": "promise id",
+                        "subject": "subject",
+                        "scope": "scope",
+                        "evidence_references": "evidence references",
+                        "evidence_classes": "evidence classes",
+                        "unknowns": "unknowns",
+                        "transition": "transition",
+                        "exception": "exception",
+                    },
+                }
+            }
+            coverage_path.write_text(json.dumps(document), encoding="utf-8")
+            completed = run_cli(
+                "coverage", "--check", "--root", target, "--group", "executable", "--json"
+            )
+        report = json.loads(completed.stdout)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM071", [item["code"] for item in report["findings"]])
+
+    def test_runtime_binding_source_read_is_bounded(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            coverage_path, document = write_coverage_fixture(target)
+            skill = target / "plugins/hexaemeron/skills/elenchus/SKILL.md"
+            skill.write_text(
+                skill.read_text(encoding="utf-8").replace(
+                    "- Consequence: 1", "- Consequence: 2"
+                ),
+                encoding="utf-8",
+            )
+            oversized = target / "tests/oversized.bin"
+            oversized.write_bytes(b"x" * (1024 * 1024 + 1))
+            document["runtime"] = {
+                "example-check": {
+                    "source": "tests/oversized.bin",
+                    "sha256": hashlib.sha256(oversized.read_bytes()).hexdigest(),
                     "bindings": {
                         "promise_id": "promise id",
                         "subject": "subject",

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -998,6 +998,82 @@ class PromiseCoverageTests(unittest.TestCase):
             },
         )
 
+    def test_repository_high_consequence_runtime_bindings_are_complete(self):
+        coverage = json.loads(
+            (ROOT / "tests" / "promise_machine_coverage.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        expected_fields = {
+            "promise_id",
+            "subject",
+            "scope",
+            "evidence_references",
+            "evidence_classes",
+            "unknowns",
+            "transition",
+            "exception",
+        }
+        self.assertEqual(len(coverage["runtime"]), 29)
+        for promise_id, binding in coverage["runtime"].items():
+            with self.subTest(promise_id=promise_id):
+                self.assertEqual(set(binding), {"source", "bindings"})
+                self.assertEqual(set(binding["bindings"]), expected_fields)
+                self.assertTrue((ROOT / binding["source"]).is_file())
+
+    def test_high_consequence_promise_without_runtime_binding_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            coverage_path, document = write_coverage_fixture(target)
+            skill = target / "plugins/hexaemeron/skills/elenchus/SKILL.md"
+            skill.write_text(
+                skill.read_text(encoding="utf-8").replace(
+                    "- Consequence: 1", "- Consequence: 2"
+                ),
+                encoding="utf-8",
+            )
+            coverage_path.write_text(json.dumps(document), encoding="utf-8")
+            completed = run_cli(
+                "coverage", "--check", "--root", target, "--group", "executable", "--json"
+            )
+        report = json.loads(completed.stdout)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM070", [item["code"] for item in report["findings"]])
+
+    def test_runtime_binding_source_must_be_confined(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            coverage_path, document = write_coverage_fixture(target)
+            skill = target / "plugins/hexaemeron/skills/elenchus/SKILL.md"
+            skill.write_text(
+                skill.read_text(encoding="utf-8").replace(
+                    "- Consequence: 1", "- Consequence: 2"
+                ),
+                encoding="utf-8",
+            )
+            document["runtime"] = {
+                "example-check": {
+                    "source": "../outside.json",
+                    "bindings": {
+                        "promise_id": "promise id",
+                        "subject": "subject",
+                        "scope": "scope",
+                        "evidence_references": "evidence references",
+                        "evidence_classes": "evidence classes",
+                        "unknowns": "unknowns",
+                        "transition": "transition",
+                        "exception": "exception",
+                    },
+                }
+            }
+            coverage_path.write_text(json.dumps(document), encoding="utf-8")
+            completed = run_cli(
+                "coverage", "--check", "--root", target, "--group", "executable", "--json"
+            )
+        report = json.loads(completed.stdout)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("PM070", [item["code"] for item in report["findings"]])
+
     def test_repository_prompt_and_vendored_coverage_is_complete(self):
         completed = run_cli(
             "coverage", "--check", "--group", "prompt,vendored", "--json"

--- a/tests/test_version_propagation.py
+++ b/tests/test_version_propagation.py
@@ -34,6 +34,22 @@ PLUGINS = ROOT / "plugins"
 MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
 
 UNGOVERNED = {"fizz", "fizz-convert", "fizz-sync", "x-ray", "solidity-auditor"}
+DELIVERY_PACKAGE_VERSIONS = {
+    "alexandria": "0.2.1",
+    "ariadne": "1.2.1",
+    "berean": "0.1.1",
+    "brevitas": "0.2.1",
+    "hermes": "0.1.1",
+    "hexaemeron": "1.5.1",
+    "horos": "0.1.1",
+    "janus": "0.1.1",
+    "lazarus": "1.1.1",
+    "lemma": "0.1.1",
+    "pandects": "0.1.1",
+    "probitas": "0.1.1",
+    "sapheneia": "0.1.1",
+    "tabularium": "0.3.1",
+}
 
 
 def marketplace_versions():
@@ -69,11 +85,11 @@ class PluginVersionPropagationTests(unittest.TestCase):
                     f"{name} is not listed with a version in the marketplace",
                 )
                 codex = directory / ".codex-plugin" / "plugin.json"
-                if codex.is_file():
-                    self.assertIsNotNone(
-                        manifest_version(codex),
-                        f"{name} Codex manifest states no version",
-                    )
+                self.assertTrue(codex.is_file(), f"{name} has no Codex manifest")
+                self.assertIsNotNone(
+                    manifest_version(codex),
+                    f"{name} Codex manifest states no version",
+                )
 
     def test_the_three_manifests_agree(self):
         for name, directory in plugin_dirs():
@@ -93,6 +109,18 @@ class PluginVersionPropagationTests(unittest.TestCase):
                         f"{claude}. A host that reads only one of these gets a "
                         f"different answer from a host that reads the other.",
                     )
+
+    def test_promise_machine_delivery_versions_are_exact_and_current(self):
+        self.assertEqual(set(self.marketplace), set(DELIVERY_PACKAGE_VERSIONS))
+        for name, directory in plugin_dirs():
+            expected = DELIVERY_PACKAGE_VERSIONS[name]
+            actual = {
+                "marketplace": self.marketplace[name],
+                "claude": manifest_version(directory / ".claude-plugin" / "plugin.json"),
+                "codex": manifest_version(directory / ".codex-plugin" / "plugin.json"),
+            }
+            with self.subTest(plugin=name):
+                self.assertEqual(actual, {key: expected for key in actual})
 
     def test_a_codex_manifest_exists_wherever_codex_metadata_ships(self):
         """A plugin shipping a .codex-plugin directory must put a manifest in it.


### PR DESCRIPTION
# Demonstrate the Promise Machine against itself

## What changed

- Recorded the complete repository, runtime, plugin, Foundry, prose and tree
  demonstration at `docs/promise-machine/evidence/2026-08-20-self-demonstration.md`.
- Verified the discovered universe of 14 plugins, 28 canonical skills, 23
  governed skills, five vendored skills, one router and one overlay.
- Measured the full Promise Machine check at 0.10 seconds against its
  five-second budget.
- Refreshed Codex and Claude Code through their supported marketplace
  installers and observed all 14 release-candidate package versions.
- Recorded Codex's model-visible resolver with one qualified Protasis, Berean
  and Janus implementation plus the unversioned Promise Machine router.
- Recorded the host-neutral route to `protasis-v2.2.0`, `berean-v0.1.0` and
  `janus-v0.1.0`.
- Left the unavailable Codex picker screenshot and Claude model invocation
  explicitly unobserved rather than inferring them from installation.

## Audit

The Step 9 round is appended to `audit/AUDIT.md`. It found no defect in the
evidence record. The review checked every count against its command result,
confirmed that Step 9 changes no executable or Solidity file, and retained the
two unavailable host observations as named limits.

The complete demonstration also found four stale package-version assumptions
in Alexandria, Berean, Probitas and Tabularium. Those repairs belong to Step 8,
are recorded there, and pass the four full plugin suites.

## Proof

```bash
python3 scripts/promise_machine.py inventory --check
/usr/bin/time -p python3 scripts/promise_machine.py check
python3 -m unittest discover -s tests
python3 plugins/hexaemeron/tests/run_tests.py
python3 plugins/hexaemeron/skills/imprimatur/tests/run_tests.py
python3 -m unittest discover -s plugins/berean/tests -t plugins/berean
python3 -m unittest discover -s plugins/janus/tests -t plugins/janus
(cd plugins/janus/harness && forge build && forge test -vv)
(cd plugins/pandects && forge build && forge test)
python3 plugins/hexaemeron/skills/fiat/scripts/hexctl.py verify
```

All root and plugin suites named in the runbook pass. Janus passes 14 Python
and 24 Foundry tests; Pandects passes 116 Python and 79 Foundry tests; Berean
passes 151 tests. Fiat verifies a 55-entry ledger before the Step 9 receipts.

This pull request stacks on the runtime, evolution, release and public-prose
step.

<!-- wildcat-origin: shoggoth -->
