### PR TITLE
chore(hypomnema): close the recorded-reasons frontier

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5772,3 +5772,25 @@ applicable, no row cut this step. Phylax and ephoros exit 0. Root
 104/104; hexaemeron 490/492 with the two recorded environment failures.
 
 Leads not pursued: none
+
+## Hypomnema first records, step 2, round 1 -- 2026-08-20
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+No findings open. One fault surfaced and was fixed before the step's
+commit: ADR-006's first consequences sentence used a metaphor the prose
+lint refuses; the sentence was rewritten with the fact intact. Per the
+register: content-drift reviewed, the normalisation diff over ADR-002,
+ADR-003 and ADR-004 touches status shape and one heading name only, 11
+insertions against 9 deletions, and ADR-001 needed no change; pointer-rot
+reviewed, the hypomnema lint exits 0 and every ADR cross-reference
+(ADR-003 from ADR-005, ADR-004 from ADR-006) resolves; ledger-arithmetic
+not applicable, no row cut this step. Phylax and ephoros exit 0. Root
+104/104; hexaemeron 490/492 with the two recorded environment failures.
+
+Leads not pursued: ADR-002 and ADR-004 carry no Alternatives section;
+their rejected options live as prose in their context and decision
+sections, written by the run that authored them. Restructuring that prose
+into sections risks rewording another run's reasoning, so the gap is left
+for the shape check this run's close names as the successor frontier.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5794,3 +5794,21 @@ their rejected options live as prose in their context and decision
 sections, written by the run that authored them. Restructuring that prose
 into sections risks rewording another run's reasoning, so the gap is left
 for the shape check this run's close names as the successor frontier.
+
+## Hypomnema first records, step 3, round 1 -- 2026-08-20
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+One fault surfaced and was fixed within the step: the contract edit moved
+the bytes of a Promise Machine runtime binding surface, and the coverage
+gate refused the drift (PM071). The field map was reviewed as unchanged
+and the inventory digest updated with the surface, which is the checker's
+own remedy; the full promise_machine check returns clean. Per the
+register: content-drift reviewed, no record changed this step;
+pointer-rot reviewed, the hypomnema lint exits 0; ledger-arithmetic
+reviewed, the evolution suite passes over the new row and its digest
+matches the new frontier line. Phylax and ephoros exit 0. Root 104/104;
+hexaemeron 490/492 with the two recorded environment failures.
+
+Leads not pursued: none

--- a/docs/decisions/ADR-002-use-one-portable-promise-machine-router.md
+++ b/docs/decisions/ADR-002-use-one-portable-promise-machine-router.md
@@ -1,6 +1,8 @@
-# ADR-002: use one portable Promise Machine router
+# ADR-002: Use one portable Promise Machine router
 
-Status: accepted on 20 August 2026.
+## Status
+
+Accepted, 2026-08-20.
 
 ## Context
 

--- a/docs/decisions/ADR-003-bind-vendored-promises-with-digests.md
+++ b/docs/decisions/ADR-003-bind-vendored-promises-with-digests.md
@@ -1,8 +1,8 @@
 # ADR-003: Bind vendored promises with digests
 
-- Status: Accepted
-- Date: 2026-08-20
-- Promise Machine contract: `promise-machine/v1`
+## Status
+
+Accepted, 2026-08-20. Promise Machine contract: `promise-machine/v1`.
 
 ## Context
 
@@ -27,7 +27,7 @@ skills and byte drift. A runtime that selects a vendored skill reads its block
 and compares the recorded digest before relying on the overlay. Digest drift
 blocks the Wildcat promise; it does not authorise editing the upstream file.
 
-## Alternatives rejected
+## Alternatives
 
 - Editing vendored instructions would create an unattributed local fork and
   make upstream comparison unreliable.

--- a/docs/decisions/ADR-004-release-the-promise-machine-without-moving-skill-frontiers.md
+++ b/docs/decisions/ADR-004-release-the-promise-machine-without-moving-skill-frontiers.md
@@ -1,8 +1,8 @@
 # ADR-004: Release the Promise Machine without moving skill frontiers
 
-- Status: Accepted
-- Date: 2026-08-20
-- Contract: `promise-machine/v1`
+## Status
+
+Accepted, 2026-08-20. Contract: `promise-machine/v1`.
 
 ## Context
 

