### PR TITLE
Seal the corpus at Gate 1 and require a rule at Gate 2

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -6261,3 +6261,45 @@ remains reachable through MEM-14, which is what keeps the bidirectional
 mapping test meaningful after MEM-12 moved.
 
 Leads not pursued: the class vocabulary, unchanged from round 1.
+
+## Hermes rule corpus, step 5, round 1 -- 2026-08-21
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S5-R1-01 | high | `plugins/hermes/skills/hermes/scripts/hermes.py` | A run directory sealed by the previous Hermes carries neither `corpus_sha256` nor `forge_config`, and Gate 2 read both by subscript. An operator resuming against an older baseline got an unhandled `KeyError` traceback rather than a refusal with an exit code, which is the one failure mode a fail-closed harness must not have. | fixed in this round |
+| S5-R1-02 | medium | `plugins/hermes/skills/hermes/scripts/hermes.py` | `resolve_scope` indexed `fork_order` for the rule's floor without checking the floor was in it, so a corpus fault escaped as an uncontrolled `ValueError`. Unreachable through `verify`, because validation runs first; reachable at the function boundary, which is where the guard now sits. | fixed in this round |
+| S5-R1-03 | low | `plugins/hermes/skills/hermes/scripts/hermes.py` | The rejected-rule citation scan was case-sensitive, so the same citation written in lower case went unnoticed. The refusal now matches either case and names the canonical id beside what was written. | fixed in this round |
+
+The Pashov pair did not run under the recorded waiver. Phylax, Ephoros and
+Hypomnema each exit 0. The root suite passes 104/104 and the Hermes suite
+71/71, of which 22 are new this step.
+
+The review drove the new helpers adversarially rather than reading them. Six
+probes: a rejected-rule id inside an obligation answer, the same in lower case,
+an obligation answer at 19, 20 and 21 characters against the 20-character
+minimum the existing rationale flag already uses, an obligation index of zero
+and of minus one, an answer supplied to a rule that states no obligation, and a
+`fork_order` with the rule's floor removed. Four refused correctly, one refused
+by design and case-sensitively, and the last produced the S5-R1-02 traceback.
+S5-R1-01 came out of asking what a run directory from the previous version
+looks like.
+
+One thing the round changed about method rather than code. S5-R1-02's first
+guard test drove the fault through `verify` and passed for the wrong reason:
+`validate_corpus` catches the same corpus first and refuses with its own
+message, so the test proved validation worked and said nothing about the guard.
+It is now a direct call on `resolve_scope`, which is where the guard applies.
+A guard test that cannot fail without its fix is the whole point of writing one.
+
+The budget in the study's item 10 was measured, not asserted, and measuring it
+found a defect. The suite had grown to 82 cases in 34.5 seconds against a
+25-second ceiling. The cause was not the new cases: `CorpusGateTests` inherited
+`HermesHarnessTests`, so all fourteen harness cases ran a second time under a
+`verify` the subclass had overridden. The fixture is now a plain mixin that is
+not itself collected, and the suite runs 71 cases in 23.9 seconds. Corpus
+validation runs in 0.04 seconds against its one-second ceiling.
+
+Leads not pursued: the 20-character minimum for an obligation answer is
+inherited from the existing rationale flags rather than derived from anything.
+It stops an empty field and nothing more, which is what the boundary language
+in the new promise says out loud.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -6242,3 +6242,22 @@ candidate.
 Leads not pursued: the class vocabulary itself. Twelve classes cover 62 of the
 120 documented rules, and widening them is a change to the harness's public
 interface that the study's constraints put out of scope for this run.
+
+## Hermes rule corpus, step 4, round 2 -- 2026-08-21
+
+Round 1's two fixes introduced no regression and this round found nothing.
+Status: clean.
+
+Phylax, Ephoros and Hypomnema each exit 0. The root suite passes 104/104 and
+the Hermes suite 49/49. `corpus --validate` is clean at 120 rules.
+
+The second look re-read both fixes and the guards now holding them. MEM-12
+takes `assembly` and its guard asserts the mapping beside the word
+`scratch-memory` in the rule's own statement, so the reason travels with the
+assertion. DEP-07 and DEP-08 floor at Homestead and their guard requires
+EIP-3860 to stay named in the reason, so the initcode half of each rule cannot
+quietly disappear from the record while the floor moves. `hashing-encoding`
+remains reachable through MEM-14, which is what keeps the bidirectional
+mapping test meaningful after MEM-12 moved.
+
+Leads not pursued: the class vocabulary, unchanged from round 1.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -6303,3 +6303,25 @@ Leads not pursued: the 20-character minimum for an obligation answer is
 inherited from the existing rationale flags rather than derived from anything.
 It stops an empty field and nothing more, which is what the boundary language
 in the new promise says out loud.
+
+## Hermes rule corpus, step 5, round 2 -- 2026-08-21
+
+Round 1's three fixes introduced no regression and this round found nothing.
+Status: clean.
+
+Phylax, Ephoros and Hypomnema each exit 0. The root suite passes 104/104 and
+the Hermes suite 71/71 in 24.4 seconds, inside the 25-second ceiling. Corpus
+validation is clean at 120 rules.
+
+The three probes that produced round 1's findings were re-run against the fixed
+tree. A rejected-rule citation is refused in either case and the refusal names
+the canonical id beside what the operator wrote. A `fork_order` missing a rule's
+floor is refused as `corpus/invalid` rather than raising. The shipped corpus
+reports no fault, so neither fix moved the data.
+
+The stale-baseline guard was read once more for the direction it fails in. It
+refuses the run rather than taking a fresh baseline on the operator's behalf,
+which is right: a baseline is the thing the whole record hangs from and Hermes
+does not seal one as a side effect of being asked to verify.
+
+Leads not pursued: the obligation-answer minimum, unchanged from round 1.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -6198,3 +6198,47 @@ candidates.
 
 Leads not pursued: the class-vocabulary hole recorded in round 1 stands as a
 successor-frontier candidate.
+
+## Hermes rule corpus, step 4, round 1 -- 2026-08-21
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S4-R1-01 | medium | `plugins/hermes/skills/hermes/references/gas-rule-corpus.json` | MEM-12 mapped to `hashing-encoding`. The rule states its own implementation is scratch-memory `KECCAK256`, and Gate 2 already refuses added assembly outside the `assembly` class, so a candidate declared under that mapping would have been refused every time it was attempted. Now `assembly`. | fixed in this round |
+| S4-R1-02 | medium | `plugins/hermes/skills/hermes/references/gas-rule-corpus.json` | DEP-07 and DEP-08 floored at Shanghai on the strength of EIP-3860. Both rules hold wherever EIP-170's runtime limit applies, so the floor refused correct advice on every earlier fork. The same shape as step 3's TRN-07 finding. Now floored at Homestead with the initcode half named in the reason. | fixed in this round |
+
+The Pashov pair did not run under the recorded waiver. Phylax, Ephoros and
+Hypomnema each exit 0. The root suite passes 104/104 and the Hermes suite
+49/49. `corpus --validate` is clean at 120 rules, 28 myths and 40 references,
+and a test now asserts the corpus id set equals the source's rather than only
+the count.
+
+S4-R1-01 is the more useful of the two, because it is the first case where the
+class mapping had to be decided against an existing gate rather than against a
+description. Gate 2 refuses a candidate that adds assembly under any class but
+`assembly`, so a rule whose own statement names an assembly implementation has
+only one correct mapping whatever its subject matter is. That reading was
+applied across the group: MEM-06, MEM-10, MEM-11, MEM-13, CTL-18 and all
+fourteen YUL rules take `assembly` for the same reason.
+
+CTL-13 was examined under the same test and kept as `loop-arithmetic`. Its
+canonical implementation is Uniswap v3's tick bitmap, whose `BitMath` is
+ordinary Solidity, so a candidate under it does not have to add assembly and
+the mapping does not set up a refusal.
+
+The review read all 58 assignments and all 58 scopes. 62 of the 120 rules now
+name a class and 58 do not. All twelve DEP rules are null and carry
+`architecture` as their kind, all fourteen YUL rules take `assembly`, and a
+bidirectional test holds the mapping from the other side: every class the
+harness knows is named by at least one rule, so the vocabulary is not
+over-broad even though it is plainly under-broad.
+
+The unclassed CTL and EXT rules are the ones worth naming, because unlike DEP
+they are real source changes with measurable savings that no class describes:
+removing a generic SafeMath wrapper, omitting a redundant zero initialisation,
+batching, pull settlement, and adopting a mature safe-transfer implementation.
+With STO-12 from step 3 they are the evidence behind the successor-frontier
+candidate.
+
+Leads not pursued: the class vocabulary itself. Twelve classes cover 62 of the
+120 documented rules, and widening them is a change to the harness's public
+interface that the study's constraints put out of scope for this run.

--- a/plugins/hermes/skills/hermes/SKILL.md
+++ b/plugins/hermes/skills/hermes/SKILL.md
@@ -26,7 +26,16 @@ Hermes measures one Solidity gas optimisation class at a time and rejects the ca
 
 The ideas are cheap. The evidence is the job.
 
-Use `scripts/hermes.py` for every run. It owns the order, seals the baseline, writes the evidence, and exits non-zero at the first bad gate. Use [references/optimisation-catalogue.md](references/optimisation-catalogue.md) to pick a candidate class.
+Use `scripts/hermes.py` for every run. It owns the order, seals the baseline, writes the evidence, and exits non-zero at the first bad gate. Every candidate names a rule from [references/gas-rule-corpus.json](references/gas-rule-corpus.json), the pinned corpus of 120 rules, 28 rejected universal rules and 40 citations transcribed from one source document. Use [references/optimisation-catalogue.md](references/optimisation-catalogue.md) to read the twelve classes those rules map onto.
+
+Check the corpus before a run and read what it holds:
+
+```bash
+python3 "$HERMES_PY" corpus --validate
+python3 "$HERMES_PY" corpus --validate --json
+```
+
+62 of the 120 rules name a class and can be selected. The other 58 constrain how a run is conducted, or they are architecture; the harness refuses them as candidates and says so rather than measuring something they do not describe.
 
 ## Day to day
 
@@ -71,11 +80,33 @@ python3 "$HERMES_PY" baseline \
 
 Add `--layout-contract "Label=path:Contract"` for a non-frozen contract whose layout still needs recording. This is useful for a deliberate packing change.
 
-Gate 1 runs `forge snapshot` and then `forge test`, in that order. It records the snapshot, green test result, Forge version, canonical Foundry config, Git revision, Solidity sources, storage layouts, and method identifiers. A dirty tree, red suite, missing snapshot, failed inspect, or invalid JSON ends the run.
+Gate 1 runs `forge snapshot` and then `forge test`, in that order. It records the snapshot, green test result, Forge version, canonical Foundry config, Git revision, Solidity sources, storage layouts, method identifiers, and the rule corpus with its digest. A corpus that fails its own schema ends the run here, so a candidate is never judged under advice nobody checked. A dirty tree, red suite, missing snapshot, failed inspect, or invalid JSON ends the run.
 
-## Gate 2: make one class of change
+## Gate 2: name a rule and make one class of change
 
-Choose one value from the catalogue and make only that kind of source change. Do not mix cleanup, compiler settings, test edits, or a second gas idea into the candidate.
+Every `verify` names one corpus rule with `--rule`. The rule decides the class, so a declared
+`--optimisation-class` that disagrees with it is refused. Gate 2 refuses before Gate 3
+spends a Forge run, and `result.json` carries a `refusal` field naming which condition failed:
+
+| `refusal` | Condition |
+| --- | --- |
+| `corpus/unknown-rule` | no rule of that id |
+| `corpus/myth-selected` | a rejected universal rule named as a candidate, answered with its correction |
+| `corpus/myth-cited` | a rationale or obligation answer citing a rejected rule as its justification |
+| `corpus/rule-names-no-class` | a rule that constrains the run or is architecture, so no candidate implements it |
+| `corpus/class-disagreement` | the declared class is not the rule's class |
+| `corpus/out-of-scope` | the target's compiler, fork or pipeline is outside the rule's declared scope |
+| `corpus/scope-unresolved` | the target pins no readable `solc`, or names a fork the corpus does not order |
+| `corpus/obligation-unanswered` | an obligation the rule's own statement makes has no substantive answer |
+| `corpus/obligation-malformed` | an `--obligation` argument is not `<n>=<answer>`, or names an index the rule lacks |
+| `corpus/digest-moved` | the corpus changed after the baseline sealed it |
+| `corpus/invalid` | the corpus does not pass its own schema |
+
+Answer each of the rule's obligations with `--obligation "<n>=<answer>"`, one per obligation, indexed
+from one. Those answers are recorded judgement rather than measurement, and `result.json` marks them
+as such. The six gates below do not move because of them.
+
+Then choose that rule's class and make only that kind of source change. Do not mix cleanup, compiler settings, test edits, or a second gas idea into the candidate.
 
 Review `candidate.solidity.diff` before attesting. The harness rejects Solidity file additions or removals, test-source edits, an empty candidate, added `unchecked` outside `unchecked-arithmetic`, and added assembly outside `assembly`. The attestation remains a judgement: read the diff and confirm that every hunk belongs to the declared class.
 
@@ -88,6 +119,8 @@ For an ordinary candidate:
 ```bash
 python3 "$HERMES_PY" verify \
   --run-dir "<run-dir>" \
+  --rule STO-09 \
+  --obligation "1=The cache is loaded after the last write and every use sits inside one call frame." \
   --optimisation-class storage-load-caching \
   --attest-single-class \
   --gas-target 'LedgerTest:test_update' \
@@ -107,6 +140,9 @@ For unchecked arithmetic that can affect persistent state, asset accounting, ext
 ```bash
 python3 "$HERMES_PY" verify \
   --run-dir "<run-dir>" \
+  --rule CTL-05 \
+  --obligation "1=Every intermediate is bounded by the array length checked at the loop head." \
+  --obligation "2=The unchecked region is three lines and the bound is stated beside it." \
   --optimisation-class unchecked-arithmetic \
   --attest-single-class \
   --gas-target 'LedgerTest:test_update' \
@@ -180,30 +216,43 @@ That accepted state becomes the baseline for the next class. Never run two class
 - If someone asks to bundle changes, run them in sequence.
 - If the gas saving cannot be quantified, reject it.
 - If a state-sensitive unchecked change lacks the targeted proof, reject it whatever the gas number says.
+- If the candidate implements no corpus rule, add the rule to the corpus in separate work first. There is no flag that skips the requirement.
 
 ## Promise Machine contract
 
 ### hermes-sealed-baseline
 
-- Promise: A successful `baseline` seals a green, clean Foundry baseline with the named gas measurements, configuration, seed, source revision, protected layouts and method identifiers.
+- Promise: A successful `baseline` seals a green, clean Foundry baseline with the named gas measurements, configuration, seed, source revision, protected layouts, method identifiers and the validated rule corpus with its digest.
 - Evidence: The run directory, baseline snapshot, full test log, Foundry version, canonical configuration, Git and source records, storage layouts and method maps.
 - Evidence classes: checked, measured, recorded
 - Boundary: The baseline describes one repository state and environment; it does not establish that a later candidate preserves behaviour or improves gas.
 - Authorises: Evaluation of one declared optimisation class against the sealed baseline and fixed measurement set.
 - Consequence: 1
-- Refuses: Beginning a candidate comparison from a dirty tree, red suite, missing snapshot, unresolved protected set or changed exclusions.
+- Refuses: Beginning a candidate comparison from a dirty tree, red suite, missing snapshot, unresolved protected set, changed exclusions or a corpus that fails its own schema.
 - Recovery: Restore a clean green repository, re-derive the protected and measured sets and take a fresh baseline.
