### PR TITLE
Seal a Procrustes size baseline against EIP-170

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5932,3 +5932,22 @@ Phylax and ephoros exit 0; hypomnema exits 0 over the unchanged documents.
 Procrustes 31/31; root 104/104.
 
 Leads not pursued: the `--force` question on the size build, still step 3's.
+
+## Procrustes, step 2, round 4 -- 2026-08-21
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S2-R4-01 | medium | plugins/hermes/skills/procrustes/scripts/procrustes.py | `load_hermes` inserted the sibling directory on `sys.path` and then imported the plain name `hermes`, so a module already in `sys.modules` or earlier on the path could answer instead. The pinned-signature check would catch a different shape but not a same-shaped impostor, and the harness would run foreign code under the name it pinned. The loader now compares the imported module's file to the sibling path and refuses anything else. | fixed in 3483459 |
+
+Per the register: `import-coupling` reviewed, which is where this finding came
+from, and the pin is now a pin on identity as well as on shape;
+`subprocess-input`, `partial-write`, `size-accounting` and
+`layout-selector-drift` reviewed with no change this round.
+
+Phylax and ephoros exit 0. Procrustes 33/33; root 104/104.
+
+Leads not pursued: `PINNED_HERMES_SURFACE` compares rendered `inspect.signature`
+strings, so a future Python whose rendering differs would refuse a Hermes that
+had not moved. The refusal is loud and fail-closed, names the signature it saw,
+and the recovery is to re-pin, so it is not worth trading for a looser
+comparison. The `--force` question on the size build remains step 3's.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5896,3 +5896,23 @@ on disk. Gate 1 requires a clean tree and Forge recompiles on source change, so
 the exposure here is narrow. It stops being narrow in the candidate loop, where
 the baseline and candidate builds must not share a stale artefact, so the
 decision belongs to step 3 rather than to a fix here.
+
+## Procrustes, step 2, round 2 -- 2026-08-21
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S2-R2-01 | medium | plugins/hermes/skills/procrustes/scripts/procrustes.py | `--fuzz-seed` was optional, so a sealed baseline could record a green suite under a seed nobody pinned. The promise authorises comparing a candidate against that baseline, and a candidate suite run under a different seed is not comparable to it. The flag is now required and the sealed state records the value the suite ran under. | fixed in 6b8e850 |
+| S2-R2-02 | low | plugins/hermes/skills/procrustes/scripts/procrustes.py | A JSON boolean passed the integer size check, since `isinstance(True, int)` holds in Python, and every later margin and comparison would have treated it as a byte count. Refused explicitly now. | fixed in 6b8e850 |
+
+Per the register: `size-accounting` reviewed again, which is where S2-R2-02 came
+from; `subprocess-input` reviewed, the pinned seed is passed through Hermes's
+`forge_test_arguments` as a list element rather than interpolated;
+`partial-write` and `import-coupling` reviewed with no change. `deleted-check`,
+`delegatecall-surface`, `gas-regression` and `metadata-only-win` remain not
+applicable until the candidate loop exists.
+
+Phylax, ephoros and hypomnema exit 0. Procrustes 30/30; root 104/104; the
+promise_machine check and the Horos boundary check exit 0.
+
+Leads not pursued: the `--force` question on the size build stands, unchanged
+from round 1, and still belongs to step 3.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5916,3 +5916,19 @@ promise_machine check and the Horos boundary check exit 0.
 
 Leads not pursued: the `--force` question on the size build stands, unchanged
 from round 1, and still belongs to step 3.
+
+## Procrustes, step 2, round 3 -- 2026-08-21
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S2-R3-01 | medium | plugins/hermes/skills/procrustes/scripts/procrustes.py | The sealed state hashed `sizes.json`, the Foundry config and the source manifest, but not the storage layouts or method identifier maps. Those are the files the candidate gates compare against, so a change to one between Gate 1 and the comparison would not have been detectable from the record the promise names as evidence. | fixed in f6df3c6 |
+
+Per the register: `layout-selector-drift` reviewed, which is where this finding
+came from; `size-accounting`, `subprocess-input`, `partial-write` and
+`import-coupling` reviewed with no change this round. The candidate-side ids stay
+not applicable.
+
+Phylax and ephoros exit 0; hypomnema exits 0 over the unchanged documents.
+Procrustes 31/31; root 104/104.
+
+Leads not pursued: the `--force` question on the size build, still step 3's.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5951,3 +5951,28 @@ strings, so a future Python whose rendering differs would refuse a Hermes that
 had not moved. The refusal is loud and fail-closed, names the signature it saw,
 and the recovery is to re-pin, so it is not worth trading for a looser
 comparison. The `--force` question on the size build remains step 3's.
+
+## Procrustes, step 2, round 5 -- 2026-08-21
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+No findings. Two things this round checked against forge 1.7.1 rather than
+against the fake forge the tests use, because a harness that only ever meets its
+own stub is not evidence. On a cold build with `out/` and `cache/` removed,
+`forge build --sizes --json` writes only JSON to stdout and sends compilation
+progress to stderr, so the parse is not exposed to compile chatter. And the
+over-limit comparison uses a strict `>`, which is EIP-170's own boundary: a
+contract of exactly 24576 bytes deploys.
+
+Per the register: every id reviewed with no change. `deleted-check`,
+`delegatecall-surface`, `gas-regression` and `metadata-only-win` remain not
+applicable until the candidate loop exists, and each is named in the step 3
+runbook entry that will incur it.
+
+Phylax, ephoros and hypomnema exit 0. Procrustes 33/33; root 104/104; the
+promise_machine check and the Horos boundary check exit 0.
+
+Leads not pursued: two carried forward, both recorded in round 4 -- the
+`inspect.signature` rendering pin, and the `--force` question on the size build
+that belongs to step 3.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -5862,3 +5862,37 @@ confirmed against the checkout rather than recalled. Root 104/104; the
 promise_machine check and the Horos boundary check exit 0.
 
 Leads not pursued: none
+
+## Procrustes, step 2, round 1 -- 2026-08-21
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S2-R1-01 | high | plugins/hermes/skills/procrustes/scripts/procrustes.py | `CONTRACT_KEY_RE` accepted only bare contract names, so any repository declaring one name in two files could not be baselined at all. `forge build --sizes --json` keys those rows `A (src/A.sol)`, confirmed against forge 1.7.1 on a two-file fixture. A mock or an interface twin is the ordinary case, not an edge one. | fixed in 1362bba |
+| S2-R1-02 | medium | plugins/hermes/skills/procrustes/scripts/procrustes.py | Forge reports `runtime_margin` and `init_margin` beside each size and the harness silently ignored both. A toolchain measuring against a different code-size limit than EIP-170 would therefore be recorded as agreement. Now recomputed, compared, and refused on disagreement. | fixed in 1362bba |
+
+Both fixes carry a guard. Reverting either one and rerunning the suite fails
+exactly its own test: `test_accepts_disambiguated_contract_names` and
+`test_rejects_a_margin_measured_against_another_limit`. Verified by staging a
+reverted copy of the harness, not by inspection.
+
+Per the register: `subprocess-input` reviewed, every argv is a pinned list with
+no shell and the target is resolved and checked for `foundry.toml` before use;
+`partial-write` reviewed, evidence is written through Hermes's atomic replace and
+a killed run leaves no `result.json`, so `status` reports absence rather than
+success; `size-accounting` reviewed, and it is where both findings came from;
+`import-coupling` reviewed, the pinned map now carries only names the harness
+actually calls, which a test enforces. `deleted-check`,
+`delegatecall-surface`, `gas-regression` and `metadata-only-win` are not
+applicable this step, since no candidate gate exists yet. `layout-selector-drift`
+reviewed, the baseline seals both sides through Hermes's comparison unchanged.
+
+Phylax, ephoros and hypomnema exit 0 over the changed harness and documents.
+Procrustes 27/27; root 104/104; the promise_machine check and the Horos boundary
+check exit 0.
+
+Leads not pursued: `forge build --sizes --json` is read without `--force`, so a
+stale build cache could in principle report sizes for sources that are no longer
+on disk. Gate 1 requires a clean tree and Forge recompiles on source change, so
+the exposure here is narrow. It stops being narrow in the candidate loop, where
+the baseline and candidate builds must not share a stale artefact, so the
+decision belongs to step 3 rather than to a fix here.

--- a/plugins/hermes/AGENTS.md
+++ b/plugins/hermes/AGENTS.md
@@ -13,9 +13,18 @@ only the transition its canonical skill declares; missing, stale or
 insufficient evidence blocks that dependent transition while leaving recovery
 available.
 
-Hermes is one Agent Skill. Its canonical instructions are in
-`skills/hermes/SKILL.md`; read that file in full before working on Solidity gas
-usage. It is the only instruction copy; do not add a sibling browsing README.
+This plugin holds two Agent Skills. Select from this table, then read the
+chosen `SKILL.md` in full. Each is the only instruction copy for its skill; do
+not add a sibling browsing README.
+
+| Skill | Canonical instructions | Select when |
+| --- | --- | --- |
+| `hermes` | `skills/hermes/SKILL.md` | The number that matters is gas |
+| `procrustes` | `skills/procrustes/SKILL.md` | The number that matters is deployed bytes, or a contract will not deploy under EIP-170 |
+
+The two disagree by design. A size reduction usually costs gas, so Hermes
+refuses most of what Procrustes exists to measure. Pick by the number that
+matters and do not run the other one to check its work.
 
 ## Capabilities and paths
 
@@ -24,18 +33,26 @@ usage. It is the only instruction copy; do not add a sibling browsing README.
 - The target needs Git, Python 3, Foundry, and a clean working tree. If one is
   absent, follow the refusal in `SKILL.md` rather than estimating a result.
 - Resolve `scripts/hermes.py` and `references/optimisation-catalogue.md` from
-  `skills/hermes/`, regardless of the current working directory.
+  `skills/hermes/`, and `scripts/procrustes.py` and
+  `references/size-catalogue.md` from `skills/procrustes/`, regardless of the
+  current working directory.
+- Procrustes imports its sealing helpers from `skills/hermes/scripts/hermes.py`.
+  Do not vendor, move or rename either script directory; the harness refuses to
+  run when the pinned signatures move.
 - Run the harness in the target Foundry repository. Do not use this plugin
   checkout as the target unless the user explicitly names it.
 
 ## Interpretation
 
 - `$hermes`, `/hermes:hermes`, and a plain request to use Hermes are equivalent
