### PR TITLE
Drop the sibling-handoff paragraph from every skill surface

### DIFF
--- a/plugins/alexandria/README.md
+++ b/plugins/alexandria/README.md
@@ -5,8 +5,6 @@
 
 Alexandria preserves heterogeneous lending data as digest-bound releases, then derives only the credit views a reviewed mapping can defend.
 
-**Try something else when.** Use Tabularium when the job is semantic event mapping, Probitas when the deliverable is a counterparty dossier, and Lazarus when a test needs finite historical state or exact RPC replay.
-
 **Current frontier.** Compound v3 Phase 0 now pins the Comet registry and preserves one verified Ethereum execution witness; a resumable, reconciled Ethereum USDC interval harvester remains unimplemented.
 
 **Next Fiat job.** Use /hexaemeron:fiat to build the first resumable Ethereum USDC interval collector with implementation-epoch discovery, bounded shards, a second-provider reconciliation path, explicit finality and offline raw-release verification. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.

--- a/plugins/alexandria/skills/alexandria/SKILL.md
+++ b/plugins/alexandria/skills/alexandria/SKILL.md
@@ -26,8 +26,6 @@ another frontier pass after that ledger becomes mature.
 
 Alexandria preserves heterogeneous lending data as digest-bound releases, then derives only the credit views a reviewed mapping can defend.
 
-**Use another tool when.** Use Tabularium when the job is semantic event mapping, Probitas when the deliverable is a counterparty dossier, and Lazarus when a test needs finite historical state or exact RPC replay.
-
 **Current frontier.** Compound v3 Phase 0 now pins the Comet registry and preserves one verified Ethereum execution witness; a resumable, reconciled Ethereum USDC interval harvester remains unimplemented.
 <!-- marketplace-context:end -->
 

--- a/plugins/ariadne/README.md
+++ b/plugins/ariadne/README.md
@@ -5,8 +5,6 @@
 
 Ariadne binds an artefact digest to the build, test, review and deployment evidence behind a release.
 
-**Try something else when.** Use an external Sigstore or cosign verifier for signature identity; use Lazarus for historical fixtures and Pandects for executable credit-law evidence.
-
 **Current frontier.** The grounded-agent predicate remains unimplemented; the state-fixture predicate now ships with its schema, gates, conformance fixtures and a capture path that reads a Lazarus fixture's evidence counts rather than recomputing them.
 
 **Next Fiat job.** Use /hexaemeron:fiat to implement the state-fixture predicate with its schema, gates, conformance fixtures and capture path, and close the gate 5 hole the dataset run recorded against the Solidity release predicate, which a new predicate would inherit. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.

--- a/plugins/ariadne/skills/ariadne/SKILL.md
+++ b/plugins/ariadne/skills/ariadne/SKILL.md
@@ -26,8 +26,6 @@ another frontier pass after that ledger becomes mature.
 
 Ariadne binds an artefact digest to the build, test, review and deployment evidence behind a release.
 
-**Use another tool when.** Use an external Sigstore or cosign verifier for signature identity; use Lazarus for historical fixtures and Pandects for executable credit-law evidence.
-
 **Current frontier.** The grounded-agent predicate remains unimplemented; the state-fixture predicate now ships with its schema, gates, conformance fixtures and a capture path that reads a Lazarus fixture's evidence counts rather than recomputing them.
 <!-- marketplace-context:end -->
 

--- a/plugins/berean/README.md
+++ b/plugins/berean/README.md
@@ -5,8 +5,6 @@
 
 Berean pins the corpus, chain readings and evaluation record a protocol agent's answers rest on, so a release can be checked without the model that produced it.
 
-**Try something else when.** Use Lemma to produce source-linked chunks, Lazarus to preserve the chain evidence itself, and Ariadne to bind a released artefact digest to its evidence.
-
 **Current frontier.** The reference release answers against a frozen demonstration corpus and preserved Goldfinch mainnet reads; no release yet cites live Wildcat documentation or a captured Wildcat market read, and no Ariadne statement binds a berean release.
 
 **Next Fiat job.** Use /hexaemeron:fiat to ship the first berean release grounded in captured Wildcat documentation and Wildcat market reads, replacing the demonstration corpus in the reference deployment. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.