+- Exceptions: none
+
+### hermes-corpus-selection
+
+- Promise: A successful Gate 2 corpus selection establishes that the named rule exists in the corpus the baseline sealed, that it names the declared optimisation class, that the target's pinned compiler, fork and pipeline fall inside the rule's declared scope, and that every obligation the rule's own statement makes carries a recorded answer.
+- Evidence: The sealed corpus digest, the corpus schema result, the selected rule with its grade and automation level, the resolved compiler, fork and pipeline read from the sealed Foundry configuration, the paired obligation answers and the `refusal` field on any rejection.
+- Evidence classes: checked, recorded
+- Boundary: Selection establishes that the candidate is in scope for reviewed advice and that its obligations were answered; it does not establish that the answers are correct, that the optimisation saves gas, or that behaviour is preserved. Obligation answers are recorded judgement rather than measurement and the six gates do not move because of them.
+- Authorises: Measurement of that one candidate against the sealed baseline under the named rule, with the rule id and corpus digest carried into the accepted record.
+- Consequence: 1
+- Refuses: An unknown rule, a rejected universal rule named as a candidate or cited as a justification, a rule that names no class, a declared class the rule does not name, a compiler, fork or pipeline outside the declared scope, a scope that cannot be resolved from the sealed configuration, an unanswered or malformed obligation, a corpus that moved after the baseline, and a corpus that fails its own schema.
+- Recovery: Select the rule the candidate actually implements, answer each of its obligations, pin the target's `solc_version` and `evm_version` where the scope cannot be resolved, or add the missing rule to the corpus in separate work before starting a new run.
 - Exceptions: none
 
 ### hermes-candidate-acceptance
 
-- Promise: A successful `verify` with `result.json` status `accepted` establishes measured savings for every named target, no deterministic regression, passing pinned and unpinned behaviour suites, preserved protected layouts and selectors, and the required unchecked-arithmetic evidence for one declared class.
-- Evidence: The sealed baseline, candidate Solidity diff, gas snapshot comparison, gas report, both full test runs, layout and selector comparisons, targeted property result when required and accepted `result.json`.
+- Promise: A successful `verify` with `result.json` status `accepted` establishes measured savings for every named target, no deterministic regression, passing pinned and unpinned behaviour suites, preserved protected layouts and selectors, and the required unchecked-arithmetic evidence for one declared class, under one named corpus rule whose scope the target satisfies.
+- Evidence: The sealed baseline, candidate Solidity diff, gas snapshot comparison, gas report, both full test runs, layout and selector comparisons, targeted property result when required, the corpus digest with the selected rule and its answered obligations, and accepted `result.json`.
 - Evidence classes: checked, measured, recomputed, recorded
 - Boundary: Acceptance covers one candidate, repository state, toolchain, measurement set and optimisation class; it is not a general security proof or permission to combine another change.
 - Authorises: Retaining and reviewing that exact gas candidate as a repository mutation with its complete evidence directory.
 - Consequence: 2
-- Refuses: Acceptance after any gate fails, a target lacks a saving, the measurement set moves, a protected interface changes or sensitive unchecked arithmetic lacks its named property evidence.
+- Refuses: Acceptance after any gate fails, a target lacks a saving, the measurement set moves, a protected interface changes, sensitive unchecked arithmetic lacks its named property evidence, or the candidate names no corpus rule.
 - Recovery: Remove only the rejected candidate, return to the sealed green state, correct prerequisite tests separately and start a new Hermes run.
 - Exceptions: none
 

--- a/plugins/hermes/skills/hermes/references/gas-rule-corpus.json
+++ b/plugins/hermes/skills/hermes/references/gas-rule-corpus.json
@@ -2402,7 +2402,7 @@
       "priority": "P2",
       "evidence_grade": "B",
       "automation": "never",
-      "hermes_class": "hashing-encoding",
+      "hermes_class": "assembly",
       "statement": "for a fixed sequence of canonical 32-byte words, scratch-memory `KECCAK256` can replace generic `abi.encode`. differential-test every helper against the canonical encoding.",
       "obligations": [],
       "references": [],
@@ -3778,14 +3778,14 @@
       "scope": {
         "compiler_min": "0.8.0",
         "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "Initcode metering is a consensus rule rather than compiler behaviour.",
-        "evm_floor": "shanghai",
-        "evm_reason": "EIP-3860 introduced the initcode limit and its per-word cost, which the source cites for this rule.",
+        "compiler_reason": "The limits are consensus rules rather than compiler behaviour; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "EIP-170's runtime code limit applies from Spurious Dragon onward and the source treats it as a standing budget; the initcode half of the rule gains EIP-3860's metering at Shanghai without the rest of it needing that fork.",
         "pipelines": [
           "legacy",
           "via-ir"
         ],
-        "pipeline_reason": "Initcode size differs between pipelines, which is why the rule asks for a budget rather than a number."
+        "pipeline_reason": "Code size and initcode size both differ between pipelines, which is why the rule asks for a budget rather than a number."
       }
     },
     {
@@ -3811,14 +3811,14 @@
       "scope": {
         "compiler_min": "0.8.0",
         "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "Initcode metering is a consensus rule rather than compiler behaviour.",
-        "evm_floor": "shanghai",
-        "evm_reason": "EIP-3860 introduced the initcode limit and its per-word cost, which the source cites for this rule.",
+        "compiler_reason": "The limits are consensus rules rather than compiler behaviour; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "EIP-170's runtime code limit applies from Spurious Dragon onward and the source treats it as a standing budget; the initcode half of the rule gains EIP-3860's metering at Shanghai without the rest of it needing that fork.",
         "pipelines": [
           "legacy",
           "via-ir"
         ],
-        "pipeline_reason": "Initcode size differs between pipelines, which is why the rule asks for a budget rather than a number."
+        "pipeline_reason": "Code size and initcode size both differ between pipelines, which is why the rule asks for a budget rather than a number."
       }
     },
     {

--- a/plugins/hermes/skills/hermes/references/gas-rule-corpus.json
+++ b/plugins/hermes/skills/hermes/references/gas-rule-corpus.json
@@ -948,508 +948,6 @@
       }
     },
     {
-      "id": "MEM-01",
-      "title": "retain read-only dynamic inputs in calldata",
-      "kind": "technique",
-      "category": "calldata-memory-and-abi",
-      "priority": "P1",
-      "evidence_grade": "A",
-      "automation": "safe",
-      "hermes_class": "calldata-memory",
-      "statement": "declare external read-only dynamic arguments as `calldata` and avoid implicit conversion to memory.",
-      "obligations": [],
-      "references": [],
-      "source_section": "7",
-      "verified_on": {
-        "compiler": "0.8.25",
-        "evm": "cancun"
-      },
-      "scope": {
-        "compiler_min": "0.8.0",
-        "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
-        "evm_floor": "homestead",
-        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
-        "pipelines": [
-          "legacy",
-          "via-ir"
-        ],
-        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
-      }
-    },
-    {
-      "id": "MEM-02",
-      "title": "preserve calldata through internal helpers",
-      "kind": "technique",
-      "category": "calldata-memory-and-abi",
-      "priority": "P1",
-      "evidence_grade": "A",
-      "automation": "guarded",
-      "hermes_class": "calldata-memory",
-      "statement": "a calldata parameter loses its advantage when the first helper accepts memory. use calldata helpers or carefully selected overloads.",
-      "obligations": [],
-      "references": [],
-      "source_section": "7",
-      "verified_on": {
-        "compiler": "0.8.25",
-        "evm": "cancun"
-      },
-      "scope": {
-        "compiler_min": "0.8.0",
-        "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
-        "evm_floor": "homestead",
-        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
-        "pipelines": [
-          "legacy",
-          "via-ir"
-        ],
-        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
-      }
-    },
-    {
-      "id": "MEM-03",
-      "title": "use calldata slices",
-      "kind": "technique",
-      "category": "calldata-memory-and-abi",
-      "priority": "P1",
-      "evidence_grade": "A",
-      "automation": "guarded",
-      "hermes_class": "calldata-memory",
-      "statement": "validate offset and length once, then pass a calldata view rather than allocating and copying a subrange.",
-      "obligations": [],
-      "references": [],
-      "source_section": "7",
-      "verified_on": {
-        "compiler": "0.8.25",
-        "evm": "cancun"
-      },
-      "scope": {
-        "compiler_min": "0.8.0",
-        "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
-        "evm_floor": "homestead",
-        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
-        "pipelines": [
-          "legacy",
-          "via-ir"
-        ],
-        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
-      }
-    },
-    {
-      "id": "MEM-04",
-      "title": "use custom packed calldata only on concentrated hot paths",
-      "kind": "technique",
-      "category": "calldata-memory-and-abi",
-      "priority": "P0",
-      "evidence_grade": "B",
-      "automation": "never",
-      "hermes_class": "calldata-memory",
-      "statement": "a custom byte format can remove ABI padding and redundant fields, but it creates a parser and a new external protocol. requirements: - versioned wire-format specification - canonical widths and byte order - off-chain reference encoder - reference Solidity decoder - malformed and truncated input fuzzing - signature and commitment compatibility tests - separate L1 and L2 fee measurements",
-      "obligations": [],
-      "references": [],
-      "source_section": "7",
-      "verified_on": {
-        "compiler": "0.8.25",
-        "evm": "cancun"
-      },
-      "scope": {
-        "compiler_min": "0.8.0",
-        "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
-        "evm_floor": "homestead",
-        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
-        "pipelines": [
-          "legacy",
-          "via-ir"
-        ],
-        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
-      }
-    },
-    {
-      "id": "MEM-05",
-      "title": "decode only the consumed fields",
-      "kind": "technique",
-      "category": "calldata-memory-and-abi",
-      "priority": "P1",
-      "evidence_grade": "B",
-      "automation": "never",
-      "hermes_class": "calldata-memory",
-      "statement": "a specialized path need not allocate a maximal nested structure when it uses a few fixed fields. keep the generic decoder as a differential oracle. Seaport’s basic-order path demonstrates this optimization at production scale.",
-      "obligations": [
-        "keep the generic decoder as a differential oracle."
-      ],
-      "references": [
-        "REF-27"
-      ],
-      "source_section": "7",
-      "verified_on": {
-        "compiler": "0.8.25",
-        "evm": "cancun"
-      },
-      "scope": {
-        "compiler_min": "0.8.0",
-        "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
-        "evm_floor": "homestead",
-        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
-        "pipelines": [
-          "legacy",
-          "via-ir"
-        ],
-        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
-      }
-    },
-    {
-      "id": "MEM-06",
-      "title": "use scratch memory for fixed short-lived operations",
-      "kind": "technique",
-      "category": "calldata-memory-and-abi",
-      "priority": "P2",
-      "evidence_grade": "A",
-      "automation": "never",
-      "hermes_class": "assembly",
-      "statement": "use `0x00–0x3f` for ephemeral hashes or call data only when no pointer escapes and Solidity’s zero-slot and free-memory-pointer invariants remain valid.",
-      "obligations": [],
-      "references": [
-        "REF-06"
-      ],
-      "source_section": "7",
-      "verified_on": {
-        "compiler": "0.8.25",
-        "evm": "cancun"
-      },
-      "scope": {
-        "compiler_min": "0.8.0",
-        "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
-        "evm_floor": "homestead",
-        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
-        "pipelines": [
-          "legacy",
-          "via-ir"
-        ],
-        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
-      }
-    },
-    {
-      "id": "MEM-07",
-      "title": "allocate exact buffers",
-      "kind": "technique",
-      "category": "calldata-memory-and-abi",
-      "priority": "P2",
-      "evidence_grade": "B",
-      "automation": "never",
-      "hermes_class": "calldata-memory",
-      "statement": "construct only the memory span required for a call, hash, event, revert, or return value. memory expansion is monotonic within the call frame.",
-      "obligations": [
-        "construct only the memory span required for a call, hash, event, revert, or return value."
-      ],
-      "references": [],
-      "source_section": "7",
-      "verified_on": {
-        "compiler": "0.8.25",
-        "evm": "cancun"
-      },
-      "scope": {
-        "compiler_min": "0.8.0",
-        "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
-        "evm_floor": "homestead",
-        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
-        "pipelines": [
-          "legacy",
-          "via-ir"
-        ],
-        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
-      }
-    },
-    {
-      "id": "MEM-08",
-      "title": "re-benchmark old memory-copy assembly under `MCOPY`",
-      "kind": "technique",
-      "category": "calldata-memory-and-abi",
-      "priority": "P2",
-      "evidence_grade": "A",
-      "automation": "guarded",
-      "hermes_class": "assembly",
-      "statement": "Solidity 0.8.25 can emit `MCOPY` for ordinary memory byte-array copies. preserve legacy assembly only when it retains a measured shape-specific advantage or different semantics.",
-      "obligations": [
-        "preserve legacy assembly only when it retains a measured shape-specific advantage or different semantics."
-      ],
-      "references": [
-        "REF-01"
-      ],
-      "source_section": "7",
-      "verified_on": {
-        "compiler": "0.8.25",
-        "evm": "cancun"
-      },
-      "scope": {
-        "compiler_min": "0.8.25",
-        "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "The source states 0.8.25 can emit MCOPY for ordinary memory byte-array copies.",
-        "evm_floor": "cancun",
-        "evm_reason": "MCOPY is a Cancun opcode, so the comparison the rule asks for only exists at or after that fork.",
-        "pipelines": [
-          "legacy",
-          "via-ir"
-        ],
-        "pipeline_reason": "Both pipelines can emit the copy the rule re-benchmarks."
-      }
-    },
-    {
-      "id": "MEM-09",
-      "title": "avoid distant memory offsets",
-      "kind": "technique",
-      "category": "calldata-memory-and-abi",
-      "priority": "P1",
-      "evidence_grade": "A",
-      "automation": "guarded",
-      "hermes_class": null,
-      "statement": "one access at a high offset expands memory over the entire intervening range. all attacker-controlled offset and length arithmetic requires explicit bounds.",
-      "obligations": [
-        "all attacker-controlled offset and length arithmetic requires explicit bounds."
-      ],
-      "references": [],
-      "source_section": "7",
-      "verified_on": {
-        "compiler": "0.8.25",
-        "evm": "cancun"
-      },
-      "scope": {
-        "compiler_min": "0.8.0",
-        "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
-        "evm_floor": "homestead",
-        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
-        "pipelines": [
-          "legacy",
-          "via-ir"
-        ],
-        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
-      }
-    },
-    {
-      "id": "MEM-10",
-      "title": "handle fixed returndata directly",
-      "kind": "technique",
-      "category": "calldata-memory-and-abi",
-      "priority": "P2",
-      "evidence_grade": "B",
-      "automation": "never",
-      "hermes_class": "assembly",
-      "statement": "when a caller needs only success, no data, or one fixed word, avoid allocating arbitrary bytes and passing them through a generic decoder.",
-      "obligations": [],
-      "references": [],
-      "source_section": "7",
-      "verified_on": {
-        "compiler": "0.8.25",
-        "evm": "cancun"
-      },
-      "scope": {
-        "compiler_min": "0.8.0",
-        "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
-        "evm_floor": "homestead",
-        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
-        "pipelines": [
-          "legacy",
-          "via-ir"
-        ],
-        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
-      }
-    },
-    {
-      "id": "MEM-11",
-      "title": "bound revert-data bubbling",
-      "kind": "technique",
-      "category": "calldata-memory-and-abi",
-      "priority": "P2",
-      "evidence_grade": "B",
-      "automation": "never",
-      "hermes_class": "assembly",
-      "statement": "unbounded `RETURNDATACOPY` allows a callee to force memory expansion. define whether errors are propagated, truncated, mapped, or replaced.",
-      "obligations": [
-        "define whether errors are propagated, truncated, mapped, or replaced."
-      ],
-      "references": [],
-      "source_section": "7",
-      "verified_on": {
-        "compiler": "0.8.25",
-        "evm": "cancun"
-      },
-      "scope": {
-        "compiler_min": "0.8.0",
-        "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
-        "evm_floor": "homestead",
-        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
-        "pipelines": [
-          "legacy",
-          "via-ir"
-        ],
-        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
-      }
-    },
-    {
-      "id": "MEM-12",
-      "title": "hash fixed static tuples directly",
-      "kind": "technique",
-      "category": "calldata-memory-and-abi",
-      "priority": "P2",
-      "evidence_grade": "B",
-      "automation": "never",
-      "hermes_class": "hashing-encoding",
-      "statement": "for a fixed sequence of canonical 32-byte words, scratch-memory `KECCAK256` can replace generic `abi.encode`. differential-test every helper against the canonical encoding.",
-      "obligations": [],
-      "references": [],
-      "source_section": "7",
-      "verified_on": {
-        "compiler": "0.8.25",
-        "evm": "cancun"
-      },
-      "scope": {
-        "compiler_min": "0.8.0",
-        "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
-        "evm_floor": "homestead",
-        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
-        "pipelines": [
-          "legacy",
-          "via-ir"
-        ],
-        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
-      }
-    },
-    {
-      "id": "MEM-13",
-      "title": "return exact-size fixed data",
-      "kind": "technique",
-      "category": "calldata-memory-and-abi",
-      "priority": "P2",
-      "evidence_grade": "B",
-      "automation": "never",
-      "hermes_class": "assembly",
-      "statement": "assembly may write fixed ABI words and `return(pointer, length)` directly. every byte in the returned span must be initialized.",
-      "obligations": [
-        "every byte in the returned span must be initialized."
-      ],
-      "references": [],
-      "source_section": "7",
-      "verified_on": {
-        "compiler": "0.8.25",
-        "evm": "cancun"
-      },
-      "scope": {
-        "compiler_min": "0.8.0",
-        "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
-        "evm_floor": "homestead",
-        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
-        "pipelines": [
-          "legacy",
-          "via-ir"
-        ],
-        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
-      }
-    },
-    {
-      "id": "MEM-14",
-      "title": "support EIP-2098 compact signatures where compatible",
-      "kind": "technique",
-      "category": "calldata-memory-and-abi",
-      "priority": "P2",
-      "evidence_grade": "A",
-      "automation": "guarded",
-      "hermes_class": "hashing-encoding",
-      "statement": "accept 64-byte compact signatures alongside standard 65-byte signatures when wallet and library compatibility is established.",
-      "obligations": [],
-      "references": [],
-      "source_section": "7",
-      "verified_on": {
-        "compiler": "0.8.25",
-        "evm": "cancun"
-      },
-      "scope": {
-        "compiler_min": "0.8.0",
-        "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
-        "evm_floor": "homestead",
-        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
-        "pipelines": [
-          "legacy",
-          "via-ir"
-        ],
-        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
-      }
-    },
-    {
-      "id": "MEM-15",
-      "title": "use Merkle commitments for large static sets",
-      "kind": "technique",
-      "category": "calldata-memory-and-abi",
-      "priority": "P0",
-      "evidence_grade": "A",
-      "automation": "never",
-      "hermes_class": null,
-      "statement": "replace large on-chain membership maps with a root plus proofs where set mutability and proof availability permit. define canonical leaf encoding, domain separation, ordering, and replay protection.",
-      "obligations": [
-        "define canonical leaf encoding, domain separation, ordering, and replay protection."
-      ],
-      "references": [],
-      "source_section": "7",
-      "verified_on": {
-        "compiler": "0.8.25",
-        "evm": "cancun"
-      },
-      "scope": {
-        "compiler_min": "0.8.0",
-        "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
-        "evm_floor": "homestead",
-        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
-        "pipelines": [
-          "legacy",
-          "via-ir"
-        ],
-        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
-      }
-    },
-    {
-      "id": "MEM-16",
-      "title": "never copy an unbounded storage array wholesale",
-      "kind": "technique",
-      "category": "calldata-memory-and-abi",
-      "priority": "P0",
-      "evidence_grade": "A",
-      "automation": "never",
-      "hermes_class": "calldata-memory",
-      "statement": "narrow storage element types still consume ordinary 32-byte memory words after copying. expose indexed or bounded retrieval instead.",
-      "obligations": [],
-      "references": [
-        "REF-06"
-      ],
-      "source_section": "7",
-      "verified_on": {
-        "compiler": "0.8.25",
-        "evm": "cancun"
-      },
-      "scope": {
-        "compiler_min": "0.8.0",
-        "compiler_max_exclusive": "0.9.0",
-        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
-        "evm_floor": "homestead",
-        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
-        "pipelines": [
-          "legacy",
-          "via-ir"
-        ],
-        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
-      }
-    },
-    {
       "id": "STO-01",
       "title": "pack co-accessed bounded fields",
       "kind": "technique",
@@ -2548,6 +2046,2355 @@
           "via-ir"
         ],
         "pipeline_reason": "The capability gate is about the deployment chain, not the pipeline that produced the bytecode."