-  activation forms.
+  activation forms. The same holds for `$procrustes` and `/hermes:procrustes`.
 - Shell snippets describe commands to execute, not text to paraphrase.
 - A non-zero harness exit is a rejected gate. Do not continue, weaken a check,
   or report the candidate as accepted.
 - `result.json` with status `accepted` and exit code 0 is the only acceptance
   signal. Report the evidence directory with the result.
+- A Procrustes `result.json` with status `sealed` is a baseline, not an
+  acceptance. This version of that skill has no candidate gates; do not report a
+  size candidate as accepted.
 - Repository issue, branch, review, and approval rules still apply before
   Hermes changes target source.

--- a/plugins/hermes/skills/procrustes/EVOLUTION.md
+++ b/plugins/hermes/skills/procrustes/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Procrustes evolution ledger
+
+Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
+
+- Current version: `procrustes-v0.1.0`
+- Frontier status: `open`
+- Frontier revision: `live-protocol-evidence`
+- Current frontier: No Procrustes run against a real protocol is published; the recorded evidence comes from fixtures.
+- Next Fiat job: Publish a complete, reproducible Procrustes evidence bundle for a real contract held over EIP-170, naming the chosen size class, every gate outcome, and the accepted or refused result. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `procrustes-v0.1.0` | baseline | `live-protocol-evidence` | `57ca48f66a9c5bd2b77aef970ad9904431358df3244ca66f4f95356608b4cb0a` | [study](../../../../docs/procrustes/study.md) | Versioning starts here. Gate 1 seals a size baseline; the candidate gates are the held job. |

--- a/plugins/hermes/skills/procrustes/SKILL.md
+++ b/plugins/hermes/skills/procrustes/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: procrustes
+description: Cut a Solidity contract to fit EIP-170's deployed-code limit with an executable, fail-closed Foundry loop that measures runtime and initcode bytes, keeps behaviour tests green, holds storage layouts and method identifiers still, and refuses a reduction bought by deleting a check or by moving code behind delegatecall unannounced. Use for contract-size work, EIP-170 or EIP-3860 limit failures, `forge build --sizes` reductions, library or facet extraction for size, and any proposed change whose purpose is smaller deployed bytecode.
+metadata:
+  version: "0.1.0"
+---
+
+# procrustes code-size optimiser
+
+## Frontier
+
+Procrustes owns its own code-size evidence frontier, not Hermes's gas frontier
+and not Hexaemeron's delivery frontier. Its version, held target, next job and
+maturity state live in [EVOLUTION.md](EVOLUTION.md). Do not recommend or run
+another frontier pass after that ledger becomes mature.
+
+The bed is 24576 bytes. The point of the gates is that the contract fits without
+being maimed to get there.
+
+## Where this sits
+
+Procrustes measures deployed bytecode. Hermes measures gas, and rejects any
+candidate whose declared target shows no gas saving, so it refuses most size
+reductions by construction rather than by judgement. That refusal is correct for
+Hermes and useless when the deployment is the thing that fails.
+
+Use Hermes when the number that matters is gas. Use Procrustes when the number
+that matters is bytes, and expect the two to disagree: a size win usually costs
+gas, which is why a Procrustes run declares the gas regression it will tolerate
+before it measures anything.
+
+Pick a candidate class from [references/size-catalogue.md](references/size-catalogue.md).
+
+## What the limits are
+
+EIP-170 caps deployed runtime code at 24576 bytes. EIP-3860 caps the initcode
+that returns it at 49152 bytes, and charges gas per initcode word, so a
+constructor-heavy contract can sit inside one limit and outside the other.
+`forge build --sizes --json` reports both, and Procrustes records both. A run
+that quotes one number and calls it "the size" is the first mistake this harness
+exists to prevent.
+
+## Before touching source
+
+1. Work from the Foundry root. If the repository keeps `foundry.toml` under
+   `build/`, pass `build/` as `--repo`.
+2. Start from a clean Git tree with a green suite. Finish unrelated work first.
+3. Re-derive the layout set. Search for proxies, `delegatecall`, clones,
+   factories, hooks, role providers, and contracts called by them. Treat doubt
+   as frozen layout.
+4. Name the contracts whose size must fall, before editing. Each
+   `--size-target` is a regular expression over compiled contract names and must
+   carry a measured reduction.
+5. Read the target's `foundry.toml` before running anything. A target controls
+   its own `ffi` and `fs_permissions`, so running its suite executes its code as
+   you. An unvetted target belongs in a container, and this harness does not put
+   it in one.
+
+Set `PROCRUSTES_PY` to this skill's `scripts/procrustes.py` path.
+
+## Gate 1: seal a green baseline
+
+```bash
+python3 "$PROCRUSTES_PY" baseline \
+  --repo "<foundry-root>" \
+  --size-target "^Market$" \
+  --fuzz-seed 0x5EED \
+  --no-match-path "test/Fork.t.sol" \
+  --protected-contract "Market=src/Market.sol:Market"
+```
+
+Repeat `--size-target`, `--protected-contract` and `--no-match-path` as needed.
+Where no layout is frozen, say so explicitly with
+`--assert-no-protected-contracts`; the harness refuses a silent empty set.
+
+Gate 1 records the per-contract runtime and initcode sizes with both margins,
+the declared targets and the contracts each one matched, the resolved Foundry
+configuration, the Forge version, the Git revision, every Solidity source, and
+the protected storage layouts and method identifiers. Then it runs the suite and
+requires it green.
+
+A contract already over a limit is recorded rather than refused. Being over the
+limit is why somebody runs this.
+
+Gate 1 refuses a dirty tree, a red suite, a failed or unparsable size report, a
+`--size-target` matching no compiled contract, an evidence directory inside the
+target or holding somebody else's run, and a missing `foundry.toml`.
+
+Keep the printed run directory. Every later command uses it.
+
+## The imported surface
+
+Procrustes takes its sealing, layout and selector machinery from Hermes rather
+than copying it, and `PINNED_HERMES_SURFACE` in `scripts/procrustes.py` names
+every helper it takes with the signature it was written against. When a Hermes
+change moves one of those, the harness exits 70 and says which name moved,
+before it touches a repository. `test_procrustes.py` fails at the same point.
+
+That coupling is deliberate and it is the skill's main structural risk. Do not
+work around a drift refusal by loosening the pin: fix the call, or record why
+the new signature is compatible and pin the new one.
+
+## Refusals that are not about size
+
+Two refusals exist because a harness that only measures bytes will happily
+accept a smaller, weaker contract.
+
+**A deleted check.** Removing a `require`, `revert`, `assert`, modifier
+application or custom-error throw does make a contract smaller. The candidate
+gates refuse a diff that removes one unless the declared class names it and a
+test proves the revert still happens.
+
+**A moved delegatecall surface.** Extracting an external library or splitting
+into facets does not delete code; it moves it somewhere the size report no longer
+counts. A run must declare the new library link or `delegatecall` site, and the
+evidence records which contract the bytes went to.
+
+Both gates ship in the candidate loop, which this version of the skill does not
+have yet. The ledger holds that as the next job; do not report a candidate as
+accepted until the gates exist.
+
+## Promise Machine contract
+
+### procrustes-sealed-baseline
+
+- Promise: A successful `baseline` seals a green, clean Foundry baseline carrying the per-contract runtime and initcode sizes, the declared size targets and the contracts they matched, the resolved configuration, the source revision, and the protected storage layouts and method identifiers.
+- Evidence: The run directory, `sizes.json` with both limits and both margins, the full test log, the Forge version, the canonical Foundry configuration, the Git revision and source manifest, the sealed layouts and method maps, and the pinned Hermes surface the run loaded under.
+- Evidence classes: checked, measured, recorded
+- Boundary: The baseline describes one repository state and one toolchain. It does not establish that a later candidate preserves behaviour, reduces deployed code, brings any contract inside either limit, or leaves the delegatecall surface where it was.
+- Authorises: Comparison of one declared size class against this sealed baseline and its fixed target set.
+- Consequence: 1
+- Refuses: Sealing from a dirty tree, a red suite, a failed or unparsable size report, a target expression matching no compiled contract, an unresolved protected set, an evidence directory inside the target, or a moved Hermes helper signature.
+- Recovery: Restore a clean green repository, re-derive the protected and target sets, and take a fresh baseline into an empty evidence directory.
+- Exceptions: none

--- a/plugins/hermes/skills/procrustes/SKILL.md
+++ b/plugins/hermes/skills/procrustes/SKILL.md
@@ -77,8 +77,9 @@ not comparable to the candidate suite that follows it.
 
 Gate 1 records the per-contract runtime and initcode sizes with both margins,
 the declared targets and the contracts each one matched, the resolved Foundry
-configuration, the Forge version, the Git revision, every Solidity source, and
-the protected storage layouts and method identifiers. Then it runs the suite and
+configuration, the Forge version, the Git revision and every Solidity source. It
+seals the protected storage layouts and method identifiers by digest, since those
+are the files a candidate is later compared against. Then it runs the suite and
 requires it green.
 
 A contract already over a limit is recorded rather than refused. Being over the

--- a/plugins/hermes/skills/procrustes/SKILL.md
+++ b/plugins/hermes/skills/procrustes/SKILL.md
@@ -72,6 +72,8 @@ python3 "$PROCRUSTES_PY" baseline \
 Repeat `--size-target`, `--protected-contract` and `--no-match-path` as needed.
 Where no layout is frozen, say so explicitly with
 `--assert-no-protected-contracts`; the harness refuses a silent empty set.
+`--fuzz-seed` is required: a green suite recorded under a seed nobody pinned is
+not comparable to the candidate suite that follows it.
 
 Gate 1 records the per-contract runtime and initcode sizes with both margins,
 the declared targets and the contracts each one matched, the resolved Foundry