--- a/docs/decisions/ADR-005-vendor-the-pashov-suite-whole-and-ungoverned.md
+++ b/docs/decisions/ADR-005-vendor-the-pashov-suite-whole-and-ungoverned.md
@@ -1,0 +1,54 @@
+# ADR-005: Vendor the Pashov suite whole and ungoverned
+
+## Status
+
+Accepted, 2026-08-20. Records a boundary in force since the suite was
+vendored; superseded by a later numbered record once it stops being true.
+
+## Context
+
+Hexaemeron bundles five skills that originate outside Wildcat Labs: `x-ray`,
+`solidity-auditor`, `fizz` and fizz's two nested skills, together the Pashov
+suite. The delivery loop depends on them for its security rounds, so they have
+to ship inside the plugin. They are also another author's working method, and
+every other first-party skill here is governed by an `EVOLUTION.md` ledger
+under the versioning contract. The question the repository answered in
+practice, and never wrote down, is how upstream instructions live inside a
+governed marketplace.
+
+## Decision
+
+The suite is vendored whole: upstream-owned, byte-for-byte unmodified, and
+ungoverned. No vendored skill keeps a ledger or a Wildcat version; the
+versioning contract exempts them by name and Hexaemeron's plugin frontier
+covers them as a bundle. What the Wildcat suite accepts from a vendored
+operation is stated outside the vendored bytes, in digest-bound overlay
+declarations; ADR-003 records that binding.
+
+## Alternatives
+
+- Fork and adapt the suite. Editing the instructions would let the loop's
+  conventions reach inside them, but the files would stop being comparable to
+  upstream, so an upstream improvement or correction could never be reviewed
+  in or attributed. It lost because an unattributable fork costs more than
+  the adaptation buys.
+- Govern each vendored skill with its own ledger. Ledgers would make the
+  suite look like the rest of the marketplace, but the frontier discipline
+  would then hold Wildcat accountable for evolving another author's method,
+  and a `Next Fiat job` on someone else's instructions is a promise nobody
+  here can keep. It lost because a ledger states ownership the suite does not
+  have.
+- Pin the suite as an external dependency and fetch it at install time. The
+  plugin would stay small, but installation would gain a network dependency
+  and an unpinned trust boundary, and offline installs would break. It lost
+  because the loop's security rounds cannot depend on a fetch.
+
+## Consequences
+
+Upstream updates arrive as deliberate re-vendoring: new bytes, reviewed, with
+the overlay digests recomputed or the update refused. The suite's behaviour
+is always attributable to its author, and Wildcat's claims about it live in
+first-party files the checker can hold to account. The cost is that the
+loop's own conventions stop at the vendored boundary: the prose masks, the
+ledgers and the promise declarations never reach inside those directories,
+and `hypomnema.py` skips them unless asked not to.

--- a/docs/decisions/ADR-006-skill-ledgers-are-not-semver.md
+++ b/docs/decisions/ADR-006-skill-ledgers-are-not-semver.md
@@ -1,0 +1,54 @@
+# ADR-006: Skill ledgers are not SemVer
+
+## Status
+
+Accepted, 2026-08-20. Records a choice in force since the versioning contract
+was adopted; superseded by a later numbered record once it stops being true.
+
+## Context
+
+Every governed skill carries a label of the form
+`{skill}-v{evolution}.{generation}.{epoch}` in its `EVOLUTION.md`, defined by
+`plugins/hexaemeron/skills/VERSIONING.md`. The label looks like SemVer, and
+the contract has to say in passing that it is not, because a reader who
+assumes SemVer will misread every row: they will take the first number for a
+breaking change, the second for a feature, the third for a patch, and none of
+those readings is what the ledger records.
+
+## Decision
+
+The three counters are independent axes of a skill's history, not
+compatibility semantics. Evolution increments exactly once per completed
+frontier Fiat job; generation increments for meaningful non-frontier change;
+epoch increments only when a compatibility or provenance boundary makes the
+earlier lineage an unsafe guide. The counters never reset, and a skill adopts
+at whatever version it already declared, so no baseline value can be assumed
+across the marketplace.
+
+## Alternatives
+
+- SemVer. It is the convention every reader already knows, which is exactly
+  the problem: skills are instruction sets, not APIs, so "breaking change"
+  has no defined subject, and mapping frontier work onto major-minor-patch
+  would either inflate majors on every held-job completion or hide frontier
+  advances inside minors. It lost because its promises are about
+  compatibility this artefact cannot make.
+- The plugin's package version. One number per plugin would be simpler, but a
+  plugin bundles skills whose frontiers move independently, and ADR-004
+  records a whole release where package versions moved and no skill did. It
+  lost because it collapses histories the ledgers exist to keep apart.
+- Date-based versions. Dates order history but carry no arithmetic: nothing
+  in a date says whether a frontier advanced, and the frontier-hold rule
+  (a generation retains the prior revision and digest byte for byte) needs
+  counters a checker can verify. It lost because the ledger's guards would
+  have nothing to hold.
+
+## Consequences
+
+A ledger row's axis carries meaning a checker enforces: the evolution suite
+verifies the arithmetic, the digest hold, and the header-row agreement, and
+Fiat's integrate gate refuses a frontier run whose row breaks them. Readers
+pay a one-time cost of unlearning SemVer, which this record and the contract
+both state plainly. Tools that want compatibility semantics read the package
+versions in the plugin manifests instead, which ADR-004 keeps deliberately
+separate.

--- a/plugins/hexaemeron/skills/hypomnema/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/hypomnema/EVOLUTION.md
@@ -2,14 +2,15 @@
 
 Policy: [../VERSIONING.md](../VERSIONING.md)
 
-- Current version: `hypomnema-v0.1.0`
+- Current version: `hypomnema-v1.1.0`
 - Frontier status: `open`