--- a/plugins/berean/skills/berean/SKILL.md
+++ b/plugins/berean/skills/berean/SKILL.md
@@ -26,10 +26,6 @@ Berean pins the corpus, chain readings and evaluation record a protocol
 agent's answers rest on, so a release can be checked without the model that
 produced it.
 
-**Use another tool when.** Use Lemma to produce source-linked chunks, Lazarus
-to preserve the chain evidence itself, and Ariadne to bind a released
-artefact digest to its evidence.
-
 **Current frontier.** The reference release answers against a frozen demonstration corpus and preserved Goldfinch mainnet reads; no release yet cites live Wildcat documentation or a captured Wildcat market read, and no Ariadne statement binds a berean release.
 <!-- marketplace-context:end -->
 

--- a/plugins/brevitas/README.md
+++ b/plugins/brevitas/README.md
@@ -5,8 +5,6 @@
 
 Brevitas puts mechanical volume and structure limits on engineering review prose without cutting its evidence.
 
-**Try something else when.** Use Imprimatur for banned vocabulary, Vulgate for register, and Sapheneia for AuDHD interaction shape. Brevitas does not own any of those jobs.
-
 **Current frontier.** The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked.
 
 **Next Fiat job.** Use /hexaemeron:fiat to Forward-test Brevitas across held x-ray, Solidity-auditor, gas, `invariant` and diff-review outputs, then add every confirmed structural bypass to the corpus without weakening evidence precedence. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.

--- a/plugins/brevitas/skills/brevitas/SKILL.md
+++ b/plugins/brevitas/skills/brevitas/SKILL.md
@@ -19,8 +19,6 @@ that ledger is mature.
 
 Brevitas enforces mechanical volume and structure budgets on engineering review prose while preserving evidence.
 
-**Use another tool when.** Use Imprimatur for banned vocabulary, Vulgate for register, and Sapheneia for AuDHD interaction shape. Brevitas does not own any of those jobs.
-
 **Current frontier.** The linter has not been forward-tested across a held cross-model corpus of engineering reviews, and preservation of counterexamples and reproduction steps remains agent-checked.
 <!-- marketplace-context:end -->
 

--- a/plugins/hermes/README.md
+++ b/plugins/hermes/README.md
@@ -5,8 +5,6 @@
 
 Hermes measures one Solidity gas optimisation class at a time and rejects the candidate when its Foundry evidence does not clear every gate.
 
-**Try something else when.** Use Pandects for credit-specific laws or Hexaemeron's audit skills for a broader security review.
-
 **Current frontier.** Hermes's twelve optimisation classes name 62 of the corpus's 120 rules, so 58 documented rules cannot be selected as candidates.
 
 **Next Fiat job.** Use /hexaemeron:fiat to widen the Hermes optimisation classes against the pinned rule corpus until every rule with a source-level candidate can be selected, starting with the reduction in storage writes that no class names. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.

--- a/plugins/hermes/skills/hermes/SKILL.md
+++ b/plugins/hermes/skills/hermes/SKILL.md
@@ -19,8 +19,6 @@ another frontier pass after that ledger becomes mature.
 
 Hermes measures one Solidity gas optimisation class at a time and rejects the candidate when its Foundry evidence does not clear every gate.
 
-**Use another tool when.** Use Pandects for credit-specific laws, or Hexaemeron's audit skills for a broader security review.
-
 **Current frontier.** Hermes's twelve optimisation classes name 62 of the corpus's 120 rules, so 58 documented rules cannot be selected as candidates.
 <!-- marketplace-context:end -->
 

--- a/plugins/hexaemeron/README.md
+++ b/plugins/hexaemeron/README.md
@@ -5,8 +5,6 @@
 
 Hexaemeron runs an explicit, receipted delivery loop, and every skill it uses answers on its own: fuzzing, audit-readiness and security review, prose lint and voice, and the specification, debugging, hardening, telemetry, measurement and record-keeping skills the loop holds each phase to.
 