+      }
+    },
+    {
+      "id": "MEM-01",
+      "title": "retain read-only dynamic inputs in calldata",
+      "kind": "technique",
+      "category": "calldata-memory-and-abi",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "safe",
+      "hermes_class": "calldata-memory",
+      "statement": "declare external read-only dynamic arguments as `calldata` and avoid implicit conversion to memory.",
+      "obligations": [],
+      "references": [],
+      "source_section": "7",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "MEM-02",
+      "title": "preserve calldata through internal helpers",
+      "kind": "technique",
+      "category": "calldata-memory-and-abi",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "guarded",
+      "hermes_class": "calldata-memory",
+      "statement": "a calldata parameter loses its advantage when the first helper accepts memory. use calldata helpers or carefully selected overloads.",
+      "obligations": [],
+      "references": [],
+      "source_section": "7",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "MEM-03",
+      "title": "use calldata slices",
+      "kind": "technique",
+      "category": "calldata-memory-and-abi",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "guarded",
+      "hermes_class": "calldata-memory",
+      "statement": "validate offset and length once, then pass a calldata view rather than allocating and copying a subrange.",
+      "obligations": [],
+      "references": [],
+      "source_section": "7",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "MEM-04",
+      "title": "use custom packed calldata only on concentrated hot paths",
+      "kind": "technique",
+      "category": "calldata-memory-and-abi",
+      "priority": "P0",
+      "evidence_grade": "B",
+      "automation": "never",
+      "hermes_class": "calldata-memory",
+      "statement": "a custom byte format can remove ABI padding and redundant fields, but it creates a parser and a new external protocol. requirements: - versioned wire-format specification - canonical widths and byte order - off-chain reference encoder - reference Solidity decoder - malformed and truncated input fuzzing - signature and commitment compatibility tests - separate L1 and L2 fee measurements",
+      "obligations": [],
+      "references": [],
+      "source_section": "7",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "MEM-05",
+      "title": "decode only the consumed fields",
+      "kind": "technique",
+      "category": "calldata-memory-and-abi",
+      "priority": "P1",
+      "evidence_grade": "B",
+      "automation": "never",
+      "hermes_class": "calldata-memory",
+      "statement": "a specialized path need not allocate a maximal nested structure when it uses a few fixed fields. keep the generic decoder as a differential oracle. Seaport’s basic-order path demonstrates this optimization at production scale.",
+      "obligations": [
+        "keep the generic decoder as a differential oracle."
+      ],
+      "references": [
+        "REF-27"
+      ],
+      "source_section": "7",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "MEM-06",
+      "title": "use scratch memory for fixed short-lived operations",
+      "kind": "technique",
+      "category": "calldata-memory-and-abi",
+      "priority": "P2",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "use `0x00–0x3f` for ephemeral hashes or call data only when no pointer escapes and Solidity’s zero-slot and free-memory-pointer invariants remain valid.",
+      "obligations": [],
+      "references": [
+        "REF-06"
+      ],
+      "source_section": "7",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "MEM-07",
+      "title": "allocate exact buffers",
+      "kind": "technique",
+      "category": "calldata-memory-and-abi",
+      "priority": "P2",
+      "evidence_grade": "B",
+      "automation": "never",
+      "hermes_class": "calldata-memory",
+      "statement": "construct only the memory span required for a call, hash, event, revert, or return value. memory expansion is monotonic within the call frame.",
+      "obligations": [
+        "construct only the memory span required for a call, hash, event, revert, or return value."
+      ],
+      "references": [],
+      "source_section": "7",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "MEM-08",
+      "title": "re-benchmark old memory-copy assembly under `MCOPY`",
+      "kind": "technique",
+      "category": "calldata-memory-and-abi",
+      "priority": "P2",
+      "evidence_grade": "A",
+      "automation": "guarded",
+      "hermes_class": "assembly",
+      "statement": "Solidity 0.8.25 can emit `MCOPY` for ordinary memory byte-array copies. preserve legacy assembly only when it retains a measured shape-specific advantage or different semantics.",
+      "obligations": [
+        "preserve legacy assembly only when it retains a measured shape-specific advantage or different semantics."
+      ],
+      "references": [
+        "REF-01"
+      ],
+      "source_section": "7",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.25",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The source states 0.8.25 can emit MCOPY for ordinary memory byte-array copies.",
+        "evm_floor": "cancun",
+        "evm_reason": "MCOPY is a Cancun opcode, so the comparison the rule asks for only exists at or after that fork.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Both pipelines can emit the copy the rule re-benchmarks."
+      }
+    },
+    {
+      "id": "MEM-09",
+      "title": "avoid distant memory offsets",
+      "kind": "technique",
+      "category": "calldata-memory-and-abi",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "guarded",
+      "hermes_class": null,
+      "statement": "one access at a high offset expands memory over the entire intervening range. all attacker-controlled offset and length arithmetic requires explicit bounds.",
+      "obligations": [
+        "all attacker-controlled offset and length arithmetic requires explicit bounds."
+      ],
+      "references": [],
+      "source_section": "7",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "MEM-10",
+      "title": "handle fixed returndata directly",
+      "kind": "technique",
+      "category": "calldata-memory-and-abi",
+      "priority": "P2",
+      "evidence_grade": "B",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "when a caller needs only success, no data, or one fixed word, avoid allocating arbitrary bytes and passing them through a generic decoder.",
+      "obligations": [],
+      "references": [],
+      "source_section": "7",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "MEM-11",
+      "title": "bound revert-data bubbling",
+      "kind": "technique",
+      "category": "calldata-memory-and-abi",
+      "priority": "P2",
+      "evidence_grade": "B",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "unbounded `RETURNDATACOPY` allows a callee to force memory expansion. define whether errors are propagated, truncated, mapped, or replaced.",
+      "obligations": [
+        "define whether errors are propagated, truncated, mapped, or replaced."
+      ],
+      "references": [],
+      "source_section": "7",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "MEM-12",
+      "title": "hash fixed static tuples directly",
+      "kind": "technique",
+      "category": "calldata-memory-and-abi",
+      "priority": "P2",
+      "evidence_grade": "B",
+      "automation": "never",
+      "hermes_class": "hashing-encoding",
+      "statement": "for a fixed sequence of canonical 32-byte words, scratch-memory `KECCAK256` can replace generic `abi.encode`. differential-test every helper against the canonical encoding.",
+      "obligations": [],
+      "references": [],
+      "source_section": "7",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "MEM-13",
+      "title": "return exact-size fixed data",
+      "kind": "technique",
+      "category": "calldata-memory-and-abi",
+      "priority": "P2",
+      "evidence_grade": "B",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "assembly may write fixed ABI words and `return(pointer, length)` directly. every byte in the returned span must be initialized.",
+      "obligations": [
+        "every byte in the returned span must be initialized."
+      ],
+      "references": [],
+      "source_section": "7",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "MEM-14",
+      "title": "support EIP-2098 compact signatures where compatible",
+      "kind": "technique",
+      "category": "calldata-memory-and-abi",
+      "priority": "P2",
+      "evidence_grade": "A",
+      "automation": "guarded",
+      "hermes_class": "hashing-encoding",
+      "statement": "accept 64-byte compact signatures alongside standard 65-byte signatures when wallet and library compatibility is established.",
+      "obligations": [],
+      "references": [],
+      "source_section": "7",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "MEM-15",
+      "title": "use Merkle commitments for large static sets",
+      "kind": "technique",
+      "category": "calldata-memory-and-abi",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "replace large on-chain membership maps with a root plus proofs where set mutability and proof availability permit. define canonical leaf encoding, domain separation, ordering, and replay protection.",
+      "obligations": [
+        "define canonical leaf encoding, domain separation, ordering, and replay protection."
+      ],
+      "references": [],
+      "source_section": "7",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "MEM-16",
+      "title": "never copy an unbounded storage array wholesale",
+      "kind": "technique",
+      "category": "calldata-memory-and-abi",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "calldata-memory",
+      "statement": "narrow storage element types still consume ordinary 32-byte memory words after copying. expose indexed or bounded retrieval instead.",
+      "obligations": [],
+      "references": [
+        "REF-06"
+      ],
+      "source_section": "7",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "CTL-01",
+      "title": "order independent checks by cost and failure probability",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "guarded",
+      "hermes_class": "control-flow",
+      "statement": "cheap, frequently failing conditions should generally precede hashes, signatures, storage mutations, and external calls. preserve required error precedence and information policy.",
+      "obligations": [
+        "preserve required error precedence and information policy."
+      ],
+      "references": [],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "CTL-02",
+      "title": "finish validation and effects before external interactions",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "use checks-effects-interactions or a deliberately locked callback state machine. do not move writes after a call merely to reduce reverted-write gas.",
+      "obligations": [
+        "do not move writes after a call merely to reduce reverted-write gas."
+      ],
+      "references": [],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "CTL-03",
+      "title": "hoist loop invariants",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "safe",
+      "hermes_class": "loop-arithmetic",
+      "statement": "move invariant hashes, storage reads, lengths, address derivations, and conversions outside loops when neither the loop body nor callbacks can mutate their dependencies.",
+      "obligations": [],
+      "references": [],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "CTL-04",
+      "title": "use canonical `for` loops",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P2",
+      "evidence_grade": "A",
+      "automation": "safe",
+      "hermes_class": "loop-arithmetic",
+      "statement": "prefer: ```solidity uint256 length = items.length; for (uint256 i; i < length; ++i) { _consume(items[i]); } ``` on 0.8.25, manually wrapping the increment in `unchecked` is generally redundant for recognized canonical loops.",
+      "obligations": [],
+      "references": [
+        "REF-02"
+      ],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.22",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The source states canonical for-loop increments have been automatically unchecked since 0.8.22, which is what makes the rule's advice correct rather than redundant.",
+        "evm_floor": "homestead",
+        "evm_reason": "Loop shape is a compiler concern; no fork gates it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Both pipelines recognise the canonical loop the source describes."
+      }
+    },
+    {
+      "id": "CTL-05",
+      "title": "use `unchecked` only under a local proof",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "guarded",
+      "hermes_class": "unchecked-arithmetic",
+      "statement": "prove every intermediate value, not merely the final result. keep unchecked regions small and colocate the bound or invariant.",
+      "obligations": [
+        "prove every intermediate value, not merely the final result.",
+        "keep unchecked regions small and colocate the bound or invariant."
+      ],
+      "references": [],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The source states 0.8.25 already provides checked arithmetic, which is the whole reason a generic wrapper is redundant; the 0.8 line is where that holds.",
+        "evm_floor": "homestead",
+        "evm_reason": "Checked arithmetic is compiler-emitted; no fork gates it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Both pipelines emit the same checks for the same expression."
+      }
+    },
+    {
+      "id": "CTL-06",
+      "title": "validate a range once and reuse the proof",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "guarded",
+      "hermes_class": "unchecked-arithmetic",
+      "statement": "a dominating boundary check can justify downstream unchecked arithmetic, narrow casts, or unsafe array access. ensure no independently callable helper bypasses it.",
+      "obligations": [
+        "ensure no independently callable helper bypasses it."
+      ],
+      "references": [],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The source states 0.8.25 already provides checked arithmetic, which is the whole reason a generic wrapper is redundant; the 0.8 line is where that holds.",
+        "evm_floor": "homestead",
+        "evm_reason": "Checked arithmetic is compiler-emitted; no fork gates it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Both pipelines emit the same checks for the same expression."
+      }
+    },
+    {
+      "id": "CTL-07",
+      "title": "remove generic SafeMath wrappers",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "safe",
+      "hermes_class": null,
+      "statement": "Solidity 0.8.25 already provides checked arithmetic. preserve only wrappers that add domain-specific errors, saturating behavior, or other semantics.",
+      "obligations": [
+        "preserve only wrappers that add domain-specific errors, saturating behavior, or other semantics."
+      ],
+      "references": [],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The source states 0.8.25 already provides checked arithmetic, which is the whole reason a generic wrapper is redundant; the 0.8 line is where that holds.",
+        "evm_floor": "homestead",
+        "evm_reason": "Checked arithmetic is compiler-emitted; no fork gates it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Both pipelines emit the same checks for the same expression."
+      }
+    },
+    {
+      "id": "CTL-08",
+      "title": "batch operations",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "amortize authorization, hashing, state warming, setup, and settlement across bounded batches. specify atomic versus partial failure and enforce maximum size.",
+      "obligations": [
+        "specify atomic versus partial failure and enforce maximum size."
+      ],
+      "references": [],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "CTL-09",
+      "title": "prohibit unbounded mutable-state loops",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "replace them with pull claims, pagination, incremental cursors, cumulative indexes, heaps, bitmaps, or other bounded structures.",
+      "obligations": [],
+      "references": [],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "CTL-10",
+      "title": "use reviewed full-precision `mulDiv`",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "when `x * y` can overflow despite the quotient fitting, use a 512-bit intermediate implementation with explicit rounding. Uniswap v3 `FullMath` and OpenZeppelin `Math.mulDiv` are mature references.",
+      "obligations": [],
+      "references": [
+        "REF-20",
+        "REF-36"
+      ],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "CTL-11",
+      "title": "normalize fixed-point scale and delay division",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P1",
+      "evidence_grade": "B",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "reduce repeated scale conversions and divisions, but use full-precision intermediates and prove rounding, monotonicity, and conservation.",
+      "obligations": [
+        "reduce repeated scale conversions and divisions, but use full-precision intermediates and prove rounding, monotonicity, and conservation."
+      ],
+      "references": [],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "CTL-12",
+      "title": "cache type hashes and domain components",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "guarded",
+      "hermes_class": "constants-immutables",
+      "statement": "type hashes can be constants. deployment-invariant domain components can be immutable or cached, provided chain ID, proxy address, and replay behavior remain correct.",
+      "obligations": [],
+      "references": [],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "CTL-13",
+      "title": "use bit scans for bitmap navigation",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "loop-arithmetic",
+      "statement": "use reviewed MSB/LSB routines and bit identities instead of scanning all 256 positions. specify zero-input and signed-index behavior. Uniswap v3’s tick bitmap is the canonical example.",
+      "obligations": [
+        "specify zero-input and signed-index behavior."
+      ],
+      "references": [
+        "REF-19"
+      ],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "CTL-14",
+      "title": "specialize the dominant path",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "control-flow",
+      "statement": "a narrow fixed-shape path can remove generic decoding, loops, feature branches, and unused checks. differential-test it against the generic path for every input in its eligible subset. Seaport’s basic-order fulfiller is a mature example.",
+      "obligations": [],
+      "references": [
+        "REF-27"
+      ],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "CTL-15",
+      "title": "benchmark branchless rewrites",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P2",
+      "evidence_grade": "C",
+      "automation": "never",
+      "hermes_class": "control-flow",
+      "statement": "the EVM lacks a branch predictor, but arithmetic selection can still use more operations and bytecode than a branch. signed extrema are a common failure mode.",
+      "obligations": [],
+      "references": [],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "CTL-16",
+      "title": "omit redundant zero initialization",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P2",
+      "evidence_grade": "A",
+      "automation": "safe",
+      "hermes_class": null,
+      "statement": "remove assignments that are semantically identical to Solidity’s default initialization, but reject the patch when the optimizer already removes them.",
+      "obligations": [],
+      "references": [],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "CTL-17",
+      "title": "use logarithmic search for sorted state",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "replace linear scans of sorted checkpoints or epochs with reviewed lower/upper-bound searches. maintain sortedness as a protocol invariant.",
+      "obligations": [],
+      "references": [],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "CTL-18",
+      "title": "increment pointers in assembly loops",
+      "kind": "technique",
+      "category": "control-flow-and-arithmetic",
+      "priority": "P2",
+      "evidence_grade": "B",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "use start/end pointers rather than recomputing `base + i * width` each iteration. prove fixed width, exact termination, and offset arithmetic.",
+      "obligations": [
+        "prove fixed width, exact termination, and offset arithmetic."
+      ],
+      "references": [],
+      "source_section": "8",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "EXT-01",
+      "title": "use version-correct custom errors",
+      "kind": "technique",
+      "category": "external-calls-errors-and-events",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "safe",
+      "hermes_class": "custom-errors",
+      "statement": "for Solidity 0.8.25: ```solidity error Unauthorized(address caller); function execute() external { if (msg.sender != owner) revert Unauthorized(msg.sender); } ``` do not generate `require(condition, CustomError())`; custom-error arguments to `require` were introduced after Solidity 0.8.25. use explicit `if` and `revert` for this target.",
+      "obligations": [
+        "} ``` do not generate `require(condition, CustomError())`;",
+        "custom-error arguments to `require` were introduced after Solidity 0.8.25."
+      ],
+      "references": [
+        "REF-07"
+      ],
+      "source_section": "9",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.8.26",
+        "compiler_reason": "The source states custom-error arguments to require were introduced after 0.8.25, so the prohibition half of this rule holds up to and including that release and stops at the next one.",
+        "evm_floor": "homestead",
+        "evm_reason": "Revert data shape is a compiler concern; no fork gates it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Both pipelines encode a custom error the same way."
+      }
+    },
+    {
+      "id": "EXT-02",
+      "title": "use selector-only errors narrowly",
+      "kind": "technique",
+      "category": "external-calls-errors-and-events",
+      "priority": "P2",
+      "evidence_grade": "B",
+      "automation": "never",
+      "hermes_class": "custom-errors",
+      "statement": "for parameterless errors in closed assembly-heavy libraries, four-byte revert data may be sufficient. this degrades diagnostics and must be asserted byte-for-byte.",
+      "obligations": [
+        "this degrades diagnostics and must be asserted byte-for-byte."
+      ],
+      "references": [],
+      "source_section": "9",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "EXT-03",
+      "title": "remove long revert strings",
+      "kind": "technique",
+      "category": "external-calls-errors-and-events",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "safe",
+      "hermes_class": "custom-errors",
+      "statement": "replace them with custom errors and maintain human-readable explanations in NatSpec and client-side error maps.",
+      "obligations": [],
+      "references": [],
+      "source_section": "9",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "EXT-04",
+      "title": "avoid external self-calls",
+      "kind": "technique",
+      "category": "external-calls-errors-and-events",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "guarded",
+      "hermes_class": "external-call-reduction",
+      "statement": "extract an internal implementation rather than invoking `this.foo()`. preserve modifiers, `msg.sender`, `msg.value`, and reentrancy semantics explicitly.",
+      "obligations": [
+        "preserve modifiers, `msg.sender`, `msg.value`, and reentrancy semantics explicitly."
+      ],
+      "references": [],
+      "source_section": "9",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "EXT-05",
+      "title": "balance inlining against code size",
+      "kind": "technique",
+      "category": "external-calls-errors-and-events",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "let the optimizer decide first. source flattening may reduce a jump while multiplying bytecode at several call sites.",
+      "obligations": [],
+      "references": [],
+      "source_section": "9",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The limits are consensus rules rather than compiler behaviour; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "EIP-170's runtime code limit applies from Spurious Dragon onward and the source treats it as a standing budget.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Code size differs between pipelines, which is the reason the rule says to measure both."
+      }
+    },
+    {
+      "id": "EXT-06",
+      "title": "use external libraries as a fleet/code-size trade",
+      "kind": "technique",
+      "category": "external-calls-errors-and-events",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "external libraries share code but introduce linking and `DELEGATECALL` overhead. keep hot arithmetic internal and model fleet break-even.",
+      "obligations": [
+        "keep hot arithmetic internal and model fleet break-even."
+      ],
+      "references": [],
+      "source_section": "9",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The limits are consensus rules rather than compiler behaviour; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "EIP-170's runtime code limit applies from Spurious Dragon onward and the source treats it as a standing budget.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Code size differs between pipelines, which is the reason the rule says to measure both."
+      }
+    },
+    {
+      "id": "EXT-07",
+      "title": "define the return-data contract for every low-level call",
+      "kind": "technique",
+      "category": "external-calls-errors-and-events",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "specify accepted lengths and values, EOA behavior, copy limits, failure propagation, and malformed-return policy.",
+      "obligations": [
+        "specify accepted lengths and values, EOA behavior, copy limits, failure propagation, and malformed-return policy."
+      ],
+      "references": [],
+      "source_section": "9",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "EXT-08",
+      "title": "expose a controlled multicall when composition is common",
+      "kind": "technique",
+      "category": "external-calls-errors-and-events",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "define `CALL` versus `DELEGATECALL`, `msg.value` accounting, reentrancy across subcalls, and atomicity.",
+      "obligations": [
+        "define `CALL` versus `DELEGATECALL`, `msg.value` accounting, reentrancy across subcalls, and atomicity."
+      ],
+      "references": [],
+      "source_section": "9",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "EXT-09",
+      "title": "group warm accesses only when operations commute",
+      "kind": "technique",
+      "category": "external-calls-errors-and-events",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "external-call-reduction",
+      "statement": "reordering a batch by token, market, or account may reduce cold accesses, but can change prices, limits, logs, and MEV semantics.",
+      "obligations": [],
+      "references": [
+        "REF-10"
+      ],
+      "source_section": "9",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "Access pricing is an EVM property; no 0.8 release changes it.",
+        "evm_floor": "berlin",
+        "evm_reason": "The saving rests on the cold and warm access distinction EIP-2929 introduced, which the source cites for this rule.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Both pipelines emit the same access opcodes for the same reads."
+      }
+    },
+    {
+      "id": "EXT-10",
+      "title": "mark a function payable only when receiving ETH is harmless",
+      "kind": "technique",
+      "category": "external-calls-errors-and-events",
+      "priority": "P2",
+      "evidence_grade": "B",
+      "automation": "never",
+      "hermes_class": "control-flow",
+      "statement": "removing the nonpayable call-value check is a small optimization with a potentially permanent trapped-ETH or accounting consequence.",
+      "obligations": [],
+      "references": [],
+      "source_section": "9",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "EXT-11",
+      "title": "minimize event data without harming observability",
+      "kind": "technique",
+      "category": "external-calls-errors-and-events",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "event-packing",
+      "statement": "remove duplicated or derivable values and unnecessary topics only after specifying indexer queries, forensic requirements, and reconstruction rules.",
+      "obligations": [],
+      "references": [],
+      "source_section": "9",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "EXT-12",
+      "title": "use pull settlement instead of push loops",
+      "kind": "technique",
+      "category": "external-calls-errors-and-events",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "record claimable balances or cumulative entitlements and let each recipient withdraw. prove no double claim, reentrancy safety, and conservation.",
+      "obligations": [
+        "prove no double claim, reentrancy safety, and conservation."
+      ],
+      "references": [],
+      "source_section": "9",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "EXT-13",
+      "title": "use a mature safe-transfer implementation",
+      "kind": "technique",
+      "category": "external-calls-errors-and-events",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "accept the intended ERC-20 success forms—commonly no return data or exact `true`—while rejecting false and malformed responses. token balance semantics such as fee-on-transfer and rebasing require separate handling. Solady and Seaport both contain heavily optimized implementations of this pattern.",
+      "obligations": [
+        "token balance semantics such as fee-on-transfer and rebasing require separate handling."
+      ],
+      "references": [
+        "REF-28",
+        "REF-29"
+      ],
+      "source_section": "9",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "EXT-14",
+      "title": "never use `transfer` or `send` as a reentrancy proof",
+      "kind": "technique",
+      "category": "external-calls-errors-and-events",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "the 2300-gas stipend is not a stable security boundary. use explicit call-result handling and reentrancy-safe state design.",
+      "obligations": [],
+      "references": [
+        "REF-34"
+      ],
+      "source_section": "9",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "DEP-01",
+      "title": "use ERC-1167 clones for homogeneous fleets",
+      "kind": "architecture",
+      "category": "deployment-and-architecture",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "use audited clone construction, atomic initialization, a locked implementation, and an instance-count/call-count break-even.",
+      "obligations": [],
+      "references": [
+        "REF-33"
+      ],
+      "source_section": "10",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The limits are consensus rules rather than compiler behaviour; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "EIP-170's runtime code limit applies from Spurious Dragon onward and the source treats it as a standing budget.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Code size differs between pipelines, which is the reason the rule says to measure both."
+      }
+    },
+    {
+      "id": "DEP-02",
+      "title": "use clone immutable arguments conditionally",
+      "kind": "architecture",
+      "category": "deployment-and-architecture",
+      "priority": "P1",
+      "evidence_grade": "B",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "append read-heavy permanent configuration to clone code rather than storing it. prove argument offsets and prevent direct implementation calls from spoofing the argument convention. Solady contains a production-oriented implementation corpus for this technique.",
+      "obligations": [
+        "prove argument offsets and prevent direct implementation calls from spoofing the argument convention."
+      ],
+      "references": [
+        "REF-30"
+      ],
+      "source_section": "10",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The limits are consensus rules rather than compiler behaviour; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "EIP-170's runtime code limit applies from Spurious Dragon onward and the source treats it as a standing budget.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Code size differs between pipelines, which is the reason the rule says to measure both."
+      }
+    },
+    {
+      "id": "DEP-03",
+      "title": "justify proxies by lifecycle and governance",
+      "kind": "architecture",
+      "category": "deployment-and-architecture",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "shared implementation deployment savings do not automatically justify permanent delegation overhead, initialization risk, storage complexity, and upgrade authority.",
+      "obligations": [
+        "shared implementation deployment savings do not automatically justify permanent delegation overhead, initialization risk, storage complexity, and upgrade authority."
+      ],
+      "references": [],
+      "source_section": "10",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "DEP-04",
+      "title": "consider a singleton architecture",
+      "kind": "architecture",
+      "category": "deployment-and-architecture",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "a singleton can share code, custody, warm state, and accounting across logical instances. it also turns instance isolation into one large security domain. Uniswap v4 is the strongest current production reference for the pattern.",
+      "obligations": [],
+      "references": [
+        "REF-24"
+      ],
+      "source_section": "10",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "DEP-05",
+      "title": "net system-level transfers",
+      "kind": "architecture",
+      "category": "deployment-and-architecture",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "compute final asset movement and execute the minimum transfers. prove conservation under fees, rebasing, callbacks, and insolvency paths.",
+      "obligations": [
+        "prove conservation under fees, rebasing, callbacks, and insolvency paths."
+      ],
+      "references": [
+        "REF-24"
+      ],
+      "source_section": "10",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "DEP-06",
+      "title": "split rare code from the hot runtime",
+      "kind": "architecture",
+      "category": "deployment-and-architecture",
+      "priority": "P1",
+      "evidence_grade": "B",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "move bulky migration, administration, or rarely used computation into immutable helpers when runtime size is binding. avoid unsafe delegatecalled migration modules.",
+      "obligations": [],
+      "references": [],
+      "source_section": "10",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The limits are consensus rules rather than compiler behaviour; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "EIP-170's runtime code limit applies from Spurious Dragon onward and the source treats it as a standing budget.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Code size differs between pipelines, which is the reason the rule says to measure both."
+      }
+    },
+    {
+      "id": "DEP-07",
+      "title": "minimize constructor work and initcode",
+      "kind": "architecture",
+      "category": "deployment-and-architecture",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "precompute off-chain, use commitments, constants, immutables, or safe lazy initialization instead of large constructor loops and initialization writes.",
+      "obligations": [],
+      "references": [],
+      "source_section": "10",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "Initcode metering is a consensus rule rather than compiler behaviour.",
+        "evm_floor": "shanghai",
+        "evm_reason": "EIP-3860 introduced the initcode limit and its per-word cost, which the source cites for this rule.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Initcode size differs between pipelines, which is why the rule asks for a budget rather than a number."
+      }
+    },
+    {
+      "id": "DEP-08",
+      "title": "enforce code-size and initcode budgets",
+      "kind": "architecture",
+      "category": "deployment-and-architecture",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "safe",
+      "hermes_class": null,
+      "statement": "Ethereum limits deployed runtime code and meters/limits initcode. track linked artifacts in CI with margin for future changes.",
+      "obligations": [],
+      "references": [
+        "REF-13",
+        "REF-37"
+      ],
+      "source_section": "10",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "Initcode metering is a consensus rule rather than compiler behaviour.",
+        "evm_floor": "shanghai",
+        "evm_reason": "EIP-3860 introduced the initcode limit and its per-word cost, which the source cites for this rule.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Initcode size differs between pipelines, which is why the rule asks for a budget rather than a number."
+      }
+    },
+    {
+      "id": "DEP-09",
+      "title": "use `CREATE2` where deterministic addressing removes state",
+      "kind": "architecture",
+      "category": "deployment-and-architecture",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "derive instance addresses instead of maintaining a registry when the salt and initcode format can be canonicalized. prove collision, front-running, and versioning behavior.",
+      "obligations": [
+        "prove collision, front-running, and versioning behavior."
+      ],
+      "references": [],
+      "source_section": "10",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "DEP-10",
+      "title": "amortize approvals through a shared authorization layer",
+      "kind": "architecture",
+      "category": "deployment-and-architecture",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "Permit2 demonstrates packed allowances, batched transfers, and bitmap nonces, but adds a shared systemic dependency and signature-phishing surface.",
+      "obligations": [],
+      "references": [
+        "REF-25",
+        "REF-26"
+      ],
+      "source_section": "10",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "DEP-11",
+      "title": "lazily initialize records",
+      "kind": "architecture",
+      "category": "deployment-and-architecture",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": null,
+      "statement": "derive zero/default state until first use. define an unambiguous initialization sentinel and prevent first-touch races.",
+      "obligations": [
+        "define an unambiguous initialization sentinel and prevent first-touch races."
+      ],
+      "references": [],
+      "source_section": "10",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "DEP-12",
+      "title": "calculate architecture break-even",
+      "kind": "architecture",
+      "category": "deployment-and-architecture",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "safe",
+      "hermes_class": null,
+      "statement": "for direct deployments, clones, proxies, SSTORE2, singletons, and external libraries, model: ```text total = deployments * deployment_cost + calls * runtime_cost + calldata_cost + persistent_state_cost + operational_and_security_cost ```",
+      "obligations": [],
+      "references": [],
+      "source_section": "10",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The limits are consensus rules rather than compiler behaviour; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "EIP-170's runtime code limit applies from Spurious Dragon onward and the source treats it as a standing budget.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Code size differs between pipelines, which is the reason the rule says to measure both."
+      }
+    },
+    {
+      "id": "YUL-01",
+      "title": "use `assembly (\"memory-safe\")` only after proving it",
+      "kind": "technique",
+      "category": "yul-and-inline-assembly",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "a correct annotation preserves optimizer freedom. a false annotation is a correctness bug, not an optimistic hint. memory-using assembly without a valid memory-safe contract can disable optimizer memory reasoning around the function; falsely asserting safety permits undefined behavior.",
+      "obligations": [
+        "a correct annotation preserves optimizer freedom."
+      ],
+      "references": [
+        "REF-05"
+      ],
+      "source_section": "11",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "YUL-02",
+      "title": "preserve Solidity’s memory conventions",
+      "kind": "technique",
+      "category": "yul-and-inline-assembly",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "respect: ```text 0x00–0x3f scratch 0x40 free-memory pointer 0x60 zero slot 0x80+ ordinary allocation ``` restore the free-memory pointer and zero slot before returning to Solidity whenever the block mutates them.",
+      "obligations": [],
+      "references": [
+        "REF-06"
+      ],
+      "source_section": "11",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "YUL-03",
+      "title": "clean dirty upper bits",
+      "kind": "technique",
+      "category": "yul-and-inline-assembly",
+      "priority": "P0",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "mask unsigned narrow values and `signextend` signed values before hashing, comparing full words, or merging packed slots.",
+      "obligations": [],
+      "references": [
+        "REF-05"
+      ],
+      "source_section": "11",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "YUL-04",
+      "title": "use direct `CALLDATALOAD` only with complete bounds validation",
+      "kind": "technique",
+      "category": "yul-and-inline-assembly",
+      "priority": "P2",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "truncated calldata reads zero beyond the end; a manual decoder must not accept a malformed input because absent bytes appear as valid zero fields.",
+      "obligations": [
+        "a manual decoder must not accept a malformed input because absent bytes appear as valid zero fields."
+      ],
+      "references": [],
+      "source_section": "11",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "YUL-05",
+      "title": "use one mask-and-merge packed-slot update",
+      "kind": "technique",
+      "category": "yul-and-inline-assembly",
+      "priority": "P2",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "load the slot, clear the field mask, merge the range-checked value, and store once. generate constants from a layout specification rather than handwriting them independently.",
+      "obligations": [],
+      "references": [],
+      "source_section": "11",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "Storage write pricing is an EVM property; no 0.8 release changes it.",
+        "evm_floor": "istanbul",
+        "evm_reason": "The rule turns on original, current and new value metering, which EIP-2200 defines and the source cites.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Both pipelines emit the same store opcodes for the same writes."
+      }
+    },
+    {
+      "id": "YUL-06",
+      "title": "centralize `TLOAD` and `TSTORE`",
+      "kind": "technique",
+      "category": "yul-and-inline-assembly",
+      "priority": "P1",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "on 0.8.25, wrap transient access in reviewed assembly helpers with namespaced slots, chain gates, and lifecycle documentation.",
+      "obligations": [],
+      "references": [
+        "REF-01",
+        "REF-09"
+      ],
+      "source_section": "11",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.25",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The source states 0.8.25 exposes TLOAD and TSTORE through inline assembly; no earlier bound is claimed here.",
+        "evm_floor": "cancun",
+        "evm_reason": "EIP-1153 defines the opcodes, so bytecode reaching them fails on any earlier fork, which the source states as its own chain-capability rule.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Transient access is written as inline assembly and both pipelines carry it."
+      }
+    },
+    {
+      "id": "YUL-07",
+      "title": "use fixed-shape scratch-memory hashing",
+      "kind": "technique",
+      "category": "yul-and-inline-assembly",
+      "priority": "P2",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "retain a canonical `abi.encode` reference and differential-test every assembly hash helper.",
+      "obligations": [
+        "retain a canonical `abi.encode` reference and differential-test every assembly hash helper."
+      ],
+      "references": [],
+      "source_section": "11",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "YUL-08",
+      "title": "construct minimal call data",
+      "kind": "technique",
+      "category": "yul-and-inline-assembly",
+      "priority": "P2",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "for fixed simple ABIs, write selector and arguments at exact offsets and call with the smallest correct span. clean address and narrow integer inputs first.",
+      "obligations": [],
+      "references": [],
+      "source_section": "11",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "YUL-09",
+      "title": "use unsafe array access only after a dominating bound proof",
+      "kind": "technique",
+      "category": "yul-and-inline-assembly",
+      "priority": "P2",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "encapsulate the primitive and make the proof visible at every call site. OpenZeppelin’s explicit `unsafeAccess` naming is the right design signal.",
+      "obligations": [],
+      "references": [
+        "REF-32"
+      ],
+      "source_section": "11",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "YUL-10",
+      "title": "cast pointers only across identical representations",
+      "kind": "technique",
+      "category": "yul-and-inline-assembly",
+      "priority": "P2",
+      "evidence_grade": "C",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "pointer reinterpretation is valid only when header, element layout, lifetime, and mutability are identical. never forge storage pointers.",
+      "obligations": [
+        "never forge storage pointers."
+      ],
+      "references": [],
+      "source_section": "11",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "YUL-11",
+      "title": "return and revert exact spans",
+      "kind": "technique",
+      "category": "yul-and-inline-assembly",
+      "priority": "P2",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "every byte between pointer and pointer-plus-length becomes externally visible returndata. assert raw bytes in tests.",
+      "obligations": [
+        "assert raw bytes in tests."
+      ],
+      "references": [],
+      "source_section": "11",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
+      }
+    },
+    {
+      "id": "YUL-12",
+      "title": "avoid custom dispatch except in extreme stable interfaces",
+      "kind": "technique",
+      "category": "yul-and-inline-assembly",
+      "priority": "P2",
+      "evidence_grade": "C",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "a custom dispatcher duplicates selector routing, payability, length checks, and decoding. use it only after code splitting, optimizer tuning, and architectural alternatives fail.",
+      "obligations": [],
+      "references": [],
+      "source_section": "11",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The limits are consensus rules rather than compiler behaviour; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "EIP-170's runtime code limit applies from Spurious Dragon onward and the source treats it as a standing budget.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Code size differs between pipelines, which is the reason the rule says to measure both."
+      }
+    },
+    {
+      "id": "YUL-13",
+      "title": "use `EXTCODECOPY` for code-resident immutable data",
+      "kind": "technique",
+      "category": "yul-and-inline-assembly",
+      "priority": "P2",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "verify code existence, size, sentinel prefix, offsets, and cold account cost. an EOA or wrong data contract must not silently decode as valid zero bytes.",
+      "obligations": [
+        "verify code existence, size, sentinel prefix, offsets, and cold account cost.",
+        "an EOA or wrong data contract must not silently decode as valid zero bytes."
+      ],
+      "references": [
+        "REF-10",
+        "REF-30"
+      ],
+      "source_section": "11",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "Access pricing is an EVM property; no 0.8 release changes it.",
+        "evm_floor": "berlin",
+        "evm_reason": "The saving rests on the cold and warm access distinction EIP-2929 introduced, which the source cites for this rule.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Both pipelines emit the same access opcodes for the same reads."
+      }
+    },
+    {
+      "id": "YUL-14",
+      "title": "call precompiles with exact failure handling",
+      "kind": "technique",
+      "category": "yul-and-inline-assembly",
+      "priority": "P2",
+      "evidence_grade": "A",
+      "automation": "never",
+      "hermes_class": "assembly",
+      "statement": "construct the specified input, verify call success and output shape, and test chain-specific precompile availability.",
+      "obligations": [
+        "construct the specified input, verify call success and output shape, and test chain-specific precompile availability."
+      ],
+      "references": [],
+      "source_section": "11",
+      "verified_on": {
+        "compiler": "0.8.25",
+        "evm": "cancun"
+      },
+      "scope": {
+        "compiler_min": "0.8.0",
+        "compiler_max_exclusive": "0.9.0",
+        "compiler_reason": "The mechanism is a property of EVM execution, not of a compiler release; the source scopes itself to the 0.8 line.",
+        "evm_floor": "homestead",
+        "evm_reason": "No fork-gated opcode or repricing is involved, so any fork the source's baseline succeeds carries it.",
+        "pipelines": [
+          "legacy",
+          "via-ir"
+        ],
+        "pipeline_reason": "Neither pipeline removes the cost the rule addresses; the source says neither is a universal winner."
       }
     }
   ]