--- a/plugins/hermes/skills/procrustes/references/size-catalogue.md
+++ b/plugins/hermes/skills/procrustes/references/size-catalogue.md
@@ -1,0 +1,58 @@
+# Size catalogue
+
+Use this list to nominate one size class. Predict the saving, then let Procrustes
+measure it. A plausible compiler story is not a result, and neither is a smaller
+contract that lost a check on the way down.
+
+Every entry costs gas somewhere unless the row says otherwise. Declare the gas
+regression the run will tolerate before measuring.
+
+| Procrustes class | Candidate idea | Usual risk | Checks before trying it |
+| --- | --- | --- | --- |
+| `revert-strings` | Replace revert strings with custom errors | Low | Find tests and callers that match on revert data; a string moved into an error name is not a deleted check |
+| `dead-code` | Remove unreachable internal functions, unused inherited contracts and unused imports | Low | Confirm nothing reaches them through inheritance, a library or an interface cast |
+| `error-arguments` | Drop arguments from custom errors that nobody decodes | Low-medium | Read every off-chain consumer of the revert data first |
+| `public-to-external` | Narrow `public` functions to `external`, drop generated getters nobody calls | Medium | Selectors must not move; a dropped getter is an ABI change |
+| `modifier-to-function` | Move a modifier's body into an internal function so it is not inlined at every use site | Medium | The check has to remain on every path it guarded; this is the class most likely to trip the deleted-check gate by accident |
+| `immutable-to-storage` | Move a rarely-read `immutable` back to storage, since its value is inlined at every use | Medium | Expect a layout change and a gas cost; frozen contracts cannot take this class |
+| `constant-data` | Move a large constant array or string out of code and read it from storage or a data contract | Medium | Compare the read path's gas and confirm nothing assumed a compile-time constant |
+| `library-extraction` | Move code into an external library that is linked rather than inlined | High | The bytes move behind `delegatecall`; declare the link, and account for where the size went |
+| `facet-split` | Split a contract into facets behind one dispatcher, as in EIP-2535 | High | A new trust and upgrade surface, not only a size change; layouts and selectors both need holding still |
+| `assembly` | Replace Solidity with a small assembly section | High | Prove memory safety, returndata handling and revert behaviour; keep this class on its own |
+
+## Settings are their own experiment
+
+`optimizer_runs`, `via_ir`, the Solidity version, `bytecode_hash` and
+`cbor_metadata` reprice every contract at once, so they never share attribution
+with a source change. Run each as its own class from a clean baseline.
+
+Two are worth knowing about before reaching for source edits. Lowering
+`optimizer_runs` tells solc to favour deployment size over call cost, which is
+the whole trade in one setting. Setting `bytecode_hash = "none"` and
+`cbor_metadata = false` removes the metadata trailer solc appends after the
+runtime code, which is tens of bytes and no behaviour at all -- worth taking
+first when the overshoot is small, and worth checking against any verification
+or provenance workflow that expects the trailer to be there.
+
+## Quick source searches
+
+Run these from the Foundry root and adapt the names:
+
+```bash
+forge build --sizes
+rg -n 'revert\("|require\([^,]+,\s*"' src
+rg -n '\bmodifier\b' src
+rg -n '\bimmutable\b|\bconstant\b' src
+rg -n 'delegatecall|library |using .* for' src
+```
+
+`forge build --sizes` first, every time. The contract that is actually over the
+limit is often not the one somebody remembers being large.
+
+## Pick in this order
+
+Start with the metadata trailer and revert strings, then dead code. Those are
+cheap to prove and rarely controversial. Move to the getter and modifier classes
+once the easy bytes are gone. Leave library extraction, facet splitting and
+assembly until the overshoot is large enough to be worth their proof cost, and
+never reach for them to save a few dozen bytes.

--- a/plugins/hermes/skills/procrustes/references/size-catalogue.md
+++ b/plugins/hermes/skills/procrustes/references/size-catalogue.md
@@ -30,9 +30,9 @@ Two are worth knowing about before reaching for source edits. Lowering
 `optimizer_runs` tells solc to favour deployment size over call cost, which is
 the whole trade in one setting. Setting `bytecode_hash = "none"` and
 `cbor_metadata = false` removes the metadata trailer solc appends after the
-runtime code, which is tens of bytes and no behaviour at all -- worth taking
-first when the overshoot is small, and worth checking against any verification
-or provenance workflow that expects the trailer to be there.
+runtime code. That is tens of bytes and no behaviour at all, so it is worth
+taking first when the overshoot is small. Check it against any verification or
+provenance workflow that expects the trailer to be there.
 
 ## Quick source searches
 

--- a/plugins/hermes/skills/procrustes/scripts/procrustes.py
+++ b/plugins/hermes/skills/procrustes/scripts/procrustes.py
@@ -100,7 +100,12 @@ forge_test_arguments = hermes.forge_test_arguments
 artifact_hashes = hermes.artifact_hashes
 git = hermes.git
 
-CONTRACT_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+# Forge keys each size row by contract name, and disambiguates a name that
+# several files declare as `Name (path/to/File.sol)`. Both forms are legitimate
+# and a real repository with a mock or an interface twin produces the second.
+CONTRACT_KEY_RE = re.compile(
+    r"^[A-Za-z_][A-Za-z0-9_]*(?: \((?!/)[A-Za-z0-9_./-]+\.sol\))?$"
+)
 
 
 def pinned_surface_drift() -> dict[str, str]:
@@ -172,7 +177,7 @@ def parse_size_report(raw: str, gate: int, exit_code: int) -> dict[str, dict[str
         raise GateFailure(gate, "forge build --sizes --json returned no contract sizes", exit_code)
     sizes: dict[str, dict[str, int]] = {}
     for name, entry in value.items():
-        if not isinstance(name, str) or not CONTRACT_NAME_RE.fullmatch(name):
+        if not isinstance(name, str) or not CONTRACT_KEY_RE.fullmatch(name):
             raise GateFailure(gate, f"unexpected contract name in size report: {name!r}", exit_code)
         if not isinstance(entry, dict):
             raise GateFailure(gate, f"size report entry for {name} is not an object", exit_code)
@@ -186,6 +191,22 @@ def parse_size_report(raw: str, gate: int, exit_code: int) -> dict[str, dict[str
             )
         if runtime < 0 or initcode < 0:
             raise GateFailure(gate, f"negative size reported for {name}", exit_code)
+        # Forge reports its own margins. They are recomputed here rather than
+        # trusted, and a disagreement means Forge is measuring against a
+        # different limit than this harness claims to enforce.
+        for field, size, limit in (
+            ("runtime_margin", runtime, EIP170_RUNTIME_LIMIT),
+            ("init_margin", initcode, EIP3860_INITCODE_LIMIT),
+        ):
+            reported = entry.get(field)
+            if isinstance(reported, int) and reported != limit - size:
+                raise GateFailure(
+                    gate,
+                    f"forge reports {field} {reported} for {name}, which is not "
+                    f"{limit} - {size}: the toolchain is measuring against a "
+                    f"different code-size limit",
+                    exit_code,
+                )
         sizes[name] = {
             "runtime_size": runtime,
             "init_size": initcode,

--- a/plugins/hermes/skills/procrustes/scripts/procrustes.py
+++ b/plugins/hermes/skills/procrustes/scripts/procrustes.py
@@ -183,6 +183,10 @@ def parse_size_report(raw: str, gate: int, exit_code: int) -> dict[str, dict[str
             raise GateFailure(gate, f"size report entry for {name} is not an object", exit_code)
         runtime = entry.get("runtime_size")
         initcode = entry.get("init_size")
+        # `isinstance(True, int)` holds in Python, so a boolean would otherwise
+        # pass for a byte count and be arithmetic from there on.
+        if isinstance(runtime, bool) or isinstance(initcode, bool):
+            raise GateFailure(gate, f"size report for {name} reports a boolean size", exit_code)
         if not isinstance(runtime, int) or not isinstance(initcode, int):
             raise GateFailure(
                 gate,
@@ -422,7 +426,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-match-path", action="append", metavar="GLOB", help="Forge test exclusion; repeatable"
     )
     baseline.add_argument(
-        "--fuzz-seed", action=SingleValueAction, help="Pinned Foundry fuzz seed for the behaviour suite"
+        "--fuzz-seed",
+        required=True,
+        action=SingleValueAction,
+        help="Pinned Foundry fuzz seed; the sealed green suite is only comparable under a fixed seed",
     )
     baseline.set_defaults(handler=baseline_command)
 

--- a/plugins/hermes/skills/procrustes/scripts/procrustes.py
+++ b/plugins/hermes/skills/procrustes/scripts/procrustes.py
@@ -313,11 +313,13 @@ def baseline_command(args: argparse.Namespace) -> int:
 
         layouts: dict[str, str] = {}
         methods: dict[str, str] = {}
+        sealed_paths: list[Path] = []
         for contract in protected:
             layout_path, _ = inspect_layout(repo, run_dir, contract, "baseline", 1, 10)
             method_path, _ = inspect_methods(repo, run_dir, contract, "baseline", 1, 10)
             layouts[contract["label"]] = str(layout_path.relative_to(run_dir))
             methods[contract["label"]] = str(method_path.relative_to(run_dir))
+            sealed_paths.extend([layout_path, method_path])
 
         test_arguments = forge_test_arguments(args.fuzz_seed, args.no_match_path or [])
         tests = run_command(
@@ -343,12 +345,15 @@ def baseline_command(args: argparse.Namespace) -> int:
             "source_count": len(manifest),
             "sealed_at": utc_now(),
         }
+        # The layouts and method maps are evidence the candidate gates compare
+        # against, so they are sealed by digest here rather than merely written.
         state["artifacts"] = artifact_hashes(
             run_dir,
             [
                 run_dir / "sizes.json",
                 run_dir / "foundry-config.json",
                 run_dir / "baseline-source-manifest.json",
+                *sealed_paths,
             ],
         )
         write_json(run_dir / "state.json", state)

--- a/plugins/hermes/skills/procrustes/scripts/procrustes.py
+++ b/plugins/hermes/skills/procrustes/scripts/procrustes.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""Procrustes: fail-closed deployed-code-size evidence for one size class.
+
+Gate 1 seals a green baseline of per-contract runtime and initcode sizes beside
+the sources, storage layouts and method identifiers a later comparison needs.
+The sealing, layout and selector machinery is Hermes's; this module owns the
+size measurement and the limits it is measured against.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import inspect
+import json
+import os
+import re
+import sys
+import uuid
+from pathlib import Path
+from typing import Any, Sequence
+
+SCHEMA = "procrustes-run/v1"
+SKILL_NAME = "procrustes"
+
+# EIP-170 caps deployed runtime code; EIP-3860 caps the initcode that returns
+# it. `forge build --sizes --json` reports both, and a contract can pass one
+# and fail the other.
+EIP170_RUNTIME_LIMIT = 24576
+EIP3860_INITCODE_LIMIT = 49152
+
+HERMES_SCRIPTS = Path(__file__).resolve().parents[2] / "hermes" / "scripts"
+
+# Every name Procrustes takes from Hermes, with the signature it was written
+# against. `test_procrustes.py` compares this map to the live module, so a
+# Hermes change that moves one of these fails a test here rather than a run in
+# somebody's repository.
+PINNED_HERMES_SURFACE = {
+    "utc_now": "() -> 'str'",
+    "write_text": "(path: 'Path', text: 'str') -> 'None'",
+    "write_json": "(path: 'Path', value: 'Any') -> 'None'",
+    "read_json": "(path: 'Path') -> 'Any'",
+    "run_command": (
+        "(command: 'Sequence[str]', cwd: 'Path', log_path: 'Path', "
+        "env: 'dict[str, str] | None' = None, echo: 'bool' = True) -> 'CommandResult'"
+    ),
+    "require_success": "(result: 'CommandResult', gate: 'int', description: 'str', exit_code: 'int') -> 'None'",
+    "is_within": "(path: 'Path', parent: 'Path') -> 'bool'",
+    "git": "(repo: 'Path', arguments: 'Sequence[str]', log_path: 'Path') -> 'CommandResult'",
+    "require_git_repository": "(repo: 'Path', log_path: 'Path', gate: 'int' = 1) -> 'str'",
+    "canonical_json": "(raw: 'str', description: 'str', gate: 'int', exit_code: 'int') -> 'tuple[Any, str]'",
+    "parse_protected_contract": "(raw: 'str') -> 'dict[str, str]'",
+    "snapshot_sources": "(repo: 'Path', run_dir: 'Path') -> 'dict[str, str]'",
+    "inspect_layout": (
+        "(repo: 'Path', run_dir: 'Path', contract: 'dict[str, str]', suffix: 'str', "
+        "gate: 'int', exit_code: 'int') -> 'tuple[Path, Any]'"
+    ),
+    "inspect_methods": (
+        "(repo: 'Path', run_dir: 'Path', contract: 'dict[str, str]', suffix: 'str', "
+        "gate: 'int', exit_code: 'int') -> 'tuple[Path, Any]'"
+    ),
+    "forge_test_arguments": "(seed: 'str | None', excluded_paths: 'Sequence[str]') -> 'list[str]'",
+    "artifact_hashes": "(run_dir: 'Path', paths: 'Iterable[Path]') -> 'dict[str, str]'",
+}
+
+
+def load_hermes():
+    """Import the sibling Hermes harness, failing loudly when it is not there."""
+    if str(HERMES_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(HERMES_SCRIPTS))
+    try:
+        import hermes  # noqa: PLC0415  (located at runtime beside this skill)
+    except ImportError as exc:  # pragma: no cover - environment defect
+        raise SystemExit(
+            f"cannot import the Hermes harness from {HERMES_SCRIPTS}: {exc}"
+        ) from exc
+    return hermes
+
+
+hermes = load_hermes()
+
+CommandResult = hermes.CommandResult
+GateFailure = hermes.GateFailure
+SingleValueAction = hermes.SingleValueAction
+
+utc_now = hermes.utc_now
+write_text = hermes.write_text
+write_json = hermes.write_json
+read_json = hermes.read_json
+run_command = hermes.run_command
+require_success = hermes.require_success
+is_within = hermes.is_within
+require_git_repository = hermes.require_git_repository
+canonical_json = hermes.canonical_json
+parse_protected_contract = hermes.parse_protected_contract
+snapshot_sources = hermes.snapshot_sources
+inspect_layout = hermes.inspect_layout
+inspect_methods = hermes.inspect_methods
+forge_test_arguments = hermes.forge_test_arguments
+artifact_hashes = hermes.artifact_hashes
+git = hermes.git
+
+CONTRACT_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def pinned_surface_drift() -> dict[str, str]:
+    """Names whose live signature no longer matches the pinned one."""
+    drift: dict[str, str] = {}
+    for name, expected in sorted(PINNED_HERMES_SURFACE.items()):
+        target = getattr(hermes, name, None)
+        if target is None:
+            drift[name] = "absent"
+            continue
+        actual = str(inspect.signature(target))
+        if actual != expected:
+            drift[name] = actual
+    return drift
+
+
+def default_evidence_dir(repo: Path) -> Path:
+    codex_root = Path(os.environ.get("CODEX_HOME", str(Path.home() / ".codex"))).expanduser()
+    stamp = dt.datetime.now().strftime("%Y%m%dT%H%M%S")
+    return codex_root / "procrustes-runs" / f"{repo.name}-{stamp}-{uuid.uuid4().hex[:8]}"
+
+
+def prepare_evidence_dir(repo: Path, requested: str | None) -> Path:
+    run_dir = Path(requested).expanduser().resolve() if requested else default_evidence_dir(repo).resolve()
+    if is_within(run_dir, repo):
+        raise GateFailure(1, "evidence directory must be outside the target repository", 10)
+    if run_dir.exists() and any(run_dir.iterdir()):
+        raise GateFailure(1, f"evidence directory is not empty: {run_dir}", 10)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir
+
+
+def mark_failure(run_dir: Path | None, state: dict[str, Any] | None, failure: GateFailure) -> None:
+    """Write the refusal into the evidence directory before the process ends."""
+    if run_dir is None:
+        return
+    result = {
+        "schema": SCHEMA,
+        "skill": SKILL_NAME,
+        "status": "rejected",
+        "failed_gate": failure.gate,
+        "exit_code": failure.exit_code,
+        "reason": str(failure),
+        "finished_at": utc_now(),
+    }
+    write_json(run_dir / "result.json", result)
+    if state is not None:
+        state["status"] = "rejected"
+        state["result"] = result
+        write_json(run_dir / "state.json", state)
+
+
+def require_clean_tree(repo: Path, run_dir: Path, gate: int, exit_code: int) -> None:
+    result = git(repo, ["status", "--porcelain"], run_dir / "logs" / f"gate{gate}.git-status.log")
+    require_success(result, gate, "git status --porcelain", exit_code)
+    if result.stdout.strip():
+        raise GateFailure(gate, "target repository has uncommitted changes", exit_code)
+
+
+def parse_size_report(raw: str, gate: int, exit_code: int) -> dict[str, dict[str, int]]:
+    """Read `forge build --sizes --json` into a contract-keyed size map.
+
+    Forge prints one JSON object per contract name, each carrying a runtime and
+    an initcode size. Anything else is a refusal rather than a partial parse:
+    a size this harness guessed is worse than no size at all.
+    """
+    value, _ = canonical_json(raw, "forge build --sizes --json", gate, exit_code)
+    if not isinstance(value, dict) or not value:
+        raise GateFailure(gate, "forge build --sizes --json returned no contract sizes", exit_code)
+    sizes: dict[str, dict[str, int]] = {}
+    for name, entry in value.items():
+        if not isinstance(name, str) or not CONTRACT_NAME_RE.fullmatch(name):
+            raise GateFailure(gate, f"unexpected contract name in size report: {name!r}", exit_code)
+        if not isinstance(entry, dict):
+            raise GateFailure(gate, f"size report entry for {name} is not an object", exit_code)
+        runtime = entry.get("runtime_size")
+        initcode = entry.get("init_size")
+        if not isinstance(runtime, int) or not isinstance(initcode, int):
+            raise GateFailure(
+                gate,
+                f"size report for {name} lacks integer runtime_size and init_size",
+                exit_code,
+            )
+        if runtime < 0 or initcode < 0:
+            raise GateFailure(gate, f"negative size reported for {name}", exit_code)
+        sizes[name] = {
+            "runtime_size": runtime,
+            "init_size": initcode,
+            "runtime_margin": EIP170_RUNTIME_LIMIT - runtime,
+            "init_margin": EIP3860_INITCODE_LIMIT - initcode,
+        }
+    return sizes
+
+
+def match_size_targets(
+    sizes: dict[str, dict[str, int]], targets: Sequence[str], gate: int, exit_code: int
+) -> dict[str, list[str]]:
+    """Resolve each declared target expression to the contracts it names."""
+    matched: dict[str, list[str]] = {}
+    for expression in targets:
+        try:
+            pattern = re.compile(expression)
+        except re.error as exc:
+            raise GateFailure(gate, f"invalid --size-target expression {expression!r}: {exc}", exit_code) from exc
+        names = sorted(name for name in sizes if pattern.search(name))
+        if not names:
+            raise GateFailure(gate, f"--size-target {expression!r} matched no compiled contract", exit_code)
+        matched[expression] = names
+    return matched
+
+
+def over_limit(sizes: dict[str, dict[str, int]]) -> dict[str, dict[str, int]]:
+    """Contracts already past either limit, recorded rather than refused.
+
+    A contract over EIP-170 is the reason somebody runs this harness, so the
+    baseline states the fact and leaves the judgement to the candidate gates.
+    """
+    return {
+        name: entry
+        for name, entry in sorted(sizes.items())
+        if entry["runtime_size"] > EIP170_RUNTIME_LIMIT or entry["init_size"] > EIP3860_INITCODE_LIMIT
+    }
+
+
+def baseline_command(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).expanduser().resolve()
+    run_dir: Path | None = None
+    state: dict[str, Any] | None = None
+    try:
+        if not repo.is_dir():
+            raise GateFailure(1, f"target repository is not a directory: {repo}", 10)
+        if not (repo / "foundry.toml").is_file():
+            raise GateFailure(1, f"no foundry.toml at the target root: {repo}", 10)
+        run_dir = prepare_evidence_dir(repo, args.evidence_dir)
+
+        protected = list(args.protected_contract or [])
+        if not protected and not args.assert_no_protected_contracts:
+            raise GateFailure(
+                1,
+                "name every frozen layout with --protected-contract, or state "
+                "there are none with --assert-no-protected-contracts",
+                10,
+            )
+        if protected and args.assert_no_protected_contracts:
+            raise GateFailure(1, "--assert-no-protected-contracts contradicts --protected-contract", 10)
+
+        revision = require_git_repository(repo, run_dir / "logs" / "gate1.git-revision.log")
+        require_clean_tree(repo, run_dir, 1, 10)
+
+        version = run_command(
+            ["forge", "--version"], repo, run_dir / "logs" / "gate1.forge-version.log", echo=False
+        )
+        require_success(version, 1, "forge --version", 10)
+        config = run_command(
+            ["forge", "config", "--json"], repo, run_dir / "logs" / "gate1.forge-config.log", echo=False
+        )
+        require_success(config, 1, "forge config --json", 10)
+        _, canonical_config = canonical_json(config.stdout, "forge config --json", 1, 10)
+        write_text(run_dir / "foundry-config.json", canonical_config)
+
+        report = run_command(
+            ["forge", "build", "--sizes", "--json"],
+            repo,
+            run_dir / "logs" / "gate1.forge-sizes.log",
+            echo=False,
+        )
+        require_success(report, 1, "forge build --sizes --json", 10)
+        sizes = parse_size_report(report.stdout, 1, 10)
+        matched = match_size_targets(sizes, args.size_target, 1, 10)
+        write_json(
+            run_dir / "sizes.json",
+            {
+                "schema": SCHEMA,
+                "limits": {
+                    "eip170_runtime": EIP170_RUNTIME_LIMIT,
+                    "eip3860_initcode": EIP3860_INITCODE_LIMIT,
+                },
+                "sizes": sizes,
+                "targets": matched,
+                "over_limit": over_limit(sizes),
+            },
+        )
+
+        manifest = snapshot_sources(repo, run_dir)
+
+        layouts: dict[str, str] = {}
+        methods: dict[str, str] = {}
+        for contract in protected:
+            layout_path, _ = inspect_layout(repo, run_dir, contract, "baseline", 1, 10)
+            method_path, _ = inspect_methods(repo, run_dir, contract, "baseline", 1, 10)
+            layouts[contract["label"]] = str(layout_path.relative_to(run_dir))
+            methods[contract["label"]] = str(method_path.relative_to(run_dir))
+
+        test_arguments = forge_test_arguments(args.fuzz_seed, args.no_match_path or [])
+        tests = run_command(
+            ["forge", "test", *test_arguments], repo, run_dir / "logs" / "gate1.forge-test.log"
+        )
+        require_success(tests, 1, "forge test", 10)
+
+        state = {
+            "schema": SCHEMA,
+            "skill": SKILL_NAME,
+            "status": "sealed",
+            "gate": 1,
+            "repo": str(repo),
+            "revision": revision,
+            "forge_version": version.stdout.strip(),
+            "fuzz_seed": args.fuzz_seed,
+            "excluded_paths": list(args.no_match_path or []),
+            "protected_contracts": protected,
+            "size_targets": list(args.size_target),
+            "matched_targets": matched,
+            "storage_layouts": layouts,
+            "method_identifiers": methods,
+            "source_count": len(manifest),
+            "sealed_at": utc_now(),
+        }
+        state["artifacts"] = artifact_hashes(
+            run_dir,
+            [
+                run_dir / "sizes.json",
+                run_dir / "foundry-config.json",
+                run_dir / "baseline-source-manifest.json",
+            ],
+        )
+        write_json(run_dir / "state.json", state)
+        write_json(
+            run_dir / "result.json",
+            {
+                "schema": SCHEMA,
+                "skill": SKILL_NAME,
+                "status": "sealed",
+                "gate": 1,
+                "revision": revision,
+                "size_targets": list(args.size_target),
+                "over_limit": sorted(over_limit(sizes)),
+                "finished_at": utc_now(),
+            },
+        )
+        print(f"sealed baseline at {run_dir}")
+        for expression, names in matched.items():
+            for name in names:
+                entry = sizes[name]
+                print(
+                    f"  {name}: runtime {entry['runtime_size']} "
+                    f"(margin {entry['runtime_margin']}), initcode {entry['init_size']} "
+                    f"(margin {entry['init_margin']})  [{expression}]"
+                )
+        return 0
+    except GateFailure as failure:
+        mark_failure(run_dir, state, failure)
+        print(f"gate {failure.gate} refused: {failure}", file=sys.stderr)
+        return failure.exit_code
+
+
+def status_command(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir).expanduser().resolve()
+    result = run_dir / "result.json"
+    if not result.is_file():
+        print(f"no result.json in {run_dir}", file=sys.stderr)
+        return 10
+    print(json.dumps(read_json(result), indent=2, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="procrustes",
+        description="Fail-closed deployed-code-size evidence against EIP-170 and EIP-3860.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    baseline = subparsers.add_parser("baseline", help="Run Gate 1 and seal size baseline evidence")
+    baseline.add_argument("--repo", required=True, action=SingleValueAction, help="Foundry repository root")
+    baseline.add_argument(
+        "--evidence-dir", action=SingleValueAction, help="Empty evidence directory outside the repository"
+    )
+    baseline.add_argument(
+        "--size-target",
+        action="append",
+        required=True,
+        metavar="REGEX",
+        help="Contract-name expression that must carry a measured reduction; repeatable",
+    )
+    baseline.add_argument(
+        "--protected-contract",
+        action="append",
+        type=parse_protected_contract,
+        metavar="LABEL=PATH:CONTRACT",
+        help="Frozen storage layout and selector set; repeatable",
+    )
+    baseline.add_argument(
+        "--assert-no-protected-contracts",
+        action="store_true",
+        help="State explicitly that no frozen layout is in scope",
+    )
+    baseline.add_argument(
+        "--no-match-path", action="append", metavar="GLOB", help="Forge test exclusion; repeatable"
+    )
+    baseline.add_argument(
+        "--fuzz-seed", action=SingleValueAction, help="Pinned Foundry fuzz seed for the behaviour suite"
+    )
+    baseline.set_defaults(handler=baseline_command)
+
+    status = subparsers.add_parser("status", help="Print the run's result JSON")
+    status.add_argument("--run-dir", required=True, action=SingleValueAction)
+    status.set_defaults(handler=status_command)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    drift = pinned_surface_drift()
+    if drift:
+        print(
+            "the Hermes harness moved under Procrustes: "
+            + ", ".join(f"{name} is now {signature}" for name, signature in drift.items()),
+            file=sys.stderr,
+        )
+        return 70
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/hermes/skills/procrustes/scripts/procrustes.py
+++ b/plugins/hermes/skills/procrustes/scripts/procrustes.py
@@ -74,6 +74,15 @@ def load_hermes():
         raise SystemExit(
             f"cannot import the Hermes harness from {HERMES_SCRIPTS}: {exc}"
         ) from exc
+    # `hermes` is a plain module name. Something else on the path, or already in
+    # sys.modules, can answer to it, and this harness would then run foreign code
+    # under the name it pinned. Bind to the sibling file or refuse.
+    loaded = Path(getattr(hermes, "__file__", "") or "").resolve()
+    expected = (HERMES_SCRIPTS / "hermes.py").resolve()
+    if loaded != expected:
+        raise SystemExit(
+            f"the imported hermes module is {loaded or 'unlocatable'}, not {expected}"
+        )
     return hermes
 
 

--- a/plugins/hermes/skills/procrustes/scripts/test_procrustes.py
+++ b/plugins/hermes/skills/procrustes/scripts/test_procrustes.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Hermetic tests for the Procrustes size-baseline harness."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+import procrustes  # noqa: E402
+
+FAKE_FORGE = r'''#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+repo = Path.cwd()
+args = sys.argv[1:]
+
+if args == ["--version"]:
+    print("forge Version: procrustes-test")
+    raise SystemExit(0)
+
+if args == ["config", "--json"]:
+    print(json.dumps({"profile": "default", "optimizer": True, "optimizer_runs": 200}))
+    raise SystemExit(0)
+
+if args[:1] == ["build"]:
+    if (repo / ".fail-sizes").exists():
+        print("build failed", file=sys.stderr)
+        raise SystemExit(1)
+    if (repo / ".garbage-sizes").exists():
+        print("Compiling 1 file with 0.8.28")
+        raise SystemExit(0)
+    if (repo / ".shapeless-sizes").exists():
+        print(json.dumps({"A": {"runtime_size": "297", "init_size": 325}}))
+        raise SystemExit(0)
+    runtime = 297
+    init = 325
+    if (repo / ".over-limit").exists():
+        runtime = 25000
+        init = 25400
+    print(json.dumps({"A": {
+        "runtime_size": runtime,
+        "init_size": init,
+        "runtime_margin": 24576 - runtime,
+        "init_margin": 49152 - init,
+    }}))
+    raise SystemExit(0)
+
+if args[:1] == ["test"]:
+    if (repo / ".fail-test").exists():
+        print("suite failed", file=sys.stderr)
+        raise SystemExit(1)
+    print("Suite result: ok. 1 passed; 0 failed; 0 skipped")
+    raise SystemExit(0)
+
+if args[:1] == ["inspect"]:
+    if args[2] == "methodIdentifiers":
+        print(json.dumps({"setX(uint256)": "4018d879"}))
+        raise SystemExit(0)
+    print(json.dumps({
+        "storage": [{"astId": 1, "contract": args[1], "label": "x", "offset": 0, "slot": "0", "type": "t_uint256"}],
+        "types": {"t_uint256": {"encoding": "inplace", "label": "uint256", "numberOfBytes": "32"}},
+    }))
+    raise SystemExit(0)
+
+print(f"unsupported fake forge invocation: {args}", file=sys.stderr)
+raise SystemExit(64)
+'''
+
+SOURCE = """// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+contract A {
+    uint256 public x;
+
+    function setX(uint256 v) external {
+        require(v < 1000, "too big");
+        x = v;
+    }
+}
+"""
+
+
+class HarnessCase(unittest.TestCase):
+    """A temporary Foundry-shaped git repository with a fake forge on PATH."""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        root = Path(self.temporary.name)
+        self.repo = root / "target"
+        self.evidence = root / "evidence"
+        (self.repo / "src").mkdir(parents=True)
+        (self.repo / "foundry.toml").write_text("[profile.default]\nsrc = 'src'\n", encoding="utf-8")
+        (self.repo / "src" / "A.sol").write_text(SOURCE, encoding="utf-8")
+
+        self.bin_dir = root / "bin"
+        self.bin_dir.mkdir()
+        forge = self.bin_dir / "forge"
+        forge.write_text(FAKE_FORGE, encoding="utf-8")
+        forge.chmod(0o755)
+
+        for command in (
+            ["git", "init", "--quiet"],
+            ["git", "config", "user.email", "test@example.com"],
+            ["git", "config", "user.name", "Procrustes Test"],
+            ["git", "add", "-A"],
+            ["git", "commit", "--quiet", "-m", "fixture"],
+        ):
+            subprocess.run(command, cwd=self.repo, check=True)
+
+        self.environment = dict(os.environ)
+        self.environment["PATH"] = f"{self.bin_dir}{os.pathsep}{self.environment['PATH']}"
+        self.addCleanup(self.temporary.cleanup)
+
+    def marker(self, name: str) -> None:
+        (self.repo / name).write_text("", encoding="utf-8")
+        subprocess.run(["git", "add", "-A"], cwd=self.repo, check=True)
+        subprocess.run(["git", "commit", "--quiet", "-m", name], cwd=self.repo, check=True)
+
+    def run_baseline(self, *extra: str, evidence: Path | None = None) -> int:
+        argv = [
+            "baseline",
+            "--repo",
+            str(self.repo),
+            "--evidence-dir",
+            str(evidence if evidence is not None else self.evidence),
+            "--size-target",
+            "^A$",
+            "--assert-no-protected-contracts",
+            *extra,
+        ]
+        with mock.patch.dict(os.environ, self.environment, clear=True):
+            return procrustes.main(argv)
+
+    def result(self, evidence: Path | None = None) -> dict:
+        path = (evidence if evidence is not None else self.evidence) / "result.json"
+        return json.loads(path.read_text(encoding="utf-8"))
+
+
+class BaselineTests(HarnessCase):
+    def test_seals_a_green_baseline_with_measured_sizes(self) -> None:
+        self.assertEqual(self.run_baseline(), 0)
+        result = self.result()
+        self.assertEqual(result["status"], "sealed")
+        self.assertEqual(result["over_limit"], [])
+        sizes = json.loads((self.evidence / "sizes.json").read_text(encoding="utf-8"))
+        self.assertEqual(sizes["sizes"]["A"]["runtime_size"], 297)
+        self.assertEqual(sizes["targets"], {"^A$": ["A"]})
+        self.assertEqual(sizes["limits"]["eip170_runtime"], 24576)
+        self.assertTrue((self.evidence / "baseline-source-manifest.json").is_file())
+        self.assertTrue((self.evidence / "logs" / "gate1.forge-test.log").is_file())
+
+    def test_rejects_a_missing_or_unparsable_size_report(self) -> None:
+        self.marker(".garbage-sizes")
+        self.assertEqual(self.run_baseline(), 10)
+        self.assertIn("did not return valid JSON", self.result()["reason"])
+
+    def test_rejects_a_shapeless_size_report(self) -> None:
+        self.marker(".shapeless-sizes")
+        self.assertEqual(self.run_baseline(), 10)
+        self.assertIn("integer runtime_size and init_size", self.result()["reason"])
+
+    def test_rejects_a_failed_size_build(self) -> None:
+        self.marker(".fail-sizes")
+        self.assertEqual(self.run_baseline(), 10)
+        self.assertIn("forge build --sizes --json exited 1", self.result()["reason"])
+
+    def test_rejects_a_dirty_tree(self) -> None:
+        (self.repo / "src" / "A.sol").write_text(SOURCE + "\n// edited\n", encoding="utf-8")
+        self.assertEqual(self.run_baseline(), 10)
+        self.assertIn("uncommitted changes", self.result()["reason"])
+
+    def test_records_initcode_beside_runtime_without_calling_either_the_limit(self) -> None:
+        self.assertEqual(self.run_baseline(), 0)
+        sizes = json.loads((self.evidence / "sizes.json").read_text(encoding="utf-8"))
+        entry = sizes["sizes"]["A"]
+        self.assertEqual(entry["init_size"], 325)
+        self.assertNotEqual(entry["init_size"], entry["runtime_size"])
+        self.assertEqual(entry["runtime_margin"], 24576 - 297)
+        self.assertEqual(entry["init_margin"], 49152 - 325)
+        self.assertEqual(sizes["limits"]["eip3860_initcode"], 49152)
+
+    def test_rejects_a_size_target_matching_no_contract(self) -> None:
+        argv = [
+            "baseline",
+            "--repo",
+            str(self.repo),
+            "--evidence-dir",
+            str(self.evidence),
+            "--size-target",
+            "^NoSuchContract$",
+            "--assert-no-protected-contracts",
+        ]
+        with mock.patch.dict(os.environ, self.environment, clear=True):
+            self.assertEqual(procrustes.main(argv), 10)
+        self.assertIn("matched no compiled contract", self.result()["reason"])
+
+    def test_rejects_an_invalid_size_target_expression(self) -> None:
+        argv = [
+            "baseline",
+            "--repo",
+            str(self.repo),
+            "--evidence-dir",
+            str(self.evidence),
+            "--size-target",
+            "A(",
+            "--assert-no-protected-contracts",
+        ]
+        with mock.patch.dict(os.environ, self.environment, clear=True):
+            self.assertEqual(procrustes.main(argv), 10)
+        self.assertIn("invalid --size-target", self.result()["reason"])
+
+    def test_rejects_a_red_behaviour_suite(self) -> None:
+        self.marker(".fail-test")
+        self.assertEqual(self.run_baseline(), 10)
+        self.assertIn("forge test exited 1", self.result()["reason"])
+
+    def test_records_a_contract_over_the_limit_without_refusing_it(self) -> None:
+        self.marker(".over-limit")
+        self.assertEqual(self.run_baseline(), 0)
+        result = self.result()
+        self.assertEqual(result["status"], "sealed")
+        self.assertEqual(result["over_limit"], ["A"])
+        sizes = json.loads((self.evidence / "sizes.json").read_text(encoding="utf-8"))
+        self.assertEqual(sizes["over_limit"]["A"]["runtime_size"], 25000)
+        self.assertLess(sizes["over_limit"]["A"]["runtime_margin"], 0)
+
+    def test_seals_a_protected_layout_and_selector_set(self) -> None:
+        with mock.patch.dict(os.environ, self.environment, clear=True):
+            code = procrustes.main([
+                "baseline",
+                "--repo",
+                str(self.repo),
+                "--evidence-dir",
+                str(self.evidence),
+                "--size-target",
+                "^A$",
+                "--protected-contract",
+                "A=src/A.sol:A",
+            ])
+        self.assertEqual(code, 0)
+        self.assertTrue((self.evidence / "storage-layout" / "A.baseline.json").is_file())
+        self.assertTrue((self.evidence / "method-identifiers" / "A.baseline.json").is_file())
+
+    def test_requires_a_protected_set_or_an_explicit_denial(self) -> None:
+        argv = [
+            "baseline",
+            "--repo",
+            str(self.repo),
+            "--evidence-dir",
+            str(self.evidence),
+            "--size-target",
+            "^A$",
+        ]
+        with mock.patch.dict(os.environ, self.environment, clear=True):
+            self.assertEqual(procrustes.main(argv), 10)
+        self.assertIn("--protected-contract", self.result()["reason"])
+
+    def test_rejects_an_evidence_directory_inside_the_target(self) -> None:
+        inside = self.repo / "evidence"
+        with mock.patch.dict(os.environ, self.environment, clear=True):
+            self.assertEqual(self.run_baseline(evidence=inside), 10)
+        self.assertFalse((inside / "result.json").exists())
+
+    def test_rejects_a_non_empty_evidence_directory(self) -> None:
+        self.evidence.mkdir(parents=True)
+        (self.evidence / "stray.json").write_text("{}", encoding="utf-8")
+        self.assertEqual(self.run_baseline(), 10)
+
+    def test_rejects_a_target_without_a_foundry_root(self) -> None:
+        (self.repo / "foundry.toml").unlink()
+        subprocess.run(["git", "add", "-A"], cwd=self.repo, check=True)
+        subprocess.run(["git", "commit", "--quiet", "-m", "drop config"], cwd=self.repo, check=True)
+        self.assertEqual(self.run_baseline(), 10)
+
+    def test_status_prints_the_recorded_result(self) -> None:
+        self.assertEqual(self.run_baseline(), 0)
+        with mock.patch.dict(os.environ, self.environment, clear=True):
+            self.assertEqual(procrustes.main(["status", "--run-dir", str(self.evidence)]), 0)
+
+
+class CouplingTests(unittest.TestCase):
+    def test_pinned_hermes_surface_matches_the_live_module(self) -> None:
+        self.assertEqual(procrustes.pinned_surface_drift(), {})
+
+    def test_every_pinned_name_is_used_by_the_harness(self) -> None:
+        source = (SCRIPT_DIR / "procrustes.py").read_text(encoding="utf-8")
+        for name in procrustes.PINNED_HERMES_SURFACE:
+            with self.subTest(name=name):
+                self.assertIn(f"hermes.{name}", source)
+
+    def test_drift_is_detected_when_a_pinned_signature_moves(self) -> None:
+        with mock.patch.dict(
+            procrustes.PINNED_HERMES_SURFACE, {"utc_now": "(tz: 'str') -> 'str'"}, clear=False
+        ):
+            self.assertEqual(procrustes.pinned_surface_drift(), {"utc_now": "() -> 'str'"})
+
+    def test_drift_is_detected_when_a_pinned_name_disappears(self) -> None:
+        with mock.patch.dict(
+            procrustes.PINNED_HERMES_SURFACE, {"never_existed": "() -> 'None'"}, clear=False
+        ):
+            self.assertEqual(procrustes.pinned_surface_drift(), {"never_existed": "absent"})
+
+    def test_main_refuses_to_run_under_a_moved_surface(self) -> None:
+        with mock.patch.object(procrustes, "pinned_surface_drift", return_value={"utc_now": "absent"}):
+            self.assertEqual(procrustes.main(["status", "--run-dir", "/nonexistent"]), 70)
+
+    def test_the_limits_are_the_consensus_numbers(self) -> None:
+        self.assertEqual(procrustes.EIP170_RUNTIME_LIMIT, 24576)
+        self.assertEqual(procrustes.EIP3860_INITCODE_LIMIT, 49152)
+        self.assertEqual(procrustes.EIP3860_INITCODE_LIMIT, 2 * procrustes.EIP170_RUNTIME_LIMIT)
+
+    def test_the_harness_names_itself_in_its_records(self) -> None:
+        self.assertEqual(procrustes.SKILL_NAME, "procrustes")
+        self.assertEqual(procrustes.SCHEMA, "procrustes-run/v1")
+        self.assertNotEqual(procrustes.SCHEMA, procrustes.hermes.SCHEMA)
+
+    def test_the_pinned_map_carries_signatures_rather_than_names(self) -> None:
+        for name, signature in procrustes.PINNED_HERMES_SURFACE.items():
+            with self.subTest(name=name):
+                self.assertTrue(signature.startswith("("), signature)
+                self.assertEqual(
+                    signature, str(inspect.signature(getattr(procrustes.hermes, name)))
+                )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/plugins/hermes/skills/procrustes/scripts/test_procrustes.py
+++ b/plugins/hermes/skills/procrustes/scripts/test_procrustes.py
@@ -43,6 +43,21 @@ if args[:1] == ["build"]:
     if (repo / ".shapeless-sizes").exists():
         print(json.dumps({"A": {"runtime_size": "297", "init_size": 325}}))
         raise SystemExit(0)
+    if (repo / ".odd-key").exists():
+        print(json.dumps({"src/A.sol": {"runtime_size": 297, "init_size": 325}}))
+        raise SystemExit(0)
+    if (repo / ".duplicate-names").exists():
+        print(json.dumps({
+            "A (src/A.sol)": {"runtime_size": 297, "init_size": 325,
+                              "runtime_margin": 24279, "init_margin": 48827},
+            "A (src/nested/A.sol)": {"runtime_size": 170, "init_size": 196,
+                                     "runtime_margin": 24406, "init_margin": 48956},
+        }))
+        raise SystemExit(0)
+    if (repo / ".other-limit").exists():
+        print(json.dumps({"A": {"runtime_size": 297, "init_size": 325,
+                                "runtime_margin": 48279, "init_margin": 48827}}))
+        raise SystemExit(0)
     runtime = 297
     init = 325
     if (repo / ".over-limit").exists():
@@ -189,6 +204,34 @@ class BaselineTests(HarnessCase):
         self.assertEqual(entry["runtime_margin"], 24576 - 297)
         self.assertEqual(entry["init_margin"], 49152 - 325)
         self.assertEqual(sizes["limits"]["eip3860_initcode"], 49152)
+
+    def test_accepts_disambiguated_contract_names(self) -> None:
+        self.marker(".duplicate-names")
+        argv = [
+            "baseline",
+            "--repo",
+            str(self.repo),
+            "--evidence-dir",
+            str(self.evidence),
+            "--size-target",
+            r"^A \(src/A\.sol\)$",
+            "--assert-no-protected-contracts",
+        ]
+        with mock.patch.dict(os.environ, self.environment, clear=True):
+            self.assertEqual(procrustes.main(argv), 0)
+        sizes = json.loads((self.evidence / "sizes.json").read_text(encoding="utf-8"))
+        self.assertEqual(sorted(sizes["sizes"]), ["A (src/A.sol)", "A (src/nested/A.sol)"])
+        self.assertEqual(sizes["targets"], {r"^A \(src/A\.sol\)$": ["A (src/A.sol)"]})
+
+    def test_rejects_a_size_report_key_that_is_not_a_contract(self) -> None:
+        self.marker(".odd-key")
+        self.assertEqual(self.run_baseline(), 10)
+        self.assertIn("unexpected contract name", self.result()["reason"])
+
+    def test_rejects_a_margin_measured_against_another_limit(self) -> None:
+        self.marker(".other-limit")
+        self.assertEqual(self.run_baseline(), 10)
+        self.assertIn("different code-size limit", self.result()["reason"])
 
     def test_rejects_a_size_target_matching_no_contract(self) -> None:
         argv = [

--- a/plugins/hermes/skills/procrustes/scripts/test_procrustes.py
+++ b/plugins/hermes/skills/procrustes/scripts/test_procrustes.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import inspect
 import json
 import os
@@ -335,6 +336,38 @@ class BaselineTests(HarnessCase):
         self.assertEqual(code, 0)
         self.assertTrue((self.evidence / "storage-layout" / "A.baseline.json").is_file())
         self.assertTrue((self.evidence / "method-identifiers" / "A.baseline.json").is_file())
+
+    def test_seals_every_protected_artefact_by_digest(self) -> None:
+        with mock.patch.dict(os.environ, self.environment, clear=True):
+            code = procrustes.main([
+                "baseline",
+                "--repo",
+                str(self.repo),
+                "--evidence-dir",
+                str(self.evidence),
+                "--size-target",
+                "^A$",
+                "--fuzz-seed",
+                "0x5EED",
+                "--protected-contract",
+                "A=src/A.sol:A",
+            ])
+        self.assertEqual(code, 0)
+        state = json.loads((self.evidence / "state.json").read_text(encoding="utf-8"))
+        artifacts = state["artifacts"]
+        for relative in (
+            "sizes.json",
+            "foundry-config.json",
+            "baseline-source-manifest.json",
+            "storage-layout/A.baseline.json",
+            "method-identifiers/A.baseline.json",
+        ):
+            with self.subTest(artefact=relative):
+                self.assertIn(relative, artifacts)
+                self.assertEqual(
+                    artifacts[relative],
+                    hashlib.sha256((self.evidence / relative).read_bytes()).hexdigest(),
+                )
 
     def test_requires_a_protected_set_or_an_explicit_denial(self) -> None:
         argv = [

--- a/plugins/hermes/skills/procrustes/scripts/test_procrustes.py
+++ b/plugins/hermes/skills/procrustes/scripts/test_procrustes.py
@@ -43,6 +43,9 @@ if args[:1] == ["build"]:
     if (repo / ".shapeless-sizes").exists():
         print(json.dumps({"A": {"runtime_size": "297", "init_size": 325}}))
         raise SystemExit(0)
+    if (repo / ".boolean-size").exists():
+        print(json.dumps({"A": {"runtime_size": True, "init_size": 325}}))
+        raise SystemExit(0)
     if (repo / ".odd-key").exists():
         print(json.dumps({"src/A.sol": {"runtime_size": 297, "init_size": 325}}))
         raise SystemExit(0)
@@ -151,6 +154,8 @@ class HarnessCase(unittest.TestCase):
             str(evidence if evidence is not None else self.evidence),
             "--size-target",
             "^A$",
+            "--fuzz-seed",
+            "0x5EED",
             "--assert-no-protected-contracts",
             *extra,
         ]
@@ -215,6 +220,8 @@ class BaselineTests(HarnessCase):
             str(self.evidence),
             "--size-target",
             r"^A \(src/A\.sol\)$",
+            "--fuzz-seed",
+            "0x5EED",
             "--assert-no-protected-contracts",
         ]
         with mock.patch.dict(os.environ, self.environment, clear=True):
@@ -222,6 +229,34 @@ class BaselineTests(HarnessCase):
         sizes = json.loads((self.evidence / "sizes.json").read_text(encoding="utf-8"))
         self.assertEqual(sorted(sizes["sizes"]), ["A (src/A.sol)", "A (src/nested/A.sol)"])
         self.assertEqual(sizes["targets"], {r"^A \(src/A\.sol\)$": ["A (src/A.sol)"]})
+
+    def test_refuses_to_seal_without_a_pinned_fuzz_seed(self) -> None:
+        argv = [
+            "baseline",
+            "--repo",
+            str(self.repo),
+            "--evidence-dir",
+            str(self.evidence),
+            "--size-target",
+            "^A$",
+            "--assert-no-protected-contracts",
+        ]
+        with mock.patch.dict(os.environ, self.environment, clear=True):
+            with self.assertRaises(SystemExit) as raised:
+                procrustes.main(argv)
+        self.assertEqual(raised.exception.code, 2)
+
+    def test_records_the_pinned_seed_in_the_sealed_state(self) -> None:
+        self.assertEqual(self.run_baseline(), 0)
+        state = json.loads((self.evidence / "state.json").read_text(encoding="utf-8"))
+        self.assertEqual(state["fuzz_seed"], "0x5EED")
+        log = (self.evidence / "logs" / "gate1.forge-test.log").read_text(encoding="utf-8")
+        self.assertIn("--fuzz-seed 0x5EED", log)
+
+    def test_rejects_a_boolean_size(self) -> None:
+        self.marker(".boolean-size")
+        self.assertEqual(self.run_baseline(), 10)
+        self.assertIn("boolean size", self.result()["reason"])
 
     def test_rejects_a_size_report_key_that_is_not_a_contract(self) -> None:
         self.marker(".odd-key")
@@ -242,6 +277,8 @@ class BaselineTests(HarnessCase):
             str(self.evidence),
             "--size-target",
             "^NoSuchContract$",
+            "--fuzz-seed",
+            "0x5EED",
             "--assert-no-protected-contracts",
         ]
         with mock.patch.dict(os.environ, self.environment, clear=True):
@@ -257,6 +294,8 @@ class BaselineTests(HarnessCase):
             str(self.evidence),
             "--size-target",
             "A(",
+            "--fuzz-seed",
+            "0x5EED",
             "--assert-no-protected-contracts",
         ]
         with mock.patch.dict(os.environ, self.environment, clear=True):
@@ -288,6 +327,8 @@ class BaselineTests(HarnessCase):
                 str(self.evidence),
                 "--size-target",
                 "^A$",
+                "--fuzz-seed",
+                "0x5EED",
                 "--protected-contract",
                 "A=src/A.sol:A",
             ])
@@ -304,6 +345,8 @@ class BaselineTests(HarnessCase):
             str(self.evidence),
             "--size-target",
             "^A$",
+            "--fuzz-seed",
+            "0x5EED",
         ]
         with mock.patch.dict(os.environ, self.environment, clear=True):
             self.assertEqual(procrustes.main(argv), 10)

--- a/plugins/hermes/skills/procrustes/scripts/test_procrustes.py
+++ b/plugins/hermes/skills/procrustes/scripts/test_procrustes.py
@@ -434,6 +434,31 @@ class CouplingTests(unittest.TestCase):
         with mock.patch.object(procrustes, "pinned_surface_drift", return_value={"utc_now": "absent"}):
             self.assertEqual(procrustes.main(["status", "--run-dir", "/nonexistent"]), 70)
 
+    def test_binds_to_the_sibling_hermes_file(self) -> None:
+        self.assertEqual(
+            Path(procrustes.hermes.__file__).resolve(),
+            (procrustes.HERMES_SCRIPTS / "hermes.py").resolve(),
+        )
+
+    def test_refuses_a_foreign_module_answering_to_the_name(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            impostor = Path(directory) / "hermes.py"
+            impostor.write_text("SCHEMA = 'not-hermes'\n", encoding="utf-8")
+            saved = sys.modules.pop("hermes", None)
+            sys.path.insert(0, directory)
+            try:
+                with mock.patch.object(procrustes, "HERMES_SCRIPTS", Path(directory) / "elsewhere"):
+                    with self.assertRaises(SystemExit) as raised:
+                        procrustes.load_hermes()
+                message = str(raised.exception)
+                self.assertIn("the imported hermes module is", message)
+                self.assertIn(str(impostor), message)
+            finally:
+                sys.path.remove(directory)
+                sys.modules.pop("hermes", None)
+                if saved is not None:
+                    sys.modules["hermes"] = saved
+
     def test_the_limits_are_the_consensus_numbers(self) -> None:
         self.assertEqual(procrustes.EIP170_RUNTIME_LIMIT, 24576)
         self.assertEqual(procrustes.EIP3860_INITCODE_LIMIT, 49152)

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -503,6 +503,31 @@
       "selector": "test_rejects_any_gas_regression_at_gate_three",
       "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
     },
+    "procrustes-p": {
+      "path": "plugins/hermes/skills/procrustes/scripts/test_procrustes.py",
+      "selector": "test_seals_a_green_baseline_with_measured_sizes",
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "procrustes-m": {
+      "path": "plugins/hermes/skills/procrustes/scripts/test_procrustes.py",
+      "selector": "test_rejects_a_missing_or_unparsable_size_report",
+      "claim": "Missing required evidence is refused rather than treated as success."
+    },
+    "procrustes-s": {
+      "path": "plugins/hermes/skills/procrustes/scripts/test_procrustes.py",
+      "selector": "test_rejects_a_dirty_tree",
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped."
+    },
+    "procrustes-o": {
+      "path": "plugins/hermes/skills/procrustes/scripts/test_procrustes.py",
+      "selector": "test_records_initcode_beside_runtime_without_calling_either_the_limit",
+      "claim": "The nearest tempting overclaim remains explicitly unavailable."
+    },
+    "procrustes-r": {
+      "path": "plugins/hermes/skills/procrustes/scripts/test_procrustes.py",
+      "selector": "test_rejects_a_size_target_matching_no_contract",
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path."
+    },
     "elenchus-p": {
       "path": "plugins/hexaemeron/tests/test_elenchus_checker.py",
       "selector": "test_runner_categories_distinguish_all_three_outcomes",
@@ -2318,6 +2343,22 @@
         "S": "probitas-s",
         "O": "probitas-o",
         "R": "probitas-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "procrustes-sealed-baseline",
+      "skill_path": "plugins/hermes/skills/procrustes/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "procrustes-p",
+        "M": "procrustes-m",
+        "S": "procrustes-s",
+        "O": "procrustes-o",
+        "R": "procrustes-r",
         "X": {
           "not_applicable": true,
           "reason": "The canonical declaration supports no exception for this promise."

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -320,8 +320,8 @@ class PromiseInventoryTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertEqual(report["counts"]["plugins"], 14)
-        self.assertEqual(report["counts"]["canonical_skills"], 28)
-        self.assertEqual(report["counts"]["governed_skills"], 23)
+        self.assertEqual(report["counts"]["canonical_skills"], 29)
+        self.assertEqual(report["counts"]["governed_skills"], 24)
         self.assertEqual(report["counts"]["vendored_skills"], 5)
         self.assertEqual(report["counts"]["routers"], 1)
 
@@ -455,6 +455,9 @@ class PromiseStructureTests(unittest.TestCase):
                 "hermes-candidate-acceptance",
                 "hermes-baseline-promotion",
             },
+            "plugins/hermes/skills/procrustes/SKILL.md": {
+                "procrustes-sealed-baseline",
+            },
             "plugins/horos/skills/horos/SKILL.md": {
                 "horos-boundary-scan",
                 "horos-boundary-check",
@@ -517,7 +520,7 @@ class PromiseStructureTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["promises"], 61)
+        self.assertEqual(report["counts"]["promises"], 62)
 
     def test_hexaemeron_contract_population_is_complete(self):
         expected = {
@@ -579,7 +582,7 @@ class PromiseOverlayTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["promises"], 66)
+        self.assertEqual(report["counts"]["promises"], 67)
         self.assertEqual(report["counts"]["overlays"], 1)
 
     def test_one_byte_vendored_mutation_is_refused(self):
@@ -781,12 +784,12 @@ class PromiseIdentityTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["canonical_skills"], 28)
+        self.assertEqual(report["counts"]["canonical_skills"], 29)
         self.assertEqual(report["counts"]["routers"], 1)
         self.assertEqual(report["counts"]["claude_plugins"], 14)
         self.assertEqual(report["counts"]["codex_plugins"], 14)
         self.assertEqual(report["counts"]["package_versions"], 14)
-        self.assertEqual(report["counts"]["skill_versions"], 23)
+        self.assertEqual(report["counts"]["skill_versions"], 24)
 
     def test_unresolved_router_fixture_is_refused(self):
         completed = run_cli(
@@ -955,8 +958,8 @@ class PromiseCoverageTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["coverage_rows"], 66)
-        self.assertEqual(report["counts"]["coverage_selected"], 50)
+        self.assertEqual(report["counts"]["coverage_rows"], 67)
+        self.assertEqual(report["counts"]["coverage_selected"], 51)
 
     def test_berean_and_janus_boundaries_are_explicit(self):
         coverage = json.loads(
@@ -1154,7 +1157,7 @@ class PromiseCoverageTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["coverage_rows"], 66)
+        self.assertEqual(report["counts"]["coverage_rows"], 67)
         self.assertEqual(report["counts"]["coverage_selected"], 16)
 
     def test_prompt_and_vendored_evaluations_never_claim_proof(self):


### PR DESCRIPTION
## What changed

Procrustes arrives as a second skill in the `hermes` plugin. Gate 1 seals a
green, clean Foundry baseline carrying per-contract runtime and initcode sizes
with both margins, the declared size targets and the contracts each one matched,
the resolved Foundry config, the Forge version, the Git revision, every Solidity
source, and the protected storage layouts and method identifiers sealed by
digest.

EIP-170 caps deployed runtime code at 24576 bytes. EIP-3860 caps the initcode
that returns it at 49152. `forge build --sizes --json` reports both, and this
harness records both, because a constructor-heavy contract can sit inside one
limit and outside the other.

The sealing, layout and selector machinery is Hermes's, imported rather than
copied or edited. `PINNED_HERMES_SURFACE` names every helper taken with the
signature it was written against, the loader refuses a `hermes` module that is
not the sibling file, and the harness exits 70 before touching a repository when
either check fails. That coupling is the skill's main structural risk and it now
has two mechanical guards rather than a comment.

A contract already over a limit is recorded, not refused. Being over the limit is
why somebody runs this. What Gate 1 refuses is a dirty tree, a red suite, a
failed or unparsable size report, a `--size-target` matching no compiled
contract, an unresolved protected set, a missing `foundry.toml`, an evidence
directory inside the target or holding another run, and a Forge whose reported
margins are measured against some other limit.

The candidate gates are the held frontier job. This version cannot accept a size
candidate, and both `SKILL.md` and the plugin's runtime contract say so.

Repository wiring: `plugins/hermes/AGENTS.md` becomes a two-skill selection
table, the new promise declaration and its five conformance records join the
coverage map, and five hard-coded counts in the Promise Machine contract test
move by one.

## Audit

Five rounds, appended to `audit/AUDIT.md`. Rounds 1 to 4 found five defects and
each fix carries a guard test that fails when the fix is reverted, verified by
staging a reverted copy of the harness rather than by inspection:

- The size-report key pattern accepted only bare contract names, so any
  repository declaring one name in two files could not be baselined at all.
  Forge keys those rows `A (src/A.sol)`.
- Forge's own reported margins were ignored, so a toolchain measuring against a
  different limit would have been recorded as agreement.
- `--fuzz-seed` was optional, so a sealed baseline could claim a green suite
  nobody can reproduce or compare against.
- A JSON boolean passed the integer size check, because `isinstance(True, int)`
  holds in Python.
- The sealed state hashed the size report, the config and the source manifest but
  not the layouts or method maps, which are the files a candidate is compared
  against.

Round 5 was clean, and checked two things against forge 1.7.1 rather than against
the tests' fake forge: a cold build writes only JSON to stdout, and the
over-limit comparison uses EIP-170's own strict boundary, so a contract of
exactly 24576 bytes deploys.

Two leads are recorded and not pursued: the pinned signatures are compared as
rendered `inspect.signature` strings, and the size build is read without
`--force`. The second belongs to step 3, where a baseline and a candidate must
not share a stale artefact.

## Proof

```bash
python3 plugins/hermes/skills/procrustes/scripts/test_procrustes.py
python3 -m unittest discover -s tests
python3 scripts/promise_machine.py check
python3 plugins/horos/skills/horos/scripts/horos.py check .
```

Procrustes 33/33 with a fake `forge` on `PATH`. Root 104/104. The Promise Machine
check reports 14 plugins, 24 governed skills and 67 promises with no finding. The
Horos boundary check exits 0.

This pull request stacks on the committed spec.

<!-- wildcat-origin: shoggoth -->