-**Try something else when.** Use Hermes for measured gas work, Pandects for reviewed credit laws, and Lemma when the output needed is source-linked retrieval chunks.
-
 **Current frontier.** The bundled Solidity audit suite has not yet been exercised in a published end-to-end Fiat delivery.
 
 **Next Fiat job.** Use /hexaemeron:fiat to run and publish the first Solidity delivery that exercises the bundled x-ray, solidity-auditor and fizz loop end to end, recording every round and closing state. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.

--- a/plugins/hexaemeron/skills/elenchus/SKILL.md
+++ b/plugins/hexaemeron/skills/elenchus/SKILL.md
@@ -23,12 +23,6 @@ about why the thing broke. The job is to try to refute it, not to confirm it.
 Elenchus owns root-cause work on a failure that has already happened: a red
 test, a broken build, a returned counterexample, a behaviour that changed.
 
-**Use another tool when.** `solidity-auditor` and `x-ray` look for findings
-nobody has observed yet; elenchus starts from an observation. `fizz` produces
-the campaign, and elenchus works the counterexample it hands back. `ephoros`
-owns telemetry meant to stay; elenchus adds instrumentation and removes it.
-`metron` owns something that works and is slow.
-
 Serves the `implement` and `audit-round` phases. Fiat has no counterpart for
 this work today, so nothing is superseded.
 

--- a/plugins/hexaemeron/skills/ephoros/SKILL.md
+++ b/plugins/hexaemeron/skills/ephoros/SKILL.md
@@ -24,11 +24,6 @@ first incident becomes archaeology.
 Ephoros owns the telemetry that stays: what a step emits, in what shape, and
 what wakes someone up.
 
-**Use another tool when.** `elenchus` adds logging to chase a failure and takes
-it out again. `metron` measures something slow in order to change it. `hermes`
-measures gas. `phylax` decides what must never appear in output at all, and
-this skill obeys that rule rather than restating it.
-
 Serves the `implement` phase. Fiat has no counterpart for this work today, so
 nothing is superseded.
 

--- a/plugins/hexaemeron/skills/fiat/SKILL.md
+++ b/plugins/hexaemeron/skills/fiat/SKILL.md
@@ -19,11 +19,6 @@ skills. Its version, held frontier, next job, and maturity state live in
 [EVOLUTION.md](EVOLUTION.md). Read that ledger before suggesting, starting, or
 resuming work intended to advance Fiat itself.
 
-**Use another tool when.** Run `imprimatur` or `vulgate` directly for prose,
-the bundled Pashov skills directly for standalone Solidity review, and any
-phase skill on its own when the question is its and the controller is not
-wanted.
-
 **Current frontier.** The ledger above is authoritative. Never substitute
 Hexaemeron's plugin-wide Solidity frontier for Fiat's own held target.
 

--- a/plugins/hexaemeron/skills/hypomnema/SKILL.md
+++ b/plugins/hexaemeron/skills/hypomnema/SKILL.md
@@ -22,12 +22,6 @@ it. Code records what was built. This records why, and what was turned down.
 
 Hypomnema owns what gets recorded and where it goes.
 
-**Use another tool when.** `imprimatur` lints the words and `vulgate` sets
-their register, both after this skill has decided there is something to write.
-`protasis` says what a study must contain before code exists; this covers what
-survives after it. `ephoros` chooses the signals, and this says where the
-runbook behind an alert lives.
-
 Serves the `prose` phase. Fiat's prose pass owns the mask order, the PR text
 and the receipt, and none of that moves here.
 

--- a/plugins/hexaemeron/skills/metron/SKILL.md
+++ b/plugins/hexaemeron/skills/metron/SKILL.md
@@ -21,11 +21,6 @@ a number, and the number comes first.
 Metron owns every measurement except gas: the page, the route, the query, the
 harvest, the release build.
 