--- a/plugins/hermes/skills/hermes/scripts/hermes.py
+++ b/plugins/hermes/skills/hermes/scripts/hermes.py
@@ -738,11 +738,19 @@ def verify_command(args: argparse.Namespace) -> int:
             raise GateFailure(2, "Foundry configuration changed after baseline", 20)
 
         corpus, corpus_schema, corpus_digest = load_corpus()
-        if corpus_digest != state["baseline"]["corpus_sha256"]:
+        baseline = state["baseline"]
+        for required in ("corpus_sha256", "forge_config"):
+            if required not in baseline:
+                raise CorpusRefusal(
+                    "corpus/baseline-predates-corpus",
+                    f"this run directory was sealed before the corpus gate "
+                    f"existed and carries no {required}; take a fresh baseline",
+                )
+        if corpus_digest != baseline["corpus_sha256"]:
             raise CorpusRefusal(
                 "corpus/digest-moved",
                 f"the corpus changed after the baseline sealed it: baseline "
-                f"{state['baseline']['corpus_sha256'][:16]}, now "
+                f"{baseline['corpus_sha256'][:16]}, now "
                 f"{corpus_digest[:16]}",
             )
         corpus_faults = validate_corpus(corpus, corpus_schema)
@@ -772,7 +780,7 @@ def verify_command(args: argparse.Namespace) -> int:
             "--property-proof": args.property_proof,
             "--obligation": " ".join(args.obligation or []),
         })
