### PR TITLE
Mirror every branch again, now that the token allows it

### DIFF
--- a/.github/workflows/sync-skills-marketplace.yml
+++ b/.github/workflows/sync-skills-marketplace.yml
@@ -18,20 +18,20 @@ jobs:
     if: github.repository == 'wildcat-finance/skills-marketplace'
     runs-on: ubuntu-latest
     steps:
-      # Only main and tags, and that is a choice rather than a limit now.
+      # Every branch and tag, so the private mirror tracks the public
+      # repository exactly. With wildcard refspecs `--prune` sweeps both, which
+      # is what makes this a mirror rather than an append-only pile: a ref
+      # deleted upstream is deleted here on the next run.
       #
       # The push carries MARKETPLACE_SYNC_TOKEN, a fine-grained token holding
-      # Contents and Workflows write on this repository. The Workflows
-      # permission is the one that matters: GitHub refuses any push that
-      # creates or updates a file under `.github/workflows/` unless the token
-      # holds it, and GITHUB_TOKEN never can, which is why mirroring main broke
-      # the moment main gained a workflow file.
-      #
-      # Widening back to `refs/heads/*` would work with this token, and would
-      # also restore every branch the narrowing left behind, which is why it
-      # stays as it is. `--prune` sweeps tags that no longer exist upstream; it
-      # cannot sweep branches, because a single-ref refspec gives it no pattern
-      # to sweep.
+      # Contents and Workflows write on this repository. That is what makes
+      # full mirroring possible at all. GitHub refuses any push that creates or
+      # updates a file under `.github/workflows/` unless the token holds the
+      # Workflows permission, and GITHUB_TOKEN can never hold it, so under
+      # GITHUB_TOKEN every branch carrying a workflow file was rejected and one
+      # rejected ref failed the whole push. If this ever reverts to
+      # `github.token`, narrow the refspec back to `refs/heads/main` in the
+      # same change or the mirror starts failing every five minutes again.
       - name: Mirror public repository
         env:
           DESTINATION_REPOSITORY: ${{ github.repository }}
@@ -40,5 +40,5 @@ jobs:
           git clone --bare https://github.com/wildcat-finance/skills.git source.git
           git -C source.git push --force --prune \
             "https://x-access-token:${DESTINATION_TOKEN}@github.com/${DESTINATION_REPOSITORY}.git" \
-            "refs/heads/main:refs/heads/main" \
+            "refs/heads/*:refs/heads/*" \
             "refs/tags/*:refs/tags/*"


### PR DESCRIPTION
Restores full branch mirroring to the private marketplace, which the
Workflows-permission token now makes possible.

The refspec was narrowed to `main` in
[#280](https://github.com/wildcat-finance/skills/pull/280) because
`github.token` cannot push a branch carrying a workflow file, and one rejected
ref fails the whole push. [#281](https://github.com/wildcat-finance/skills/pull/281)
replaced that token with `MARKETPLACE_SYNC_TOKEN`, which holds Contents and
Workflows write, so the restriction is gone and the narrowing has nothing left
to protect.

Measured before the change: public `skills` has 92 branches, the mirror has 81,
and **no branch exists in the mirror that is absent upstream**. So widening
adds the 11 missing branches and prunes nothing. The 84 branches this run
earlier offered to delete as stale were not stale at all: they are faithful
copies of branches that still exist here, because this repository does not
delete its branches. Deleting them would have made the mirror diverge from its
source and the next widened run would have restored them.

With wildcard refspecs `--prune` sweeps branches as well as tags, so from here
the mirror tracks the source exactly and a ref deleted here disappears there on
the next run. That is the property the narrow refspec could not have.

The comment above the step now records the coupling in the direction that
matters: if this ever reverts to `github.token`, the refspec has to narrow back
to `main` in the same change, or the mirror fails every five minutes again.

## Carried forward

- The token has no expiry, so nothing will warn when it is revoked or the
  account it belongs to changes. A GitHub App installation is the version of
  this with no expiry to diary, and the App
  `wildcat-marketplace-sync` already exists.
- Nothing verifies that the mirror is current. A stale mirror is silent unless
  someone reads the Actions tab, and the plugin-currency reference tells a run
  to trigger the mirror by hand for exactly that reason.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