-**Use another tool when.** `hermes` owns Solidity gas through its own
-fail-closed Foundry loop, and this skill applies the same discipline everywhere
-else. `ephoros` decides which signals get emitted; metron reads them to make a
-decision. `elenchus` works something broken rather than something slow.
-
 Serves the `implement` phase. Fiat has no counterpart for this work today, so
 nothing is superseded.
 

--- a/plugins/hexaemeron/skills/phylax/SKILL.md
+++ b/plugins/hexaemeron/skills/phylax/SKILL.md
@@ -26,11 +26,6 @@ and the agent skills. A TypeScript application: Next.js routes, Prisma against
 Postgres, rendered markdown, sessions and wallet connection. A long-running
 service that holds a signer and submits transactions.
 
-**Use another tool when.** `solidity-auditor` and `x-ray` review contract
-source. `fizz` builds the invariant harness that covers the on-chain half.
-`elenchus` works a failure that has already happened. `ephoros` decides what
-telemetry stays.
-
 Serves the `implement` phase. Fiat has no counterpart for this work today, so
 nothing is superseded.
 

--- a/plugins/hexaemeron/skills/protasis/SKILL.md
+++ b/plugins/hexaemeron/skills/protasis/SKILL.md
@@ -26,12 +26,6 @@ Protasis owns the content contract for the `study` and `runbook` phases: what
 those two documents must answer before implementation is allowed to start. It
 owns no state, writes no receipt and gates nothing itself.
 
-**Use another tool when.** Fiat owns the controller, the artefact paths, the
-receipts and the phase gate. `hypomnema` records a decision once it has been
-made; protasis decides what has to be settled first. `elenchus` works a failure
-you already have. `metron` supplies the measurement a performance criterion
-needs.
-
 Serves the `study` and `runbook` phases.
 
 Its version, held frontier, next job, and maturity state live in

--- a/plugins/horos/README.md
+++ b/plugins/horos/README.md
@@ -5,8 +5,6 @@
 
 Horos classifies a repository's token sinks with evidence and emits the reading boundary agents respect.
 
-**Try something else when.** Use Lemma to chunk source for retrieval, Brevitas for prose budgets, and Hexaemeron's Metron for runtime cost. Horos decides what goes unread; it never rewrites what is read.
-
 **Current frontier.** The reopened scope is complete: the three home repositories carry graded boundaries, candidates, censuses and adoption stanzas, with the product pull requests awaiting their own review gates; no evidenced improvement remains.
 
 **Next Fiat job.** Use /hexaemeron:fiat to reopen this mature frontier only after new external evidence is recorded as an epoch entry on the ledger; the controller refuses a mature run otherwise. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.

--- a/plugins/horos/skills/horos/SKILL.md
+++ b/plugins/horos/skills/horos/SKILL.md
@@ -17,11 +17,6 @@ unread by default, each exclusion carrying the evidence that earned it. Its
 version, held frontier, next job, and maturity state live in
 [EVOLUTION.md](EVOLUTION.md).
 
-**Use another tool when.** Use Lemma to chunk source for retrieval rather than
-to skip it; use Brevitas for prose volume; use Metron for runtime cost. Horos
-never rewrites code: the compression premise was measured and rejected in the
-study this plugin ships at `docs/study.md`.
-
 **Current frontier.** A census roll-up of the skills repository refuted the closure: the marker rule files horos.py and test_classify.py as generated from their own rule list, 42,673 of the boundary's 114,151 bytes, and content-addressed object stores stand unclassified at 7,844,877 bytes more. The held job is the marker self-exclusion fix; the content-addressed object rule and the Markdown outline extractor follow it, with maturity expected after all three.
 
 ## The verbs

--- a/plugins/janus/README.md
+++ b/plugins/janus/README.md
@@ -5,8 +5,6 @@
 
 Janus tests a contract hook at the threshold it controls: what it may observe and change before a host action, what it may change after, and what it must never touch.
 