-        scope_resolution = resolve_scope(rule, corpus, state["baseline"]["forge_config"])
+        scope_resolution = resolve_scope(rule, corpus, baseline["forge_config"])
         obligations = pair_obligations(rule, args.obligation)
 
         changed_files, _, added_tokens = source_diff(repo, run_dir, state["baseline"]["source_manifest"])
@@ -1260,7 +1268,7 @@ class CorpusRefusal(GateFailure):
         self.reason = reason
 
 
-MYTH_CITATION_RE = re.compile(r"\bMYTH-\d{2}\b")
+MYTH_CITATION_RE = re.compile(r"\bMYTH-\d{2}\b", re.I)
 RULE_ID_RE = re.compile(r"^(CMP|STO|TRN|MEM|CTL|EXT|DEP|YUL|MYTH)-[0-9]{2}$")
 OBLIGATION_ANSWER_RE = re.compile(r"^(?P<index>[1-9][0-9]*)=(?P<answer>.*)$", re.S)
 MINIMUM_OBLIGATION_ANSWER = 20
@@ -1294,13 +1302,13 @@ def refuse_myth_citations(corpus: dict[str, Any], texts: dict[str, str | None]) 
                    if isinstance(myth, dict) and myth.get("id")}
     for where, text in sorted(texts.items()):
         for cited in MYTH_CITATION_RE.findall(text or ""):
-            myth = corrections.get(cited)
+            myth = corrections.get(cited.upper())
             if myth is None:
                 continue
             raise CorpusRefusal(
                 "corpus/myth-cited",
-                f"{where} cites {cited}, which the corpus rejects: "
-                f"{myth['claim']} -- {myth['correction']}",
+                f"{where} cites {cited} ({myth['id']}), which the corpus "
+                f"rejects: {myth['claim']} -- {myth['correction']}",
             )
 
 
