### PR TITLE
feat(protasis): a study schema check behind --study

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5644,3 +5644,16 @@ Root suite 104/104; hexaemeron suite 470/472 with the same two
 environmental failures recorded for step 1.
 
 Leads not pursued: none
+
+## Protasis study schema check, step 1, round 1 -- 2026-08-20
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+No findings. The step commits the study and runbook, byte-identical to the
+run's working copies. Phylax, ephoros and hypomnema exit 0 over the tree.
+Reviewed against the risk register: no checker code exists yet, so the
+unearned-verdict concerns do not arise this step. Root suite 104/104;
+hexaemeron 470/472 with the two recorded environment failures.
+
+Leads not pursued: none

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5657,3 +5657,24 @@ unearned-verdict concerns do not arise this step. Root suite 104/104;
 hexaemeron 470/472 with the two recorded environment failures.
 
 Leads not pursued: none
+
+## Protasis study schema check, step 2, round 1 -- 2026-08-20
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+No findings. The round worked the risk register's four unearned-verdict
+concerns directly against the code: a fenced item heading is not an item
+(backtick and tilde probed), a duplicate number returns S004 and no answer
+verdict, a bare none in five spellings is refused whole-answer only, and
+the heading form the check reads is the one every committed study uses.
+Further probes: an item 13 is ignored as unmandated, a subsection stays in
+its item's body, a CRLF document scans identically. Phylax, ephoros and
+hypomnema exit 0. Root 104/104; hexaemeron 490/492 with the two recorded
+environment failures and 20 new study cases passing.
+
+Leads not pursued: an answer asserting none with filler words but no
+reason ("None whatsoever at all.") passes as content. Distinguishing a
+reason from filler is answer quality, which the checker's stated boundary
+leaves to the reviewer; tightening it mechanically would refuse honest
+long-form answers.

--- a/docs/protasis-study-schema-check-runbook.md
+++ b/docs/protasis-study-schema-check-runbook.md
@@ -1,0 +1,30 @@
+# Runbook: Ship the protasis study schema check
+
+Derived from `.hexaemeron/study.md`. Three steps, dependency order.
+
+## Step 1: Scaffold: commit the study and runbook
+
+**Goal.** The study and runbook this run builds from are committed where the next study will find them.
+**Entry.** The run branch `fiat/ship-the-protasis-study-schema-check` at `main` (`68ddc3c`), clean tree, suites at their base state.
+**Exit.** `docs/protasis-study-schema-check-study.md` and `docs/protasis-study-schema-check-runbook.md` exist as committed copies; the imprimatur lint scores 100.0 on both; `python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py docs plugins` exits 0; `python3 -m unittest discover -s tests` passes and `python3 plugins/hexaemeron/tests/run_tests.py` reports only the two recorded environment failures.
+**Files.** `docs/protasis-study-schema-check-study.md`, `docs/protasis-study-schema-check-runbook.md`.
+**Tests.** None written; both suites run to prove the tree stayed green.
+**Disciplines.** phylax: none, a docs-only commit opens no boundary. ephoros: none, nothing runs unattended. metron: none, no performance claim. elenchus: none, no failure in hand. hypomnema: none new this step; the run's decisions land in the ledger row in step 3 and this step commits the reasoning they point at.
+
+## Step 2: The study mode, its fixtures and its tests
+
+**Goal.** `protasis.py --study` fails a study missing any of the twelve items, and one whose items 8 through 12 answer with silence or a bare none.
+**Entry.** Step 1's exit state.
+**Exit.** `python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/protasis-study-schema-check-study.md` exits 0; the same command over a fixture missing an item exits 1 naming S001; `python3 plugins/hexaemeron/tests/run_tests.py` reports the new study cases passing and only the two recorded environment failures; `python3 -m unittest discover -s tests` passes.
+**Files.** `plugins/hexaemeron/skills/protasis/scripts/protasis.py`, `plugins/hexaemeron/tests/test_protasis_checker.py`, fixtures under `plugins/hexaemeron/tests/fixtures/protasis/`.
+**Tests.** Study cases in `test_protasis_checker.py`: a complete study clean; each of the twelve items removed caught as S001; for items 8 through 12, an empty answer and a bare none each caught as S002 and a stated none with its reason passing; S000 on an unreadable path; S003 on a document with no item; S004 on a duplicate item number; a fenced quotation of an item heading not counted; the runbook mode's existing cases unchanged.
+**Disciplines.** phylax: the check reads caller-named paths, so the existing refusals (regular files only, byte cap, no subprocess, no socket) must hold in the new mode. ephoros: none, a terminal lint has no unattended signal. metron: none, no performance claim. elenchus: any case that fails mid-step is reduced and guarded in the same test module. hypomnema: none this step; the S-code decision is recorded in step 3's ledger row.
+
+## Step 3: Name the check in the contract, cut the evolution row, demonstrate
+
+**Goal.** The protasis contract names its mechanical subset, the ledger closes `study-schema-check` with one evolution row holding the next frontier judgement, and the demo path from the problem statement runs.
+**Entry.** Step 2's exit state.
+**Exit.** `plugins/hexaemeron/skills/protasis/SKILL.md` carries a mechanical-subset section naming both modes and frontmatter `version: "3.3.0"`; `EVOLUTION.md` current version reads `protasis-v3.3.0` with one new evolution row whose digest matches the new frontier line; the demo path runs: `python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/protasis-study-schema-check-study.md` exits 0, `python3 -m unittest discover -s tests` passes, `python3 plugins/hexaemeron/tests/run_tests.py` reports only the two recorded environment failures.
+**Files.** `plugins/hexaemeron/skills/protasis/SKILL.md`, `plugins/hexaemeron/skills/protasis/EVOLUTION.md`.
+**Tests.** None written; the evolution suite guards the row and both suites run as the proof.
+**Disciplines.** phylax: none, a markdown diff opens no boundary. ephoros: none, nothing runs unattended. metron: none, no performance claim. elenchus: none, no failure in hand. hypomnema: the frontier judgement and the S-code interface decision are expensive to reverse and land in `EVOLUTION.md`, the ledger the contract names for decisions about a governed skill.