-**Try something else when.** Use Hexaemeron Fizz to generate a protocol-specific fuzz harness, Pandects for the economic laws a hook-driven transition must preserve, and Ariadne to carry a manifest revision and its conformance result with a release.
-
 **Current frontier.** Janus ships the Wildcat v2.5 host adapter and its seven gates against modeled hooks, and no second host adapter yet shows the manifest format holds for another callback model.
 
 **Next Fiat job.** Use /hexaemeron:fiat to add a second host adapter once the Wildcat boundary survives its own suite, so the manifest format is shown to describe more than one callback model, starting with the ERC-7579 pre- and post-execution hooks. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.

--- a/plugins/janus/skills/janus/SKILL.md
+++ b/plugins/janus/skills/janus/SKILL.md
@@ -27,8 +27,6 @@ after that ledger becomes mature.
 
 Janus tests a contract hook at the threshold it controls: what may happen before the host action, what may happen after it, and what the hook must never change.
 
-**Use another tool when.** Use Hexaemeron Fizz to generate a protocol-specific fuzz harness, Pandects for the economic laws a hook-driven transition must preserve, and Ariadne to carry a manifest revision and its conformance result with a release.
-
 **Current frontier.** Janus ships the Wildcat v2.5 host adapter and its seven gates against modeled hooks, and no second host adapter yet shows the manifest format holds for another callback model.
 <!-- marketplace-context:end -->
 

--- a/plugins/lazarus/README.md
+++ b/plugins/lazarus/README.md
@@ -5,8 +5,6 @@
 
 Lazarus captures the finite fixed-block Ethereum state and RPC evidence an application test needs, verifies the proof-backed part and replays only exact recorded requests.
 
-**Try something else when.** Use Alexandria for a lending-data archive, Tabularium for event interpretation and Ariadne to bind a released fixture to its evidence.
-
 **Current frontier.** Receipts and logs are recorded RPC evidence only; nothing proves them against the captured header's receiptsRoot.
 
 **Next Fiat job.** Use /hexaemeron:fiat to prove the fixture's recorded transaction receipt and its logs against the captured header's receiptsRoot, so receipt evidence stops resting on the provider's word, and carry the resulting evidence class through the manifest, the verifier, the release and the Ariadne state-fixture predicate without moving any other recorded RPC response into a proved class. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.

--- a/plugins/lazarus/skills/lazarus/SKILL.md
+++ b/plugins/lazarus/skills/lazarus/SKILL.md
@@ -24,8 +24,6 @@ another frontier pass after that ledger becomes mature.
 
 Lazarus captures the finite fixed-block Ethereum state and RPC evidence an application test needs, verifies the proof-backed part and replays only exact recorded requests.
 
-**Use another tool when.** Use Alexandria for a lending-data archive, Tabularium for event interpretation and Ariadne to bind a released fixture to its evidence.
-
 **Current frontier.** Receipts and logs are recorded RPC evidence only; nothing proves them against the captured header's receiptsRoot.
 <!-- marketplace-context:end -->
 

--- a/plugins/lemma/README.md
+++ b/plugins/lemma/README.md
@@ -5,8 +5,6 @@
 
 Lemma turns Solidity compiler input or Markdown trees into validated, source-linked JSONL chunks, keeping quotation text separate from model and embedding text.
 
-**Try something else when.** It does not embed, index, retrieve or answer; Berean is the adjacent unbuilt release discipline for a grounded protocol agent.
-
 **Current frontier.** Callable-surface ABI validation does not independently check return types or state mutability.
 
 **Next Fiat job.** Use /hexaemeron:fiat to make callable-surface ABI validation cover return types and state mutability as well as names and input types, with any divergence rejecting the output. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.

--- a/plugins/lemma/skills/chunk/SKILL.md
+++ b/plugins/lemma/skills/chunk/SKILL.md
@@ -19,8 +19,6 @@ another frontier pass after that ledger becomes mature.
 
 Lemma turns Solidity compiler input or Markdown trees into validated, source-linked JSONL chunks, keeping quotation text separate from model and embedding text.
 
-**Use another tool when.** It does not embed, index, retrieve or answer; Berean is the adjacent unbuilt release discipline for a grounded protocol agent.
-
 **Current frontier.** Callable-surface ABI validation does not independently check return types or state mutability.
 <!-- marketplace-context:end -->
 