@@ -1313,6 +1321,15 @@ def resolve_scope(rule: dict[str, Any], corpus: dict[str, Any],
     """
     scope = rule["scope"]
     forks = corpus["fork_order"]
+    if scope["evm_floor"] not in forks:
+        # validate_corpus already requires this, and depending on that here
+        # without saying so turns a corpus fault into a traceback rather than a
+        # refusal with an exit code.
+        raise CorpusRefusal(
+            "corpus/invalid",
+            f"{rule['id']} floors at {scope['evm_floor']}, which the corpus "
+            f"does not order",
+        )
 
     solc = config.get("solc")
     if not isinstance(solc, str) or parse_version(solc) is None:

--- a/plugins/hermes/skills/hermes/scripts/hermes.py
+++ b/plugins/hermes/skills/hermes/scripts/hermes.py
@@ -543,6 +543,11 @@ def mark_failure(run_dir: Path | None, state: dict[str, Any] | None, failure: Ga
         "reason": str(failure),
         "finished_at": utc_now(),
     }
+    if isinstance(failure, CorpusRefusal):
+        # The exit code names the gate; this names which corpus condition
+        # failed, so a caller can tell an out-of-scope rule from a missing
+        # obligation answer without parsing prose.
+        result["refusal"] = failure.reason
     write_json(run_dir / "result.json", result)
     if state is not None:
         state["status"] = "rejected"
@@ -600,7 +605,7 @@ def baseline_command(args: argparse.Namespace) -> int:
             ["forge", "config", "--json"], repo, run_dir / "logs" / "gate1.forge-config.log", echo=False
         )
         require_success(config, 1, "forge config --json", 10)
-        _, canonical_config = canonical_json(config.stdout, "forge config", 1, 10)
+        config_document, canonical_config = canonical_json(config.stdout, "forge config", 1, 10)
         config_path = run_dir / "baseline.forge-config.json"
         write_text(config_path, canonical_config)
         version_path = run_dir / "baseline.forge-version.txt"
@@ -627,6 +632,14 @@ def baseline_command(args: argparse.Namespace) -> int:
             method_path, _ = inspect_methods(repo, run_dir, contract, "before", 1, 10)
             method_paths.append(method_path)
 
+        corpus, corpus_schema, corpus_digest = load_corpus()
+        corpus_faults = validate_corpus(corpus, corpus_schema)
+        if corpus_faults:
+            raise GateFailure(
+                1, f"the rule corpus does not validate: {corpus_faults[0]}", 10)
+        corpus_path = run_dir / "baseline.gas-rule-corpus.json"
+        write_text(corpus_path, json.dumps(corpus, indent=2, ensure_ascii=False) + "\n")
+
         source_manifest = snapshot_sources(repo, run_dir)
         status = git(repo, ["status", "--porcelain=v1", "-z"], run_dir / "logs" / "gate1.git-status.log")
         require_success(status, 1, "git status", 10)
@@ -639,6 +652,7 @@ def baseline_command(args: argparse.Namespace) -> int:
             version_path,
             status_path,
             run_dir / "baseline-source-manifest.json",
+            corpus_path,
             *layout_paths,
             *method_paths,
         ]
@@ -650,6 +664,12 @@ def baseline_command(args: argparse.Namespace) -> int:
                     "git_head": git_head,
                     "forge_version_sha256": sha256_bytes(version.stdout.encode()),
                     "forge_config_sha256": sha256_bytes(canonical_config.encode()),
+                    "forge_config": {
+                        "solc": config_document.get("solc"),
+                        "evm_version": config_document.get("evm_version"),
+                        "via_ir": bool(config_document.get("via_ir")),
+                    },
+                    "corpus_sha256": corpus_digest,
                     "gas_snapshot": str(baseline_snapshot.relative_to(run_dir)),
                     "source_manifest": source_manifest,
                     "artifact_hashes": hashes,
@@ -717,8 +737,45 @@ def verify_command(args: argparse.Namespace) -> int:
         if sha256_bytes(canonical_config.encode()) != state["baseline"]["forge_config_sha256"]:
             raise GateFailure(2, "Foundry configuration changed after baseline", 20)
 
-        changed_files, _, added_tokens = source_diff(repo, run_dir, state["baseline"]["source_manifest"])
+        corpus, corpus_schema, corpus_digest = load_corpus()
+        if corpus_digest != state["baseline"]["corpus_sha256"]:
+            raise CorpusRefusal(
+                "corpus/digest-moved",
+                f"the corpus changed after the baseline sealed it: baseline "
+                f"{state['baseline']['corpus_sha256'][:16]}, now "
+                f"{corpus_digest[:16]}",
+            )
+        corpus_faults = validate_corpus(corpus, corpus_schema)
+        if corpus_faults:
+            raise CorpusRefusal(
+                "corpus/invalid",
+                f"the rule corpus does not validate: {corpus_faults[0]}")
+
+        rule = select_rule(corpus, args.rule)
         optimisation_class = args.optimisation_class
+        if rule["hermes_class"] is None:
+            raise CorpusRefusal(
+                "corpus/rule-names-no-class",
+                f"{rule['id']} names no Hermes class: it constrains how a run "
+                f"is conducted, or it is architecture. It is advice the record "
+                f"carries, not a candidate this harness can measure.",
+            )
+        if rule["hermes_class"] != optimisation_class:
+            raise CorpusRefusal(
+                "corpus/class-disagreement",
+                f"{rule['id']} is a {rule['hermes_class']} rule; the candidate "
+                f"declares {optimisation_class}",
+            )
+        refuse_myth_citations(corpus, {
+            "--non-sensitive-rationale": args.non_sensitive_rationale,
+            "--layout-change-rationale": args.layout_change_rationale,
+            "--property-proof": args.property_proof,
+            "--obligation": " ".join(args.obligation or []),
+        })
+        scope_resolution = resolve_scope(rule, corpus, state["baseline"]["forge_config"])
+        obligations = pair_obligations(rule, args.obligation)
+
+        changed_files, _, added_tokens = source_diff(repo, run_dir, state["baseline"]["source_manifest"])
         if "unchecked" in added_tokens and optimisation_class != "unchecked-arithmetic":
             raise GateFailure(2, "candidate adds unchecked code outside the unchecked-arithmetic class", 20)
         if "assembly" in added_tokens and optimisation_class != "assembly":
@@ -731,6 +788,15 @@ def verify_command(args: argparse.Namespace) -> int:
 
         state["candidate"] = {
             "optimisation_class": optimisation_class,
+            "rule": {
+                "id": rule["id"],
+                "title": rule["title"],
+                "evidence_grade": rule["evidence_grade"],
+                "automation": rule["automation"],
+                "corpus_sha256": corpus_digest,
+                "scope_resolution": scope_resolution,
+                "obligations": obligations,
+            },
             "single_class_attested": True,
             "changed_files": changed_files,
             "added_sensitive_tokens": sorted(added_tokens),
@@ -740,9 +806,11 @@ def verify_command(args: argparse.Namespace) -> int:
         state["gates"].append(
             {
                 "id": 2,
-                "name": "single_optimisation_class",
+                "name": "corpus_rule_and_single_optimisation_class",
                 "status": "passed",
                 "optimisation_class": optimisation_class,
+                "rule": rule["id"],
+                "corpus_sha256": corpus_digest,
                 "changed_files": changed_files,
                 "passed_at": utc_now(),
             }
@@ -956,6 +1024,7 @@ def verify_command(args: argparse.Namespace) -> int:
             "run_id": state["run_id"],
             "repo": str(repo),
             "optimisation_class": optimisation_class,
+            "rule": state["candidate"]["rule"],
             "changed_files": changed_files,
             "gates": state["gates"],
             "gas": gas,
@@ -1178,6 +1247,158 @@ def validate_corpus(corpus: dict[str, Any], schema: dict[str, Any]) -> list[str]
     return faults
 
 
+class CorpusRefusal(GateFailure):
+    """A Gate 2 refusal the corpus decided, carrying a machine-readable reason.
+
+    Exit code stays 20. The published contract says an exit code names the
+    rejected gate, and there is no seventh gate; the reason is a field so the
+    cause is readable without minting one.
+    """
+
+    def __init__(self, reason: str, message: str):
+        super().__init__(2, message, 20)
+        self.reason = reason
+
+
+MYTH_CITATION_RE = re.compile(r"\bMYTH-\d{2}\b")
+RULE_ID_RE = re.compile(r"^(CMP|STO|TRN|MEM|CTL|EXT|DEP|YUL|MYTH)-[0-9]{2}$")
+OBLIGATION_ANSWER_RE = re.compile(r"^(?P<index>[1-9][0-9]*)=(?P<answer>.*)$", re.S)
+MINIMUM_OBLIGATION_ANSWER = 20
+
+
+def parse_version(value: str) -> tuple[int, int, int] | None:
+    match = VERSION_RE.match(value or "")
+    return tuple(int(part) for part in match.groups()) if match else None
+
+
+def select_rule(corpus: dict[str, Any], identifier: str) -> dict[str, Any]:
+    for rule in corpus.get("rules") or []:
+        if rule.get("id") == identifier:
+            return rule
+    for myth in corpus.get("myths") or []:
+        if myth.get("id") == identifier:
+            raise CorpusRefusal(
+                "corpus/myth-selected",
+                f"{identifier} is a rejected universal rule, not a candidate: "
+                f"{myth.get('claim')} -- {myth.get('correction')}",
+            )
+    raise CorpusRefusal("corpus/unknown-rule", f"no rule {identifier} in the corpus")
+
+
+def refuse_myth_citations(corpus: dict[str, Any], texts: dict[str, str | None]) -> None:
+    """A justification naming a rejected rule is refused with its correction.
+
+    Cheap to satisfy: do not cite a myth id as the reason a candidate is sound.
+    """
+    corrections = {myth["id"]: myth for myth in corpus.get("myths") or []
+                   if isinstance(myth, dict) and myth.get("id")}
+    for where, text in sorted(texts.items()):
+        for cited in MYTH_CITATION_RE.findall(text or ""):
+            myth = corrections.get(cited)
+            if myth is None:
+                continue
+            raise CorpusRefusal(
+                "corpus/myth-cited",
+                f"{where} cites {cited}, which the corpus rejects: "
+                f"{myth['claim']} -- {myth['correction']}",
+            )
+
+
+def resolve_scope(rule: dict[str, Any], corpus: dict[str, Any],
+                  config: dict[str, Any]) -> dict[str, Any]:
+    """Whether the rule holds for the configuration the baseline sealed.
+
+    Fails closed: a configuration this cannot read refuses rather than being
+    assumed to match the source document's own single pin.
+    """
+    scope = rule["scope"]
+    forks = corpus["fork_order"]
+
+    solc = config.get("solc")
+    if not isinstance(solc, str) or parse_version(solc) is None:
+        raise CorpusRefusal(
+            "corpus/scope-unresolved",
+            f"the target does not pin a readable solc version ({solc!r}), so "
+            f"{rule['id']}'s compiler range {scope['compiler_min']} to "
+            f"{scope['compiler_max_exclusive']} cannot be resolved; pin "
+            f"solc_version in foundry.toml",
+        )
+    target_version = parse_version(solc)
+    if not (parse_version(scope["compiler_min"]) <= target_version
+            < parse_version(scope["compiler_max_exclusive"])):
+        raise CorpusRefusal(
+            "corpus/out-of-scope",
+            f"{rule['id']} holds for solc {scope['compiler_min']} up to but not "
+            f"including {scope['compiler_max_exclusive']}; the target resolves "
+            f"{solc}. {scope['compiler_reason']}",
+        )
+
+    evm = config.get("evm_version")
+    if evm not in forks:
+        raise CorpusRefusal(
+            "corpus/scope-unresolved",
+            f"the target's evm_version {evm!r} is not a fork this corpus orders, "
+            f"so {rule['id']}'s floor {scope['evm_floor']} cannot be compared; "
+            f"the ordered names are {', '.join(forks)}",
+        )
+    if forks.index(evm) < forks.index(scope["evm_floor"]):
+        raise CorpusRefusal(
+            "corpus/out-of-scope",
+            f"{rule['id']} needs {scope['evm_floor']} or later; the target "
+            f"resolves {evm}. {scope['evm_reason']}",
+        )
+
+    pipeline = "via-ir" if config.get("via_ir") else "legacy"
+    if pipeline not in scope["pipelines"]:
+        raise CorpusRefusal(
+            "corpus/out-of-scope",
+            f"{rule['id']} holds for the {', '.join(scope['pipelines'])} "
+            f"pipeline; the target compiles with {pipeline}. "
+            f"{scope['pipeline_reason']}",
+        )
+    return {"solc": solc, "evm_version": evm, "pipeline": pipeline}
+
+
+def pair_obligations(rule: dict[str, Any], answers: Sequence[str] | None) -> list[dict[str, str]]:
+    """One recorded answer per obligation the rule's own statement makes.
+
+    Answers are recorded judgement, not measurement. The six hard gates do not
+    move, and `result.json` says which fields are which.
+    """
+    obligations = rule["obligations"]
+    parsed: dict[int, str] = {}
+    for raw in answers or []:
+        match = OBLIGATION_ANSWER_RE.match(raw)
+        if match is None:
+            raise CorpusRefusal(
+                "corpus/obligation-malformed",
+                f"--obligation takes <n>=<answer>, not {raw!r}",
+            )
+        index = int(match.group("index"))
+        if index in parsed:
+            raise CorpusRefusal(
+                "corpus/obligation-malformed",
+                f"obligation {index} answered more than once",
+            )
+        if not 1 <= index <= len(obligations):
+            raise CorpusRefusal(
+                "corpus/obligation-malformed",
+                f"{rule['id']} states {len(obligations)} obligation(s); "
+                f"there is no obligation {index}",
+            )
+        parsed[index] = match.group("answer")
+    for index, obligation in enumerate(obligations, start=1):
+        answer = parsed.get(index, "")
+        if len(answer.strip()) < MINIMUM_OBLIGATION_ANSWER:
+            raise CorpusRefusal(
+                "corpus/obligation-unanswered",
+                f"{rule['id']} obligation {index} has no substantive answer: "
+                f"{obligation}",
+            )
+    return [{"obligation": obligation, "answer": parsed[index].strip(), "kind": "recorded judgement"}
+            for index, obligation in enumerate(obligations, start=1)]
+
+
 def corpus_command(args: argparse.Namespace) -> int:
     try:
         corpus, schema, digest = load_corpus()
@@ -1246,6 +1467,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     verify = subparsers.add_parser("verify", help="Run Gates 2-6 against a sealed baseline")
     verify.add_argument("--run-dir", required=True, help="Evidence directory emitted by baseline")
+    verify.add_argument("--rule", required=True, action=SingleValueAction,
+                        help="Corpus rule id the candidate implements, such as STO-09")
+    verify.add_argument("--obligation", action="append",
+                        help="Answer one of the rule's obligations as <n>=<answer>; repeat for each")
     verify.add_argument(
         "--optimisation-class",
         choices=OPTIMISATION_CLASSES,
@@ -1324,6 +1549,8 @@ def validate_cross_arguments(parser: argparse.ArgumentParser, args: argparse.Nam
         return
     if args.command != "verify":
         return
+    if not RULE_ID_RE.match(args.rule or ""):
+        parser.error("--rule takes a corpus identifier such as STO-09 or MYTH-02")
     targeted = [args.targeted_match_path, args.targeted_match_test, args.property_proof]
     if args.sensitive_unchecked and not all(targeted):
         parser.error(

--- a/plugins/hermes/skills/hermes/scripts/test_hermes.py
+++ b/plugins/hermes/skills/hermes/scripts/test_hermes.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Any, Sequence
 from unittest import mock
 
 
@@ -37,7 +38,13 @@ if args == ["--version"]:
     raise SystemExit(0)
 
 if args == ["config", "--json"]:
-    print(json.dumps({"profile": "default", "optimizer": True, "optimizer_runs": 200}))
+    config = {"profile": "default", "optimizer": True, "optimizer_runs": 200,
+              "solc": "0.8.25", "evm_version": "cancun", "via_ir": False}
+    import os
+    override = os.environ.get("HERMES_TEST_CONFIG_OVERRIDE")
+    if override and Path(override).exists():
+        config.update(json.loads(Path(override).read_text()))
+    print(json.dumps(config))
     raise SystemExit(0)
 
 if args and args[0] == "snapshot":
@@ -137,7 +144,15 @@ contract C {
 """
 
 
-class HermesHarnessTests(unittest.TestCase):
+class HarnessFixture:
+    """The hermetic repository, fake Forge and baseline every gate case needs.
+
+    Deliberately not a TestCase: a fixture that is one gets collected, and a
+    subclass then re-runs every case it inherited under whatever the subclass
+    overrode. That is how this file briefly ran its fourteen harness cases
+    twice, the second time through a `verify` the subclass had changed.
+    """
+
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory(prefix="hermes-tests-")
         self.root = Path(self.temporary.name)
@@ -190,7 +205,32 @@ class HermesHarnessTests(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertEqual(json.loads((self.run_dir / "state.json").read_text())["status"], "baseline_ready")
 
-    def verify(self, *extra: str, optimisation_class: str = "storage-load-caching") -> int:
+    # One rule per class the cases use, with an answer for each obligation the
+    # rule's own statement makes. STO-09 states one, CTL-05 states two.
+    RULES = {
+        "storage-load-caching": ("STO-09", [
+            "1=The cache lives inside the one function and dies with the call frame.",
+        ]),
+        "unchecked-arithmetic": ("CTL-05", [
+            "1=Every intermediate is bounded by the array length, proved at the loop head.",
+            "2=The unchecked region is three lines and the bound is stated beside it.",
+        ]),
+        "constants-immutables": ("STO-15", []),
+        "storage-packing": ("STO-01", []),
+    }
+
+    def override_config(self, **fields: Any) -> None:
+        """Point the fake Forge at a configuration written outside the
+        repository, so Gate 1 still sees a clean tree."""
+        path = self.root / "forge-config-override.json"
+        path.write_text(json.dumps(fields))
+        os.environ["HERMES_TEST_CONFIG_OVERRIDE"] = str(path)
+        self.addCleanup(os.environ.pop, "HERMES_TEST_CONFIG_OVERRIDE", None)
+
+    def verify(self, *extra: str, optimisation_class: str = "storage-load-caching",
+               rule: str | None = None, obligations: Sequence[str] | None = None) -> int:
+        default_rule, default_obligations = self.RULES[optimisation_class]
+        answers = default_obligations if obligations is None else obligations
         return hermes.main(
             [
                 "verify",
@@ -199,6 +239,9 @@ class HermesHarnessTests(unittest.TestCase):
                 "--optimisation-class",
                 optimisation_class,
                 "--attest-single-class",
+                "--rule",
+                rule or default_rule,
+                *[argument for answer in answers for argument in ("--obligation", answer)],
                 "--gas-target",
                 "testGas_target",
                 *extra,
@@ -209,6 +252,8 @@ class HermesHarnessTests(unittest.TestCase):
         (self.repo / "src" / "C.sol").write_text(source)
         (self.repo / ".candidate-gas").write_text(str(gas))
 
+
+class HermesHarnessTests(HarnessFixture, unittest.TestCase):
     def test_accepts_and_promotes_a_fully_verified_candidate(self) -> None:
         self.baseline()
         self.prepare_candidate()
@@ -566,6 +611,209 @@ def _rule_record(**overrides) -> dict:
     record.update(overrides)
     return record
 
+
+
+class CorpusGateTests(HarnessFixture, unittest.TestCase):
+    """Gate 2 refuses seven ways before Gate 3 spends a Forge run.
+
+    Inherits the harness fixture: same fake Forge, same baseline, same
+    candidate. Each case asserts the exit code, the failed gate and the
+    machine-readable refusal reason, because the exit code names the gate and
+    the reason names the condition.
+    """
+
+    def refusal(self) -> dict:
+        return json.loads((self.run_dir / "result.json").read_text())
+
+    def verify(self, *extra: str, **kwargs) -> int:  # type: ignore[override]
+        """Every case here is an ordinary candidate unless it says otherwise,
+        so the classification flag the parser demands is supplied once."""
+        if not any(argument.endswith("sensitive-unchecked") for argument in extra):
+            extra = ("--no-sensitive-unchecked", *extra)
+        return super().verify(*extra, **kwargs)
+
+    def assert_refused(self, code: int, reason: str) -> dict:
+        self.assertEqual(code, 20)
+        result = self.refusal()
+        self.assertEqual(result["failed_gate"], 2)
+        self.assertEqual(result["refusal"], reason)
+        return result
+
+    def test_an_unknown_rule_id_is_refused(self) -> None:
+        self.baseline()
+        self.prepare_candidate()
+        self.assert_refused(self.verify(rule="STO-99"), "corpus/unknown-rule")
+
+    def test_a_rejected_universal_rule_cannot_be_selected(self) -> None:
+        self.baseline()
+        self.prepare_candidate()
+        result = self.assert_refused(self.verify(rule="MYTH-02"), "corpus/myth-selected")
+        self.assertIn("canonical loops are automatically handled", result["reason"])
+
+    def test_a_rule_naming_no_class_is_refused(self) -> None:
+        """58 of the 120 rules are advice the record carries, not candidates."""
+        self.baseline()
+        self.prepare_candidate()
+        result = self.assert_refused(self.verify(rule="CMP-01"), "corpus/rule-names-no-class")
+        self.assertIn("not a candidate", result["reason"])
+
+    def test_a_class_disagreement_is_refused(self) -> None:
+        self.baseline()
+        self.prepare_candidate()
+        result = self.assert_refused(
+            self.verify(rule="STO-15", obligations=[]), "corpus/class-disagreement")
+        self.assertIn("constants-immutables", result["reason"])
+
+    def test_a_myth_cited_as_justification_is_refused(self) -> None:
+        """Naming a rejected rule as the reason a candidate is sound is
+        refused with the correction quoted back."""
+        self.baseline()
+        self.prepare_candidate(source=SOURCE_UNCHECKED)
+        code = self.verify(
+            "--no-sensitive-unchecked",
+            "--non-sensitive-rationale",
+            "Safe by MYTH-28: ordinary unit tests cover the unchecked block.",
+            optimisation_class="unchecked-arithmetic",
+        )
+        result = self.assert_refused(code, "corpus/myth-cited")
+        self.assertIn("every intermediate bound needs a durable proof", result["reason"])
+
+    def test_an_unanswered_obligation_is_refused(self) -> None:
+        self.baseline()
+        self.prepare_candidate()
+        result = self.assert_refused(
+            self.verify(obligations=[]), "corpus/obligation-unanswered")
+        self.assertIn("keep the cache", result["reason"])
+
+    def test_a_blank_obligation_answer_is_refused(self) -> None:
+        self.baseline()
+        self.prepare_candidate()
+        self.assert_refused(self.verify(obligations=["1=    "]),
+                            "corpus/obligation-unanswered")
+
+    def test_an_obligation_index_the_rule_does_not_have_is_refused(self) -> None:
+        self.baseline()
+        self.prepare_candidate()
+        result = self.assert_refused(
+            self.verify(obligations=["1=The cache lives inside one call frame and dies with it.",
+                                     "2=There is no second obligation to answer here."]),
+            "corpus/obligation-malformed")
+        self.assertIn("there is no obligation 2", result["reason"])
+
+    def test_a_malformed_obligation_answer_is_refused(self) -> None:
+        self.baseline()
+        self.prepare_candidate()
+        self.assert_refused(self.verify(obligations=["no index here at all, just prose"]),
+                            "corpus/obligation-malformed")
+
+    def test_an_unpinned_solc_refuses_rather_than_assuming_one(self) -> None:
+        """The failure the source document sets up: its header pins 0.8.25, and
+        a target that pins nothing at all must not be read as matching it."""
+        self.override_config(solc=None)
+        self.baseline()
+        self.prepare_candidate()
+        result = self.assert_refused(self.verify(), "corpus/scope-unresolved")
+        self.assertIn("does not pin a readable solc", result["reason"])
+        self.assertIn("foundry.toml", result["reason"])
+
+    def test_a_fork_below_the_rules_floor_is_refused(self) -> None:
+        """Istanbul, not Paris: Paris is later than Berlin in the order and so
+        satisfies STO-09's floor. Reaching for the newest-sounding name is how
+        a scope check gets a passing test that proves nothing."""
+        self.override_config(evm_version="istanbul")
+        self.baseline()
+        self.prepare_candidate()
+        result = self.assert_refused(self.verify(), "corpus/out-of-scope")
+        self.assertIn("needs berlin or later", result["reason"])
+        self.assertIn("EIP-2929", result["reason"])
+
+    def test_a_fork_above_the_floor_is_in_scope(self) -> None:
+        """Ordering, not string equality. The source was written against
+        Cancun and the Foundry build in this checkout defaults to Osaka, so an
+        equality check would refuse every correct candidate."""
+        self.override_config(evm_version="osaka")
+        self.baseline()
+        self.prepare_candidate()
+        self.assertEqual(self.verify(), 0)
+        self.assertEqual(self.refusal()["status"], "accepted")
+
+    def test_an_unknown_fork_name_refuses(self) -> None:
+        self.override_config(evm_version="verkle")
+        self.baseline()
+        self.prepare_candidate()
+        result = self.assert_refused(self.verify(), "corpus/scope-unresolved")
+        self.assertIn("not a fork this corpus orders", result["reason"])
+
+    def test_a_compiler_outside_the_rules_range_is_refused(self) -> None:
+        self.override_config(solc="0.7.6")
+        self.baseline()
+        self.prepare_candidate()
+        result = self.assert_refused(self.verify(), "corpus/out-of-scope")
+        self.assertIn("0.7.6", result["reason"])
+
+    def test_a_pipeline_outside_the_rules_set_is_refused(self) -> None:
+        """No rule in the corpus is single-pipeline today, so this drives the
+        check through a rule whose scope is narrowed in place."""
+        self.baseline()
+        self.prepare_candidate()
+        self.assertTrue((self.run_dir / "baseline.gas-rule-corpus.json").is_file())
+        corpus, schema, _digest = hermes.load_corpus()
+        for rule in corpus["rules"]:
+            if rule["id"] == "STO-09":
+                rule["scope"]["pipelines"] = ["via-ir"]
+        state = json.loads((self.run_dir / "state.json").read_text())
+        with mock.patch.object(
+            hermes, "load_corpus",
+            return_value=(corpus, schema, state["baseline"]["corpus_sha256"]),
+        ):
+            result = self.assert_refused(self.verify(), "corpus/out-of-scope")
+        self.assertIn("legacy", result["reason"])
+
+    def test_a_corpus_edited_after_the_baseline_is_refused(self) -> None:
+        self.baseline()
+        self.prepare_candidate()
+        corpus, schema, _digest = hermes.load_corpus()
+        with mock.patch.object(hermes, "load_corpus",
+                               return_value=(corpus, schema, "0" * 64)):
+            result = self.assert_refused(self.verify(), "corpus/digest-moved")
+        self.assertIn("changed after the baseline", result["reason"])
+
+    def test_verify_without_a_rule_is_refused_by_the_parser(self) -> None:
+        self.baseline()
+        self.prepare_candidate()
+        with self.assertRaises(SystemExit) as raised:
+            hermes.main(["verify", "--run-dir", str(self.run_dir),
+                         "--optimisation-class", "storage-load-caching",
+                         "--attest-single-class", "--gas-target", "testGas_target"])
+        self.assertNotEqual(raised.exception.code, 0)
+
+    def test_an_accepted_candidate_records_the_corpus_that_judged_it(self) -> None:
+        self.baseline()
+        self.prepare_candidate()
+        self.assertEqual(self.verify(), 0)
+        result = self.refusal()
+        self.assertEqual(result["status"], "accepted")
+        rule = result["rule"]
+        self.assertEqual(rule["id"], "STO-09")
+        self.assertEqual(rule["evidence_grade"], "A")
+        self.assertEqual(rule["automation"], "safe")
+        self.assertEqual(len(rule["corpus_sha256"]), 64)
+        self.assertEqual(rule["scope_resolution"],
+                         {"solc": "0.8.25", "evm_version": "cancun", "pipeline": "legacy"})
+        self.assertEqual(len(rule["obligations"]), 1)
+        self.assertEqual(rule["obligations"][0]["kind"], "recorded judgement")
+        self.assertIn("one function", rule["obligations"][0]["answer"])
+
+    def test_the_baseline_seals_the_corpus_beside_the_configuration(self) -> None:
+        self.baseline()
+        state = json.loads((self.run_dir / "state.json").read_text())
+        _corpus, _schema, digest = hermes.load_corpus()
+        self.assertEqual(state["baseline"]["corpus_sha256"], digest)
+        self.assertEqual(state["baseline"]["forge_config"],
+                         {"solc": "0.8.25", "evm_version": "cancun", "via_ir": False})
+        sealed = self.run_dir / "baseline.gas-rule-corpus.json"
+        self.assertIn(str(sealed.relative_to(self.run_dir)),
+                      state["baseline"]["artifact_hashes"])
 
 
 def _repository_root() -> Path:

--- a/plugins/hermes/skills/hermes/scripts/test_hermes.py
+++ b/plugins/hermes/skills/hermes/scripts/test_hermes.py
@@ -639,23 +639,66 @@ class CorpusFidelityTests(unittest.TestCase):
                 with self.subTest(rule=rule["id"], obligation=obligation[:40]):
                     self.assertIn(obligation, rule["statement"])
 
-    def test_the_section_counts_the_corpus_holds_so_far(self) -> None:
+    def test_the_corpus_holds_every_rule_the_source_states(self) -> None:
         counts = {}
         for rule in self.corpus["rules"]:
             prefix = rule["id"].split("-")[0]
             counts[prefix] = counts.get(prefix, 0) + 1
-        self.assertEqual(counts, {"CMP": 12, "STO": 27, "TRN": 7, "MEM": 16})
-        self.assertEqual(len(self.corpus["rules"]), 62)
+        self.assertEqual(counts, {"CMP": 12, "STO": 27, "TRN": 7, "MEM": 16,
+                                  "CTL": 18, "EXT": 14, "DEP": 12, "YUL": 14})
+        self.assertEqual(len(self.corpus["rules"]), 120)
+        self.assertEqual(sorted(r["id"] for r in self.corpus["rules"]),
+                         sorted(self.source_rules()))
 
     def test_a_rule_with_no_class_is_recorded_rather_than_guessed(self) -> None:
-        """Half of this group constrains the run or the architecture, so it
-        names no candidate. The count is asserted because quietly mapping one
-        of them to the nearest-sounding class is the failure to catch."""
+        """58 of the 120 rules name no candidate: they constrain how a run is
+        conducted, or they are architecture. The count is asserted because
+        quietly mapping one of them to the nearest-sounding class is the
+        failure worth catching, and because the size of that number is the
+        finding this corpus produced about Hermes itself."""
         unclassed = [r["id"] for r in self.corpus["rules"] if r["hermes_class"] is None]
-        self.assertEqual(len(unclassed), 31)
+        self.assertEqual(len(unclassed), 58)
+        self.assertEqual(sum(1 for r in self.corpus["rules"] if r["hermes_class"]), 62)
         for identifier in ("CMP-01", "TRN-01", "STO-23", "MEM-15",
-                           "STO-12", "MEM-09"):
+                           "STO-12", "MEM-09", "CTL-07", "EXT-13"):
             self.assertIn(identifier, unclassed)
+
+    def test_every_deployment_rule_names_no_class(self) -> None:
+        """Every DEP rule is an architecture decision rather than a change
+        inside one contract, so the whole section carries null."""
+        deployment = [r for r in self.corpus["rules"] if r["id"].startswith("DEP-")]
+        self.assertEqual(len(deployment), 12)
+        for rule in deployment:
+            with self.subTest(rule=rule["id"]):
+                self.assertIsNone(rule["hermes_class"])
+                self.assertEqual(rule["kind"], "architecture")
+
+    def test_every_assembly_section_rule_takes_the_assembly_class(self) -> None:
+        """The one section where the class vocabulary fits exactly."""
+        yul = [r for r in self.corpus["rules"] if r["id"].startswith("YUL-")]
+        self.assertEqual(len(yul), 14)
+        for rule in yul:
+            with self.subTest(rule=rule["id"]):
+                self.assertEqual(rule["hermes_class"], "assembly")
+
+    def test_the_require_custom_error_prohibition_stops_at_its_release(self) -> None:
+        """EXT-01 is the one rule whose upper bound matters: the source says
+        custom-error arguments to require arrived after 0.8.25, so the
+        prohibition cannot be carried into the release that introduced them."""
+        rule = next(r for r in self.corpus["rules"] if r["id"] == "EXT-01")
+        self.assertEqual(rule["scope"]["compiler_max_exclusive"], "0.8.26")
+        self.assertEqual(rule["hermes_class"], "custom-errors")
+
+    def test_the_canonical_loop_rule_floors_at_the_release_that_changed_it(self) -> None:
+        rule = next(r for r in self.corpus["rules"] if r["id"] == "CTL-04")
+        self.assertEqual(rule["scope"]["compiler_min"], "0.8.22")
+        self.assertIn("0.8.22", rule["scope"]["compiler_reason"])
+
+    def test_every_class_the_harness_knows_is_reachable_from_some_rule(self) -> None:
+        """A class no rule names would be a class the corpus cannot select,
+        which is the other half of the mapping question."""
+        named = {r["hermes_class"] for r in self.corpus["rules"]} - {None}
+        self.assertEqual(named, set(hermes.OPTIMISATION_CLASSES))
 
     def test_every_measurement_rule_names_no_class(self) -> None:
         for rule in self.corpus["rules"]:

--- a/plugins/hermes/skills/hermes/scripts/test_hermes.py
+++ b/plugins/hermes/skills/hermes/scripts/test_hermes.py
@@ -787,6 +787,52 @@ class CorpusGateTests(HarnessFixture, unittest.TestCase):
                          "--attest-single-class", "--gas-target", "testGas_target"])
         self.assertNotEqual(raised.exception.code, 0)
 
+    def test_a_baseline_sealed_before_the_corpus_gate_refuses(self) -> None:
+        """Round 1 finding: a run directory from the previous Hermes carries
+        neither the corpus digest nor the sealed configuration, and reading a
+        missing key is a traceback rather than a refusal."""
+        self.baseline()
+        self.prepare_candidate()
+        state_path = self.run_dir / "state.json"
+        state = json.loads(state_path.read_text())
+        del state["baseline"]["corpus_sha256"]
+        state_path.write_text(json.dumps(state))
+        result = self.assert_refused(self.verify(), "corpus/baseline-predates-corpus")
+        self.assertIn("take a fresh baseline", result["reason"])
+
+    def test_a_floor_the_corpus_does_not_order_is_a_refusal_not_a_traceback(self) -> None:
+        """Round 1 finding: `resolve_scope` indexed `fork_order` for the rule's
+        floor without checking it was there, so a corpus fault escaped as a
+        ValueError instead of a refusal with an exit code.
+
+        Driven directly rather than through `verify`, because `validate_corpus`
+        runs first and catches the same corpus with its own message. The guard
+        is at the function boundary and that is where it is proved.
+        """
+        corpus, _schema, _digest = hermes.load_corpus()
+        corpus["fork_order"] = ["homestead", "cancun"]
+        rule = next(r for r in corpus["rules"] if r["id"] == "STO-09")
+        with self.assertRaises(hermes.CorpusRefusal) as raised:
+            hermes.resolve_scope(rule, corpus,
+                                 {"solc": "0.8.25", "evm_version": "cancun", "via_ir": False})
+        self.assertEqual(raised.exception.reason, "corpus/invalid")
+        self.assertIn("does not order", str(raised.exception))
+
+    def test_a_lowercased_myth_citation_is_still_refused(self) -> None:
+        """Round 1 finding: the citation scan was case-sensitive, so the same
+        citation written in lower case went unnoticed."""
+        self.baseline()
+        self.prepare_candidate(source=SOURCE_UNCHECKED)
+        code = self.verify(
+            "--no-sensitive-unchecked",
+            "--non-sensitive-rationale",
+            "This is safe for the reason given in myth-28 about unit tests.",
+            optimisation_class="unchecked-arithmetic",
+        )
+        result = self.assert_refused(code, "corpus/myth-cited")
+        self.assertIn("myth-28 (MYTH-28)", result["reason"])
+        self.assertIn("every intermediate bound needs a durable proof", result["reason"])
+
     def test_an_accepted_candidate_records_the_corpus_that_judged_it(self) -> None:
         self.baseline()
         self.prepare_candidate()

--- a/plugins/hermes/skills/hermes/scripts/test_hermes.py
+++ b/plugins/hermes/skills/hermes/scripts/test_hermes.py
@@ -694,6 +694,24 @@ class CorpusFidelityTests(unittest.TestCase):
         self.assertEqual(rule["scope"]["compiler_min"], "0.8.22")
         self.assertIn("0.8.22", rule["scope"]["compiler_reason"])
 
+    def test_a_rule_stating_its_own_assembly_takes_the_assembly_class(self) -> None:
+        """Round 1 finding: MEM-12 states its implementation is scratch-memory
+        hashing, and Gate 2 refuses added assembly outside the assembly class,
+        so any other class would have been refused every time."""
+        rule = next(r for r in self.corpus["rules"] if r["id"] == "MEM-12")
+        self.assertEqual(rule["hermes_class"], "assembly")
+        self.assertIn("scratch-memory", rule["statement"])
+
+    def test_a_code_size_rule_is_not_floored_at_the_initcode_fork(self) -> None:
+        """Round 1 finding: DEP-07 and DEP-08 hold where EIP-170 already
+        applies, so a Shanghai floor refused advice correct on every earlier
+        fork."""
+        for identifier in ("DEP-07", "DEP-08"):
+            rule = next(r for r in self.corpus["rules"] if r["id"] == identifier)
+            with self.subTest(rule=identifier):
+                self.assertEqual(rule["scope"]["evm_floor"], "homestead")
+                self.assertIn("EIP-3860", rule["scope"]["evm_reason"])
+
     def test_every_class_the_harness_knows_is_reachable_from_some_rule(self) -> None:
         """A class no rule names would be a class the corpus cannot select,
         which is the other half of the mapping question."""

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -156,7 +156,7 @@
     },
     "hermes-baseline-promotion": {
       "source": "plugins/hermes/skills/hermes/scripts/hermes.py",
-      "sha256": "6ad048b98202d8120c2ca74781c628fe551c7c06998da250adcfd4ec65d0125d",
+      "sha256": "4210eaf9b6d4b3ae307674203e491790486f5a43eb9daeed3d92dafcfd6cf14c",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "candidate commit, target set and sealed run directory",
@@ -170,7 +170,7 @@
     },
     "hermes-candidate-acceptance": {
       "source": "plugins/hermes/skills/hermes/scripts/hermes.py",
-      "sha256": "6ad048b98202d8120c2ca74781c628fe551c7c06998da250adcfd4ec65d0125d",
+      "sha256": "4210eaf9b6d4b3ae307674203e491790486f5a43eb9daeed3d92dafcfd6cf14c",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "baseline commit, candidate commit and named targets",
@@ -490,6 +490,31 @@
       "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
       "selector": "test_accepts_and_promotes_a_fully_verified_candidate",
       "claim": "Positive evidence exercises the declared operation inside its stated boundary."
+    },
+    "hermes-corpus-m": {
+      "claim": "Missing required evidence is refused rather than treated as success.",
+      "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
+      "selector": "test_an_unanswered_obligation_is_refused"
+    },
+    "hermes-corpus-o": {
+      "claim": "The nearest tempting overclaim remains explicitly unavailable.",
+      "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
+      "selector": "test_a_rule_naming_no_class_is_refused"
+    },
+    "hermes-corpus-p": {
+      "claim": "Positive evidence exercises the declared operation inside its stated boundary.",
+      "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
+      "selector": "test_an_accepted_candidate_records_the_corpus_that_judged_it"
+    },
+    "hermes-corpus-r": {
+      "claim": "The failure is contained and leaves a concrete rerun, rollback or repair path.",
+      "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
+      "selector": "test_an_unpinned_solc_refuses_rather_than_assuming_one"
+    },
+    "hermes-corpus-s": {
+      "claim": "Stale or mismatched subject evidence is refused or kept visibly scoped.",
+      "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
+      "selector": "test_a_corpus_edited_after_the_baseline_is_refused"
     },
     "hermes-m": {
       "path": "plugins/hermes/skills/hermes/scripts/test_hermes.py",
@@ -1725,6 +1750,22 @@
         "S": "hermes-s",
         "O": "hermes-o",
         "R": "hermes-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "hermes-corpus-selection",
+      "skill_path": "plugins/hermes/skills/hermes/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "hermes-corpus-p",
+        "M": "hermes-corpus-m",
+        "S": "hermes-corpus-s",
+        "O": "hermes-corpus-o",
+        "R": "hermes-corpus-r",
         "X": {
           "not_applicable": true,
           "reason": "The canonical declaration supports no exception for this promise."

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -156,7 +156,7 @@
     },
     "hermes-baseline-promotion": {
       "source": "plugins/hermes/skills/hermes/scripts/hermes.py",
-      "sha256": "4210eaf9b6d4b3ae307674203e491790486f5a43eb9daeed3d92dafcfd6cf14c",
+      "sha256": "36e80da4405645486e4f34caf6fa59ed795d864c685e04a9b37a959bc43c1805",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "candidate commit, target set and sealed run directory",
@@ -170,7 +170,7 @@
     },
     "hermes-candidate-acceptance": {
       "source": "plugins/hermes/skills/hermes/scripts/hermes.py",
-      "sha256": "4210eaf9b6d4b3ae307674203e491790486f5a43eb9daeed3d92dafcfd6cf14c",
+      "sha256": "36e80da4405645486e4f34caf6fa59ed795d864c685e04a9b37a959bc43c1805",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "baseline commit, candidate commit and named targets",

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -451,6 +451,7 @@ class PromiseStructureTests(unittest.TestCase):
                 "brevitas-evidence-preservation",
             },
             "plugins/hermes/skills/hermes/SKILL.md": {
+                "hermes-corpus-selection",
                 "hermes-sealed-baseline",
                 "hermes-candidate-acceptance",
                 "hermes-baseline-promotion",
@@ -517,7 +518,7 @@ class PromiseStructureTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["promises"], 61)
+        self.assertEqual(report["counts"]["promises"], 62)
 
     def test_hexaemeron_contract_population_is_complete(self):
         expected = {
@@ -579,7 +580,7 @@ class PromiseOverlayTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["promises"], 66)
+        self.assertEqual(report["counts"]["promises"], 67)
         self.assertEqual(report["counts"]["overlays"], 1)
 
     def test_one_byte_vendored_mutation_is_refused(self):
@@ -955,8 +956,8 @@ class PromiseCoverageTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["coverage_rows"], 66)
-        self.assertEqual(report["counts"]["coverage_selected"], 50)
+        self.assertEqual(report["counts"]["coverage_rows"], 67)
+        self.assertEqual(report["counts"]["coverage_selected"], 51)
 
     def test_berean_and_janus_boundaries_are_explicit(self):
         coverage = json.loads(
@@ -1154,7 +1155,7 @@ class PromiseCoverageTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["coverage_rows"], 66)
+        self.assertEqual(report["counts"]["coverage_rows"], 67)
         self.assertEqual(report["counts"]["coverage_selected"], 16)
 
     def test_prompt_and_vendored_evaluations_never_claim_proof(self):


