### PR TITLE
The corpus schema, its validator, and the refusal data

### DIFF
--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 1360
+    "files_walked": 1369
   },
   "entries": [
     {

--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 1369
+    "files_walked": 1372
   },
   "entries": [
     {

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -6021,3 +6021,46 @@ marketplace prose 13/13. Promise Machine checks 14 plugins and copies clean;
 Horos scans 1,360 files with 89 classified entries and none unreadable.
 
 Leads not pursued: none
+
+## Hermes rule corpus, step 1, round 1 -- 2026-08-21
+
+The committed non-Solidity diff has no open finding. Status: clean.
+
+The Pashov pair did not run: the `security_suite` receipt records a waiver
+because the run ships Python, JSON and Markdown and creates or changes no
+Solidity, contract or Foundry project. Phylax, Ephoros and Hypomnema each
+exit 0 over `plugins`, `tests` and the document set. The root suite passes
+104/104 and the Hermes suite 14/14. Protasis is clean over both artefacts and
+Imprimatur scores each 100/100.
+
+The look the lints cannot do covered the three risk-register concerns this
+step can carry. On `frontier-displacement`: the study states the displacement
+in its assumptions, its amendment, its risk register and item 12, and the
+runbook puts the single epoch row and its reopening text in step 6. The body
+of the study still describes two ledger rows where the amendment describes
+one; that is the append-rather-than-edit rule the spec contract states, and
+the amendment carries the correction, so it is reviewed rather than fixed. On
+`successor-judgement`: neither document names the successor frontier, which
+matches the study's position that the choice is an end-of-run judgement
+against the run's own evidence. On `cli-break` and the ten remaining
+concerns: not reachable from a Markdown and boundary-counter diff.
+
+One in-step fault, found before this round and fixed at its cause. The study
+quoted the rolling-job marker verbatim while describing the constraint that
+governs it, and `test_rolling_fiat_jobs_exist_only_in_plugin_landing_readmes`
+scans every tracked Markdown file for that literal, so the document tripped
+the guard it was describing. The detector cannot tell a quotation from a
+declaration and should not try; the sentence now names the line without
+reproducing its marker. The existing test is the guard, so no new one was
+written.
+
+The boundary regeneration moved `files_walked` from 1,360 to 1,369 with the
+entry set unchanged at 89. Two of the nine are this step's documents. The
+other seven are the Hypomnema runbook fixtures that landed after that round
+wrote its boundary, which is why its own log reports 1,360 beside them.
+
+Leads not pursued: the boundary currency guard compares entry sets and not
+the counts beside them, so a stale `files_walked` ships without a test
+noticing, as it just did. Correcting it here was a side effect of following
+the regeneration rule rather than a fix, and widening that guard belongs to
+Horos rather than to a Hermes corpus run.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -6064,3 +6064,48 @@ the counts beside them, so a stale `files_walked` ships without a test
 noticing, as it just did. Correcting it here was a side effect of following
 the regeneration rule rather than a fix, and widening that guard belongs to
 Horos rather than to a Hermes corpus run.
+
+## Hermes rule corpus, step 2, round 1 -- 2026-08-21
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S2-R1-01 | low | `plugins/hermes/skills/hermes/scripts/hermes.py` | The header check named the three record classes in its own tuple, so a schema that grew a fourth class would report the corpus key holding it as an unknown top-level field rather than validating its records. | fixed in this round |
+
+The Pashov pair did not run under the recorded waiver. Phylax, Ephoros and
+Hypomnema each exit 0. The root suite passes 104/104 and the Hermes suite
+32/32, of which 18 are new this step. `corpus --validate` reports 28 myths and
+40 references with no fault.
+
+The review read the whole validator against the risk register. On
+`corpus-schema-drift`: records are lists rather than objects keyed by id,
+because `json.load` drops a duplicate key silently and a duplicate rule id has
+to be a refusal; the duplicate, unknown-field, missing-field, bad-pattern and
+unimplemented-token cases each have a test. On `citation-network`: the new code
+imports nothing that can open a socket and the citations are inert strings; the
+`https` shape check is a format rule, not a fetch. On `binding-digest`: the
+`hermes.py` digest in the Promise Machine coverage moved twice in this step,
+once for the implementation and once for the round's fix, and the file was
+edited by substring replacement rather than reserialised, which is what keeps
+the diff at two lines instead of 1,908. On `citation-shape`: the extraction
+counts footnote definitions, and the test pins REF-25 at one entry because the
+source states it both as a line-initial citation and as a definition.
+
+One candidate finding was investigated and rejected. The nested shape tokens
+(`source`, `verified_on`, `scope`) are read out of the schema, which looks like
+a cycle a malformed schema could ride into unbounded recursion. It cannot: each
+level recurses only when the value at that level is an object, so the walk is
+bounded by the nesting of the data and JSON cannot express infinite nesting. A
+depth limit and its test were written, shown not to fire, and removed rather
+than kept as a guard against a fault that has no reachable path. Deeply nested
+input would exhaust the recursion limit inside `json.loads` before the
+validator saw it, and the corpus is in-tree data rather than caller input.
+
+Leads not pursued: the corpus records were produced by a throwaway extractor
+run against the pinned source, which cross-checked every citation's footnote
+URL against its table URL and found all 40 in agreement. That extractor is not
+committed, so `transcription-fidelity` rests on counts, id shape and reference
+resolution rather than on text equality with the source. Committing an
+extractor and asserting it reproduces the committed bytes would close the gap
+for the mechanically derivable fields. The runbook does not ask for it, and
+adding it here would be scope the step did not carry; it belongs to a later
+frontier judgement.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -6109,3 +6109,22 @@ extractor and asserting it reproduces the committed bytes would close the gap
 for the mechanically derivable fields. The runbook does not ask for it, and
 adding it here would be scope the step did not carry; it belongs to a later
 frontier judgement.
+
+## Hermes rule corpus, step 2, round 2 -- 2026-08-21
+
+Round 1's fix introduced no regression and this round found nothing. Status:
+clean.
+
+Phylax, Ephoros and Hypomnema each exit 0 against the fixed tree. The root
+suite passes 104/104 and the Hermes suite 32/32. `corpus --validate` reports
+28 myths and 40 references with no fault, at corpus digest `0692e53d` and
+source digest `297c926d`, so neither the data nor the pinned document moved
+while the validator was corrected.
+
+The second look re-read the fix itself. Deriving the record classes from the
+schema means the header check and the record walk now read one declaration
+rather than two, so a class added to the schema cannot be a class the header
+rejects. Its guard adds a fourth class in a temporary copy and requires the
+corpus holding it to validate.
+
+Leads not pursued: the extractor gap recorded in round 1 stands unchanged.

--- a/docs/hermes-rule-corpus-runbook.md
+++ b/docs/hermes-rule-corpus-runbook.md
@@ -1,0 +1,122 @@
+# Runbook: A pinned gas-rule corpus Hermes enforces
+
+Derived from the study of the same name, as amended on 2026-08-21. Six steps,
+one pull request each, stacked on the run branch
+`fiat/a-pinned-gas-rule-corpus-hermes-enforces` cut from `origin/main` at
+`0bfad60bb482245dd08d9747139d26824392a2c7`, with `main` as the single merge
+target at the end.
+
+Steps 3 and 4 split the 120-rule transcription in half on purpose. Each half is
+one audit round of the same kind of review, rule by rule, against the two
+authored fields the study's risk register calls out; one round of 120 records
+is the shape that gets skimmed.
+
+## Step 1: Scaffold: commit the study and runbook
+
+**Goal.** The run's spec is a reviewed artefact in the tree rather than a controller state file.
+**Entry.** The run branch at `0bfad60bb482245dd08d9747139d26824392a2c7`, a clean tree.
+**Exit.** Both committed documents pass their checks and the tree's guards hold:
+
+```bash
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/hermes-rule-corpus-study.md
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/hermes-rule-corpus-runbook.md
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs
+python3 -m unittest discover -s tests
+python3 plugins/hermes/skills/hermes/scripts/test_hermes.py
+```
+
+**Files.** `docs/hermes-rule-corpus-study.md`, `docs/hermes-rule-corpus-runbook.md`, `.horos/boundary.json` (regenerated for the two new paths).
+**Tests.** None new; the root suite and the Hermes suite run as the regression net.
+**Disciplines.** hypomnema: the committed study is the standing source the step 6 ledger row and both decision records point at. phylax: none, a Markdown diff opens no boundary. ephoros: none, nothing runs unattended. metron: none, no performance claim. elenchus: none, no failure in hand.
+
+## Step 2: The schema, the validator, and the refusal data
+
+**Goal.** `hermes.py corpus --validate` holds a corpus file to a pinned schema, and the 28 rejected universal rules and 40 citations are in the tree with the source document they came from.
+**Entry.** Step 1's exit state, on a branch cut from the step 1 branch.
+**Exit.** The validator passes over the refusal data and refuses a corrupted copy:
+
+```bash
+python3 plugins/hermes/skills/hermes/scripts/hermes.py corpus --validate
+python3 plugins/hermes/skills/hermes/scripts/test_hermes.py
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+shasum -a 256 docs/hermes-rule-corpus/reference-solidity-0.8.25.md
+```
+
+The last command has to print `297c926dc0a2e011e31da5245273c136273b8faa390f3691910c22c870068449`.
+The document commits byte for byte, including the two lines that end in whitespace. No committed check runs `git diff --check` here, and tidying those lines would break the digest the corpus cites, so the round leaves them alone.
+
+**Files.** `plugins/hermes/skills/hermes/references/gas-rule-corpus.schema.json`, `plugins/hermes/skills/hermes/references/gas-rule-corpus.json` (myths, references, and an empty rule list), `plugins/hermes/skills/hermes/scripts/hermes.py` (the `corpus` subcommand), `plugins/hermes/skills/hermes/scripts/test_hermes.py`, `docs/hermes-rule-corpus/reference-solidity-0.8.25.md` (the pinned source, byte for byte), `tests/promise_machine_coverage.json` (the `hermes.py` digest moves with the source), `.horos/boundary.json`.
+**Tests.** A corpus class in `test_hermes.py`: schema acceptance, an unknown field refused, a duplicate id refused, a myth id whose correction is empty refused, a citation id that resolves to two URLs refused, the 28 and 40 counts asserted, and a citation written at the start of a line counted as a use rather than a definition. Expected around ten new cases, on top of the existing fourteen.
+**Disciplines.** phylax: this step opens the corpus read, so the path is fixed relative to the script, the content is schema-validated before use, and no record is imported or evaluated. hypomnema: the schema file is the interface a later promise pins, and its shape is recorded in the study rather than invented here. elenchus: the Promise Machine binding-digest refusal is expected on the `hermes.py` edit and takes the checker's own remedy if it fires. ephoros: none, nothing runs unattended. metron: none, the budget claim belongs to step 5 where the corpus is loaded on every verify.
+
+## Step 3: The first 61 rules
+
+**Goal.** The `CMP`, `STO`, `TRN` and `MEM` rules are in the corpus, each tracing to its source section, each carrying its Hermes class or none, and each carrying a declared scope with the reason for its bounds.
+**Entry.** Step 2's exit state, on a branch cut from the step 2 branch.
+**Exit.** The validator passes over the larger corpus and the counts are asserted:
+
+```bash
+python3 plugins/hermes/skills/hermes/scripts/hermes.py corpus --validate
+python3 plugins/hermes/skills/hermes/scripts/test_hermes.py
+python3 -m unittest discover -s tests
+```
+
+**Files.** `plugins/hermes/skills/hermes/references/gas-rule-corpus.json`, `plugins/hermes/skills/hermes/scripts/test_hermes.py`, `.horos/boundary.json`.
+**Tests.** Per-section counts asserted at 12, 27, 7 and 16; every rule's class resolving to one of the twelve or to none; every rule carrying a source section, a scope range, a fork floor and a stated reason per bound; every automation value inside `safe`, `guarded`, `never`; every evidence grade inside `A`, `B`, `C`, `X`. Expected around six new cases.
+**Disciplines.** hypomnema: the identifier namespace becomes public here, and the decision record naming it is cut in step 6 against this data. elenchus: a transcription fault found in the round is worked to its cause in the source section rather than patched in the record. phylax: none beyond step 2's corpus read, which this step only feeds. ephoros: none, nothing runs unattended. metron: none, no performance claim.
+
+## Step 4: The remaining 58 rules
+
+**Goal.** The `CTL`, `EXT`, `DEP` and `YUL` rules complete the corpus at 120.
+**Entry.** Step 3's exit state, on a branch cut from the step 3 branch.
+**Exit.** The complete corpus validates and the total is asserted:
+
+```bash
+python3 plugins/hermes/skills/hermes/scripts/hermes.py corpus --validate
+python3 plugins/hermes/skills/hermes/scripts/test_hermes.py
+python3 -m unittest discover -s tests
+```
+
+**Files.** `plugins/hermes/skills/hermes/references/gas-rule-corpus.json`, `plugins/hermes/skills/hermes/scripts/test_hermes.py`, `.horos/boundary.json`.
+**Tests.** Per-section counts asserted at 18, 14, 12 and 14, the total asserted at 120, and every rule id in the source document present in the corpus exactly once. Expected around five new cases.
+**Disciplines.** hypomnema: same namespace decision as step 3, now complete. elenchus: as step 3, a transcription fault goes back to its source section. phylax: none beyond the corpus read. ephoros: none, nothing runs unattended. metron: none, no performance claim.
+
+## Step 5: Seal the corpus at Gate 1 and require a rule at Gate 2
+
+**Goal.** `baseline` seals the corpus digest beside the Foundry configuration, `verify` requires `--rule`, and the seven refusals in the study's item 11 each stop the run at Gate 2 with a structured reason before any Forge test or snapshot runs.
+**Entry.** Step 4's exit state, on a branch cut from the step 4 branch.
+**Exit.** The refusals fire, the accepted record carries the corpus fields, and the budget holds:
+
+```bash
+python3 plugins/hermes/skills/hermes/scripts/test_hermes.py
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+time python3 plugins/hermes/skills/hermes/scripts/hermes.py corpus --validate
+```
+
+The timed command stays under one second and the Hermes suite stays under 25 seconds, both compared against the recorded 10.7 seconds the suite takes at the run's base.
+
+**Files.** `plugins/hermes/skills/hermes/scripts/hermes.py`, `plugins/hermes/skills/hermes/scripts/test_hermes.py`, `plugins/hermes/skills/hermes/SKILL.md` (the command contract, the required flag, and the new promise heading), `tests/promise_machine_coverage.json`, `tests/test_promise_machine_contract.py`, `.horos/boundary.json`.
+**Tests.** One case per refusal: unknown rule id, myth cited as justification, declared class disagreeing with the rule's class, rule outside the resolved scope, scope unresolvable because `solc` is null, scope unresolvable because the fork name is unknown, obligation answer blank, corpus digest moved since the baseline, and a `verify` call omitting `--rule` altogether. Plus an accepted run whose `result.json` carries the corpus digest, the rule id and the obligation answers, and a case proving a fork floor of `cancun` is satisfied by `osaka` rather than refused. Expected around eleven new cases.
+**Disciplines.** phylax: rule ids and obligation text reach the process here, so ids are pattern-matched before they select anything and text is recorded as JSON data, never interpolated into a command. metron: the budget in the study's item 10 is claimed by this step, so it is measured before and after rather than asserted. ephoros: `result.json` gains the two fields that answer the study's item 8 questions. hypomnema: the exit-code decision and the required-flag decision are cut in step 6 against this implementation. elenchus: the Promise Machine coverage and contract refusals are expected on this diff and take their own remedies.
+
+## Step 6: Record the decisions, close the frontier, and demonstrate
+
+**Goal.** Two decision records stand, the catalogue points at the corpus, the six frontier surfaces carry one agreed successor, the ledger gains its single epoch row, and the demo path from the study runs clean.
+**Entry.** Step 5's exit state, on a branch cut from the step 5 branch.
+**Exit.** The demo path from the study's problem statement, plus every guard the changed surfaces incur:
+
+```bash
+python3 plugins/hermes/skills/hermes/scripts/hermes.py corpus --validate
+python3 plugins/hermes/skills/hermes/scripts/test_hermes.py
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+python3 plugins/horos/skills/horos/scripts/horos.py scan . --write
+```
+
+**Files.** `docs/decisions/ADR-007-displace-the-hermes-evidence-bundle-target.md`, `docs/decisions/ADR-008-adopt-the-source-document-rule-namespace.md`, `plugins/hermes/skills/hermes/EVOLUTION.md` (the epoch row `hermes-v0.1.1`), `plugins/hermes/skills/hermes/SKILL.md`, `plugins/hermes/skills/hermes/references/optimisation-catalogue.md`, `plugins/hermes/AGENTS.md`, `plugins/hermes/README.md`, `README.md`, `.horos/boundary.json`.
+**Tests.** No new test file; the standing guards are the evolution suite over the epoch row, the marketplace-prose suite over the six frontier surfaces and the uniqueness of the landing README's job topic, the shipped-prose lint over every changed document, and the hypomnema shape codes over both decision records.
+**Disciplines.** hypomnema: this step is the record, so the two decision records and the ledger row are its whole subject, and each takes the template shape the record lint holds. ephoros: none, nothing runs unattended. phylax: none, a prose and ledger diff opens no boundary. metron: none, the budget was measured in step 5. elenchus: the evolution row arithmetic and the frontier-agreement suite are the two most likely failures here, and each is worked to its cause rather than by adjusting a row until a test passes.

--- a/docs/hermes-rule-corpus-study.md
+++ b/docs/hermes-rule-corpus-study.md
@@ -1,0 +1,168 @@
+# Study: A pinned gas-rule corpus Hermes enforces
+
+Assuming, unless corrected:
+
+1. This is a frontier advance, and the held `live-evidence-bundle` target is displaced rather than completed. The ledger takes two rows: an epoch row `hermes-v0.1.1` cut in step 1, carrying the new frontier revision, gap and digest and stating that the evidence-bundle target is reopened rather than closed; then an evolution row `hermes-v1.1.1` cut in the last step when the corpus job completes, carrying its successor. The epoch row's change text has to contain the word `reopen`, which is what the root evolution suite checks when an epoch row moves the digest. That arithmetic, the header agreement and the reopen guard were run against `tests/test_evolution_contract.py`'s own helpers before this study was written, so the construction is checked rather than assumed.
+2. The reading behind assumption 1 is worth one look, because the contract's reopening paragraph is written for a frontier that has gone `mature`, and this one is `open`. Two readings are available: the epoch mechanism generalises, so a maintainer-supplied requirement can displace an open target as long as the boundary is recorded, which is the reading this study takes; or nothing may displace an open target, in which case the corpus cannot become the frontier until the evidence bundle ships and this run is a generation advance instead. The second reading changes the ledger rows and the two prose sweeps, and nothing else in this study.
+3. Being a frontier run, this owes the reconciliation the versioning contract states: a cold read of all mutable first-party marketplace prose across the checkout before the job is recorded as done, not only the six Hermes surfaces that carry the frontier sentence.
+4. `--rule` becomes required on `verify`. That deliberately breaks every existing Hermes invocation, which is the second half of what makes the epoch row honest. A candidate with no corpus rule cannot run; the corpus gains the rule in a separate change first, the way a missing property test already gets added in a preparatory change before the candidate is measured.
+5. The reference document supplied for this run, SHA-256 `297c926dc0a2e011e31da5245273c136273b8faa390f3691910c22c870068449`, is the only source for the corpus. Every record traces to one of its sections, and this run adds no rule of its own invention.
+6. The corpus ships as JSON data with generated prose beside it. The document scores 35.3/100 with 168 imprimatur defects, and the root suite holds every tracked `.md` outside `audit/` and `docs/` clean, so the document itself cannot ship under `plugins/`.
+7. Python 3.11 and stdlib unittest, matching the existing Hermes suite. The harness stays dependency-free, so the document's YAML schema is transcribed into JSON rather than parsed as YAML.
+8. `forge config --json` supplies `solc`, `evm_version` and `via_ir`, and `baseline` already seals that output as `baseline.forge-config.json` with its digest. The scope gate reads the sealed record rather than shelling out again.
+9. The run starts from `main` at `87e213c19e64687406d7ba7601e093929bb3d813`.
+
+## 1. Problem statement
+
+Hermes has gates and no knowledge. Six gates measure a candidate, refuse a regression, hold a storage layout and demand a property test for state-sensitive unchecked arithmetic, and the whole judgement of whether the candidate's idea is sound for this compiler and this fork sits outside the harness in twelve rows of catalogue prose. Two consequences are visible in the checkout today. The catalogue's `loop-arithmetic` row offers "a proven-safe unchecked increment", which the document's MYTH-02 rejects for every compiler at or above 0.8.22, and nothing in the run records which body of advice judged an accepted candidate.
+
+This run gives Hermes a corpus it enforces: 120 rules with their evidence grade, automation level, preconditions and proof obligations, 28 rejected universal rules, and 40 citations, transcribed into a JSON corpus whose digest `baseline` seals beside the Foundry configuration and which `verify` consults before any Forge test or snapshot runs. Rule selection becomes required, so the corpus is the way in rather than an option beside it.
+
+Done means a rule id selects the candidate; the harness refuses an unknown id, a rejected universal rule, a rule whose class disagrees with the declared class, a rule outside the scope the sealed configuration resolves, an unresolvable scope, an unanswered proof obligation, and a corpus whose digest moved after the baseline, each before Gate 3 spends a Forge run; an accepted `result.json` carries the corpus digest, the rule id and the recorded obligation answers; the six Hermes surfaces and the root selection table carry one agreed successor frontier; and the demo path holds:
+
+```bash
+python3 plugins/hermes/skills/hermes/scripts/hermes.py corpus --validate
+python3 plugins/hermes/skills/hermes/scripts/test_hermes.py
+python3 -m unittest discover -s tests
+```
+
+## 2. Prior art
+
+- `plugins/hermes/skills/hermes/scripts/hermes.py` owns the run: `baseline`, `verify`, `promote`, `status`, the six gates, exit codes `10` to `60`, the twelve `OPTIMISATION_CLASSES`, the evidence directory and `result.json`. `baseline` writes `baseline.forge-config.json` and records its SHA-256; `verify` already refuses a changed Forge version or Foundry configuration. That is the record the scope gate reads and the pattern the corpus digest follows.
+- `references/optimisation-catalogue.md` holds the twelve classes as prose with per-class risk and pre-checks. It stays the reading surface; the corpus becomes the machine surface beneath it.
+- The last two merged pull requests that changed the target: [skills#95](https://github.com/wildcat-finance/skills/pull/95) compressed the six Hermes Markdown surfaces and states that the gates, the exit codes `0/10/20/30/40/50/60`, the layout checks and the arithmetic refusals stay intact, which item 3 turns into a bounded constraint rather than a blanket one now that the command surface breaks on purpose; and [skills#22](https://github.com/wildcat-finance/skills/pull/22) normalised compilation-local AST identifiers in the Gate 5 layout comparison and removed the incomplete `v2-protocol` example. Both closed their issues with every box ticked ([skills#21](https://github.com/wildcat-finance/skills/issues/21), [skills#23](https://github.com/wildcat-finance/skills/issues/23)), so neither carries unfinished work forward. The one open item they leave behind is the held frontier, which assumption 1 reopens rather than drops.
+- `audit/AUDIT.md` holds no Hermes round. It was read before design options were drawn, and there is no accepted lead and no prior finding bearing on this work.
+- Sibling precedent in this checkout: Imprimatur ships `lexicon/hard.json`, `gated.json` and `structural.json` as data behind one script, which is the shape this corpus takes. Alexandria, Berean and Lazarus each pin a schema file rather than a script in `tests/promise_machine_coverage.json`, so a corpus schema is an accepted subject for a promise.
+- `plugins/pandects/` is a Foundry root in this checkout at `solc_version = "0.8.28"` and `evm_version = "cancun"`, available as a real smoke target beside the hermetic fake-Forge fixture the Hermes suite already uses.
+- `.agents/skills/` now holds only the portable Promise Machine router, so the Hermes copy that skills#95 also had to edit no longer exists and is not a surface this run reconciles.
+- Outside: the document's own evidence corpus, meaning Aave v3, Uniswap v3 and v4, Permit2, Seaport, Solady and OpenZeppelin v5.0.2, plus EIP-1153, EIP-2929, EIP-2200, EIP-3529, EIP-3860, EIP-6780, EIP-170 and the versioned Solidity 0.8.25 documentation.
+
+## 3. Constraints and non-goals
+
+- Starting ref: `main` at `87e213c19e64687406d7ba7601e093929bb3d813`, clean tree.
+- Exit codes `10` to `60` keep their published per-gate meanings, and no seventh code is minted. The command surface is what breaks: `verify` gains a required flag, and every documented invocation moves with it.
+- The six gates, their order, and the twelve class names do not move. A corpus rule maps onto one existing class or onto none.
+- Six surfaces carry the frontier sentence and are held in agreement by the root suite: `plugins/hermes/README.md`, which also carries the single rolling-job line the root suite allows nowhere else, `plugins/hermes/AGENTS.md`, `plugins/hermes/skills/hermes/SKILL.md`, `references/optimisation-catalogue.md`, `EVOLUTION.md`, and the root `README.md` selection table. The landing README's job topic has to stay unique across all fourteen plugins and end with a full stop. Both the epoch row and the evolution row move that sentence, so the prose sweep happens twice.
+- `tests/promise_machine_coverage.json` pins the SHA-256 of `hermes.py`, so the coverage digest moves in the same commit as the source. A new authorising transition earns a promise heading in `SKILL.md`, which also touches `tests/test_promise_machine_contract.py`.
+- `tests/test_version_propagation.py` pins the Hermes package version at `0.1.1`, separately from the skill label. The package version moves only if that test moves with it.
+- `.horos/boundary.json` is regenerated for every added path, and the corpus stays pretty-printed so it is readable rather than classified as a blob.
+- Every rule record cites the document section it came from. A record with no traceable source is a defect, not a judgement call.
+- Non-goal: detectors. The document's `detector_signals` ship as recorded data, not as an engine that nominates candidates. Hermes measures what a human nominated, and the document's own section 16 says a detector still needs the artifact benchmark.
+- Non-goal: publishing the live Wildcat evidence bundle. The epoch row reopens that target; this run does not deliver it.
+- Non-goal: L2 and non-Ethereum fee models, which the document scopes out itself.
+- Non-goal: implementing CMP-12. Custom optimizer step sequences are transcribed as a rule with automation `never` and nothing more.
+- Non-goal: rewriting the reference document into house register. It is preserved as a source of record.
+
+The topic stays one study rather than a decomposition. The corpus, its validator and the required Gate 2 binding cannot be verified apart: a corpus nobody consults proves nothing, a validator with no corpus has nothing to hold, and the binding with neither has no rule to resolve. One demo path exercises all three, so the criteria do not cluster into separately shippable groups.
+
+Boundaries this run works under:
+
+- Always. Both the Hermes suite and the root suite before a commit. The imprimatur lint on every changed document. The three tree-reading skill lints from the root. A regenerated `.horos/boundary.json` for every added path. A recorded measurement before any claim about the budget in item 10.
+- Ask first. Adding a dependency of any kind, including a YAML parser. Changing an exit code, a gate order or a class name. Moving the package version pinned in `tests/test_version_propagation.py`. Adding or amending a Promise Machine heading. Choosing the successor frontier the evolution row carries.
+- Never. Commit an RPC credential or key material. Rewrite the pinned source document. Delete or weaken a failing Hermes test to make the suite pass. Fetch a citation URL from the harness. Invent a rule, a scope bound or a citation the source document does not carry. Move the held target without the epoch row that records the boundary. Report a gate as passed when its command did not run.
+
+## 4. Design options
+
+1. **Ship the document as a reference and cite it from the catalogue.** Cheapest, and it fails on two counts: the document carries 168 lint defects so it cannot ship under `plugins/`, and it leaves every one of its disciplines as advice the run may skip. Hermes exists because the ideas are cheap and the evidence is the job, and a second document adds ideas.
+2. **Corpus and validator, advisory to the harness.** The rules become JSON records with the document's schema, and a validator holds the schema, unique ids, resolvable citations and the class mapping. Better, and the gates still cannot see it: a candidate justified by MYTH-02 passes every gate it passed yesterday.
+3. **Corpus, validator, and a required Gate 2 binding, with the corpus digest sealed at Gate 1.** Chosen. `verify` requires `--rule <ID>`, resolves it in the corpus the baseline sealed, and refuses seven ways before Gate 3 spends a Forge run: an unknown id, a rejected universal rule, a class disagreement, a rule outside the resolved scope, a scope that cannot be resolved, a proof obligation with no recorded answer, and a corpus whose digest moved since the baseline. `result.json` gains the corpus digest, the rule id and the obligation answers. It trades away the automatic candidate discovery of option 4 and every existing invocation script, and it accepts a real hazard: obligation answers are recorded judgement, not proof, so the run can produce a well-filled form. The mitigation is that the six hard gates are untouched, the obligations are per-rule and few, and the record says plainly which fields are judgement.
+4. **A detector engine over the source.** Rejected, and rejected again after the run was reframed as a frontier advance, since the reframing changes none of its costs. Executable `detector_signals` make Hermes propose candidates, which inverts the discipline the skill is built on, and it is a second product with a false-positive budget nobody has asked for.
+
+A fifth option was considered and dropped inside option 3: an escape hatch for a candidate with no corpus rule, taking a rationale the way the layout-change and non-sensitive-unchecked flags already do. It loses because a rationale flag is the one refusal every operator can satisfy by typing, which would leave the required binding required in name only.
+
+## 5. Risk register seed
+
+```risk-register
+frontier-displacement | the epoch row against the versioning contract and the public job text | the row states that the evidence-bundle target is reopened rather than completed, contains the word reopen, carries a new revision and digest, and lands before the frontier job starts
+cli-break | the required rule flag against every documented invocation | every command in the six surfaces moves with the flag, and the suite covers a verify call that omits it
+successor-judgement | the evolution row's next job against the run's own evidence | the successor is chosen at the end of the run, not assumed here, and the reopened evidence bundle is the default the row has to argue against
+corpus-schema-drift | the corpus file against its validator | every record validates, ids are unique, an unknown field is refused, and each rule's class resolves to one of the twelve or to none
+transcription-fidelity | 120 rules, 28 myths and 40 citations against the pinned source document | each record cites its source section, each citation id resolves to exactly one URL, and the counts 120, 28 and 40 are asserted
+citation-shape | a citation written at the start of a line against a footnote definition | the validator counts definitions rather than line-initial markers, since REF-25 appears both ways in the source
+myth-as-justification | the candidate's declared rule and rationale text against the 28 rejected rules | a myth id named as a rule is refused, and a rationale citing one is refused with the myth's correction quoted
+scope-false-refusal | a rule's declared range against the configuration the baseline sealed | a fork ordering decides cancun against osaka rather than string equality, a null solc refuses the scope claim instead of assuming one, and an unknown fork name refuses
+corpus-digest-drift | the corpus at verify against the corpus the baseline sealed | a corpus edited between the two commands refuses rather than judging the candidate under advice nobody sealed
+obligation-theatre | the recorded obligation answers against the six hard gates | a blank or whitespace answer is refused, the six gates are unchanged, and result.json marks obligation answers as recorded judgement
+exit-code-interface | the corpus refusals against the published codes 10 to 60 | corpus refusals exit 20 with a structured reason field, and the existing per-gate codes keep their firing conditions under the current tests
+binding-digest | hermes.py against its pinned SHA-256 in the Promise Machine coverage | the coverage digest and any new promise heading land in the same commit as the source change
+citation-network | the 40 reference URLs against the harness boundary | citations are recorded data, never fetched, and the harness opens no socket
+class-mapping-error | each rule's declared Hermes class against what the rule actually changes | the mapping is reviewed rule by rule in the audit round, and a rule with no source-level candidate maps to none and is refused as a candidate with that reason
+```
+
+The audit loop should look hardest at frontier-displacement, scope-false-refusal and class-mapping-error. The first is the one a later reader will most easily mistake for a rolling target, since the marketplace's own published sentence tells them a job changes only when that exact job completed, and the epoch row is the only thing that makes this run's move legible instead. The other two are authored fields rather than transcribed ones, so no schema check can catch a wrong value, and both fail in the direction that refuses a correct candidate or admits one the target's compiler cannot support.
+
+## 6. Glossary seeds
+
+- Rule id: one of the document's 120 identifiers, such as `STO-09`, adopted verbatim as the public selector.
+- Myth id: one of the 28 `MYTH-NN` entries in the document's rejected-rules table, refusable as a justification and never selectable as a rule.
+- Hermes class: one of the twelve existing `OPTIMISATION_CLASSES`, or none for a rule that constrains the run rather than changing source.
+- Declared scope: the compiler range, fork floor and pipeline set over which a rule's mechanism holds, each with a stated reason, as distinct from the single 0.8.25 and Cancun pins the document was written against.
+- Fork order: the authored ordering of EVM fork names the scope gate compares against, with an unknown name refusing rather than passing.
+- Obligation answer: the recorded text answering one of a rule's proof obligations, marked in the evidence as judgement rather than measurement.
+- Corpus digest: the SHA-256 of the corpus file, sealed at Gate 1 and written into `result.json`, so an accepted candidate names the advice that judged it.
+- Displaced target: a held frontier job that a maintainer decision moves off the frontier without completing it, recorded as an epoch boundary and reopened as a candidate successor.
+
+## 7. Sources
+
+- The reference document supplied for this run, SHA-256 `297c926dc0a2e011e31da5245273c136273b8faa390f3691910c22c870068449`, 1188 lines, 120 rules, 28 rejected rules, 40 citations.
+- `plugins/hermes/skills/hermes/SKILL.md`, `scripts/hermes.py`, `scripts/test_hermes.py`, `references/optimisation-catalogue.md`, `EVOLUTION.md`, `plugins/hermes/AGENTS.md`, `plugins/hermes/README.md`
+- `plugins/hexaemeron/skills/VERSIONING.md`, for the axis definitions, the frontier-hold rule and the reopening boundary
+- `tests/promise_machine_coverage.json`, `tests/test_promise_machine_contract.py`, `tests/test_evolution_contract.py`, `tests/test_marketplace_prose.py`, `tests/test_shipped_prose_lints.py`, `tests/test_version_propagation.py`
+- `audit/AUDIT.md`, which holds no Hermes round
+- [skills#95](https://github.com/wildcat-finance/skills/pull/95), [skills#22](https://github.com/wildcat-finance/skills/pull/22), [skills#21](https://github.com/wildcat-finance/skills/issues/21), [skills#23](https://github.com/wildcat-finance/skills/issues/23)
+- `forge config --json` observed in `plugins/pandects` and in an unpinned scratch root, which is where assumption 8 and the scope-false-refusal risk come from
+
+## 8. Signals, and the questions behind them
+
+Two questions, both asked of a run that already finished, and both answered by the step that adds the Gate 2 binding.
+
+- Which corpus and which rule judged this accepted candidate? Answered by the corpus digest and rule id in `result.json`, beside the existing class and target set.
+- Why did this run refuse before any Forge test or snapshot ran? Answered by the structured refusal reason in `result.json` and the same text on stderr, naming the rule and the failed condition.
+
+No alert and no unattended path: Hermes is invoked from a terminal in the user's target repository and writes its record there. [ephoros](../plugins/hexaemeron/skills/ephoros/SKILL.md) owns what a signal carries.
+
+## 9. Boundaries, per capability
+
+- Reading the corpus. The path is fixed relative to the script rather than taken from the caller, the content is schema-validated before use, and no record is imported or evaluated as code.
+- Rule ids and obligation text reaching the process. Ids are matched against a strict pattern before they select anything, obligation and rationale text is recorded as JSON data and never interpolated into a command, and the existing list-form subprocess calls are unchanged.
+- The 40 citation URLs. Recorded data only. The harness fetches nothing and opens no socket, and this run adds no dependency that would.
+- The scope gate's input. It reads the Foundry configuration the baseline already sealed, so it opens no boundary the run did not already have.
+
+[phylax](../plugins/hexaemeron/skills/phylax/SKILL.md) owns the boundary rules, and its lint runs each round.
+
+## 10. The budget, or its absence
+
+One budget, because the corpus is the first data file the harness loads on every `verify`, and a slow gate gets skipped.
+
+```bash
+time python3 plugins/hermes/skills/hermes/scripts/hermes.py corpus --validate
+time python3 plugins/hermes/skills/hermes/scripts/test_hermes.py
+```
+
+Full corpus validation stays under one second, and the Hermes suite stays under 25 seconds against the 10.7 seconds it takes today. [metron](../plugins/hexaemeron/skills/metron/SKILL.md) owns how a budget is measured and what a breach costs.
+
+## 11. The fail-closed posture
+
+Seven new refusals stop the run at Gate 2 with exit `20` and a structured reason: an unknown rule id, a myth cited as justification, a declared class disagreeing with the rule's class, a rule outside the resolved scope, a scope that cannot be resolved because `solc` is null or the fork name is unknown, a proof obligation with no substantive answer, and a corpus digest that moved since the baseline sealed it. A corpus that fails its own validation refuses the same way, so a corrupt corpus cannot admit a candidate. Each refusal ships with the test that fails without its check, which is the guard convention [elenchus](../plugins/hexaemeron/skills/elenchus/SKILL.md) owns, and the standing guards are the Hermes suite, the evolution suite over both new ledger rows, the marketplace-prose suite over the six frontier surfaces, the Promise Machine contract test over the promise headings, and the shipped-prose lint over every changed document.
+
+## 12. Decisions and their homes
+
+Five decisions are expensive to reverse, and the first two are the ones a later reader will most need explained.
+
+- The held `live-evidence-bundle` target is displaced by maintainer decision rather than completed, and the corpus becomes the frontier. Recorded as a decision record under `docs/decisions/`, and as the epoch row's change text, because the marketplace publishes the opposite default in every landing README and a displacement with no record reads later as a rolling target.
+- `--rule` becomes required, breaking every existing invocation. Recorded in the same decision record as the compatibility half of the same boundary, with the dropped escape hatch from item 4 named as the rejected alternative.
+- The corpus adopts the document's identifiers verbatim as its public namespace, and scope becomes a declared range with a stated reason rather than the document's literal 0.8.25 and Cancun pins. Recorded in a second decision record, because the namespace is what every later citation depends on and the scope model is the part a reader would otherwise reconstruct wrongly from the document's own header.
+- Corpus refusals keep exit code `20` and carry a structured reason rather than minting a seventh code. Recorded in that second record, with the rejected alternative stated: a new code would read as a seventh gate that does not exist.
+- The corpus is data with generated prose rather than a shipped document. Recorded in the evolution row and in this study, since the reason is the lint scope stated in assumption 6 rather than a design preference.
+
+[hypomnema](../plugins/hexaemeron/skills/hypomnema/SKILL.md) owns which decisions earn a record and where each one lives.
+
+### Amendment -- 2026-08-21
+
+**What changed.** Three things, all settled by reading the controller rather than the contract prose. First, the ledger takes one row, not two: an epoch row `hermes-v0.1.1` whose change text records the reopening, carrying the new revision, gap, next job and digest. The evolution counter stays where it is, because the contract reserves it for completing a held job and the held evidence-bundle job is not what this run completes. Second, the starting ref moves from `87e213c19e64687406d7ba7601e093929bb3d813` to `0bfad60bb482245dd08d9747139d26824392a2c7`. Third, the frontier sentence moves once rather than twice, since one row means one prose sweep.
+
+**Why.** `hexctl`'s `frontier_close_fault` refuses a declared ledger that gained other than exactly one history row, and refuses an epoch row that moves the digest without the word `reopen` in its evidence or change text. Fiat's hard rules also state that an epoch is the axis that may replace a held next job, which settles the reading assumption 2 left open in favour of the epoch and against a generation. On the base: `origin/main` advanced nine commits ahead of the local ref while this study was being written, all of them Hypomnema's H007 alert-runbook shape check. None of them touches Hermes, `VERSIONING.md`, or the four root suites this study depends on, and the `hermes.py` digest pinned in `tests/promise_machine_coverage.json` still matches the file, so every other fact on this page survives the move. The local `main` is checked out in another worktree and cannot be fast-forwarded from here without disturbing it, so the run branch is cut from `origin/main` at that SHA and `main` stays the base the run merges into once.
+
+**Steps touched.** None. No step exists yet; the runbook is derived from this amended study, and assumptions 1, 2 and 3 above are read as amended here.
+
+**Still holding.** Every other item. The problem statement, the chosen design and its rejected alternatives, the seven Gate 2 refusals, the corpus digest sealed at Gate 1, the required rule flag and the dropped escape hatch, the risk register, the boundary tiers, the budget, and the six frontier surfaces are unchanged. The `frontier-displacement` and `successor-judgement` risk lines still apply and now read against one row rather than two.

--- a/docs/hermes-rule-corpus/reference-solidity-0.8.25.md
+++ b/docs/hermes-rule-corpus/reference-solidity-0.8.25.md
@@ -1,0 +1,1188 @@
+# Solidity 0.8.25 Gas Optimization Reference
+
+**revision:** citation-preserving markdown edition  
+**compiler target:** Solidity `0.8.25`  
+**baseline EVM target:** Cancun / Ethereum L1
+
+> citation convention: inline references use standard Markdown footnotes such as `[^REF-01]`. Every footnote contains an ordinary Markdown link, and the final citation table duplicates the complete source list so the references survive download, copy/paste, GitHub rendering, and most static-site generators.
+
+## 1. scope
+
+this reference is intended for an agent that evaluates an existing Solidity codebase and proposes gas optimizations. it targets:
+
+- Solidity `0.8.25`
+- `evmVersion = "cancun"`
+- both legacy and via-IR compiler pipelines
+- Ethereum L1 Cancun gas semantics as the baseline
+- separate benchmarking for every L2 or non-Ethereum EVM chain
+- production systems where correctness, upgrade safety, auditability, and liveness dominate minor gas reductions
+
+Solidity 0.8.25 defaults to Cancun, can emit `MCOPY` for memory copies, and exposes `TLOAD`/`TSTORE` through inline assembly. canonical standard `for`-loop increments have been automatically unchecked since Solidity 0.8.22.[^REF-01][^REF-02]
+
+## 2. operating principles
+
+### optimization priority
+
+evaluate candidates in this order:
+
+1. remove unnecessary transactions, transfers, callbacks, or persistent state transitions;
+2. replace unbounded or asymptotically poor state models;
+3. reduce `SSTORE`, then `SLOAD`;
+4. reduce external calls and token movements;
+5. reduce calldata, memory allocation, copying, and hashing;
+6. improve control flow and arithmetic;
+7. consider assembly and opcode-level transformations last.
+
+the major production patterns support this order: Aave compresses and lazily updates protocol state; Uniswap v3 uses bitmaps and specialized arithmetic; Uniswap v4 replaces intermediate transfers with transient net-delta accounting; Seaport specializes common execution paths.[^REF-15][^REF-16][^REF-19][^REF-20][^REF-22][^REF-23][^REF-27]
+
+### evidence grades
+
+| grade | meaning |
+|---|---|
+| A | mechanism is defined by compiler or EVM semantics and appears in mature, audited production code |
+| B | mechanism is sound and has production evidence, but applicability is strongly workload-dependent |
+| C | specialist or research-backed optimization requiring local artifact evidence and strong equivalence testing |
+| X | obsolete advice, folklore, or a contextual technique that must not be emitted as a universal rule |
+
+### automation levels
+
+| level | agent policy |
+|---|---|
+| safe | agent may patch after mechanically establishing preconditions, then run the full validation gate |
+| guarded | agent may prepare a patch, but a human must review the proof and approve the change |
+| never | suggestion only; architecture, storage layout, ABI, transient-storage, and assembly consequences remain human-owned |
+
+## 3. proposed rule schema
+
+```yaml
+id: STO-09
+title: cache repeated storage reads
+type: technique
+category: state-model-and-storage
+
+compiler_scope:
+  - 0.8.25
+evm_scope:
+  - cancun
+pipelines:
+  - legacy
+  - via-ir
+
+priority: P1
+expected_impact: high
+correctness_risk: low
+evidence_grade: A
+status: recommended
+
+summary: >
+  Copy a storage value to a stack local when it is read repeatedly
+  and cannot change during the relevant region.
+
+mechanism: >
+  Even warm SLOADs cost more than stack operations. The first access
+  may additionally be cold.
+
+detector_signals:
+  - same storage expression read multiple times
+  - repeated getters for the same packed word
+  - repeated mapping key and member path
+
+recommendation: >
+  Load once after the last preceding mutation and keep the cache scope narrow.
+
+preconditions:
+  - no internal write invalidates the cached value
+  - no callback or external call can make the value stale
+
+proof_obligations:
+  - every use observes the same version of the value
+  - cache placement dominates all uses
+
+failure_modes:
+  - stale state after callback or reentrancy
+  - excess stack pressure or code-size regression
+
+validation:
+  - optimized IR and assembly diff
+  - success and failure gas snapshots
+  - mutation and reentrancy tests
+
+automation:
+  autofix: safe
+
+references:
+  - EIP-2929
+  - Aave BorrowLogic
+tags:
+  - sload
+  - cache
+```
+
+## 4. compiler and measurement rules
+
+### CMP-01 — pin the complete build configuration
+
+**P0 · A · safe**
+
+pin the exact compiler binary, EVM target, optimizer state, run count, pipeline, metadata settings, libraries, and linked addresses. do not compare gas results produced by different configurations.
+
+### CMP-02 — optimize the production artifact
+
+**P0 · A · safe**
+
+production tests, fuzzing, invariants, audits, gas snapshots, and bytecode review must run against the optimized artifact. testing only an unoptimized debug build does not validate production code generation.
+
+### CMP-03 — treat optimizer runs as a lifecycle parameter
+
+**P1 · A · guarded**
+
+`runs` models expected lifetime executions and trades deployment/code size against runtime cost; it is not the number of optimizer iterations. benchmark a matrix of plausible values against expected deployment count and call frequency.[^REF-03]
+
+### CMP-04 — benchmark legacy and via-IR
+
+**P1 · B · never**
+
+neither pipeline is a universal winner. compile and validate both where the project is free to choose, but retain one canonical audited configuration.
+
+### CMP-05 — inspect optimized IR, assembly, and bytecode
+
+**P1 · A · safe**
+
+a source rewrite is not evidence of an optimization. confirm that generated code changes in the expected way and does not create a larger regression through inlining, stack layout, or code size.
+
+### CMP-06 — profile representative transaction paths
+
+**P0 · A · safe**
+
+define success, revert, cold, warm, first-use, repeat-use, batch, maximum-size, and adversarial scenarios before ranking candidates.
+
+### CMP-07 — measure cold and warm state independently
+
+**P0 · A · safe**
+
+state access and account access differ between first and subsequent uses within a transaction. `SSTORE` cost also depends on original, current, and new values.[^REF-10][^REF-11] one aggregate gas figure for a stateful function is generally lossy.
+
+### CMP-08 — report a cost vector, not one percentage
+
+**P0 · A · safe**
+
+report:
+
+- deployment and initcode
+- runtime success paths
+- runtime failure paths
+- calldata or data-availability cost
+- persistent state growth
+- number of transactions
+- system-wide transfers and approvals
+- break-even by usage scenario
+
+### CMP-09 — apply the compiler known-bugs gate
+
+**P0 · A · safe**
+
+a long-lived 0.8.25 pin needs an automated review against Solidity’s known-bugs list whenever source features or compiler settings change.[^REF-08]
+
+### CMP-10 — require semantic equivalence testing
+
+**P0 · A · guarded**
+
+optimization validation must cover outputs, storage, logs, reverts, calls, value movement, and protocol invariants. assembly and decoder rewrites should retain an executable reference implementation wherever possible.
+
+### CMP-11 — maintain scenario-level gas snapshots
+
+**P1 · A · safe**
+
+track named gas scenarios and linked runtime/initcode size in CI. accepted regressions require an explicit explanation.
+
+### CMP-12 — do not customize optimizer step sequences casually
+
+**P2 · C · never**
+
+a custom Yul optimizer sequence creates a bespoke compiler configuration with a large validation and maintenance burden. Solidity’s Yul optimizer is a set of interacting greedy passes rather than a globally optimal superoptimizer.[^REF-03]
+
+## 5. state model and storage
+
+### STO-01 — pack co-accessed bounded fields
+
+**P1 · A · never**
+
+pack fields when they are commonly read or written together and have durable range bounds. generate a bit-allocation specification and storage-layout diff.
+
+### STO-02 — use full-width arithmetic locals
+
+**P1 · A · guarded**
+
+use `uint256` or `int256` for stack and ordinary memory arithmetic unless narrow semantics are required. narrow widths usually help only when they improve storage packing; EVM stack words and ordinary memory elements remain 256 bits.
+
+### STO-03 — do not pack independently hot fields blindly
+
+**P1 · A · never**
+
+updating one packed field requires loading, masking, and rewriting the shared slot. packing fields that are usually updated separately can cost more despite using fewer slots. Solidity explicitly documents this read-modify-write trade-off.[^REF-04]
+
+### STO-04 — use packed configuration words
+
+**P1 · A · never**
+
+for stable protocol configuration, encode bounded fields with named masks and offsets. reserve extension bits and expose typed getters and setters.
+
+Aave v3’s reserve configuration is the canonical production model: many risk, collateral, borrowing, cap, and status values share packed words.[^REF-15]
+
+### STO-05 — load a packed word once
+
+**P1 · A · guarded**
+
+when several fields from one packed slot are required, cache the raw word and decode all values locally rather than invoking multiple getters.
+
+### STO-06 — aggregate packed updates into one write
+
+**P1 · A · guarded**
+
+load the word, apply every bit mutation locally, validate the final representation, and perform one `SSTORE`. do not expose unsafe intermediate state through callbacks.
+
+### STO-07 — use bitmaps for dense boolean state
+
+**P1 · A · guarded**
+
+use `mapping(uint256 => uint256)` words for dense flags, membership, initialization state, or bounded indexed domains.
+
+Uniswap v3 stores 256 tick initialization flags per word and uses bit scans to find the next initialized tick. Aave stores two user-state bits per reserve.[^REF-19][^REF-16]
+
+### STO-08 — use nonce bitmaps for unordered authorization
+
+**P1 · A · never**
+
+for parallel signed authorizations, partition a nonce into word index and bit position. Permit2 uses an unordered nonce bitmap instead of one storage slot per nonce.[^REF-25]
+
+### STO-09 — cache repeated `SLOAD`s
+
+**P1 · A · safe**
+
+load storage once when no mutation or callback can invalidate the value. keep the cache’s lifetime narrow. even a warm `SLOAD` is more expensive than stack reuse, while the first access to a slot may be cold.[^REF-10]
+
+### STO-10 — cache a storage base pointer
+
+**P1 · A · safe**
+
+replace repeated `mapping[key].member` expressions with a local storage reference when several members are accessed.
+
+### STO-11 — cache storage-array length when invariant
+
+**P1 · A · safe**
+
+cache `.length` before a loop only when the loop body and every reachable callback cannot change it. this is useful for storage arrays, not a universal rule for memory or calldata.
+
+### STO-12 — accumulate locally, commit once
+
+**P0 · A · guarded**
+
+load initial accounting state, perform bounded calculations locally, validate the final value, and execute one storage write.
+
+### STO-13 — skip common no-op writes
+
+**P1 · B · guarded**
+
+guard an `SSTORE` when idempotent calls are common and the old value is already loaded. benchmark the actual state distribution; adding an `SLOAD` and branch solely for the guard can lose.
+
+### STO-14 — validate before persistent writes
+
+**P0 · A · guarded**
+
+perform deterministic parameter, authorization, balance, and limit checks before storage mutation when this does not weaken reentrancy safety or required error precedence.
+
+### STO-15 — use constants for true compile-time values
+
+**P1 · A · safe**
+
+constants avoid storage initialization and reads. check code-size effects when a large expression or value is substituted at many call sites.
+
+### STO-16 — use immutables for deployment-time constants
+
+**P1 · A · guarded**
+
+immutables remove `SLOAD` at the cost of embedding values into runtime code. model repeated references, fleet size, proxies, and clone alternatives.
+
+### STO-17 — use fixed-width internal representations
+
+**P1 · A · never**
+
+use `bytes32` or another fixed-width type when protocol data is canonically bounded to one word. define padding and encoding at the boundary.
+
+### STO-18 — use short-string representations conditionally
+
+**P2 · A · never**
+
+for immutable labels bounded to 31 bytes, a `ShortString`-style word representation can avoid dynamic handling. retain a fallback when arbitrary strings are part of the interface.[^REF-31]
+
+### STO-19 — use code-as-data for large immutable blobs
+
+**P1 · B · never**
+
+an SSTORE2-style data contract can replace many storage slots with deployed code and `EXTCODECOPY`. include deployment, cold account access, copy cost, offsets, read frequency, code limits, and chain support in the break-even.[^REF-30]
+
+### STO-20 — use sentinel values to collapse state
+
+**P1 · B · never**
+
+reserve a value such as zero or maximum to represent uninitialized, unlimited, disabled, or another state only when that value can never become valid protocol data.
+
+### STO-21 — skip decrementing unlimited allowances
+
+**P1 · A · guarded**
+
+when maximum value explicitly means unlimited, branch before subtraction and avoid repeated allowance writes. Aave and Permit2 both use this motif.[^REF-17][^REF-26]
+
+### STO-22 — emit non-consensus history instead of storing it
+
+**P0 · A · never**
+
+use events for append-only history that no future on-chain transition needs to read. retain only current state, commitments, roots, counters, or data required for future verification.
+
+### STO-23 — use cumulative indexes and lazy checkpoints
+
+**P0 · A · never**
+
+replace iteration over every account with global cumulative indexes and per-account checkpoint-on-touch settlement. prove monotonicity, conservation, rounding, and long-horizon overflow bounds. Aave’s indexed balances and reserve-state updates are a mature production example.[^REF-18]
+
+### STO-24 — paginate or aggregate unbounded collections
+
+**P0 · A · never**
+
+do not return or process arbitrarily large storage collections. use bounded pages, indexed getters, commitments, pull claims, or event reconstruction.
+
+### STO-25 — delete storage for lifecycle correctness, not refund farming
+
+**P1 · A · never**
+
+refunds are reduced and capped under the post-London gas schedule.[^REF-12] model clearing cost, likely reuse, state growth, and liveness; never add an unbounded cleanup loop for speculative refunds.
+
+### STO-26 — use mapping plus compact indexed registry
+
+**P1 · A · never**
+
+when both keyed lookup and enumeration are required, keep canonical records in a mapping and a dense list of keys or stable IDs. define tombstones and prohibit unsafe ID reuse.
+
+### STO-27 — treat storage layout as an external interface
+
+**P0 · A · never**
+
+field order, field width, packed masks, and raw slots are ABI-like commitments for proxies, delegatecalls, and storage-reference libraries. no gas rewrite may change them without a migration or equivalence proof.[^REF-04]
+
+## 6. transient storage
+
+### TRN-01 — transient reentrancy guards
+
+**P1 · A · never**
+
+on Cancun-compatible chains, a transient guard avoids persistent lock writes. prove nested-call behavior, multicall reuse, proxy/delegatecall ownership, and every intended clear boundary.[^REF-09]
+
+### TRN-02 — transaction-local callback context
+
+**P1 · A · never**
+
+use transient state for values that must survive external calls but must not survive the transaction: unlock status, phase, temporary authorization, or callback context.[^REF-09]
+
+### TRN-03 — transient mapping emulation
+
+**P1 · A · never**
+
+hash a namespace plus fixed-width logical keys into a transient slot. avoid dynamic packed preimages and prove namespace separation.
+
+Uniswap v4 derives transient slots for per-target, per-currency signed deltas.[^REF-22]
+
+### TRN-04 — net-delta or flash accounting
+
+**P0 · A · never**
+
+record signed transaction-local asset deltas and perform only final settlement rather than transferring assets after every internal operation.
+
+this removes gross intermediate transfers but requires a locked execution boundary, strict asset-conservation invariants, adversarial-token handling, and proof that every nonzero obligation is settled before exit. Uniswap v4 is the primary production reference.[^REF-24]
+
+### TRN-05 — unresolved-obligation counter
+
+**P0 · A · never**
+
+increment a transient counter on zero-to-nonzero obligation transitions and decrement on nonzero-to-zero transitions. assert zero at the final boundary instead of enumerating every touched key.[^REF-23]
+
+### TRN-06 — model `CALL` versus `DELEGATECALL` ownership
+
+**P0 · A · never**
+
+delegatecalled code operates on the caller’s transient state; a separately called contract owns separate transient state. slot namespaces and lock domains must match the proxy and module architecture.[^REF-09]
+
+### TRN-07 — chain-capability gate
+
+**P0 · A · safe**
+
+bytecode reaching `TLOAD` or `TSTORE` fails on a chain without EIP-1153. compiler success is not evidence that every deployment chain supports the artifact.[^REF-09]
+
+## 7. calldata, memory, and ABI
+
+### MEM-01 — retain read-only dynamic inputs in calldata
+
+**P1 · A · safe**
+
+declare external read-only dynamic arguments as `calldata` and avoid implicit conversion to memory.
+
+### MEM-02 — preserve calldata through internal helpers
+
+**P1 · A · guarded**
+
+a calldata parameter loses its advantage when the first helper accepts memory. use calldata helpers or carefully selected overloads.
+
+### MEM-03 — use calldata slices
+
+**P1 · A · guarded**
+
+validate offset and length once, then pass a calldata view rather than allocating and copying a subrange.
+
+### MEM-04 — use custom packed calldata only on concentrated hot paths
+
+**P0 · B · never**
+
+a custom byte format can remove ABI padding and redundant fields, but it creates a parser and a new external protocol.
+
+requirements:
+
+- versioned wire-format specification
+- canonical widths and byte order
+- off-chain reference encoder
+- reference Solidity decoder
+- malformed and truncated input fuzzing
+- signature and commitment compatibility tests
+- separate L1 and L2 fee measurements
+
+### MEM-05 — decode only the consumed fields
+
+**P1 · B · never**
+
+a specialized path need not allocate a maximal nested structure when it uses a few fixed fields. keep the generic decoder as a differential oracle.
+
+Seaport’s basic-order path demonstrates this optimization at production scale.[^REF-27]
+
+### MEM-06 — use scratch memory for fixed short-lived operations
+
+**P2 · A · never**
+
+use `0x00–0x3f` for ephemeral hashes or call data only when no pointer escapes and Solidity’s zero-slot and free-memory-pointer invariants remain valid.[^REF-06]
+
+### MEM-07 — allocate exact buffers
+
+**P2 · B · never**
+
+construct only the memory span required for a call, hash, event, revert, or return value. memory expansion is monotonic within the call frame.
+
+### MEM-08 — re-benchmark old memory-copy assembly under `MCOPY`
+
+**P2 · A · guarded**
+
+Solidity 0.8.25 can emit `MCOPY` for ordinary memory byte-array copies. preserve legacy assembly only when it retains a measured shape-specific advantage or different semantics.[^REF-01]
+
+### MEM-09 — avoid distant memory offsets
+
+**P1 · A · guarded**
+
+one access at a high offset expands memory over the entire intervening range. all attacker-controlled offset and length arithmetic requires explicit bounds.
+
+### MEM-10 — handle fixed returndata directly
+
+**P2 · B · never**
+
+when a caller needs only success, no data, or one fixed word, avoid allocating arbitrary bytes and passing them through a generic decoder.
+
+### MEM-11 — bound revert-data bubbling
+
+**P2 · B · never**
+
+unbounded `RETURNDATACOPY` allows a callee to force memory expansion. define whether errors are propagated, truncated, mapped, or replaced.
+
+### MEM-12 — hash fixed static tuples directly
+
+**P2 · B · never**
+
+for a fixed sequence of canonical 32-byte words, scratch-memory `KECCAK256` can replace generic `abi.encode`. differential-test every helper against the canonical encoding.
+
+### MEM-13 — return exact-size fixed data
+
+**P2 · B · never**
+
+assembly may write fixed ABI words and `return(pointer, length)` directly. every byte in the returned span must be initialized.
+
+### MEM-14 — support EIP-2098 compact signatures where compatible
+
+**P2 · A · guarded**
+
+accept 64-byte compact signatures alongside standard 65-byte signatures when wallet and library compatibility is established.
+
+### MEM-15 — use Merkle commitments for large static sets
+
+**P0 · A · never**
+
+replace large on-chain membership maps with a root plus proofs where set mutability and proof availability permit. define canonical leaf encoding, domain separation, ordering, and replay protection.
+
+### MEM-16 — never copy an unbounded storage array wholesale
+
+**P0 · A · never**
+
+narrow storage element types still consume ordinary 32-byte memory words after copying. expose indexed or bounded retrieval instead.[^REF-06]
+
+## 8. control flow and arithmetic
+
+### CTL-01 — order independent checks by cost and failure probability
+
+**P1 · A · guarded**
+
+cheap, frequently failing conditions should generally precede hashes, signatures, storage mutations, and external calls. preserve required error precedence and information policy.
+
+### CTL-02 — finish validation and effects before external interactions
+
+**P0 · A · never**
+
+use checks-effects-interactions or a deliberately locked callback state machine. do not move writes after a call merely to reduce reverted-write gas.
+
+### CTL-03 — hoist loop invariants
+
+**P1 · A · safe**
+
+move invariant hashes, storage reads, lengths, address derivations, and conversions outside loops when neither the loop body nor callbacks can mutate their dependencies.
+
+### CTL-04 — use canonical `for` loops
+
+**P2 · A · safe**
+
+prefer:
+
+```solidity
+uint256 length = items.length;
+for (uint256 i; i < length; ++i) {
+    _consume(items[i]);
+}
+```
+
+on 0.8.25, manually wrapping the increment in `unchecked` is generally redundant for recognized canonical loops.[^REF-02]
+
+### CTL-05 — use `unchecked` only under a local proof
+
+**P1 · A · guarded**
+
+prove every intermediate value, not merely the final result. keep unchecked regions small and colocate the bound or invariant.
+
+### CTL-06 — validate a range once and reuse the proof
+
+**P1 · A · guarded**
+
+a dominating boundary check can justify downstream unchecked arithmetic, narrow casts, or unsafe array access. ensure no independently callable helper bypasses it.
+
+### CTL-07 — remove generic SafeMath wrappers
+
+**P1 · A · safe**
+
+Solidity 0.8.25 already provides checked arithmetic. preserve only wrappers that add domain-specific errors, saturating behavior, or other semantics.
+
+### CTL-08 — batch operations
+
+**P0 · A · never**
+
+amortize authorization, hashing, state warming, setup, and settlement across bounded batches. specify atomic versus partial failure and enforce maximum size.
+
+### CTL-09 — prohibit unbounded mutable-state loops
+
+**P0 · A · never**
+
+replace them with pull claims, pagination, incremental cursors, cumulative indexes, heaps, bitmaps, or other bounded structures.
+
+### CTL-10 — use reviewed full-precision `mulDiv`
+
+**P0 · A · never**
+
+when `x * y` can overflow despite the quotient fitting, use a 512-bit intermediate implementation with explicit rounding. Uniswap v3 `FullMath` and OpenZeppelin `Math.mulDiv` are mature references.[^REF-20][^REF-36]
+
+### CTL-11 — normalize fixed-point scale and delay division
+
+**P1 · B · never**
+
+reduce repeated scale conversions and divisions, but use full-precision intermediates and prove rounding, monotonicity, and conservation.
+
+### CTL-12 — cache type hashes and domain components
+
+**P1 · A · guarded**
+
+type hashes can be constants. deployment-invariant domain components can be immutable or cached, provided chain ID, proxy address, and replay behavior remain correct.
+
+### CTL-13 — use bit scans for bitmap navigation
+
+**P1 · A · never**
+
+use reviewed MSB/LSB routines and bit identities instead of scanning all 256 positions. specify zero-input and signed-index behavior. Uniswap v3’s tick bitmap is the canonical example.[^REF-19]
+
+### CTL-14 — specialize the dominant path
+
+**P0 · A · never**
+
+a narrow fixed-shape path can remove generic decoding, loops, feature branches, and unused checks. differential-test it against the generic path for every input in its eligible subset. Seaport’s basic-order fulfiller is a mature example.[^REF-27]
+
+### CTL-15 — benchmark branchless rewrites
+
+**P2 · C · never**
+
+the EVM lacks a branch predictor, but arithmetic selection can still use more operations and bytecode than a branch. signed extrema are a common failure mode.
+
+### CTL-16 — omit redundant zero initialization
+
+**P2 · A · safe**
+
+remove assignments that are semantically identical to Solidity’s default initialization, but reject the patch when the optimizer already removes them.
+
+### CTL-17 — use logarithmic search for sorted state
+
+**P0 · A · never**
+
+replace linear scans of sorted checkpoints or epochs with reviewed lower/upper-bound searches. maintain sortedness as a protocol invariant.
+
+### CTL-18 — increment pointers in assembly loops
+
+**P2 · B · never**
+
+use start/end pointers rather than recomputing `base + i * width` each iteration. prove fixed width, exact termination, and offset arithmetic.
+
+## 9. external calls, errors, and events
+
+### EXT-01 — use version-correct custom errors
+
+**P1 · A · safe**
+
+for Solidity 0.8.25:
+
+```solidity
+error Unauthorized(address caller);
+
+function execute() external {
+    if (msg.sender != owner) revert Unauthorized(msg.sender);
+}
+```
+
+do not generate `require(condition, CustomError())`; custom-error arguments to `require` were introduced after Solidity 0.8.25. use explicit `if` and `revert` for this target.[^REF-07]
+
+### EXT-02 — use selector-only errors narrowly
+
+**P2 · B · never**
+
+for parameterless errors in closed assembly-heavy libraries, four-byte revert data may be sufficient. this degrades diagnostics and must be asserted byte-for-byte.
+
+### EXT-03 — remove long revert strings
+
+**P1 · A · safe**
+
+replace them with custom errors and maintain human-readable explanations in NatSpec and client-side error maps.
+
+### EXT-04 — avoid external self-calls
+
+**P1 · A · guarded**
+
+extract an internal implementation rather than invoking `this.foo()`. preserve modifiers, `msg.sender`, `msg.value`, and reentrancy semantics explicitly.
+
+### EXT-05 — balance inlining against code size
+
+**P1 · A · never**
+
+let the optimizer decide first. source flattening may reduce a jump while multiplying bytecode at several call sites.
+
+### EXT-06 — use external libraries as a fleet/code-size trade
+
+**P1 · A · never**
+
+external libraries share code but introduce linking and `DELEGATECALL` overhead. keep hot arithmetic internal and model fleet break-even.
+
+### EXT-07 — define the return-data contract for every low-level call
+
+**P0 · A · never**
+
+specify accepted lengths and values, EOA behavior, copy limits, failure propagation, and malformed-return policy.
+
+### EXT-08 — expose a controlled multicall when composition is common
+
+**P1 · A · never**
+
+define `CALL` versus `DELEGATECALL`, `msg.value` accounting, reentrancy across subcalls, and atomicity.
+
+### EXT-09 — group warm accesses only when operations commute
+
+**P1 · A · never**
+
+reordering a batch by token, market, or account may reduce cold accesses, but can change prices, limits, logs, and MEV semantics.[^REF-10]
+
+### EXT-10 — mark a function payable only when receiving ETH is harmless
+
+**P2 · B · never**
+
+removing the nonpayable call-value check is a small optimization with a potentially permanent trapped-ETH or accounting consequence.
+
+### EXT-11 — minimize event data without harming observability
+
+**P1 · A · never**
+
+remove duplicated or derivable values and unnecessary topics only after specifying indexer queries, forensic requirements, and reconstruction rules.
+
+### EXT-12 — use pull settlement instead of push loops
+
+**P0 · A · never**
+
+record claimable balances or cumulative entitlements and let each recipient withdraw. prove no double claim, reentrancy safety, and conservation.
+
+### EXT-13 — use a mature safe-transfer implementation
+
+**P0 · A · never**
+
+accept the intended ERC-20 success forms—commonly no return data or exact `true`—while rejecting false and malformed responses. token balance semantics such as fee-on-transfer and rebasing require separate handling.
+
+Solady and Seaport both contain heavily optimized implementations of this pattern.[^REF-29][^REF-28]
+
+### EXT-14 — never use `transfer` or `send` as a reentrancy proof
+
+**P0 · A · never**
+
+the 2300-gas stipend is not a stable security boundary. use explicit call-result handling and reentrancy-safe state design.[^REF-34]
+
+## 10. deployment and architecture
+
+### DEP-01 — use ERC-1167 clones for homogeneous fleets
+
+**P0 · A · never**
+
+use audited clone construction, atomic initialization, a locked implementation, and an instance-count/call-count break-even.[^REF-33]
+
+### DEP-02 — use clone immutable arguments conditionally
+
+**P1 · B · never**
+
+append read-heavy permanent configuration to clone code rather than storing it. prove argument offsets and prevent direct implementation calls from spoofing the argument convention. Solady contains a production-oriented implementation corpus for this technique.[^REF-30]
+
+### DEP-03 — justify proxies by lifecycle and governance
+
+**P0 · A · never**
+
+shared implementation deployment savings do not automatically justify permanent delegation overhead, initialization risk, storage complexity, and upgrade authority.
+
+### DEP-04 — consider a singleton architecture
+
+**P0 · A · never**
+
+a singleton can share code, custody, warm state, and accounting across logical instances. it also turns instance isolation into one large security domain. Uniswap v4 is the strongest current production reference for the pattern.[^REF-24]
+
+### DEP-05 — net system-level transfers
+
+**P0 · A · never**
+
+compute final asset movement and execute the minimum transfers. prove conservation under fees, rebasing, callbacks, and insolvency paths.[^REF-24]
+
+### DEP-06 — split rare code from the hot runtime
+
+**P1 · B · never**
+
+move bulky migration, administration, or rarely used computation into immutable helpers when runtime size is binding. avoid unsafe delegatecalled migration modules.
+
+### DEP-07 — minimize constructor work and initcode
+
+**P1 · A · never**
+
+precompute off-chain, use commitments, constants, immutables, or safe lazy initialization instead of large constructor loops and initialization writes.
+
+### DEP-08 — enforce code-size and initcode budgets
+
+**P0 · A · safe**
+
+Ethereum limits deployed runtime code and meters/limits initcode. track linked artifacts in CI with margin for future changes.[^REF-13][^REF-37]
+
+### DEP-09 — use `CREATE2` where deterministic addressing removes state
+
+**P1 · A · never**
+
+derive instance addresses instead of maintaining a registry when the salt and initcode format can be canonicalized. prove collision, front-running, and versioning behavior.
+
+### DEP-10 — amortize approvals through a shared authorization layer
+
+**P1 · A · never**
+
+Permit2 demonstrates packed allowances, batched transfers, and bitmap nonces, but adds a shared systemic dependency and signature-phishing surface.[^REF-25][^REF-26]
+
+### DEP-11 — lazily initialize records
+
+**P1 · A · never**
+
+derive zero/default state until first use. define an unambiguous initialization sentinel and prevent first-touch races.
+
+### DEP-12 — calculate architecture break-even
+
+**P0 · A · safe**
+
+for direct deployments, clones, proxies, SSTORE2, singletons, and external libraries, model:
+
+```text
+total =
+    deployments * deployment_cost
+  + calls * runtime_cost
+  + calldata_cost
+  + persistent_state_cost
+  + operational_and_security_cost
+```
+
+## 11. Yul and inline assembly
+
+### YUL-01 — use `assembly ("memory-safe")` only after proving it
+
+**P0 · A · never**
+
+a correct annotation preserves optimizer freedom. a false annotation is a correctness bug, not an optimistic hint.
+
+memory-using assembly without a valid memory-safe contract can disable optimizer memory reasoning around the function; falsely asserting safety permits undefined behavior.[^REF-05]
+
+### YUL-02 — preserve Solidity’s memory conventions
+
+**P0 · A · never**
+
+respect:
+
+```text
+0x00–0x3f  scratch
+0x40       free-memory pointer
+0x60       zero slot
+0x80+      ordinary allocation
+```
+
+restore the free-memory pointer and zero slot before returning to Solidity whenever the block mutates them.[^REF-06]
+
+### YUL-03 — clean dirty upper bits
+
+**P0 · A · never**
+
+mask unsigned narrow values and `signextend` signed values before hashing, comparing full words, or merging packed slots.[^REF-05]
+
+### YUL-04 — use direct `CALLDATALOAD` only with complete bounds validation
+
+**P2 · A · never**
+
+truncated calldata reads zero beyond the end; a manual decoder must not accept a malformed input because absent bytes appear as valid zero fields.
+
+### YUL-05 — use one mask-and-merge packed-slot update
+
+**P2 · A · never**
+
+load the slot, clear the field mask, merge the range-checked value, and store once. generate constants from a layout specification rather than handwriting them independently.
+
+### YUL-06 — centralize `TLOAD` and `TSTORE`
+
+**P1 · A · never**
+
+on 0.8.25, wrap transient access in reviewed assembly helpers with namespaced slots, chain gates, and lifecycle documentation.[^REF-01][^REF-09]
+
+### YUL-07 — use fixed-shape scratch-memory hashing
+
+**P2 · A · never**
+
+retain a canonical `abi.encode` reference and differential-test every assembly hash helper.
+
+### YUL-08 — construct minimal call data
+
+**P2 · A · never**
+
+for fixed simple ABIs, write selector and arguments at exact offsets and call with the smallest correct span. clean address and narrow integer inputs first.
+
+### YUL-09 — use unsafe array access only after a dominating bound proof
+
+**P2 · A · never**
+
+encapsulate the primitive and make the proof visible at every call site. OpenZeppelin’s explicit `unsafeAccess` naming is the right design signal.[^REF-32]
+
+### YUL-10 — cast pointers only across identical representations
+
+**P2 · C · never**
+
+pointer reinterpretation is valid only when header, element layout, lifetime, and mutability are identical. never forge storage pointers.
+
+### YUL-11 — return and revert exact spans
+
+**P2 · A · never**
+
+every byte between pointer and pointer-plus-length becomes externally visible returndata. assert raw bytes in tests.
+
+### YUL-12 — avoid custom dispatch except in extreme stable interfaces
+
+**P2 · C · never**
+
+a custom dispatcher duplicates selector routing, payability, length checks, and decoding. use it only after code splitting, optimizer tuning, and architectural alternatives fail.
+
+### YUL-13 — use `EXTCODECOPY` for code-resident immutable data
+
+**P2 · A · never**
+
+verify code existence, size, sentinel prefix, offsets, and cold account cost. an EOA or wrong data contract must not silently decode as valid zero bytes.[^REF-10][^REF-30]
+
+### YUL-14 — call precompiles with exact failure handling
+
+**P2 · A · never**
+
+construct the specified input, verify call success and output shape, and test chain-specific precompile availability.
+
+## 12. production evidence
+
+### Aave v3
+
+reusable motifs:
+
+- packed reserve configuration words
+- two user-state bits per reserve
+- stable reserve IDs
+- reserve caches
+- cumulative indexes and lazy accrual
+- maximum-value allowance sentinel
+- conditional writes
+- centralized validation
+
+Aave’s v3 codebase and public audit corpus make these patterns useful evidence rather than gas-golf folklore.[^REF-15][^REF-16][^REF-17][^REF-18]
+
+### Uniswap v3
+
+reusable motifs:
+
+- tick bitmaps
+- bounded bit scanning
+- full-precision `mulDiv`
+- highly specialized pool state transitions
+- avoidance of redundant external-account checks on known call paths
+
+v3 core is a mature, heavily reviewed reference implementation for these patterns.[^REF-19][^REF-20][^REF-21]
+
+### Uniswap v4
+
+reusable motifs:
+
+- singleton state and custody
+- one unlock/callback execution boundary
+- transient lock state
+- transaction-local currency deltas
+- nonzero-obligation counter
+- final zero-delta settlement
+- direct transient and persistent slot-read helpers
+
+the main lesson is architectural: transient storage is used to remove intermediate settlement and state writes, not merely to replace one persistent boolean.[^REF-22][^REF-23][^REF-24]
+
+### Permit2
+
+reusable motifs:
+
+- `uint160 amount`, `uint48 expiration`, and `uint48 nonce` in one slot
+- maximum allowance sentinel
+- storage references
+- bounded batch loops
+- unordered nonce bitmap
+- shared approval infrastructure
+
+[^REF-25][^REF-26]
+
+### Seaport
+
+reusable motifs:
+
+- specialized basic-order entrypoint
+- fixed calldata offsets
+- selective decoding
+- exact memory reuse
+- manual event encoding
+- compact token calls
+- exact/no-return ERC-20 compatibility
+- bounded revert bubbling
+- function-specialization bypasses
+
+Seaport is a strong reference for what assembly-heavy optimization looks like after substantial review. it is not evidence that every protocol should adopt the same complexity.[^REF-27][^REF-28]
+
+### Solady
+
+reusable motifs:
+
+- scratch-memory hashing
+- selector-only errors
+- minimal token transfer encoding
+- SSTORE2
+- clone variants and immutable arguments
+- bitmaps and packed maps
+- transient reentrancy guards
+- direct return-data construction
+
+Solady is best treated as a corpus of specialist implementations and differential-test targets. its repository emphasizes extensive testing while still requiring users to validate the exact adopted code and revision.[^REF-29][^REF-30]
+
+### OpenZeppelin
+
+reusable motifs:
+
+- `ShortStrings`
+- audited ERC-1167 clones
+- full-precision math
+- explicit unsafe array-access primitives
+- maintainability-first optimization policy
+
+OpenZeppelin’s implementations are a useful counterweight to highly compressed assembly: isolate unsafe primitives, preserve readable interfaces, and make the reason for each low-level optimization legible.[^REF-31][^REF-32][^REF-33][^REF-36]
+
+## 13. rejected universal rules
+
+an agent must not emit these as unconditional recommendations:
+
+| id | claim to reject | correction |
+|---|---|---|
+| MYTH-01 | `++i` is always cheaper than `i++` | inspect optimized output; the compiler frequently normalizes them |
+| MYTH-02 | every loop increment needs manual `unchecked` | canonical loops are automatically handled on 0.8.25[^REF-02] |
+| MYTH-03 | use `uint8` or `uint16` everywhere | narrow widths mainly help through storage packing |
+| MYTH-04 | packing always wins | independently hot fields can become more expensive[^REF-04] |
+| MYTH-05 | calldata is always cheaper | copies, caller locations, mutation, and code size determine the result |
+| MYTH-06 | `external` is always cheaper than `public` | visibility is not a standalone gas proof |
+| MYTH-07 | constants always beat immutables | deployment, code size, per-instance values, and reference count matter |
+| MYTH-08 | `abi.encodePacked` is a cheaper drop-in replacement | it changes encoding semantics and can create collisions |
+| MYTH-09 | assembly always wins | the compiler may already generate equal or better code |
+| MYTH-10 | via-IR always wins | benchmark both pipelines |
+| MYTH-11 | maximum optimizer runs is optimal | runs is a lifecycle trade-off[^REF-03] |
+| MYTH-12 | cache every array length | storage length can matter; memory/calldata often does not |
+| MYTH-13 | shifts are always cheaper than multiply or divide | the compiler normally performs constant strength reduction |
+| MYTH-14 | delete storage for profit | refunds are reduced, capped, and lifecycle-dependent[^REF-12] |
+| MYTH-15 | `SELFDESTRUCT` recycles deployed contracts | Cancun semantics no longer delete an existing contract except in the creation transaction[^REF-14] |
+| MYTH-16 | `transfer` and `send` prevent reentrancy | gas stipends are not a security invariant[^REF-34] |
+| MYTH-17 | private functions are cheaper | call graph and optimizer output determine cost |
+| MYTH-18 | explicitly initialize every zero | defaults and optimizer removal make this commonly redundant |
+| MYTH-19 | prewarm every slot or account | the warm-up itself has a cost[^REF-10] |
+| MYTH-20 | `require(condition, CustomError())` works on 0.8.25 | use explicit `if` and `revert`[^REF-07] |
+| MYTH-21 | `MCOPY` obsoletes every copy helper | specialized decoding and buffer construction remain distinct[^REF-01] |
+| MYTH-22 | `memory-safe` is merely an optimization hint | it is a correctness assertion[^REF-05] |
+| MYTH-23 | branchless code is always cheaper | only artifact benchmarks decide |
+| MYTH-24 | gas savings are portable across EVM chains | fork and fee models differ |
+| MYTH-25 | events are always cheaper than storage | events cannot be consumed by future on-chain logic |
+| MYTH-26 | clones and proxies are always cheaper | deployment/runtime break-even may never be reached |
+| MYTH-27 | SSTORE2 is always cheaper | immutable size, reads, account warming, and copy costs determine break-even |
+| MYTH-28 | unchecked arithmetic is safe after ordinary unit tests | every intermediate bound needs a durable proof |
+
+## 14. agent evaluation workflow
+
+1. read the exact compiler, pipeline, optimizer, EVM target, metadata, and linking configuration;
+2. establish reproducible gas and code-size baselines;
+3. classify cost by storage, calls, transfers, calldata, memory, hashing, loops, deployment, and state growth;
+4. identify architectural candidates before local peepholes;
+5. remove candidates already handled by Solidity 0.8.25;
+6. cross-check every candidate against the rejected-rule section;
+7. attach preconditions, proof obligations, failure modes, and production evidence;
+8. classify the candidate as safe, guarded, or never-autofix;
+9. patch only safe or guarded candidates;
+10. compile and inspect optimized IR, assembly, runtime bytecode, initcode, and size;
+11. run unit, differential, fuzz, invariant, fork, malformed-input, adversarial-callee, and adversarial-token tests as applicable;
+12. report the complete cost vector and break-even;
+13. require explicit human approval for storage layout, ABI, assembly, transient storage, arithmetic-model, and architectural changes.
+
+## 15. release gate
+
+an optimization is not complete until:
+
+- compiler and settings are pinned;
+- known compiler bugs are reviewed;
+- before and after artifacts are reproducible;
+- representative cold/warm, first/repeat, success/failure, and boundary scenarios are measured;
+- deployment, runtime, calldata, persistent-state, and system costs are reported separately;
+- ABI and storage-layout diffs are empty or explicitly versioned and migrated;
+- code-size headroom remains acceptable;
+- differential and invariant tests pass;
+- assembly memory, bounds, dirty-bit, call, and returndata proofs are documented;
+- the review records why the complexity is worth maintaining.
+
+## 16. research support
+
+automated gas-analysis research broadly supports three conclusions:
+
+1. real contracts contain recurring detectable gas-waste patterns;
+2. storage behavior and asymptotic structure dominate many local source transformations;
+3. equivalence checking is necessary for aggressive bytecode or assembly optimization.
+
+PeCatch, GASOL, ebso, and SuperStack provide useful foundations for detectors, cost models, and equivalence validation, but none removes the need to benchmark the exact compiler artifact and protocol state.[^REF-35][^REF-38][^REF-39][^REF-40]
+
+## footnote definitions
+
+[^REF-01]: [Solidity Team — Solidity 0.8.25 release announcement](https://www.soliditylang.org/blog/2024/03/14/solidity-0.8.25-release-announcement/).
+[^REF-02]: [Solidity Team — Solidity 0.8.22 release announcement](https://www.soliditylang.org/blog/2023/10/25/solidity-0.8.22-release-announcement/).
+[^REF-03]: [Solidity 0.8.25 documentation — The Optimizer](https://docs.soliditylang.org/en/v0.8.25/internals/optimizer.html).
+[^REF-04]: [Solidity 0.8.25 documentation — Layout of State Variables in Storage and Transient Storage](https://docs.soliditylang.org/en/v0.8.25/internals/layout_in_storage.html).
+[^REF-05]: [Solidity 0.8.25 documentation — Inline Assembly](https://docs.soliditylang.org/en/v0.8.25/assembly.html).
+[^REF-06]: [Solidity 0.8.25 documentation — Layout in Memory](https://docs.soliditylang.org/en/v0.8.25/internals/layout_in_memory.html).
+[^REF-07]: [Solidity 0.8.25 documentation — Errors and the Revert Statement](https://docs.soliditylang.org/en/v0.8.25/contracts.html#errors-and-the-revert-statement).
+[^REF-08]: [Solidity 0.8.25 documentation — List of Known Bugs](https://docs.soliditylang.org/en/v0.8.25/bugs.html).
+[^REF-09]: [EIP-1153 — Transient storage opcodes](https://eips.ethereum.org/EIPS/eip-1153).
+[^REF-10]: [EIP-2929 — Gas cost increases for state access opcodes](https://eips.ethereum.org/EIPS/eip-2929).
+[^REF-11]: [EIP-2200 — Structured definitions for net gas metering](https://eips.ethereum.org/EIPS/eip-2200).
+[^REF-12]: [EIP-3529 — Reduction in refunds](https://eips.ethereum.org/EIPS/eip-3529).
+[^REF-13]: [EIP-3860 — Limit and meter initcode](https://eips.ethereum.org/EIPS/eip-3860).
+[^REF-14]: [EIP-6780 — SELFDESTRUCT only in same transaction](https://eips.ethereum.org/EIPS/eip-6780).
+[^REF-15]: [Aave v3 core — ReserveConfiguration.sol](https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/libraries/configuration/ReserveConfiguration.sol).
+[^REF-16]: [Aave v3 core — UserConfiguration.sol](https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/libraries/configuration/UserConfiguration.sol).
+[^REF-17]: [Aave v3 core — BorrowLogic.sol](https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/libraries/logic/BorrowLogic.sol).
+[^REF-18]: [Aave v3 core repository](https://github.com/aave/aave-v3-core).
+[^REF-19]: [Uniswap v3 core — TickBitmap.sol](https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/TickBitmap.sol).
+[^REF-20]: [Uniswap v3 core — FullMath.sol](https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/FullMath.sol).
+[^REF-21]: [Uniswap v3 core repository](https://github.com/Uniswap/v3-core).
+[^REF-22]: [Uniswap v4 core — CurrencyDelta.sol](https://github.com/Uniswap/v4-core/blob/main/src/libraries/CurrencyDelta.sol).
+[^REF-23]: [Uniswap v4 core — NonzeroDeltaCount.sol](https://github.com/Uniswap/v4-core/blob/main/src/libraries/NonzeroDeltaCount.sol).
+[^REF-24]: [Uniswap v4 core repository](https://github.com/Uniswap/v4-core).
+[^REF-25]: [Permit2 — SignatureTransfer.sol](https://github.com/Uniswap/permit2/blob/main/src/SignatureTransfer.sol).
+[^REF-26]: [Permit2 — AllowanceTransfer.sol](https://github.com/Uniswap/permit2/blob/main/src/AllowanceTransfer.sol).
+[^REF-27]: [Seaport core — BasicOrderFulfiller.sol](https://github.com/ProjectOpenSea/seaport-core/blob/main/src/lib/BasicOrderFulfiller.sol).
+[^REF-28]: [Seaport repository](https://github.com/ProjectOpenSea/seaport).
+[^REF-29]: [Solady — SafeTransferLib.sol](https://github.com/Vectorized/solady/blob/main/src/utils/SafeTransferLib.sol).
+[^REF-30]: [Solady repository](https://github.com/Vectorized/solady).
+[^REF-31]: [OpenZeppelin Contracts v5.0.2 — ShortStrings.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/utils/ShortStrings.sol).
+[^REF-32]: [OpenZeppelin Contracts v5.0.2 — Arrays.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/utils/Arrays.sol).
+[^REF-33]: [OpenZeppelin Contracts v5.0.2 — Clones.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/proxy/Clones.sol).
+[^REF-34]: [Slither detector documentation — dangerous strict equalities and transfer/send-related guidance](https://github.com/crytic/slither/wiki/Detector-Documentation).
+[^REF-35]: [He et al. — How to Save My Gas Fees: Understanding and Detecting Real-World Gas Issues in Solidity Programs / PeCatch](https://arxiv.org/abs/2403.02661).
+[^REF-36]: [OpenZeppelin Contracts v5.0.2 — Math.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/utils/math/Math.sol).
+[^REF-37]: [EIP-170 — Contract code size limit](https://eips.ethereum.org/EIPS/eip-170).
+[^REF-38]: [Albert et al. — GASOL: Gas Analysis and Optimization for Ethereum Smart Contracts](https://arxiv.org/abs/1912.11929).
+[^REF-39]: [Nagele and Schett — Blockchain Superoptimizer / ebso](https://arxiv.org/abs/2005.05912).
+[^REF-40]: [Albert et al. — SuperStack: Superoptimization of Stack-Bytecode via Greedy, Constraint-Based, and SAT Techniques](https://dl.acm.org/doi/10.1145/3656431).
+
+## citation table
+
+| id | source | type | link |
+|---|---|---|---|
+| REF-01 | Solidity 0.8.25 release announcement | compiler release note | [source](https://www.soliditylang.org/blog/2024/03/14/solidity-0.8.25-release-announcement/) |
+| REF-02 | Solidity 0.8.22 release announcement | compiler release note | [source](https://www.soliditylang.org/blog/2023/10/25/solidity-0.8.22-release-announcement/) |
+| REF-03 | Solidity 0.8.25: The Optimizer | versioned compiler documentation | [source](https://docs.soliditylang.org/en/v0.8.25/internals/optimizer.html) |
+| REF-04 | Solidity 0.8.25: storage layout | versioned compiler documentation | [source](https://docs.soliditylang.org/en/v0.8.25/internals/layout_in_storage.html) |
+| REF-05 | Solidity 0.8.25: inline assembly | versioned compiler documentation | [source](https://docs.soliditylang.org/en/v0.8.25/assembly.html) |
+| REF-06 | Solidity 0.8.25: memory layout | versioned compiler documentation | [source](https://docs.soliditylang.org/en/v0.8.25/internals/layout_in_memory.html) |
+| REF-07 | Solidity 0.8.25: errors and revert | versioned compiler documentation | [source](https://docs.soliditylang.org/en/v0.8.25/contracts.html#errors-and-the-revert-statement) |
+| REF-08 | Solidity 0.8.25: known bugs | versioned compiler documentation | [source](https://docs.soliditylang.org/en/v0.8.25/bugs.html) |
+| REF-09 | EIP-1153: transient storage | EIP | [source](https://eips.ethereum.org/EIPS/eip-1153) |
+| REF-10 | EIP-2929: cold/warm state access | EIP | [source](https://eips.ethereum.org/EIPS/eip-2929) |
+| REF-11 | EIP-2200: net `SSTORE` metering | EIP | [source](https://eips.ethereum.org/EIPS/eip-2200) |
+| REF-12 | EIP-3529: reduced refunds | EIP | [source](https://eips.ethereum.org/EIPS/eip-3529) |
+| REF-13 | EIP-3860: initcode metering and limit | EIP | [source](https://eips.ethereum.org/EIPS/eip-3860) |
+| REF-14 | EIP-6780: changed `SELFDESTRUCT` semantics | EIP | [source](https://eips.ethereum.org/EIPS/eip-6780) |
+| REF-15 | Aave v3 `ReserveConfiguration.sol` | production source | [source](https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/libraries/configuration/ReserveConfiguration.sol) |
+| REF-16 | Aave v3 `UserConfiguration.sol` | production source | [source](https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/libraries/configuration/UserConfiguration.sol) |
+| REF-17 | Aave v3 `BorrowLogic.sol` | production source | [source](https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/libraries/logic/BorrowLogic.sol) |
+| REF-18 | Aave v3 core repository | production repository / review corpus | [source](https://github.com/aave/aave-v3-core) |
+| REF-19 | Uniswap v3 `TickBitmap.sol` | production source | [source](https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/TickBitmap.sol) |
+| REF-20 | Uniswap v3 `FullMath.sol` | production source | [source](https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/FullMath.sol) |
+| REF-21 | Uniswap v3 core repository | production repository / review corpus | [source](https://github.com/Uniswap/v3-core) |
+| REF-22 | Uniswap v4 `CurrencyDelta.sol` | production source | [source](https://github.com/Uniswap/v4-core/blob/main/src/libraries/CurrencyDelta.sol) |
+| REF-23 | Uniswap v4 `NonzeroDeltaCount.sol` | production source | [source](https://github.com/Uniswap/v4-core/blob/main/src/libraries/NonzeroDeltaCount.sol) |
+| REF-24 | Uniswap v4 core repository | production repository / review corpus | [source](https://github.com/Uniswap/v4-core) |
+| REF-25 | Permit2 `SignatureTransfer.sol` | production source | [source](https://github.com/Uniswap/permit2/blob/main/src/SignatureTransfer.sol) |
+| REF-26 | Permit2 `AllowanceTransfer.sol` | production source | [source](https://github.com/Uniswap/permit2/blob/main/src/AllowanceTransfer.sol) |
+| REF-27 | Seaport `BasicOrderFulfiller.sol` | production source | [source](https://github.com/ProjectOpenSea/seaport-core/blob/main/src/lib/BasicOrderFulfiller.sol) |
+| REF-28 | Seaport repository | production repository / review corpus | [source](https://github.com/ProjectOpenSea/seaport) |
+| REF-29 | Solady `SafeTransferLib.sol` | production library source | [source](https://github.com/Vectorized/solady/blob/main/src/utils/SafeTransferLib.sol) |
+| REF-30 | Solady repository | optimized-library corpus | [source](https://github.com/Vectorized/solady) |
+| REF-31 | OpenZeppelin v5.0.2 `ShortStrings.sol` | versioned library source | [source](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/utils/ShortStrings.sol) |
+| REF-32 | OpenZeppelin v5.0.2 `Arrays.sol` | versioned library source | [source](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/utils/Arrays.sol) |
+| REF-33 | OpenZeppelin v5.0.2 `Clones.sol` | versioned library source | [source](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/proxy/Clones.sol) |
+| REF-34 | Slither detector documentation | security-tool documentation | [source](https://github.com/crytic/slither/wiki/Detector-Documentation) |
+| REF-35 | PeCatch paper | research paper | [source](https://arxiv.org/abs/2403.02661) |
+| REF-36 | OpenZeppelin v5.0.2 `Math.sol` | versioned library source | [source](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/utils/math/Math.sol) |
+| REF-37 | EIP-170: contract code-size limit | EIP | [source](https://eips.ethereum.org/EIPS/eip-170) |
+| REF-38 | GASOL paper | research paper | [source](https://arxiv.org/abs/1912.11929) |
+| REF-39 | Blockchain Superoptimizer / ebso paper | research paper | [source](https://arxiv.org/abs/2005.05912) |
+| REF-40 | SuperStack paper | research paper | [source](https://dl.acm.org/doi/10.1145/3656431) |

--- a/plugins/hermes/skills/hermes/references/gas-rule-corpus.json
+++ b/plugins/hermes/skills/hermes/references/gas-rule-corpus.json
@@ -1,0 +1,566 @@
+{
+  "schema": "hermes/gas-rule-corpus/v1",
+  "source": {
+    "path": "docs/hermes-rule-corpus/reference-solidity-0.8.25.md",
+    "sha256": "297c926dc0a2e011e31da5245273c136273b8faa390f3691910c22c870068449",
+    "compiler_target": "0.8.25",
+    "baseline_evm": "cancun"
+  },
+  "fork_order": [
+    "homestead",
+    "tangerineWhistle",
+    "spuriousDragon",
+    "byzantium",
+    "constantinople",
+    "petersburg",
+    "istanbul",
+    "berlin",
+    "london",
+    "paris",
+    "shanghai",
+    "cancun",
+    "prague",
+    "osaka"
+  ],
+  "references": [
+    {
+      "id": "REF-01",
+      "title": "Solidity 0.8.25 release announcement",
+      "kind": "compiler release note",
+      "url": "https://www.soliditylang.org/blog/2024/03/14/solidity-0.8.25-release-announcement/",
+      "footnote_title": "Solidity Team — Solidity 0.8.25 release announcement",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-02",
+      "title": "Solidity 0.8.22 release announcement",
+      "kind": "compiler release note",
+      "url": "https://www.soliditylang.org/blog/2023/10/25/solidity-0.8.22-release-announcement/",
+      "footnote_title": "Solidity Team — Solidity 0.8.22 release announcement",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-03",
+      "title": "Solidity 0.8.25: The Optimizer",
+      "kind": "versioned compiler documentation",
+      "url": "https://docs.soliditylang.org/en/v0.8.25/internals/optimizer.html",
+      "footnote_title": "Solidity 0.8.25 documentation — The Optimizer",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-04",
+      "title": "Solidity 0.8.25: storage layout",
+      "kind": "versioned compiler documentation",
+      "url": "https://docs.soliditylang.org/en/v0.8.25/internals/layout_in_storage.html",
+      "footnote_title": "Solidity 0.8.25 documentation — Layout of State Variables in Storage and Transient Storage",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-05",
+      "title": "Solidity 0.8.25: inline assembly",
+      "kind": "versioned compiler documentation",
+      "url": "https://docs.soliditylang.org/en/v0.8.25/assembly.html",
+      "footnote_title": "Solidity 0.8.25 documentation — Inline Assembly",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-06",
+      "title": "Solidity 0.8.25: memory layout",
+      "kind": "versioned compiler documentation",
+      "url": "https://docs.soliditylang.org/en/v0.8.25/internals/layout_in_memory.html",
+      "footnote_title": "Solidity 0.8.25 documentation — Layout in Memory",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-07",
+      "title": "Solidity 0.8.25: errors and revert",
+      "kind": "versioned compiler documentation",
+      "url": "https://docs.soliditylang.org/en/v0.8.25/contracts.html#errors-and-the-revert-statement",
+      "footnote_title": "Solidity 0.8.25 documentation — Errors and the Revert Statement",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-08",
+      "title": "Solidity 0.8.25: known bugs",
+      "kind": "versioned compiler documentation",
+      "url": "https://docs.soliditylang.org/en/v0.8.25/bugs.html",
+      "footnote_title": "Solidity 0.8.25 documentation — List of Known Bugs",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-09",
+      "title": "EIP-1153: transient storage",
+      "kind": "EIP",
+      "url": "https://eips.ethereum.org/EIPS/eip-1153",
+      "footnote_title": "EIP-1153 — Transient storage opcodes",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-10",
+      "title": "EIP-2929: cold/warm state access",
+      "kind": "EIP",
+      "url": "https://eips.ethereum.org/EIPS/eip-2929",
+      "footnote_title": "EIP-2929 — Gas cost increases for state access opcodes",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-11",
+      "title": "EIP-2200: net `SSTORE` metering",
+      "kind": "EIP",
+      "url": "https://eips.ethereum.org/EIPS/eip-2200",
+      "footnote_title": "EIP-2200 — Structured definitions for net gas metering",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-12",
+      "title": "EIP-3529: reduced refunds",
+      "kind": "EIP",
+      "url": "https://eips.ethereum.org/EIPS/eip-3529",
+      "footnote_title": "EIP-3529 — Reduction in refunds",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-13",
+      "title": "EIP-3860: initcode metering and limit",
+      "kind": "EIP",
+      "url": "https://eips.ethereum.org/EIPS/eip-3860",
+      "footnote_title": "EIP-3860 — Limit and meter initcode",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-14",
+      "title": "EIP-6780: changed `SELFDESTRUCT` semantics",
+      "kind": "EIP",
+      "url": "https://eips.ethereum.org/EIPS/eip-6780",
+      "footnote_title": "EIP-6780 — SELFDESTRUCT only in same transaction",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-15",
+      "title": "Aave v3 `ReserveConfiguration.sol`",
+      "kind": "production source",
+      "url": "https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/libraries/configuration/ReserveConfiguration.sol",
+      "footnote_title": "Aave v3 core — ReserveConfiguration.sol",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-16",
+      "title": "Aave v3 `UserConfiguration.sol`",
+      "kind": "production source",
+      "url": "https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/libraries/configuration/UserConfiguration.sol",
+      "footnote_title": "Aave v3 core — UserConfiguration.sol",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-17",
+      "title": "Aave v3 `BorrowLogic.sol`",
+      "kind": "production source",
+      "url": "https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/libraries/logic/BorrowLogic.sol",
+      "footnote_title": "Aave v3 core — BorrowLogic.sol",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-18",
+      "title": "Aave v3 core repository",
+      "kind": "production repository / review corpus",
+      "url": "https://github.com/aave/aave-v3-core",
+      "footnote_title": "Aave v3 core repository",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-19",
+      "title": "Uniswap v3 `TickBitmap.sol`",
+      "kind": "production source",
+      "url": "https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/TickBitmap.sol",
+      "footnote_title": "Uniswap v3 core — TickBitmap.sol",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-20",
+      "title": "Uniswap v3 `FullMath.sol`",
+      "kind": "production source",
+      "url": "https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/FullMath.sol",
+      "footnote_title": "Uniswap v3 core — FullMath.sol",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-21",
+      "title": "Uniswap v3 core repository",
+      "kind": "production repository / review corpus",
+      "url": "https://github.com/Uniswap/v3-core",
+      "footnote_title": "Uniswap v3 core repository",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-22",
+      "title": "Uniswap v4 `CurrencyDelta.sol`",
+      "kind": "production source",
+      "url": "https://github.com/Uniswap/v4-core/blob/main/src/libraries/CurrencyDelta.sol",
+      "footnote_title": "Uniswap v4 core — CurrencyDelta.sol",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-23",
+      "title": "Uniswap v4 `NonzeroDeltaCount.sol`",
+      "kind": "production source",
+      "url": "https://github.com/Uniswap/v4-core/blob/main/src/libraries/NonzeroDeltaCount.sol",
+      "footnote_title": "Uniswap v4 core — NonzeroDeltaCount.sol",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-24",
+      "title": "Uniswap v4 core repository",
+      "kind": "production repository / review corpus",
+      "url": "https://github.com/Uniswap/v4-core",
+      "footnote_title": "Uniswap v4 core repository",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-25",
+      "title": "Permit2 `SignatureTransfer.sol`",
+      "kind": "production source",
+      "url": "https://github.com/Uniswap/permit2/blob/main/src/SignatureTransfer.sol",
+      "footnote_title": "Permit2 — SignatureTransfer.sol",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-26",
+      "title": "Permit2 `AllowanceTransfer.sol`",
+      "kind": "production source",
+      "url": "https://github.com/Uniswap/permit2/blob/main/src/AllowanceTransfer.sol",
+      "footnote_title": "Permit2 — AllowanceTransfer.sol",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-27",
+      "title": "Seaport `BasicOrderFulfiller.sol`",
+      "kind": "production source",
+      "url": "https://github.com/ProjectOpenSea/seaport-core/blob/main/src/lib/BasicOrderFulfiller.sol",
+      "footnote_title": "Seaport core — BasicOrderFulfiller.sol",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-28",
+      "title": "Seaport repository",
+      "kind": "production repository / review corpus",
+      "url": "https://github.com/ProjectOpenSea/seaport",
+      "footnote_title": "Seaport repository",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-29",
+      "title": "Solady `SafeTransferLib.sol`",
+      "kind": "production library source",
+      "url": "https://github.com/Vectorized/solady/blob/main/src/utils/SafeTransferLib.sol",
+      "footnote_title": "Solady — SafeTransferLib.sol",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-30",
+      "title": "Solady repository",
+      "kind": "optimized-library corpus",
+      "url": "https://github.com/Vectorized/solady",
+      "footnote_title": "Solady repository",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-31",
+      "title": "OpenZeppelin v5.0.2 `ShortStrings.sol`",
+      "kind": "versioned library source",
+      "url": "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/utils/ShortStrings.sol",
+      "footnote_title": "OpenZeppelin Contracts v5.0.2 — ShortStrings.sol",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-32",
+      "title": "OpenZeppelin v5.0.2 `Arrays.sol`",
+      "kind": "versioned library source",
+      "url": "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/utils/Arrays.sol",
+      "footnote_title": "OpenZeppelin Contracts v5.0.2 — Arrays.sol",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-33",
+      "title": "OpenZeppelin v5.0.2 `Clones.sol`",
+      "kind": "versioned library source",
+      "url": "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/proxy/Clones.sol",
+      "footnote_title": "OpenZeppelin Contracts v5.0.2 — Clones.sol",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-34",
+      "title": "Slither detector documentation",
+      "kind": "security-tool documentation",
+      "url": "https://github.com/crytic/slither/wiki/Detector-Documentation",
+      "footnote_title": "Slither detector documentation — dangerous strict equalities and transfer/send-related guidance",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-35",
+      "title": "PeCatch paper",
+      "kind": "research paper",
+      "url": "https://arxiv.org/abs/2403.02661",
+      "footnote_title": "He et al. — How to Save My Gas Fees: Understanding and Detecting Real-World Gas Issues in Solidity Programs / PeCatch",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-36",
+      "title": "OpenZeppelin v5.0.2 `Math.sol`",
+      "kind": "versioned library source",
+      "url": "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/utils/math/Math.sol",
+      "footnote_title": "OpenZeppelin Contracts v5.0.2 — Math.sol",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-37",
+      "title": "EIP-170: contract code-size limit",
+      "kind": "EIP",
+      "url": "https://eips.ethereum.org/EIPS/eip-170",
+      "footnote_title": "EIP-170 — Contract code size limit",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-38",
+      "title": "GASOL paper",
+      "kind": "research paper",
+      "url": "https://arxiv.org/abs/1912.11929",
+      "footnote_title": "Albert et al. — GASOL: Gas Analysis and Optimization for Ethereum Smart Contracts",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-39",
+      "title": "Blockchain Superoptimizer / ebso paper",
+      "kind": "research paper",
+      "url": "https://arxiv.org/abs/2005.05912",
+      "footnote_title": "Nagele and Schett — Blockchain Superoptimizer / ebso",
+      "source_section": "footnote definitions"
+    },
+    {
+      "id": "REF-40",
+      "title": "SuperStack paper",
+      "kind": "research paper",
+      "url": "https://dl.acm.org/doi/10.1145/3656431",
+      "footnote_title": "Albert et al. — SuperStack: Superoptimization of Stack-Bytecode via Greedy, Constraint-Based, and SAT Techniques",
+      "source_section": "footnote definitions"
+    }
+  ],
+  "myths": [
+    {
+      "id": "MYTH-01",
+      "claim": "`++i` is always cheaper than `i++`",
+      "correction": "inspect optimized output; the compiler frequently normalizes them",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-02",
+      "claim": "every loop increment needs manual `unchecked`",
+      "correction": "canonical loops are automatically handled on 0.8.25",
+      "references": [
+        "REF-02"
+      ],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-03",
+      "claim": "use `uint8` or `uint16` everywhere",
+      "correction": "narrow widths mainly help through storage packing",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-04",
+      "claim": "packing always wins",
+      "correction": "independently hot fields can become more expensive",
+      "references": [
+        "REF-04"
+      ],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-05",
+      "claim": "calldata is always cheaper",
+      "correction": "copies, caller locations, mutation, and code size determine the result",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-06",
+      "claim": "`external` is always cheaper than `public`",
+      "correction": "visibility is not a standalone gas proof",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-07",
+      "claim": "constants always beat immutables",
+      "correction": "deployment, code size, per-instance values, and reference count matter",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-08",
+      "claim": "`abi.encodePacked` is a cheaper drop-in replacement",
+      "correction": "it changes encoding semantics and can create collisions",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-09",
+      "claim": "assembly always wins",
+      "correction": "the compiler may already generate equal or better code",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-10",
+      "claim": "via-IR always wins",
+      "correction": "benchmark both pipelines",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-11",
+      "claim": "maximum optimizer runs is optimal",
+      "correction": "runs is a lifecycle trade-off",
+      "references": [
+        "REF-03"
+      ],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-12",
+      "claim": "cache every array length",
+      "correction": "storage length can matter; memory/calldata often does not",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-13",
+      "claim": "shifts are always cheaper than multiply or divide",
+      "correction": "the compiler normally performs constant strength reduction",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-14",
+      "claim": "delete storage for profit",
+      "correction": "refunds are reduced, capped, and lifecycle-dependent",
+      "references": [
+        "REF-12"
+      ],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-15",
+      "claim": "`SELFDESTRUCT` recycles deployed contracts",
+      "correction": "Cancun semantics no longer delete an existing contract except in the creation transaction",
+      "references": [
+        "REF-14"
+      ],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-16",
+      "claim": "`transfer` and `send` prevent reentrancy",
+      "correction": "gas stipends are not a security invariant",
+      "references": [
+        "REF-34"
+      ],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-17",
+      "claim": "private functions are cheaper",
+      "correction": "call graph and optimizer output determine cost",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-18",
+      "claim": "explicitly initialize every zero",
+      "correction": "defaults and optimizer removal make this commonly redundant",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-19",
+      "claim": "prewarm every slot or account",
+      "correction": "the warm-up itself has a cost",
+      "references": [
+        "REF-10"
+      ],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-20",
+      "claim": "`require(condition, CustomError())` works on 0.8.25",
+      "correction": "use explicit `if` and `revert`",
+      "references": [
+        "REF-07"
+      ],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-21",
+      "claim": "`MCOPY` obsoletes every copy helper",
+      "correction": "specialized decoding and buffer construction remain distinct",
+      "references": [
+        "REF-01"
+      ],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-22",
+      "claim": "`memory-safe` is merely an optimization hint",
+      "correction": "it is a correctness assertion",
+      "references": [
+        "REF-05"
+      ],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-23",
+      "claim": "branchless code is always cheaper",
+      "correction": "only artifact benchmarks decide",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-24",
+      "claim": "gas savings are portable across EVM chains",
+      "correction": "fork and fee models differ",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-25",
+      "claim": "events are always cheaper than storage",
+      "correction": "events cannot be consumed by future on-chain logic",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-26",
+      "claim": "clones and proxies are always cheaper",
+      "correction": "deployment/runtime break-even may never be reached",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-27",
+      "claim": "SSTORE2 is always cheaper",
+      "correction": "immutable size, reads, account warming, and copy costs determine break-even",
+      "references": [],
+      "source_section": "13"
+    },
+    {
+      "id": "MYTH-28",
+      "claim": "unchecked arithmetic is safe after ordinary unit tests",
+      "correction": "every intermediate bound needs a durable proof",
+      "references": [],
+      "source_section": "13"
+    }
+  ],
+  "rules": []
+}

--- a/plugins/hermes/skills/hermes/references/gas-rule-corpus.schema.json
+++ b/plugins/hermes/skills/hermes/references/gas-rule-corpus.schema.json
@@ -1,0 +1,99 @@
+{
+  "schema": "hermes/gas-rule-corpus-schema/v1",
+  "note": "Field specs the corpus validator interprets. Type tokens are defined by hermes.py; a token here that hermes.py does not implement is a validation failure, not a skipped check.",
+  "corpus_schema": "hermes/gas-rule-corpus/v1",
+  "header": {
+    "required": {
+      "schema": "text",
+      "source": "source",
+      "fork_order": "fork-list"
+    },
+    "optional": {}
+  },
+  "source": {
+    "required": {
+      "path": "text",
+      "sha256": "digest",
+      "compiler_target": "version",
+      "baseline_evm": "fork"
+    },
+    "optional": {}
+  },
+  "records": {
+    "references": {
+      "id_pattern": "^REF-[0-9]{2}$",
+      "required": {
+        "id": "id",
+        "title": "text",
+        "kind": "text",
+        "url": "url",
+        "footnote_title": "text",
+        "source_section": "text"
+      },
+      "optional": {}
+    },
+    "myths": {
+      "id_pattern": "^MYTH-[0-9]{2}$",
+      "required": {
+        "id": "id",
+        "claim": "text",
+        "correction": "text",
+        "references": "ref-id-list",
+        "source_section": "text"
+      },
+      "optional": {}
+    },
+    "rules": {
+      "id_pattern": "^(CMP|STO|TRN|MEM|CTL|EXT|DEP|YUL)-[0-9]{2}$",
+      "required": {
+        "id": "id",
+        "title": "text",
+        "kind": "enum:rule_kind",
+        "category": "text",
+        "priority": "enum:priority",
+        "evidence_grade": "enum:evidence_grade",
+        "automation": "enum:automation",
+        "hermes_class": "hermes-class-or-none",
+        "summary": "text",
+        "mechanism": "text",
+        "recommendation": "text",
+        "detector_signals": "text-list",
+        "preconditions": "text-list",
+        "proof_obligations": "text-list",
+        "failure_modes": "text-list",
+        "validation": "text-list",
+        "references": "ref-id-list",
+        "source_section": "text",
+        "verified_on": "verified-on",
+        "scope": "scope"
+      },
+      "optional": {}
+    }
+  },
+  "verified_on": {
+    "required": {
+      "compiler": "version",
+      "evm": "fork"
+    },
+    "optional": {}
+  },
+  "scope": {
+    "required": {
+      "compiler_min": "version",
+      "compiler_max_exclusive": "version",
+      "compiler_reason": "text",
+      "evm_floor": "fork",
+      "evm_reason": "text",
+      "pipelines": "pipeline-list",
+      "pipeline_reason": "text"
+    },
+    "optional": {}
+  },
+  "enums": {
+    "rule_kind": ["technique", "measurement", "architecture", "release_gate"],
+    "priority": ["P0", "P1", "P2"],
+    "evidence_grade": ["A", "B", "C", "X"],
+    "automation": ["safe", "guarded", "never"],
+    "pipeline": ["legacy", "via-ir"]
+  }
+}

--- a/plugins/hermes/skills/hermes/scripts/hermes.py
+++ b/plugins/hermes/skills/hermes/scripts/hermes.py
@@ -1149,8 +1149,9 @@ def validate_corpus(corpus: dict[str, Any], schema: dict[str, Any]) -> list[str]
         # mismatched schema would report faults about the wrong document.
         return faults
 
+    record_classes = set((schema.get("records") or {}))
     _check_record(
-        {key: value for key, value in corpus.items() if key not in ("references", "myths", "rules")},
+        {key: value for key, value in corpus.items() if key not in record_classes},
         schema.get("header", {}), schema, corpus, "corpus", faults,
     )
     for name, spec in sorted((schema.get("records") or {}).items()):

--- a/plugins/hermes/skills/hermes/scripts/hermes.py
+++ b/plugins/hermes/skills/hermes/scripts/hermes.py
@@ -35,6 +35,14 @@ OPTIMISATION_CLASSES = (
     "storage-packing",
     "unchecked-arithmetic",
 )
+CORPUS_SCHEMA = "hermes/gas-rule-corpus/v1"
+CORPUS_SCHEMA_ID = "hermes/gas-rule-corpus-schema/v1"
+CORPUS_FILE = "gas-rule-corpus.json"
+CORPUS_SCHEMA_FILE = "gas-rule-corpus.schema.json"
+DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+VERSION_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+URL_RE = re.compile(r"^https://[^\s<>\"]+$")
+
 SNAPSHOT_RE = re.compile(r"^(?P<name>.+) \(gas: (?P<gas>[0-9]+)\)$")
 INVARIANT_SNAPSHOT_RE = re.compile(
     r"^(?P<name>.+) \(runs: (?P<runs>[0-9]+), calls: (?P<calls>[0-9]+), reverts: (?P<reverts>[0-9]+)\)$"
@@ -1004,6 +1012,198 @@ def status_command(args: argparse.Namespace) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# Rule corpus
+#
+# The corpus is data: the rules, the rejected universal rules, and the
+# citations transcribed from one pinned source document. Nothing here reaches
+# a network or evaluates a record; a field is text until a type token says
+# otherwise, and a token this module does not implement is a fault rather than
+# a check that quietly passes.
+
+
+class CorpusFault(RuntimeError):
+    """A corpus that cannot be trusted to judge a candidate."""
+
+
+def corpus_paths(directory: Path | None = None) -> tuple[Path, Path]:
+    """The corpus and its schema, resolved beside this script, never from argv."""
+    base = (directory or Path(__file__).resolve().parent.parent / "references")
+    return base / CORPUS_FILE, base / CORPUS_SCHEMA_FILE
+
+
+def load_corpus(directory: Path | None = None) -> tuple[dict[str, Any], dict[str, Any], str]:
+    corpus_path, schema_path = corpus_paths(directory)
+    for path in (corpus_path, schema_path):
+        if not path.is_file():
+            raise CorpusFault(f"missing corpus file: {path}")
+    raw = corpus_path.read_bytes()
+    try:
+        corpus = json.loads(raw.decode("utf-8"))
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CorpusFault(f"corpus is not valid JSON: {exc}") from exc
+    if not isinstance(corpus, dict) or not isinstance(schema, dict):
+        raise CorpusFault("corpus and schema must each be a JSON object")
+    return corpus, schema, sha256_bytes(raw)
+
+
+def _check_value(token: str, value: Any, schema: dict[str, Any], corpus: dict[str, Any],
+                 where: str, faults: list[str]) -> None:
+    """One field against one type token. Unknown tokens fault; they never pass."""
+    enums = schema.get("enums", {})
+    forks = corpus.get("fork_order") or []
+    if token in ("text", "id"):
+        if not isinstance(value, str) or not value.strip():
+            faults.append(f"{where}: expected non-empty text")
+    elif token == "digest":
+        if not isinstance(value, str) or not DIGEST_RE.match(value):
+            faults.append(f"{where}: expected a lowercase sha256 digest")
+    elif token == "version":
+        if not isinstance(value, str) or not VERSION_RE.match(value):
+            faults.append(f"{where}: expected a three-part version")
+    elif token == "url":
+        if not isinstance(value, str) or not URL_RE.match(value):
+            faults.append(f"{where}: expected an https URL")
+    elif token == "fork":
+        if value not in forks:
+            faults.append(f"{where}: {value!r} is not a name in fork_order")
+    elif token == "fork-list":
+        if not isinstance(value, list) or not value:
+            faults.append(f"{where}: expected a non-empty list of fork names")
+        elif len(set(value)) != len(value):
+            faults.append(f"{where}: fork_order repeats a name")
+        elif not all(isinstance(name, str) and name.strip() for name in value):
+            faults.append(f"{where}: fork_order holds a non-name")
+    elif token == "text-list":
+        if not isinstance(value, list):
+            faults.append(f"{where}: expected a list")
+        elif not all(isinstance(item, str) and item.strip() for item in value):
+            faults.append(f"{where}: every entry must be non-empty text")
+    elif token == "ref-id-list":
+        known = {entry.get("id") for entry in corpus.get("references") or []
+                 if isinstance(entry, dict)}
+        if not isinstance(value, list):
+            faults.append(f"{where}: expected a list of citation ids")
+        else:
+            for item in value:
+                if item not in known:
+                    faults.append(f"{where}: cites {item!r}, which no reference defines")
+    elif token == "pipeline-list":
+        allowed = enums.get("pipeline", [])
+        if not isinstance(value, list) or not value:
+            faults.append(f"{where}: expected a non-empty pipeline list")
+        else:
+            for item in value:
+                if item not in allowed:
+                    faults.append(f"{where}: {item!r} is not one of {allowed}")
+    elif token == "hermes-class-or-none":
+        if value is not None and value not in OPTIMISATION_CLASSES:
+            faults.append(f"{where}: {value!r} is neither null nor a Hermes class")
+    elif token.startswith("enum:"):
+        name = token.split(":", 1)[1]
+        allowed = enums.get(name)
+        if allowed is None:
+            faults.append(f"{where}: schema declares unknown enum {name!r}")
+        elif value not in allowed:
+            faults.append(f"{where}: {value!r} is not one of {allowed}")
+    elif token in ("source", "verified-on", "scope"):
+        spec = schema.get(token.replace("-", "_"))
+        if not isinstance(spec, dict):
+            faults.append(f"{where}: schema declares no shape for {token!r}")
+        elif not isinstance(value, dict):
+            faults.append(f"{where}: expected an object")
+        else:
+            _check_record(value, spec, schema, corpus, where, faults)
+    else:
+        faults.append(f"{where}: schema uses type token {token!r}, which this build cannot check")
+
+
+def _check_record(record: dict[str, Any], spec: dict[str, Any], schema: dict[str, Any],
+                  corpus: dict[str, Any], where: str, faults: list[str]) -> None:
+    required = spec.get("required", {})
+    optional = spec.get("optional", {})
+    for field in sorted(set(record) - set(required) - set(optional)):
+        faults.append(f"{where}: unknown field {field!r}")
+    for field, token in sorted(required.items()):
+        if field not in record:
+            faults.append(f"{where}: missing field {field!r}")
+        else:
+            _check_value(token, record[field], schema, corpus, f"{where}.{field}", faults)
+    for field, token in sorted(optional.items()):
+        if field in record:
+            _check_value(token, record[field], schema, corpus, f"{where}.{field}", faults)
+
+
+def validate_corpus(corpus: dict[str, Any], schema: dict[str, Any]) -> list[str]:
+    """Every fault in the corpus, in reading order. Empty means it can judge."""
+    faults: list[str] = []
+    if schema.get("schema") != CORPUS_SCHEMA_ID:
+        faults.append(f"schema declares {schema.get('schema')!r}, expected {CORPUS_SCHEMA_ID!r}")
+    if schema.get("corpus_schema") != CORPUS_SCHEMA:
+        faults.append(f"schema targets {schema.get('corpus_schema')!r}, expected {CORPUS_SCHEMA!r}")
+    if corpus.get("schema") != CORPUS_SCHEMA:
+        faults.append(f"corpus declares {corpus.get('schema')!r}, expected {CORPUS_SCHEMA!r}")
+    if faults:
+        # Every check below reads the schema's own shape declarations, so a
+        # mismatched schema would report faults about the wrong document.
+        return faults
+
+    _check_record(
+        {key: value for key, value in corpus.items() if key not in ("references", "myths", "rules")},
+        schema.get("header", {}), schema, corpus, "corpus", faults,
+    )
+    for name, spec in sorted((schema.get("records") or {}).items()):
+        records = corpus.get(name)
+        if not isinstance(records, list):
+            faults.append(f"corpus.{name}: expected a list of records")
+            continue
+        pattern = re.compile(spec.get("id_pattern", "^$"))
+        seen: set[str] = set()
+        for index, record in enumerate(records):
+            where = f"corpus.{name}[{index}]"
+            if not isinstance(record, dict):
+                faults.append(f"{where}: expected an object")
+                continue
+            identifier = record.get("id")
+            if isinstance(identifier, str):
+                where = f"corpus.{name}[{identifier}]"
+                if not pattern.match(identifier):
+                    faults.append(f"{where}: id does not match {spec['id_pattern']}")
+                if identifier in seen:
+                    faults.append(f"{where}: duplicate id")
+                seen.add(identifier)
+            _check_record(record, spec, schema, corpus, where, faults)
+    return faults
+
+
+def corpus_command(args: argparse.Namespace) -> int:
+    try:
+        corpus, schema, digest = load_corpus()
+    except CorpusFault as exc:
+        print(f"corpus unusable: {exc}", file=sys.stderr)
+        return 1
+    faults = validate_corpus(corpus, schema)
+    summary = {
+        "schema": corpus.get("schema"),
+        "corpus_sha256": digest,
+        "source_sha256": (corpus.get("source") or {}).get("sha256"),
+        "counts": {name: len(corpus.get(name) or []) for name in ("rules", "myths", "references")},
+        "faults": faults,
+        "status": "clean" if not faults else "faulted",
+    }
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        counts = summary["counts"]
+        print(f"corpus {digest[:16]} rules={counts['rules']} "
+              f"myths={counts['myths']} references={counts['references']}")
+        for fault in faults:
+            print(f"  {fault}", file=sys.stderr)
+        print("clean" if not faults else f"{len(faults)} fault(s)")
+    return 0 if not faults else 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="hermes.py",
@@ -1096,10 +1296,20 @@ def build_parser() -> argparse.ArgumentParser:
     status = subparsers.add_parser("status", help="Print the mesh-readable result JSON")
     status.add_argument("--run-dir", required=True)
     status.set_defaults(handler=status_command)
+
+    corpus = subparsers.add_parser("corpus", help="Validate the pinned gas-rule corpus")
+    corpus.add_argument("--validate", action="store_true",
+                        help="Check the corpus against its schema (the only mode)")
+    corpus.add_argument("--json", action="store_true", help="Print the machine-readable summary")
+    corpus.set_defaults(handler=corpus_command)
     return parser
 
 
 def validate_cross_arguments(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    if args.command == "corpus":
+        if not args.validate:
+            parser.error("corpus takes --validate")
+        return
     if args.command == "baseline":
         protected = args.protected_contract or []
         recorded = args.layout_contract or []

--- a/plugins/hermes/skills/hermes/scripts/test_hermes.py
+++ b/plugins/hermes/skills/hermes/scripts/test_hermes.py
@@ -498,6 +498,19 @@ class CorpusValidationTests(unittest.TestCase):
             corpus["rules"].append(_rule_record())
         self.assertEqual(self.faults(mutate), [])
 
+    def test_a_schema_class_the_header_does_not_name_is_still_a_record_class(self) -> None:
+        """Round 1 finding: the header check named the three record classes
+        itself, so a schema that grew a fourth reported it as an unknown
+        top-level field instead of validating it."""
+        def mutate(corpus, schema):
+            schema["records"]["gates"] = {
+                "id_pattern": "^GATE-[0-9]{2}$",
+                "required": {"id": "id", "title": "text"},
+                "optional": {},
+            }
+            corpus["gates"] = [{"id": "GATE-01", "title": "pin the build"}]
+        self.assertEqual(self.faults(mutate), [])
+
     def test_the_command_reports_clean_and_exits_zero(self) -> None:
         result = subprocess.run(
             [sys.executable, str(SCRIPT_DIR / "hermes.py"), "corpus", "--validate", "--json"],

--- a/plugins/hermes/skills/hermes/scripts/test_hermes.py
+++ b/plugins/hermes/skills/hermes/scripts/test_hermes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -384,6 +385,172 @@ class HermesHarnessTests(unittest.TestCase):
         self.assertEqual(code, 60)
         self.assertEqual(json.loads((self.run_dir / "result.json").read_text())["failed_gate"], 6)
 
+
+class CorpusValidationTests(unittest.TestCase):
+    """The corpus is what judges a candidate, so a corpus that cannot be
+    trusted has to refuse rather than pass a candidate under advice nobody
+    checked. Each case here mutates one field of the shipped corpus in a
+    temporary directory; nothing writes into the skill's own references."""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="hermes-corpus-")
+        self.directory = Path(self.temporary.name)
+        self.addCleanup(self.temporary.cleanup)
+        self.shipped, self.schema_path = hermes.corpus_paths()
+        shutil.copy(self.shipped, self.directory / self.shipped.name)
+        shutil.copy(self.schema_path, self.directory / self.schema_path.name)
+
+    def load(self) -> tuple[dict, dict]:
+        corpus, schema, _ = hermes.load_corpus(self.directory)
+        return corpus, schema
+
+    def faults(self, mutate) -> list[str]:
+        corpus, schema = self.load()
+        mutate(corpus, schema)
+        return hermes.validate_corpus(corpus, schema)
+
+    def test_the_shipped_corpus_validates(self) -> None:
+        corpus, schema = self.load()
+        self.assertEqual(hermes.validate_corpus(corpus, schema), [])
+
+    def test_the_shipped_corpus_carries_the_source_counts(self) -> None:
+        corpus, _ = self.load()
+        self.assertEqual(len(corpus["myths"]), 28)
+        self.assertEqual(len(corpus["references"]), 40)
+        self.assertEqual(corpus["source"]["sha256"],
+                         "297c926dc0a2e011e31da5245273c136273b8faa390f3691910c22c870068449")
+
+    def test_every_citation_id_resolves_exactly_once(self) -> None:
+        """REF-25 appears in the source at the start of a line as a citation
+        and again as a footnote definition, which is the shape that turns one
+        reference into two during transcription."""
+        corpus, _ = self.load()
+        identifiers = [entry["id"] for entry in corpus["references"]]
+        self.assertEqual(len(identifiers), len(set(identifiers)))
+        self.assertEqual(identifiers.count("REF-25"), 1)
+
+    def test_a_duplicate_record_id_is_refused(self) -> None:
+        def mutate(corpus, _schema):
+            corpus["myths"].append(dict(corpus["myths"][0]))
+        self.assertIn("duplicate id", " ".join(self.faults(mutate)))
+
+    def test_an_unknown_field_is_refused(self) -> None:
+        def mutate(corpus, _schema):
+            corpus["myths"][0]["severity"] = "high"
+        self.assertIn("unknown field 'severity'", " ".join(self.faults(mutate)))
+
+    def test_a_missing_field_is_refused(self) -> None:
+        def mutate(corpus, _schema):
+            del corpus["myths"][0]["correction"]
+        self.assertIn("missing field 'correction'", " ".join(self.faults(mutate)))
+
+    def test_an_empty_correction_is_refused(self) -> None:
+        def mutate(corpus, _schema):
+            corpus["myths"][0]["correction"] = "   "
+        self.assertIn("expected non-empty text", " ".join(self.faults(mutate)))
+
+    def test_a_citation_that_no_reference_defines_is_refused(self) -> None:
+        def mutate(corpus, _schema):
+            corpus["myths"][0]["references"] = ["REF-99"]
+        self.assertIn("cites 'REF-99'", " ".join(self.faults(mutate)))
+
+    def test_a_malformed_source_digest_is_refused(self) -> None:
+        def mutate(corpus, _schema):
+            corpus["source"]["sha256"] = "297C926D"
+        self.assertIn("expected a lowercase sha256 digest", " ".join(self.faults(mutate)))
+
+    def test_a_wrong_schema_declaration_is_refused(self) -> None:
+        def mutate(corpus, _schema):
+            corpus["schema"] = "hermes/gas-rule-corpus/v2"
+        faults = self.faults(mutate)
+        self.assertEqual(len(faults), 1, faults)
+        self.assertIn("expected 'hermes/gas-rule-corpus/v1'", faults[0])
+
+    def test_an_id_outside_its_pattern_is_refused(self) -> None:
+        def mutate(corpus, _schema):
+            corpus["myths"][0]["id"] = "MYTH-1"
+        self.assertIn("does not match", " ".join(self.faults(mutate)))
+
+    def test_a_type_token_this_build_cannot_check_is_a_fault(self) -> None:
+        """A schema that grew a token the validator does not implement must
+        fail loudly. The alternative is a field nobody checks and no sign of
+        it."""
+        def mutate(_corpus, schema):
+            schema["records"]["myths"]["required"]["claim"] = "sonnet"
+        self.assertIn("cannot check", " ".join(self.faults(mutate)))
+
+    def test_a_rule_class_outside_the_twelve_is_refused(self) -> None:
+        def mutate(corpus, _schema):
+            corpus["rules"].append(_rule_record(hermes_class="storage-golf"))
+        self.assertIn("neither null nor a Hermes class", " ".join(self.faults(mutate)))
+
+    def test_a_rule_scope_naming_an_unknown_fork_is_refused(self) -> None:
+        def mutate(corpus, _schema):
+            record = _rule_record()
+            record["scope"]["evm_floor"] = "verkle"
+            corpus["rules"].append(record)
+        self.assertIn("is not a name in fork_order", " ".join(self.faults(mutate)))
+
+    def test_a_fully_formed_rule_record_validates(self) -> None:
+        """The rule shape steps three and four fill in, proved against the
+        schema before any of those records exist."""
+        def mutate(corpus, _schema):
+            corpus["rules"].append(_rule_record())
+        self.assertEqual(self.faults(mutate), [])
+
+    def test_the_command_reports_clean_and_exits_zero(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_DIR / "hermes.py"), "corpus", "--validate", "--json"],
+            capture_output=True, text=True, check=False)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        summary = json.loads(result.stdout)
+        self.assertEqual(summary["status"], "clean")
+        self.assertEqual(summary["counts"]["myths"], 28)
+        self.assertEqual(summary["counts"]["references"], 40)
+        self.assertEqual(summary["faults"], [])
+
+    def test_the_command_refuses_without_validate(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_DIR / "hermes.py"), "corpus"],
+            capture_output=True, text=True, check=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--validate", result.stderr)
+
+
+def _rule_record(**overrides) -> dict:
+    """A minimal rule record in the shape the schema declares."""
+    record = {
+        "id": "STO-09",
+        "title": "cache repeated storage reads",
+        "kind": "technique",
+        "category": "state-model-and-storage",
+        "priority": "P1",
+        "evidence_grade": "A",
+        "automation": "safe",
+        "hermes_class": "storage-load-caching",
+        "summary": "Copy a storage value to a stack local when it is read repeatedly.",
+        "mechanism": "Even a warm SLOAD costs more than a stack operation.",
+        "recommendation": "Load once after the last preceding mutation.",
+        "detector_signals": ["same storage expression read more than once"],
+        "preconditions": ["no internal write invalidates the cached value"],
+        "proof_obligations": ["every use observes the same version of the value"],
+        "failure_modes": ["stale state after a callback"],
+        "validation": ["success and failure gas snapshots"],
+        "references": ["REF-10"],
+        "source_section": "5",
+        "verified_on": {"compiler": "0.8.25", "evm": "cancun"},
+        "scope": {
+            "compiler_min": "0.8.0",
+            "compiler_max_exclusive": "0.9.0",
+            "compiler_reason": "SLOAD pricing is an EVM property, not a compiler one.",
+            "evm_floor": "berlin",
+            "evm_reason": "EIP-2929 introduced the warm and cold distinction the saving rests on.",
+            "pipelines": ["legacy", "via-ir"],
+            "pipeline_reason": "Neither pipeline removes a repeated storage read.",
+        },
+    }
+    record.update(overrides)
+    return record
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -156,7 +156,7 @@
     },
     "hermes-baseline-promotion": {
       "source": "plugins/hermes/skills/hermes/scripts/hermes.py",
-      "sha256": "20abbce1b2db6e1a6109d08f53d0155956deae8fcb68c50dc35f6b684963a5c3",
+      "sha256": "6ad048b98202d8120c2ca74781c628fe551c7c06998da250adcfd4ec65d0125d",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "candidate commit, target set and sealed run directory",
@@ -170,7 +170,7 @@
     },
     "hermes-candidate-acceptance": {
       "source": "plugins/hermes/skills/hermes/scripts/hermes.py",
-      "sha256": "20abbce1b2db6e1a6109d08f53d0155956deae8fcb68c50dc35f6b684963a5c3",
+      "sha256": "6ad048b98202d8120c2ca74781c628fe551c7c06998da250adcfd4ec65d0125d",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "baseline commit, candidate commit and named targets",

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -156,7 +156,7 @@
     },
     "hermes-baseline-promotion": {
       "source": "plugins/hermes/skills/hermes/scripts/hermes.py",
-      "sha256": "9c7cda0947024a36a10c40c798c554521b11b5d8ef40414b877d59c7003389ea",
+      "sha256": "20abbce1b2db6e1a6109d08f53d0155956deae8fcb68c50dc35f6b684963a5c3",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "candidate commit, target set and sealed run directory",
@@ -170,7 +170,7 @@
     },
     "hermes-candidate-acceptance": {
       "source": "plugins/hermes/skills/hermes/scripts/hermes.py",
-      "sha256": "9c7cda0947024a36a10c40c798c554521b11b5d8ef40414b877d59c7003389ea",
+      "sha256": "20abbce1b2db6e1a6109d08f53d0155956deae8fcb68c50dc35f6b684963a5c3",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "baseline commit, candidate commit and named targets",


### PR DESCRIPTION
Stacks on step 1. `hermes.py corpus --validate` now holds a corpus file to a
pinned schema, and the corpus carries the 28 rejected universal rules and the
40 citations from the source document. That document is committed beside them
at its digest, so every record has something to trace back to.

Two shape decisions are worth knowing before reading the diff.

Records are lists, not objects keyed by id. `json.load` drops a duplicate key
without a word, and a duplicate rule id has to be a refusal rather than a
record nobody notices went missing. The reason lands in step 6's namespace
decision record, which is where the corpus's public shape is written down.

The schema declares each field's type token and the validator implements them.
A token the schema names and the validator doesn't implement is a fault, not a
field that quietly passes. The rule shape that steps 3 and 4 fill in is already
declared and already covered by a test, so those steps add data and nothing
else.

Audit: `audit/AUDIT.md`, "Hermes rule corpus, step 2", rounds 1 and 2, folded
into this branch. Round 1 found one low finding and fixed it: the header check
named the three record classes in its own tuple, so a schema that grew a fourth
would have reported the corpus key holding it as an unknown top-level field.
Round 2 was clean.

Round 1 also rejected a candidate finding, which is in the log with its
reasoning. The nested shape tokens are read out of the schema, which looks like
a cycle that could recurse without bound. It can't: each level recurses only
when the value there is an object, so the walk is bounded by the nesting of the
data, and JSON can't express infinite nesting. The depth limit written for it
was shown not to fire and removed rather than kept as a guard against nothing.

Proof:

```bash
python3 plugins/hermes/skills/hermes/scripts/hermes.py corpus --validate
python3 plugins/hermes/skills/hermes/scripts/test_hermes.py
python3 -m unittest discover -s tests
python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
shasum -a 256 docs/hermes-rule-corpus/reference-solidity-0.8.25.md
```

The last command prints
`297c926dc0a2e011e31da5245273c136273b8faa390f3691910c22c870068449`. The
document commits byte for byte, including its two lines that end in
whitespace: tidying those would break the digest the corpus cites.

Hermes suite 32/32, 18 of them new. Root suite 104/104. Phylax, Ephoros and
Hypomnema each exit 0.

<!-- wildcat-origin: shoggoth -->