--- a/plugins/pandects/README.md
+++ b/plugins/pandects/README.md
@@ -5,8 +5,6 @@
 
 Pandects supplies executable laws for credit contracts, each paired with a deliberately broken specimen and a reduced counterexample.
 
-**Try something else when.** Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release.
-
 **Current frontier.** The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records.
 
 **Next Fiat job.** Use /hexaemeron:fiat to widen the search-record runner to the Echidna and Medusa campaigns, so every engine result ships as a record carrying its engine, configuration, sequence length and corpus digest, with a seed where the engine exposes one and a stated absence where it does not. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.

--- a/plugins/pandects/skills/pandects/SKILL.md
+++ b/plugins/pandects/skills/pandects/SKILL.md
@@ -26,8 +26,6 @@ another frontier pass after that ledger becomes mature.
 
 Pandects supplies executable laws for credit contracts, each paired with a deliberately broken specimen and a reduced counterexample.
 
-**Use another tool when.** Use Hexaemeron Fizz to generate a protocol-specific fuzz harness and Ariadne to carry the resulting campaign evidence with a release.
-
 **Current frontier.** The search-record runner records only the Foundry campaign, so Echidna and Medusa results survive as audit prose rather than as records.
 <!-- marketplace-context:end -->
 

--- a/plugins/probitas/README.md
+++ b/plugins/probitas/README.md
@@ -5,8 +5,6 @@
 
 Probitas builds a sourced record of what a counterparty did across lending venues from addresses they declared, without identifying a person or issuing a Wildcat verdict.
 
-**Try something else when.** Use Alexandria for archived lending inputs and Tabularium when the job is publishing a reusable credit-event release rather than assessing one counterparty.
-
 **Current frontier.** Euler v1/v2 now ship; Morpho Midnight fixed-maturity coverage and curation remain unimplemented.
 
 **Next Fiat job.** Use /hexaemeron:fiat to add fail-closed Morpho Midnight fixed-maturity coverage so a dossier can establish whether repayment was timely. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.

--- a/plugins/probitas/skills/probitas/SKILL.md
+++ b/plugins/probitas/skills/probitas/SKILL.md
@@ -26,8 +26,6 @@ another frontier pass after that ledger becomes mature.
 
 Probitas builds a sourced record of what a counterparty did across lending venues from addresses they declared, without identifying a person or issuing a Wildcat verdict.
 
-**Use another tool when.** Use Alexandria for archived lending inputs and Tabularium when the job is publishing a reusable credit-event release rather than assessing one counterparty.
-
 **Current frontier.** Euler v1/v2 now ship; Morpho Midnight fixed-maturity coverage and curation remain unimplemented.
 <!-- marketplace-context:end -->
 

--- a/plugins/sapheneia/README.md
+++ b/plugins/sapheneia/README.md
@@ -5,8 +5,6 @@
 
 Sapheneia shapes the agent's own interaction with an AuDHD reader: the action, meaning, working state and evidence stay visible from turn to turn.
 
-**Try something else when.** Use Imprimatur to inspect prose for banned machine-writing patterns, and use Vulgate or another voice mask to change register. Sapheneia governs interaction shape; it does not diagnose the reader or choose a house voice.
-
 **Current frontier.** Cross-model behaviour has not yet been held against a published AuDHD task corpus.
 
 **Next Fiat job.** Use /hexaemeron:fiat to build and publish a held cross-model corpus covering debugging, explanation, destructive-action and long-running task turns, then reconcile the ten rules against its results. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.

--- a/plugins/sapheneia/skills/sapheneia/SKILL.md
+++ b/plugins/sapheneia/skills/sapheneia/SKILL.md
@@ -19,8 +19,6 @@ another frontier pass after that ledger becomes mature.
 
 Sapheneia shapes the agent's own interaction with an AuDHD reader: the action, meaning, working state and evidence stay visible from turn to turn.
 