### PR DESCRIPTION
Stacks on step 4. This is the step where the corpus starts refusing things.

Gate 1 validates the corpus and seals its digest beside the Foundry
configuration. A corpus that fails its own schema ends the run there, so a
candidate is never judged under advice nobody checked, and a corpus edited
between `baseline` and `verify` refuses.

Gate 2 now requires `--rule`. It refuses eleven ways before Gate 3 spends a
Forge run, each with a machine-readable `refusal` field on `result.json`: an
unknown rule, a rejected universal rule selected or cited as a justification, a
rule that names no class, a class the rule doesn't name, a compiler, fork or
pipeline outside the rule's declared scope, a scope that can't be resolved at
all, an unanswered or malformed obligation, a moved corpus digest, and an
invalid corpus.

The exit code stays 20. The published contract says a code names the rejected
gate, and there is no seventh gate, so the cause is a field rather than a new
number.

Scope resolution is ordering, not equality, which is the whole reason the corpus
carries a fork list. A rule flooring at Berlin is satisfied by Paris and by
Osaka. A target that pins no `solc` refuses rather than being read as matching
the source document's own single pin. A fork name the corpus doesn't order
refuses. There's a test for each, including one that would have passed for the
wrong reason: `paris` is *later* than Berlin, so proving a below-floor refusal
needs Istanbul.

