### PR TITLE
Track the Ephoros alert-runbook annotation specification

### DIFF
--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 1367
+    "files_walked": 1369
   },
   "entries": [
     {

--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 1360
+    "files_walked": 1367
   },
   "entries": [
     {

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -6031,3 +6031,7 @@ Leads not pursued: none
 Scope: `0bfad60bb482245dd08d9747139d26824392a2c7..a8f2a13f9143b0335cba514c4ef0f9dd9afa34ed`, limited to the two tracked specification documents and regenerated Horos boundary. Both documents are byte-identical to the receipted working copies; Protasis study/runbook, Imprimatur, per-file Brevitas and diff checks exit 0. Phylax, Ephoros and Hypomnema tree lints each exit 0. Evolution 18/18, root 104/104 and Hexaemeron 548/548 pass; Promise Machine reports 14 plugins and copies clean. The step commit has a good local signature and exactly one required co-author and origin trailer.
 
 Leads not pursued: none
+
+### Resolution: E319-S1-R1-01 -- 2026-08-21
+
+Resolved on the audit branch by regenerating `.horos/boundary.json` after the two specification documents were tracked. The committed document and a fresh tracked-universe scan are now byte-identical at 1,369 files walked, with 89 classified entries and none unreadable. The complete step-1 gate set remains clean: document copies, Protasis, Imprimatur, per-file Brevitas, Promise Machine, evolution 18/18, root 104/104, Hexaemeron 548/548, boundary currency 4/4, diff check and the Phylax, Ephoros and Hypomnema tree lints all exit 0. No new leads.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -6035,3 +6035,12 @@ Leads not pursued: none
 ### Resolution: E319-S1-R1-01 -- 2026-08-21
 
 Resolved on the audit branch by regenerating `.horos/boundary.json` after the two specification documents were tracked. The committed document and a fresh tracked-universe scan are now byte-identical at 1,369 files walked, with 89 classified entries and none unreadable. The complete step-1 gate set remains clean: document copies, Protasis, Imprimatur, per-file Brevitas, Promise Machine, evolution 18/18, root 104/104, Hexaemeron 548/548, boundary currency 4/4, diff check and the Phylax, Ephoros and Hypomnema tree lints all exit 0. No new leads.
+
+## Ephoros alert-runbook annotations, step 1, round 2 -- 2026-08-21
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+No findings. Re-reviewed the folded scope `0bfad60bb482245dd08d9747139d26824392a2c7..04c0df48073f79efe82e6e9999b87344e7a80e40`, including the two specification documents, corrected Horos boundary and round-1 audit history. The boundary and a fresh tracked-universe scan are byte-identical at 1,369 files walked, with 89 classified entries and none unreadable. Both documents remain byte-identical to the receipted copies. Protasis, Imprimatur, per-file Brevitas, Promise Machine, evolution 18/18, root 104/104, Hexaemeron 548/548, boundary currency 4/4, diff check and the Phylax, Ephoros and Hypomnema tree lints all exit 0.
+
+No further leads remain.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -6021,3 +6021,13 @@ marketplace prose 13/13. Promise Machine checks 14 plugins and copies clean;
 Horos scans 1,360 files with 89 classified entries and none unreadable.
 
 Leads not pursued: none
+
+## Ephoros alert-runbook annotations, step 1, round 1 -- 2026-08-21
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| E319-S1-R1-01 | low | `.horos/boundary.json` | The committed tracked-universe document reports 1,367 files walked; a fresh scan of the committed step tree reports 1,369. Removing only `counts.files_walked` makes the documents byte-identical, so the hard boundary is current but its published walk count omits the two tracked study/runbook files. | open |
+
+Scope: `0bfad60bb482245dd08d9747139d26824392a2c7..a8f2a13f9143b0335cba514c4ef0f9dd9afa34ed`, limited to the two tracked specification documents and regenerated Horos boundary. Both documents are byte-identical to the receipted working copies; Protasis study/runbook, Imprimatur, per-file Brevitas and diff checks exit 0. Phylax, Ephoros and Hypomnema tree lints each exit 0. Evolution 18/18, root 104/104 and Hexaemeron 548/548 pass; Promise Machine reports 14 plugins and copies clean. The step commit has a good local signature and exactly one required co-author and origin trailer.
+
+Leads not pursued: none

--- a/docs/ephoros-alert-runbook-annotations-runbook.md
+++ b/docs/ephoros-alert-runbook-annotations-runbook.md
@@ -1,0 +1,161 @@
+# Runbook: Require alert rules to carry a resolving runbook annotation
+
+## Commit rule
+
+Derived from `.hexaemeron/study.md`: two signed steps, each with one stacked
+pull request. The run starts from `main` at `0bfad60bb482245dd08d9747139d26824392a2c7`.
+
+Every Fiat-created commit in this run is made with `git commit -S` and ends,
+after a blank line, with these exact trailers:
+
+```text
+Co-authored-by: Shoggoth <shoggoth@wildcat.finance>
+Wildcat-Origin: shoggoth
+```
+
+Each step's exit includes local cryptographic verification and exact trailer
+checks. A missing, bad or unverifiable signature is a failed exit, even when
+the test suites are green.
+
+## Step 1: Scaffold: commit the alert-runbook annotation specification
+
+**Goal.** Put the receipted study and runbook in the tracked tree, with the
+Horos boundary regenerated, before checker behaviour changes.
+
+**Entry.** The controller-provided step-1 branch cut from
+`fiat/ephoros-1-require-alert-rules-to-carry-a-resolvi`, whose entry tree is
+`0bfad60bb482245dd08d9747139d26824392a2c7`, with no uncommitted files.
+
+**Exit.** Commit byte-identical tracked copies of the study and runbook plus
+the regenerated Horos boundary. Before the signed commit, all document,
+focused contract, repository and tree gates exit 0:
+
+```bash
+cmp -s .hexaemeron/study.md docs/ephoros-alert-runbook-annotations-study.md
+cmp -s .hexaemeron/runbook.md docs/ephoros-alert-runbook-annotations-runbook.md
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/ephoros-alert-runbook-annotations-study.md
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/ephoros-alert-runbook-annotations-runbook.md
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/ephoros-alert-runbook-annotations-study.md docs/ephoros-alert-runbook-annotations-runbook.md
+for file in docs/ephoros-alert-runbook-annotations-study.md docs/ephoros-alert-runbook-annotations-runbook.md; do python3 plugins/brevitas/skills/brevitas/scripts/brevitas.py "$file"; done
+python3 -m unittest tests.test_evolution_contract plugins.hexaemeron.tests.test_evolution
+python3 scripts/promise_machine.py check
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs
+```
+
+After those gates pass, stage only the three named paths and create one commit
+with `git commit -S`. The exact committed head then passes:
+
+```bash
+git verify-commit HEAD
+test "$(git log -1 --format=%B | grep -Fxc 'Co-authored-by: Shoggoth <shoggoth@wildcat.finance>')" -eq 1
+test "$(git log -1 --format=%B | grep -Fxc 'Wildcat-Origin: shoggoth')" -eq 1
+```
+
+**Files.** `docs/ephoros-alert-runbook-annotations-study.md`,
+`docs/ephoros-alert-runbook-annotations-runbook.md`, `.horos/boundary.json`.
+
+**Tests.** No behaviour test is added. Protasis checks both tracked documents;
+Imprimatur and Brevitas check their prose; the evolution, Promise Machine,
+root and Hexaemeron suites and all three tree lints provide the regression
+gate. Counts are reported from the commands rather than hard-coded.
+
+**Disciplines.** phylax: none, tracked Markdown and a regenerated boundary
+open no execution path. ephoros: none, nothing runs unattended. metron: none,
+no performance claim. elenchus: any failed copy, lint, suite or signature gate
+stops the step and is reproduced before repair. hypomnema: the tracked study
+is the source for the two generation records written in step 2.
+
+## Step 2: Ship E004 and the generic YAML H003 handoff
+
+**Goal.** Require each supported YAML alert entry to carry its own local
+runbook annotation, resolve that pointer through H003, preserve H007's target
+shape, and record both ordinary generation changes without moving either held
+frontier.
+
+**Entry.** The controller-provided step-2 branch cut from step 1's exact signed,
+locally verified green commit, with the tracked study and runbook present and
+no uncommitted files.
+
+**Exit.** Implement the study's chosen bounded block-YAML design and satisfy
+all of the following:
+
+- Ephoros reports E004 once per supported alert entry lacking its own nested
+  `annotations.runbook`, and no other skill emits that presence finding.
+- Comments, block scalars, top-level pointers and a neighbouring alert's
+  pointer do not create or satisfy an alert annotation.
+- Hypomnema generically scans supported YAML `runbook:` pointers and H003
+  resolves them relative to the YAML file without classifying alert entries.
+- Existing H003 Markdown behaviour and H007 runbook-shape behaviour are
+  unchanged; a complete alert-to-runbook fixture is clean under both checkers.
+- E000 to E003 and H000 to H007 keep their numbers and prior cases.
+- Ephoros becomes `ephoros-v0.2.0` and Hypomnema becomes
+  `hypomnema-v4.3.0`. Each generation row retains its previous frontier
+  revision, frontier digest, status and held `Next Fiat job` byte for byte.
+- Promise Machine evidence and hashes describe the widened mechanical parser
+  surfaces without promoting them to an observability or record-placement
+  review.
+
+Regenerate `.horos/boundary.json`, cold-read the root and Hexaemeron runtime,
+README, agent-description and manifest prose, and change only a surface made
+false by E004 or YAML H003. Do not alter CI or package versions merely because
+the canonical skill generation labels move. The focused demonstration and all
+repository gates then exit 0:
+
+```bash
+python3 -m unittest plugins.hexaemeron.tests.test_ephoros_checker plugins.hexaemeron.tests.test_hypomnema_checker
+python3 -m unittest tests.test_evolution_contract tests.test_version_propagation plugins.hexaemeron.tests.test_evolution
+python3 -m unittest tests.test_marketplace_prose
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/ephoros-alert-runbook-annotations-study.md
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/ephoros-alert-runbook-annotations-runbook.md
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/ephoros-alert-runbook-annotations-study.md docs/ephoros-alert-runbook-annotations-runbook.md plugins/hexaemeron/skills/ephoros/SKILL.md plugins/hexaemeron/skills/ephoros/EVOLUTION.md plugins/hexaemeron/skills/hypomnema/SKILL.md plugins/hexaemeron/skills/hypomnema/EVOLUTION.md
+for file in docs/ephoros-alert-runbook-annotations-study.md docs/ephoros-alert-runbook-annotations-runbook.md plugins/hexaemeron/skills/ephoros/SKILL.md plugins/hexaemeron/skills/ephoros/EVOLUTION.md plugins/hexaemeron/skills/hypomnema/SKILL.md plugins/hexaemeron/skills/hypomnema/EVOLUTION.md; do python3 plugins/brevitas/skills/brevitas/scripts/brevitas.py "$file"; done
+python3 scripts/promise_machine.py check
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs
+```
+
+After every gate passes, stage only the declared step-2 files and any reviewed
+prose surface actually made stale, then create one commit with `git commit -S`.
+The exact committed head then passes:
+
+```bash
+git verify-commit HEAD
+test "$(git log -1 --format=%B | grep -Fxc 'Co-authored-by: Shoggoth <shoggoth@wildcat.finance>')" -eq 1
+test "$(git log -1 --format=%B | grep -Fxc 'Wildcat-Origin: shoggoth')" -eq 1
+```
+
+**Files.** `plugins/hexaemeron/skills/ephoros/scripts/ephoros.py`,
+`plugins/hexaemeron/tests/test_ephoros_checker.py`,
+`plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py`,
+`plugins/hexaemeron/tests/test_hypomnema_checker.py`,
+`plugins/hexaemeron/tests/fixtures/ephoros/alert-rules/*`,
+`plugins/hexaemeron/skills/ephoros/SKILL.md`,
+`plugins/hexaemeron/skills/ephoros/EVOLUTION.md`,
+`plugins/hexaemeron/skills/hypomnema/SKILL.md`,
+`plugins/hexaemeron/skills/hypomnema/EVOLUTION.md`,
+`tests/promise_machine_coverage.json`, `.horos/boundary.json`; plus only those
+first-party README, runtime, agent-description or manifest files the cold read
+proves stale.
+
+**Tests.** Extend the Ephoros checker tests with missing, complete,
+multi-alert isolation, top-level-pointer, comment, block-scalar, unsupported
+shape, suppression and clean-tree cases. Extend the Hypomnema checker tests
+with dangling and restored YAML pointers, relative-base resolution, unchanged
+Markdown H003, unchanged H007 and one complete end-to-end fixture. Keep every
+existing case. The focused test count increases by the added cases; the exact
+total is reported by the focused command.
+
+**Disciplines.** phylax: caller-named YAML is untrusted text, so decoding,
+bounded reads, paths and non-execution stay visible and guarded. ephoros: owns
+only alert classification and E004 presence. metron: none, no performance
+claim or speed-motivated edit. elenchus: any parser, PM071, evolution, tree,
+suite or signature failure is reproduced and guarded before the step resumes.
+hypomnema: owns generic H003 resolution, unchanged H007 shape and the two
+generation records in their established skill ledgers.

--- a/docs/ephoros-alert-runbook-annotations-study.md
+++ b/docs/ephoros-alert-runbook-annotations-study.md
@@ -1,0 +1,124 @@
+# Study: Require alert rules to carry a resolving runbook annotation
+
+Assuming, unless corrected:
+
+1. An alert rule is in scope when a `.yaml` or `.yml` file contains a Prometheus-style list entry whose mapping starts with `alert:`.
+2. The required handoff is an `annotations` mapping on that alert entry containing `runbook: <relative-path>.md`; a `runbook` key elsewhere does not satisfy the alert.
+3. The supported prototype is block-style YAML. Flow mappings, anchors that supply the annotation indirectly, templated files and other configuration languages remain outside the parser's claim.
+4. Ephoros classifies alert entries and owns only annotation presence. Hypomnema does not classify alerts: its generic H003 pointer pass recognises a `runbook:` field in supported YAML and owns whether the relative target exists, while H007 continues to own the three answers in Markdown below a `runbooks` directory.
+5. Python 3.11 and the standard library remain the implementation boundary; no YAML dependency is added.
+6. E004 is the new Ephoros finding code. E000 to E003 and Hypomnema H000 to H007 retain their numbers and existing firing conditions.
+7. This is ordinary generation work under issue 319, not Ephoros's held frontier. Ephoros advances from `ephoros-v0.1.0` to `ephoros-v0.2.0`; Hypomnema advances from `hypomnema-v4.2.0` to `hypomnema-v4.3.0` for its wider H003 input surface. Both generation rows retain their current frontier revision, digest, status and `Next Fiat job` byte for byte.
+8. The run starts from `main` at `0bfad60bb482245dd08d9747139d26824392a2c7`.
+
+I will proceed on these assumptions unless corrected.
+
+## 1. Problem statement
+
+Ephoros says every alert needs a runbook, but its checker reads only Python and enforces none of that handoff. A Prometheus-style alert rule can therefore omit the annotation entirely and pass every mechanical gate. Build a bounded alert-rule pass for Wildcat contributors that reports E004 for each in-scope alert entry without its own local `runbook` annotation. Keep the three obligations separate: Ephoros requires the annotation, Hypomnema H003 resolves its relative target, and Hypomnema H007 checks the target's `What fired`, `First check` and `Who to wake` answers.
+
+A working prototype is established by these checkable criteria:
+
+- The focused Ephoros tests report one E004 for each unannotated alert entry, including one missing entry beside an annotated neighbour, and report no E004 for a correctly annotated entry.
+- Negative fixtures prove that comments, block-scalar examples, a top-level `runbook` key and a `runbook` key belonging to another alert do not satisfy an alert entry.
+- The focused Hypomnema tests report H003 for a supported YAML `runbook` annotation whose relative target is absent, accept the same annotation once its target exists, and preserve H003's existing Markdown cases.
+- H007, unchanged, rejects an existing target below a `runbooks` directory when any of its three answers is absent or empty; a complete end-to-end alert, pointer and runbook specimen is clean under both checkers.
+- Existing E000 to E003 and H000 to H007 tests pass unchanged, the full first-party tree is clean, and the root and Hexaemeron suites pass.
+- The two generation rows pass the evolution contract while retaining both held frontier jobs unchanged.
+
+The demo path is:
+
+```bash
+python3 -m unittest plugins.hexaemeron.tests.test_ephoros_checker plugins.hexaemeron.tests.test_hypomnema_checker
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/tests/run_tests.py
+```
+
+## 2. Prior art
+
+- `plugins/hexaemeron/skills/ephoros/SKILL.md`, `scripts/ephoros.py` and `tests/test_ephoros_checker.py` define E001 to E003 over Python. The current tree has no alert-rule fixture and the shipped checker returns no verdict for YAML.
+- `plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py` defines H003 as existence-only pointer resolution and H007 as the three-answer Markdown shape. The recently shipped `docs/hypomnema-runbook-shape-check-study.md` names issue 319 as the owner of annotation presence and explicitly leaves alert-rule YAML out of Hypomnema's alert classification.
+- The last two merged pull requests that changed Ephoros were [skills#293](https://github.com/wildcat-finance/skills/pull/293) and its stacked step [skills#288](https://github.com/wildcat-finance/skills/pull/288). PR 293's `Carried forward` section names host captures and other skills' frontiers, none of which applies here. PR 288 has no `Carried forward` section; its then-open behavioural-conformance work was completed by the integrated Promise Machine run. Neither PR carried an alert-rule implementation or an Ephoros-specific unresolved defect.
+- The earlier introduction PR, [skills#103](https://github.com/wildcat-finance/skills/pull/103), records why Ephoros ignores `print`, restricts duration means and resolves logger names. Its known CI gap remains outside this issue: local runs must execute the Hexaemeron suite, and changing CI requires approval.
+- `audit/AUDIT.md` records two relevant boundaries. Promise Machine step 6 found that a judgement-held Ephoros review had borrowed evidence from its narrower parser and replaced that overclaim with labelled review cases. The Hypomnema runbook-shape round records that H003 stays existence-only, H007 owns the target shape and annotation presence stays with issue 319. This build preserves both decisions.
+- `plugins/hexaemeron/audit/AUDIT.md` contains no Ephoros-specific finding; it predates the practice-skill checker. No accepted audit lead requires reopening in this generation.
+
+## 3. Constraints and non-goals
+
+- Starting ref: `main` at `0bfad60bb482245dd08d9747139d26824392a2c7`.
+- The Promise Machine boundary remains narrow: a clean E004 pass establishes annotation presence on the supported YAML subset, not correct alerting, correct YAML in every dialect, a resolving target or operationally useful runbook content.
+- Ephoros alone decides that a YAML entry is an alert and whether it carries the annotation. Hypomnema's YAML work is a generic H003 pointer scan and must not emit an alert-presence finding. H007 remains unchanged.
+- The annotation is a relative local Markdown path so H003 can establish existence and H007 can inspect a repository record. Remote runbook URLs are deferred.
+- E000 to E003 and H000 to H007 are stable interfaces. Existing suppressions retain their scope; any E004 suppression must use the existing reasoned `# ephoros: allow <why>` form on the alert line or the line above it.
+- No third-party YAML parser, network call, subprocess, Solidity, vendored file, generated artefact, CI workflow or broader configuration-language support.
+- The Ephoros held target remains wallet-address linkage across Python and TypeScript. The Hypomnema held target remains the design-bridge check. This ordinary run does not claim either frontier advance.
+- **Always.** Run the focused checker tests, root suite, Hexaemeron suite, Promise Machine check, evolution check and repository prose/tree lints before commit; lint every shipped document with Imprimatur; record a baseline before any performance-motivated change.
+- **Ask first.** Add a dependency, touch CI, change a public checker interface beyond the named codes and suffixes, widen the trust boundary, add another config dialect or rewrite a released digest.
+- **Never.** Edit vendored directories, weaken H003 or H007, let one alert borrow another's annotation, delete a failing test, commit credentials or claim an unrun command.
+
+## 4. Design options
+
+1. **One bounded, indentation-aware YAML alert pass in Ephoros plus a generic YAML H003 pointer pass in Hypomnema.** Chosen. It is the least code that preserves ownership: Ephoros identifies `alert` entries and requires their nested annotation; Hypomnema sees only a `runbook` pointer and applies its existing resolution rule. It trades away full YAML semantics and non-YAML alert formats.
+2. **Add PyYAML and parse complete YAML objects in both checkers.** This handles anchors and flow mappings, but adds an execution dependency and duplicate traversal for a narrow prototype.
+3. **Make Ephoros check both presence and target resolution.** This is locally simpler, but duplicates H003 and would let the two skills disagree about the same missing target.
+4. **Make Hypomnema classify alert rules and enforce the annotation.** This keeps pointer work together, but crosses the explicit ownership boundary and turns a record checker into an alert-rule checker.
+
+Option 1 is chosen because it is cheapest to comprehend while meeting the issue. Its deliberate trade is a documented block-YAML subset rather than the false claim of general YAML parsing.
+
+## 5. Risk register seed
+
+```risk-register
+alert-classification | the YAML lines Ephoros classifies as alert entries | only block-style list entries with an alert key are in scope and neighbouring config is left alone
+annotation-ownership | the split between E004 and H003 | Ephoros checks presence only and Hypomnema resolves the named target without classifying alerts
+record-isolation | multiple alert entries in one YAML file | each alert must carry its own nested annotation and cannot borrow one from a neighbour or top-level mapping
+yaml-lexing | comments quoted text and block scalars near alert-shaped content | non-key examples do not create alerts or satisfy annotations and unsupported forms remain visible as out of scope
+pointer-base | a relative runbook path read from YAML | H003 resolves from the alert-rule file directory and reports the original pointer line when absent
+stable-codes | E000 to E003 and H000 to H007 beside E004 | every existing test passes unchanged and the new code does not renumber or widen an old finding
+frontier-preservation | the two ordinary generation rows | current frontier revisions digests statuses and held jobs remain byte-identical while generation increments once
+tree-self-trip | the new YAML walk over first-party files | fixtures are skipped on directory walks and the complete marketplace scan exits clean
+```
+
+The audit loop should look hardest at record-isolation and annotation-ownership. A parser that lets one annotation satisfy two alerts misses the issue; a parser that resolves the target in Ephoros duplicates Hypomnema.
+
+## 6. Glossary seeds
+
+- Alert entry: a supported block-style YAML list mapping introduced by an `alert` key.
+- Runbook annotation: a `runbook` key nested under that alert entry's `annotations` mapping, containing a relative Markdown path.
+- E004: an in-scope alert entry has no qualifying runbook annotation.
+- H003: the named local runbook target does not exist relative to the file containing the pointer.
+- H007: an alert runbook below a `runbooks` directory lacks one of its three required, non-empty answers.
+- Ownership handoff: E004 establishes presence, H003 establishes existence and H007 establishes recognised shape, with no one code claiming all three.
+
+## 7. Sources
+
+- [skills#319](https://github.com/wildcat-finance/skills/issues/319)
+- `PROMISE_MACHINE.md`, `.agents/skills/promise-machine/SKILL.md`, `plugins/hexaemeron/AGENTS.md`
+- `plugins/hexaemeron/skills/fiat/SKILL.md`, `plugins/hexaemeron/skills/protasis/SKILL.md`
+- `plugins/hexaemeron/skills/ephoros/SKILL.md`, `EVOLUTION.md`, `scripts/ephoros.py`, and `plugins/hexaemeron/tests/test_ephoros_checker.py`
+- `plugins/hexaemeron/skills/hypomnema/SKILL.md`, `EVOLUTION.md`, `scripts/hypomnema.py`, and `plugins/hexaemeron/tests/test_hypomnema_checker.py`
+- `plugins/hexaemeron/skills/VERSIONING.md`
+- `docs/hypomnema-runbook-shape-check-study.md`, `docs/hypomnema-runbook-shape-check-runbook.md`
+- `audit/AUDIT.md`, Promise Machine steps 5 and 6 and Hypomnema runbook-shape steps 1 and 2; `plugins/hexaemeron/audit/AUDIT.md`
+- [skills#293](https://github.com/wildcat-finance/skills/pull/293), [skills#288](https://github.com/wildcat-finance/skills/pull/288), [skills#103](https://github.com/wildcat-finance/skills/pull/103)
+
+## 8. Signals, and the questions behind them
+
+None, and here is why: the deliverable is a lint invoked from a terminal and does not run unattended. Its result is command output rather than durable telemetry. [Ephoros](../plugins/hexaemeron/skills/ephoros/SKILL.md) remains the authority for any future unattended checker service; this run adds no such service.
+
+## 9. Boundaries, per capability
+
+The new capability reads caller-named first-party YAML as untrusted text, classifies only a bounded alert shape and returns findings without executing input or writing files. Size, decoding, path and fixture-walk behaviour must fail visibly or stay inside the existing checker boundary; no shell, URL, credential, dependency or model-output boundary is introduced. [Phylax](../plugins/hexaemeron/skills/phylax/SKILL.md) owns the boundary review and its tree lint remains an audit gate.
+
+## 10. The budget, or its absence
+
+None, and here is why: no performance claim or caller-supplied latency ceiling exists, and the supported pass is bounded by each file's bytes and lines. [Metron](../plugins/hexaemeron/skills/metron/SKILL.md) applies if implementation is proposed for speed; that would first require a recorded baseline and exact repeatable command.
+
+## 11. The fail-closed posture
+
+An unreadable or malformed supported input, focused-test failure, old-code regression, tree-lint finding, Promise Machine mismatch, evolution failure or suite failure stops the step. Any observed failure is preserved and worked under [Elenchus](../plugins/hexaemeron/skills/elenchus/SKILL.md): reproduce it, localise the mechanism and add a guard that fails without the fix before resuming. E004 ships with missing, neighbour-isolation and false-positive guards; the H003 YAML extension ships with dangling, restored-target and Markdown-regression guards.
+
+## 12. Decisions and their homes
+
+The alert classifier, E004 boundary and rejected full-YAML alternatives are Ephoros decisions and belong in the `ephoros-v0.2.0` generation row. The generic YAML input extension for H003 and its refusal to classify alerts belong in the `hypomnema-v4.3.0` generation row. This committed study supplies the source material, while the two ledgers are the standing records; no cross-cutting ADR is added and neither decision is copied into two homes. [Hypomnema](../plugins/hexaemeron/skills/hypomnema/SKILL.md) owns that placement. Both rows cite issue 319 and the delivered evidence while retaining their held frontiers unchanged.


### PR DESCRIPTION
# Track the Ephoros alert-runbook annotation specification

## Scope

This first step commits the issue 319 study and two-step runbook before checker behaviour changes. It also records the audit and regenerates the Horos boundary against the tracked documents. The diff is `0bfad60bb482245dd08d9747139d26824392a2c7..3b2d58955d483586f326ab68ed73994532a0d7bf`.

The study keeps the handoff narrow: Ephoros will own annotation presence, Hypomnema H003 will own relative target resolution, and H007 will keep owning the target's three answers. Implementation and both generation records remain in step 2.

## Audit

Round 1 found that `.horos/boundary.json` still reported 1,367 walked files after the two documents were tracked. The boundary was regenerated; it now matches a fresh scan byte for byte at 1,369 files, with 89 classified entries and none unreadable. Round 2 found nothing else, and no leads remain open.

## Checks

- Tracked study and runbook match the receipted copies byte for byte.
- Protasis, Imprimatur, per-file Brevitas and the diff check exit 0.
- Promise Machine checks 14 plugins and all generated copies clean.
- Evolution passes 18/18, the root suite 104/104, Hexaemeron 548/548 and boundary currency 4/4.
- Phylax, Ephoros and Hypomnema tree lints exit 0.
- Content commit `a8f2a13f9143b0335cba514c4ef0f9dd9afa34ed` and folded head `3b2d58955d483586f326ab68ed73994532a0d7bf` both pass local `git verify-commit`; each carries exactly one required Shoggoth co-author trailer and one `Wildcat-Origin: shoggoth` trailer.

<!-- wildcat-origin: shoggoth -->