--- a/docs/protasis-study-schema-check-study.md
+++ b/docs/protasis-study-schema-check-study.md
@@ -1,0 +1,71 @@
+# Study: Ship the protasis study schema check
+
+Assuming, unless corrected:
+
+1. The check extends `plugins/hexaemeron/skills/protasis/scripts/protasis.py` behind a `--study` flag rather than a second script, and the runbook mode's invocation and codes P000 to P004 stay untouched.
+2. Study items are level-two headings of the form `## N. Title`, numbered 1 to 12, as every committed study under `docs/` writes them.
+3. Python 3.11 and stdlib unittest, matching the existing checker and suite.
+4. The run starts from `main` at `68ddc3c09496706886542665c21f7689add1e03c`.
+
+## 1. Problem statement
+
+The runbook step schema is executable and the study contract beside it is not: twelve mandated items, every one of them read by a person. A study missing an item, or answering items 8 through 12 with silence, passes today because nothing but a reviewer's attention refuses it, and silence cannot be told apart from not having looked. This run ships the held frontier job: a check over a study that fails when one of the twelve items is absent, and when an answer to items 8 through 12 is neither content nor a stated none carrying its reason. Done means the check catches each omission in fixture studies, passes over this run's own study, and both suites pass: `python3 -m unittest discover -s tests` and `python3 plugins/hexaemeron/tests/run_tests.py`.
+
+## 2. Prior art
+
+- `protasis.py` holds the runbook mode: fence-aware scanning, a byte cap, a step cap whose dropped count is reported, findings as stable codes, and an allow pragma. The study mode reuses that machinery rather than growing a sibling implementation.
+- The audit records of the in-scope skill were read before design options were drawn. `audit/AUDIT.md` under the discipline-cores run (S3-R1-01 to S3-R4-01) shows the same fault four times: the check returning a verdict it had not earned rather than crashing -- a cap that discarded what it dropped, a last step that absorbed dropped fields, and two fence-tracking holes. Every one shapes this design: one shared scanner, spans that end at the next heading, and no silent truncation. The run-1 rounds ("Protasis audit-record source") add the two environment-bound suite failures this container cannot clear.
+- The last two merged pull requests that changed the target: [skills#297](https://github.com/wildcat-finance/skills/pull/297), which carried forward the two environment-bound hexaemeron tests (restated in item 3), this held job (this run), and installed-plugin cache staleness (stays open, owned by hosts); and [skills#293](https://github.com/wildcat-finance/skills/pull/293), which named protasis's study checker as remaining open on its own frontier -- this run is that item.
+- `plugins/hexaemeron/tests/test_protasis_checker.py` and `tests/fixtures/protasis/` hold the test conventions the new cases extend.
+
+## 3. Constraints and non-goals
+
+- Starting ref: `main` at `68ddc3c09496706886542665c21f7689add1e03c`. The container cannot run the two `test_elenchus_checker` cases needing `forge` and node v26; both fail identically on the base and are outside this run's diff.
+- Codes P000 to P004 are a cited interface and do not move. Study findings get their own S-prefixed codes.
+- Non-goal: judging answer quality. A wrong answer with words in it passes; presence is the parser's job and judgement is the reviewer's, exactly as the runbook mode states.
+- Non-goal: checking emptiness of items 1 through 7. The held job's acceptance names items 8 through 12 for the answer check because "none, and here is why" is only a complete answer there; the first seven are read whole by the reviewer.
+- Non-goal: binding the check into Fiat's directive table or receipts, which is Fiat's contract and Fiat's ledger.
+
+## 4. Design options
+
+1. **A `--study` flag on `protasis.py` with S-prefixed codes.** One file, one shared scanner, one test module; the fence and cap lessons apply to both modes by construction. Chosen: cheapest to comprehend and it cannot drift from the runbook mode's hygiene. Trades away a separate module's independence: a fault in the shared scanner now touches both modes, which the shared tests also cover.
+2. **A second script `study.py` beside the checker.** Rejected: duplicates the scanner whose duplication caused three of the four recorded faults last time.
+3. **Auto-detecting document kind from content.** Rejected: a runbook quoting a study heading, or the reverse, makes the kind a guess, and a wrong guess returns verdicts the check has not earned.
+
+## 5. Risk register seed
+
+The audit loop should look hardest at unearned verdicts, the fault every recorded protasis finding shares: an item heading quoted inside a fence being counted as an item, a duplicate item number letting one answered copy hide an empty one, a bare "None." passing because the none-rule matched too loosely, and an S001 miss when a heading deviates in whitespace or case. Partial reads are bounded by the existing byte cap; no subprocess, network or secret is involved.
+
+## 6. Glossary seeds
+
+- Study item: a level-two heading `## N. Title`, N from 1 to 12, and the lines under it up to the next level-two heading.
+- Bare none: an answer that asserts none and stops, carrying no reason.
+- S-code: a stable study finding code, S000 upward, an interface other tools may cite once shipped.
+
+## 7. Sources
+
+- `plugins/hexaemeron/skills/protasis/scripts/protasis.py` and `SKILL.md`
+- `plugins/hexaemeron/skills/protasis/EVOLUTION.md` (held job text)
+- `audit/AUDIT.md`, discipline-cores and audit-record-source sections
+- `plugins/hexaemeron/tests/test_protasis_checker.py`
+- [skills#297](https://github.com/wildcat-finance/skills/pull/297), [skills#293](https://github.com/wildcat-finance/skills/pull/293)
+
+## 8. Signals, and the questions behind them
+
+None, and here is why: the check is a lint invoked from a terminal, and the runbook mode's precedent holds -- it has no on-call question, per [ephoros](../plugins/hexaemeron/skills/ephoros/SKILL.md), whose contract owns signal content when one exists.
+
+## 9. Boundaries, per capability
+
+The check's trust boundary is its argument list, unchanged from the runbook mode: paths are read as given, anything that is not a regular file is refused, reads are byte-capped, and no subprocess or socket is opened. [phylax](../plugins/hexaemeron/skills/phylax/SKILL.md) owns the boundary rules; its lint runs in every audit round.
+
+## 10. The budget, or its absence
+
+None, and here is why: the check reads one document per path with a 2 MiB cap, the same bound the runbook mode has run under without a performance complaint. [metron](../plugins/hexaemeron/skills/metron/SKILL.md) owns budgets where one exists.
+
+## 11. The fail-closed posture
+
+An unreadable path is S000, never a silent skip; a document with no item is S003, never clean; anything dropped by a cap is reported, never discarded. A failure surfaced mid-step follows [elenchus](../plugins/hexaemeron/skills/elenchus/SKILL.md): reproduce, reduce, fix the mechanism, and guard it with a test in `test_protasis_checker.py`.
+
+## 12. Decisions and their homes
+
+Two decisions are expensive to reverse. The S-code numbering becomes a cited interface the moment it ships, and the choice to extend `protasis.py` rather than grow a sibling script shapes every later checker change. Both are recorded in the protasis ledger's evolution row for this run ([hypomnema](../plugins/hexaemeron/skills/hypomnema/SKILL.md): a decision about a governed skill lives in its `EVOLUTION.md`), with this study committed under `docs/` carrying the reasoning. The row also holds the next frontier judgement this run must make at close.

--- a/plugins/hexaemeron/skills/protasis/scripts/protasis.py
+++ b/plugins/hexaemeron/skills/protasis/scripts/protasis.py
@@ -1,15 +1,28 @@
 #!/usr/bin/env python3
-"""Protasis runbook schema check.
+"""Protasis runbook and study schema checks.
 
 A runbook step that omits a field is not caught by reading, because the phase
-that reads it carefully is the one that has already started building. This
-settles the part a parser can.
+that reads it carefully is the one that has already started building. The same
+holds for a study missing one of its twelve items. This settles the part a
+parser can.
+
+Runbook mode (the default):
 
   P000  a path that cannot be read as a runbook
   P001  a step missing a required field
   P002  a step whose exit states no command
   P003  a document in which no step was found
   P004  more steps than the check will track, so the tail went unchecked
+
+Study mode (`--study`):
+
+  S000  a path that cannot be read as a study
+  S001  one of the twelve study items is missing
+  S002  an answer to items 8 through 12 is neither content nor a stated
+        none carrying its reason
+  S003  a document in which no study item was found
+  S004  a study item number appears more than once, so no verdict on its
+        answer is earned
 
 Exit 0 clean, 1 findings, 2 bad invocation.
 
@@ -21,7 +34,10 @@ answer is any good: a Disciplines line naming the wrong gates and an Exit whose
 command proves nothing both pass. Judging an answer is the reviewer's job, and
 the study's non-goals say so. P002 is the closest to a judgement, and it is
 still only presence: a step carrying no code at all cannot have named a command,
-while a step carrying one may still have named the wrong one.
+while a step carrying one may still have named the wrong one. The study mode
+holds the same line: S002 refuses silence and a bare none, never a weak reason,
+and items 1 through 7 are checked for presence only, because "none, and here is
+why" is a complete answer solely for items 8 through 12.
 
 The trust boundary is the argument list. Paths are read as given, so the caller
 decides what is opened; the checker refuses anything that is not a regular file,
@@ -49,6 +65,37 @@ INLINE_CODE = re.compile(r"`[^`\n]+`")
 ALLOW = re.compile(r"<!--\s*protasis:\s*allow\s+(?P<reason>\S[^>]*?)\s*-->")
 
 REQUIRED = ("Goal", "Entry", "Exit", "Files", "Tests", "Disciplines")
+
+# "## 2. Prior art". The number is required and the dot ends it: a heading
+# reading "## Sources" is prose, not an item.
+ITEM = re.compile(r"^##\s+(?P<n>\d{1,3})\.\s*(?P<title>.*?)\s*$")
+
+# The twelve items the study contract mandates, by number.
+ITEMS = {
+    1: "Problem statement",
+    2: "Prior art",
+    3: "Constraints and non-goals",
+    4: "Design options",
+    5: "Risk register seed",
+    6: "Glossary seeds",
+    7: "Sources",
+    8: "Signals, and the questions behind them",
+    9: "Boundaries, per capability",
+    10: "The budget, or its absence",
+    11: "The fail-closed posture",
+    12: "Decisions and their homes",
+}
+
+# The five whose answer may be a stated none, and only with its reason.
+ANSWERED = range(8, 13)
+
+# An answer that asserts none and stops. Punctuation-stripped, lowercased,
+# whole-answer matches only: "none, and here is why: ..." carries more words
+# and passes, while judging whether the reason is any good stays the
+# reviewer's job.
+BARE = {"none", "n/a", "na", "no", "tbd"}
+
+COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
 
 # A runbook is a document somebody handed over. Bound both axes.
 MAX_BYTES = 2 * 1024 * 1024
@@ -222,15 +269,93 @@ def check(path: Path) -> list[Finding]:
     return findings
 
 
+def _item_spans(lines: list[str]) -> dict[int, list[tuple[int, int, int]]]:
+    """Item spans keyed by number: (heading line, body start, body end).
+
+    A list per number, because a duplicate is a fact to report rather than a
+    copy to silently prefer. An item owns the lines after its heading up to
+    the next level-two heading; fenced lines are content, so a study quoting
+    an item heading does not gain or truncate an item.
+    """
+    headings: list[tuple[int, int | None]] = []
+    for index, line, in_fence in _scan(lines):
+        if in_fence or not HEADING.match(line):
+            continue
+        match = ITEM.match(line)
+        number = int(match.group("n")) if match else None
+        headings.append((index, number if number in ITEMS else None))
+
+    spans: dict[int, list[tuple[int, int, int]]] = {}
+    for position, (line_number, number) in enumerate(headings):
+        if number is None:
+            continue
+        if position + 1 < len(headings):
+            end = headings[position + 1][0] - 1
+        else:
+            end = len(lines)
+        spans.setdefault(number, []).append((line_number, line_number + 1, end))
+    return spans
+
+
+def _answer(lines: list[str], start: int, end: int) -> str:
+    """The answer's text with comments and whitespace stripped."""
+    body = "\n".join(lines[start - 1:end])
+    body = COMMENT.sub(" ", body)
+    return " ".join(body.split())
+
+
+def check_study(path: Path) -> list[Finding]:
+    lines = _read(path)
+    if lines is None:
+        return [Finding(path, 1, "S000", "cannot be read as a study")]
+
+    spans = _item_spans(lines)
+    if not spans:
+        return [Finding(path, 1, "S003",
+                        "no study item found; expected '## N. Title' headings, 1 to 12")]
+
+    findings: list[Finding] = []
+    for number in sorted(ITEMS):
+        name = ITEMS[number]
+        occurrences = spans.get(number, [])
+        if not occurrences:
+            findings.append(Finding(
+                path, 1, "S001", f"study item {number} ({name}) is missing"))
+            continue
+        if len(occurrences) > 1:
+            first = occurrences[0][0]
+            findings.append(Finding(
+                path, first, "S004",
+                f"study item {number} ({name}) appears {len(occurrences)} times, "
+                f"so no verdict on its answer is earned"))
+            continue
+        heading_line, body_start, body_end = occurrences[0]
+        if number not in ANSWERED or suppressed(lines, heading_line):
+            continue
+        answer = _answer(lines, body_start, body_end)
+        stripped = answer.strip(" .,!:;-").lower()
+        if not answer or stripped in BARE:
+            findings.append(Finding(
+                path, heading_line, "S002",
+                f"item {number} ({name}) carries neither content nor a stated "
+                f"none with its reason"))
+    return findings
+
+
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Protasis runbook schema check.")
-    parser.add_argument("paths", nargs="+", help="runbook files to check")
+    parser = argparse.ArgumentParser(
+        description="Protasis runbook and study schema checks.")
+    parser.add_argument("paths", nargs="+", help="documents to check")
+    parser.add_argument("--study", action="store_true",
+                        help="check studies against the twelve-item contract "
+                             "instead of runbooks against the step schema")
     parser.add_argument("--format", choices=("text", "json"), default="text")
     args = parser.parse_args(argv)
 
+    checker = check_study if args.study else check
     findings: list[Finding] = []
     for name in args.paths:
-        findings.extend(check(Path(name)))
+        findings.extend(checker(Path(name)))
 
     if args.format == "json":
         print(json.dumps([f.as_dict() for f in findings], indent=2))

--- a/plugins/hexaemeron/tests/fixtures/protasis/complete-study.md
+++ b/plugins/hexaemeron/tests/fixtures/protasis/complete-study.md
@@ -1,0 +1,52 @@
+# Study: a complete fixture
+
+Assuming, unless corrected: nothing.
+
+## 1. Problem statement
+
+Build a thing, proved by `pytest`.
+
+## 2. Prior art
+
+The last two merged pull requests were read; there were none to carry.
+The audit records were read; there were none to read.
+
+## 3. Constraints and non-goals
+
+Python only.
+
+## 4. Design options
+
+One option, chosen for being the only one.
+
+## 5. Risk register seed
+
+Look hardest at partial writes.
+
+## 6. Glossary seeds
+
+Fixture: a small, deliberate example.
+
+## 7. Sources
+
+This repository.
+
+## 8. Signals, and the questions behind them
+
+None, and here is why: a terminal lint has no on-call question.
+
+## 9. Boundaries, per capability
+
+The argument list is the boundary; paths are read as given.
+
+## 10. The budget, or its absence
+
+None, and here is why: two file reads carry no budget.
+
+## 11. The fail-closed posture
+
+A failing check stops the step; the guard is a test.
+
+## 12. Decisions and their homes
+
+The one reversible-at-cost decision is recorded in the ledger.

--- a/plugins/hexaemeron/tests/fixtures/protasis/incomplete-study.md
+++ b/plugins/hexaemeron/tests/fixtures/protasis/incomplete-study.md
@@ -1,0 +1,47 @@
+# Study: a complete fixture
+
+Assuming, unless corrected: nothing.
+
+## 1. Problem statement
+
+Build a thing, proved by `pytest`.
+
+## 3. Constraints and non-goals
+
+Python only.
+
+## 4. Design options
+
+One option, chosen for being the only one.
+
+## 5. Risk register seed
+
+Look hardest at partial writes.
+
+## 6. Glossary seeds
+
+Fixture: a small, deliberate example.
+
+## 7. Sources
+
+This repository.
+
+## 8. Signals, and the questions behind them
+
+None, and here is why: a terminal lint has no on-call question.
+
+## 9. Boundaries, per capability
+
+The argument list is the boundary; paths are read as given.
+
+## 10. The budget, or its absence
+
+None.
+
+## 11. The fail-closed posture
+
+A failing check stops the step; the guard is a test.
+
+## 12. Decisions and their homes
+
+The one reversible-at-cost decision is recorded in the ledger.

--- a/plugins/hexaemeron/tests/test_protasis_checker.py
+++ b/plugins/hexaemeron/tests/test_protasis_checker.py
@@ -278,3 +278,150 @@ class Fixtures(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+COMPLETE_STUDY = (FIXTURES / "complete-study.md").read_text(encoding="utf-8")
+
+
+def study_findings(source):
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "study.md"
+        path.write_text(source, encoding="utf-8")
+        return protasis.check_study(path)
+
+
+def study_codes(source):
+    return sorted(f.code for f in study_findings(source))
+
+
+def without_item(number):
+    """The complete study with one item's heading and body removed."""
+    lines = COMPLETE_STUDY.splitlines()
+    kept, skipping = [], False
+    for line in lines:
+        match = protasis.ITEM.match(line)
+        if match:
+            skipping = int(match.group("n")) == number
+        if not skipping:
+            kept.append(line)
+    return "\n".join(kept) + "\n"
+
+
+def with_answer(number, answer):
+    """The complete study with one item's body replaced."""
+    lines = COMPLETE_STUDY.splitlines()
+    out, skipping = [], False
+    for line in lines:
+        match = protasis.ITEM.match(line)
+        if match:
+            if skipping:
+                skipping = False
+            if int(match.group("n")) == number:
+                out.append(line)
+                out.append("")
+                out.append(answer)
+                skipping = True
+                continue
+        if not skipping:
+            out.append(line)
+    return "\n".join(out) + "\n"
+
+
+class StudyItems(unittest.TestCase):
+    def test_a_complete_study_is_clean(self):
+        self.assertEqual(study_codes(COMPLETE_STUDY), [])
+
+    def test_each_of_the_twelve_items_is_required(self):
+        for number in protasis.ITEMS:
+            with self.subTest(item=number):
+                found = study_codes(without_item(number))
+                self.assertIn("S001", found)
+
+    def test_the_finding_names_the_missing_item(self):
+        found = study_findings(without_item(5))
+        self.assertEqual(len(found), 1)
+        self.assertIn("Risk register seed", found[0].message)
+
+    def test_a_duplicate_item_earns_no_verdict(self):
+        source = COMPLETE_STUDY + "\n## 10. The budget, or its absence\n\nAgain.\n"
+        found = study_codes(source)
+        self.assertIn("S004", found)
+        self.assertNotIn("S002", found)
+
+    def test_an_item_heading_inside_a_fence_is_not_an_item(self):
+        source = without_item(12) + "\n```markdown\n## 12. Decisions and their homes\n```\n"
+        self.assertEqual(study_codes(source), ["S001"])
+
+
+class StudyAnswers(unittest.TestCase):
+    def test_an_empty_answer_is_a_finding(self):
+        for number in protasis.ANSWERED:
+            with self.subTest(item=number):
+                self.assertIn("S002", study_codes(with_answer(number, "")))
+
+    def test_a_bare_none_is_a_finding(self):
+        for answer in ("None.", "none", "N/A.", "TBD", "No."):
+            with self.subTest(answer=answer):
+                self.assertIn("S002", study_codes(with_answer(9, answer)))
+
+    def test_a_stated_none_with_its_reason_passes(self):
+        source = with_answer(9, "None, and here is why: the diff is markdown.")
+        self.assertEqual(study_codes(source), [])
+
+    def test_content_passes(self):
+        source = with_answer(11, "A failing suite stops the step; the guard is a test.")
+        self.assertEqual(study_codes(source), [])
+
+    def test_a_comment_is_not_content(self):
+        source = with_answer(8, "<!-- filled in later -->")
+        self.assertIn("S002", study_codes(source))
+
+    def test_the_first_seven_are_presence_only(self):
+        source = with_answer(3, "")
+        self.assertEqual(study_codes(source), [])
+
+    def test_an_allow_comment_suppresses_the_answer_check(self):
+        source = with_answer(10, "").replace(
+            "## 10. The budget, or its absence",
+            "## 10. The budget, or its absence <!-- protasis: allow measured upstream -->")
+        self.assertEqual(study_codes(source), [])
+
+    def test_a_trailing_section_does_not_answer_for_the_last_item(self):
+        source = with_answer(12, "") + "\n# Appendix\n\nWords that are not item 12.\n"
+        self.assertIn("S002", study_codes(source))
+
+
+class StudyDocuments(unittest.TestCase):
+    def test_a_document_with_no_item_is_a_finding(self):
+        self.assertEqual(study_codes("# Title\n\nProse only.\n"), ["S003"])
+
+    def test_a_missing_path_is_reported_not_raised(self):
+        found = protasis.check_study(Path("does-not-exist-4c1a.md"))
+        self.assertEqual([f.code for f in found], ["S000"])
+
+    def test_a_directory_is_reported_not_raised(self):
+        with tempfile.TemporaryDirectory() as directory:
+            found = protasis.check_study(Path(directory))
+        self.assertEqual([f.code for f in found], ["S000"])
+
+    def test_the_incomplete_fixture_names_both_faults(self):
+        found = protasis.check_study(FIXTURES / "incomplete-study.md")
+        self.assertEqual(sorted(f.code for f in found), ["S001", "S002"])
+
+    def test_the_run_that_shipped_this_mode_passes_its_own_study(self):
+        study = REPO / "docs" / "protasis-study-schema-check-study.md"
+        self.assertEqual([f.code for f in protasis.check_study(study)], [])
+
+    def test_study_mode_is_selected_by_flag(self):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            code = protasis.main(["--study", str(FIXTURES / "complete-study.md")])
+        self.assertEqual(code, 0)
+        with redirect_stdout(io.StringIO()):
+            code = protasis.main(["--study", str(FIXTURES / "incomplete-study.md")])
+        self.assertEqual(code, 1)
+
+    def test_the_runbook_mode_is_unchanged_by_the_flagless_call(self):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            code = protasis.main([str(FIXTURES / "complete-runbook.md")])
+        self.assertEqual(code, 0)


### PR DESCRIPTION
A study missing one of its twelve items, or answering items 8 through 12
with silence, passed because only a reviewer's attention refused it, and
silence cannot be told apart from not having looked.

`protasis.py` gains a `--study` mode with its own stable codes: S000 an
unreadable path, S001 a missing item, S002 an answer to items 8 through
12 that is neither content nor a stated none carrying its reason, S003 a
document with no item, S004 a duplicated item number on which no verdict
is earned. The mode shares the runbook mode's fence-aware scanner, byte
cap and allow pragma; codes P000 to P004 and the flagless invocation are
untouched. Items 1 through 7 stay presence-only, because a stated none is
a complete answer solely for 8 through 12.

Audit record: `audit/AUDIT.md`, "Protasis study schema check, step 2,
round 1" -- one clean round that probed the register's four
unearned-verdict concerns directly, with one lead recorded as accepted
(a none with filler words passes; reason-versus-filler is answer
quality, the reviewer's job). Proof:
`python3 plugins/hexaemeron/tests/run_tests.py` (490/492, 20 new study
cases, the two recorded environment failures only) and
`python3 -m unittest discover -s tests` (104/104).

Stacks on: step 1 (the committed study and runbook).

&lt;!-- wildcat-origin: shoggoth --&gt;

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkVQh8WktKuwRaQy6MzQYw)_