Obligation answers are recorded judgement, and `result.json` says so in the
record. The six hard gates don't move because of them.

`hermes-corpus-selection` joins the contract at consequence 1 with its five
evidence cases. It takes no runtime binding, for the same reason
`hermes-sealed-baseline` doesn't.

Audit: `audit/AUDIT.md`, "Hermes rule corpus, step 5", rounds 1 and 2, folded
into this branch. Round 1 drove the new helpers adversarially instead of reading
them, and found three things.

The one worth reading: a run directory sealed by the previous Hermes carries
neither `corpus_sha256` nor `forge_config`, and Gate 2 read both by subscript.
An operator resuming against an older baseline got a `KeyError` traceback rather
than a refusal with an exit code, which is the single failure mode a fail-closed
harness must not have. It refuses now and says to take a fresh baseline.

The other two: `resolve_scope` indexed the fork list for a rule's floor without
checking it was there, so a corpus fault escaped as a `ValueError`; and the
rejected-rule citation scan was case-sensitive, so `myth-28` sailed past a check
that stopped `MYTH-28`.

Round 1 also corrected a test rather than code. The first guard for the
`ValueError` drove it through `verify` and passed for the wrong reason, because
validation catches the same corpus first with its own message. It's a direct
call on `resolve_scope` now, which is where the guard actually sits.

Measuring the budget found a defect rather than a cost. The suite had grown to
82 cases in 34.5s against a 25s ceiling, and the cause wasn't the new cases:
`CorpusGateTests` inherited `HermesHarnessTests`, so all fourteen harness cases
ran a second time under a `verify` the subclass had overridden. The fixture is a
plain mixin now.

Proof:

```bash
python3 plugins/hermes/skills/hermes/scripts/hermes.py corpus --validate
python3 plugins/hermes/skills/hermes/scripts/test_hermes.py
python3 -m unittest discover -s tests
python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
```

Hermes suite 71/71 in 23.9s, 22 of them new. Root suite 104/104. Corpus
validation 0.04s against its one-second ceiling. Phylax, Ephoros and Hypomnema
each exit 0.

<!-- wildcat-origin: shoggoth -->