-- Frontier revision: `recorded-reasons-and-their-homes`
-- Current frontier: A lint checks that every pointer in a first-party record resolves, and no decision-record directory exists in this marketplace yet for the skill's conventions to match.
-- Next Fiat job: Establish the first decision records for choices this marketplace already made and never wrote down, starting with the vendoring boundary around the Pashov suite and the reason skill ledgers are not SemVer. Accepted when the records exist under the convention this skill states, the lint resolves every pointer in them, and both suites pass.
+- Frontier revision: `adr-shape-check`
+- Current frontier: Six records exist and the lint resolves their pointers, but it reads no structure: the first four stated their status in three different shapes within a day of being written, and two still carry no alternatives section, which only a reader notices.
+- Next Fiat job: Ship a lint rule verifying that each record under docs/decisions/ carries the template's dated status and its five sections, with the existing pragma for deliberate exceptions. Accepted when it catches each omission in fixture records, passes over the tree's records once the two without an alternatives section are filled by their authorship trail, and both suites pass.
 
 ## History
 
 | Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
 | --- | --- | --- | --- | --- | --- |
 | `hypomnema-v0.1.0` | baseline | `recorded-reasons-and-their-homes` | `5bcbb5f56863de94e5d141ddb78afc84fcc78aea2e64971dff8e3fd1dc5ceb11` | [skill evolution contract](../VERSIONING.md) | Hypomnema starts here, holding what gets recorded and where it goes. |
+| `hypomnema-v1.1.0` | evolution | `adr-shape-check` | `5c69c143dc7adb1380e27931e5440e9772b184b96fc5964f3fb5a722d3ac59f9` | [first-records study](../../../../docs/hypomnema-first-records-study.md), [skills#308](https://github.com/wildcat-finance/skills/pull/308), [skills#309](https://github.com/wildcat-finance/skills/pull/309) | Closes the recorded-reasons-and-their-homes frontier. The marketplace's first deliberate decision records exist under the convention this skill states: ADR-005 records the vendoring boundary around the Pashov suite and ADR-006 the reason skill ledgers are not SemVer, and the lint resolves every pointer in them. The run found the convention's home already alive -- the Promise Machine run had left ADR-001 to ADR-004 under docs/decisions/ in three different status shapes -- so it continued the numbering, normalised all six records to one dated Status shape without moving other content, and named the directory as a running convention in the contract. The successor frontier is the structure the lint cannot yet read: shape drift arrived within a day of the first records, and two records still carry no alternatives section. |

--- a/plugins/hexaemeron/skills/hypomnema/SKILL.md
+++ b/plugins/hexaemeron/skills/hypomnema/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   and do not use it to decide what a study must contain, which belongs to
   protasis.
 metadata:
-  version: "0.1.0"
+  version: "1.1.0"
 ---
 
 # Hypomnema
@@ -43,12 +43,14 @@ Check for decision records already in the tree, the numbering and naming they
 use, the headings they carry, and any tooling that generates them. Where the
 evidence conflicts, say so rather than quietly picking one.
 
-Two conventions already run in this marketplace and its applications. Each
+Three conventions already run in this marketplace and its applications. Each
 governed skill records its own decisions in an `EVOLUTION.md` ledger, so a
 decision about one skill belongs there and not in a second document. The
-application generates its changelog from conventional commits through
-release-please, so the commit message is the changelog entry, and hand-editing
-the generated file loses at the next release.
+marketplace's cross-cutting decisions live under `docs/decisions/` as numbered
+records in the shape below, ADR-001 onward. The application generates its
+changelog from conventional commits through release-please, so the commit
+message is the changelog entry, and hand-editing the generated file loses at
+the next release.
 
 ## Write the record when reversing gets expensive
 

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -246,7 +246,7 @@
     },
     "hypomnema-record-placement": {
       "source": "plugins/hexaemeron/skills/hypomnema/SKILL.md",
-      "sha256": "c62f0cce2534ea935ba85b26958f851c9e162de28729a0530c31d157726a7542",
+      "sha256": "f19ed4227d8bd94fc6b93492deace8869a35b0d6afa3d233e14e3c4cb16382b8",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "named decision and changed repository surface",


### PR DESCRIPTION
The contract's conventions paragraph now names `docs/decisions/` as a
running convention, ADR-001 onward, and one evolution row takes the
ledger from `hypomnema-v0.1.0` to `hypomnema-v1.1.0`.

The successor frontier is the structure the pointer lint cannot yet
read: the first four records drifted into three status shapes within a
day of being written, and two still carry no alternatives section. The
held job is a shape rule over the records, with the backfill of the two
gap records inside its acceptance.

The contract edit moved the bytes of a Promise Machine runtime binding
surface; the coverage gate refused the drift, the field map was reviewed
as unchanged, and the inventory digest moved with the surface, which is
the checker's own remedy. The full promise_machine check returns clean.

Audit record: `audit/AUDIT.md`, "Hypomnema first records, step 3,
round 1". Demo path: `python3
plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py docs plugins`
exits 0. Proof: root suite 104/104, hexaemeron 490/492 with the two
recorded environment failures.

Stacks on: step 2 (the records).

&lt;!-- wildcat-origin: shoggoth --&gt;

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkVQh8WktKuwRaQy6MzQYw)_