-**Use another tool when.** Use Imprimatur to inspect prose for banned machine-writing patterns, and use Vulgate or another voice mask to change register. Sapheneia governs interaction shape; it does not diagnose the reader or choose a house voice.
-
 **Current frontier.** Cross-model behaviour has not yet been held against a published AuDHD task corpus.
 <!-- marketplace-context:end -->
 

--- a/plugins/tabularium/README.md
+++ b/plugins/tabularium/README.md
@@ -5,8 +5,6 @@
 
 Tabularium maps preserved venue-native records into reproducible, venue-qualified credit events without discarding the source or flattening its meaning.
 
-**Try something else when.** Use Alexandria to collect and preserve heterogeneous lending data, Probitas for a counterparty dossier, and Lazarus for proof-checked historical state or exact RPC replay.
-
 **Current frontier.** Compound v3 Phase 0 now rebuilds ordered calls and signed-principal transitions from one verified Alexandria witness; the Phase 1 canonical adapter and Ethereum USDC specimen remain unimplemented.
 
 **Next Fiat job.** Use /hexaemeron:fiat to ship Compound v3 Phase 1 from Alexandria raw evidence with a new canonical and coverage schema version, supply, withdraw, base-transfer and absorb mappings, a mined borrower-to-borrower transfer witness, hostile fixtures and a byte-identical offline Ethereum USDC specimen. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.

--- a/plugins/tabularium/skills/tabularium/SKILL.md
+++ b/plugins/tabularium/skills/tabularium/SKILL.md
@@ -27,8 +27,6 @@ another frontier pass after that ledger becomes mature.
 
 Tabularium maps preserved venue-native records into reproducible, venue-qualified credit events without discarding the source or flattening its meaning.
 
-**Use another tool when.** Use Alexandria to collect and preserve heterogeneous lending data, Probitas for a counterparty dossier, and Lazarus for proof-checked historical state or exact RPC replay.
-
 **Current frontier.** Compound v3 Phase 0 now rebuilds ordered calls and signed-principal transitions from one verified Alexandria witness; the Phase 1 canonical adapter and Ethereum USDC specimen remain unimplemented.
 <!-- marketplace-context:end -->
 

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -114,7 +114,7 @@
     },
     "ephoros-observability-review": {
       "source": "plugins/hexaemeron/skills/ephoros/SKILL.md",
-      "sha256": "50250264f46d71e945f345ad4538b1485c0a54204761763843a1887370984ecf",
+      "sha256": "547f7c241af77a04e26d8df6284230c402c9d3da7ffe83e26b708ab510285f84",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "reviewed step and build identity",
@@ -254,7 +254,7 @@
     },
     "hypomnema-record-placement": {
       "source": "plugins/hexaemeron/skills/hypomnema/SKILL.md",
-      "sha256": "0d7c67131b76e704f2d3c18c5bc3216ae33d8093ee7185fad376b89676d4c806",
+      "sha256": "ea696a2f6d94693ae86f881912bd8a79147e94dc04994570ef081356a16fe4e8",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "named decision and changed repository surface",
@@ -352,7 +352,7 @@
     },
     "metron-change-decision": {
       "source": "plugins/hexaemeron/skills/metron/SKILL.md",
-      "sha256": "575ac79da8d176d1466942c30fde70b33f59fc6e8cb07cfb7666241cda461394",
+      "sha256": "ee7b547770954dd651e2abad59eb23820b80f795a247e9acca51170bb474b5f3",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "named workload, implementation and isolated change",
@@ -380,7 +380,7 @@
     },
     "phylax-boundary-review": {
       "source": "plugins/hexaemeron/skills/phylax/SKILL.md",
-      "sha256": "abd7a080c09d22d64d1cc80f4299604f3678f35df507d9b60a3bc756bc5b1019",
+      "sha256": "cb5dbd5a82b72cc06c3629c5cde1fc771a7e611ef1f88136b97d08f71802e85b",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "reviewed step, source tree and external-input boundary",

--- a/tests/test_marketplace_prose.py
+++ b/tests/test_marketplace_prose.py
@@ -254,14 +254,37 @@ class MarketplaceProseTests(unittest.TestCase):
             with self.subTest(plugin=name, surface="root selection table"):
                 self.assertEqual(root_readme_frontier(name), expected)
 
-    def test_canonical_skills_state_handoff_and_frontier(self):
+    def test_canonical_skills_state_where_they_sit_and_their_frontier(self):
+        """The sibling-handoff paragraph is deliberately absent.
+
+        Every canonical skill used to carry a `Use another tool when.` line
+        naming siblings to reach for instead, and the landing READMEs carried
+        the same sentence under `Try something else when.`. Both were removed:
+        a reader who does not already know what Ariadne or Fizz are learns
+        nothing from being sent to one by name, and the marketplace boundaries
+        in `AGENTS.md` are where that routing belongs. This case asserts the
+        absence so neither label returns a paragraph at a time.
+        """
         self.assertEqual(set(CANONICAL_SKILLS), set(PLUGINS))
         for name, skill in CANONICAL_SKILLS.items():
             text = skill.read_text(encoding="utf-8")
             with self.subTest(plugin=name):
                 self.assertIn("## Where this sits", text)
-                self.assertIn("**Use another tool when.**", text)
                 self.assertIn("**Current frontier.**", text)
+                self.assertNotIn("**Use another tool when.**", text)
+                self.assertNotIn("**Try something else when.**", text)
+
+    def test_no_shipped_document_carries_a_sibling_handoff_label(self):
+        strays = []
+        for path in ROOT.rglob("*.md"):
+            relative = path.relative_to(ROOT)
+            if relative.parts[0] in {".git", ".hexaemeron", ".claude"}:
+                continue
+            text = path.read_text(encoding="utf-8")
+            for label in ("**Use another tool when.**", "**Try something else when.**"):
+                if label in text:
+                    strays.append(f"{relative}: {label}")
+        self.assertEqual(strays, [])
 
     def test_canonical_skill_directories_have_no_browsing_readme_mirrors(self):
         skills = sorted((ROOT / "plugins").glob("*/skills/**/SKILL.md"))


### PR DESCRIPTION
Every canonical `SKILL.md` carried a `**Use another tool when.**` paragraph naming siblings to reach for instead, and every plugin landing README carried the same sentence under `**Try something else when.**`. Both are gone: 34 paragraphs across 34 files, 9 of them wrapped over more than one line, so this is a paragraph-level removal rather than a line delete.

A reader who does not already know what Ariadne, Fizz or Pandects are learns nothing from being sent to one by name, and a reader who does know did not need telling. Where that routing belongs is the marketplace boundaries section in `AGENTS.md`, which states the same distinctions once for the whole marketplace instead of once per skill.

`test_canonical_skills_state_handoff_and_frontier` demanded the label, so it is inverted and renamed: it now asserts the absence of both labels alongside the two lines that stay. A second case sweeps every tracked Markdown file, so neither label can return a paragraph at a time.

Four Promise Machine runtime bindings pin the digest of a `SKILL.md` whose bytes this moved — ephoros, hypomnema, metron and phylax — and all four are re-pinned.

## Deliberately not touched

The same clause rides **unlabelled** inside the one-line marketplace-context blocks in 118 files, where it reads as `... Use Pandects for credit-specific laws, or Hexaemeron's audit skills for a broader security review. **Current frontier:** ...`. There its job is telling one plugin from another in a listing rather than sending a reader away mid-document, so removing it is a separate decision with a 3.5x wider blast radius. Say the word and it is a second pass.

## Pre-existing findings left alone

Brevitas reports findings in `plugins/janus/README.md`, `plugins/janus/skills/janus/SKILL.md`, `plugins/pandects/README.md` and `plugins/probitas/README.md`, on lines this change does not touch. Verified against a stash that they were failing before it.

Proof:

```bash
python3 -m unittest discover -s tests
python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs
python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
```

Root suite 105/105, up one for the new sweep. Imprimatur clean on all 34 changed documents. Hypomnema, Phylax and Ephoros each exit 0.

<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
