### PR TITLE
Read the TypeScript surface through the shared lexer

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7549,3 +7549,41 @@ dashboard access pass on both language sides alike, parity holds and widening
 either is a rule decision nobody has asked for. The study's count of 882
 tracked TypeScript files reads 875 at the pinned clone commit, a
 study-document discrepancy with no bearing on any acceptance command.
+
+## Ephoros wallet-address telemetry, step 3, round 2 -- 2026-08-21
+
+The round audited the fixed tree at `2a464fe` with the seams of round 1's nine
+fixes as its focus. All nine held: the recursion containment survives five
+other lexer stress paths and an exception-injection probe, the comment-span
+pragma collection holds under CRLF, JSX, template-expression and
+file-boundary edges, E000 stays unsuppressible without over-rotating real
+findings, and a three-way differential shows parent Python behaviour exactly
+restored. The three lints and both suites were green; the findings below came
+from fresh probes.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R2-01 | low | scripts/ephoros.py | the `?.[` bracket form of optional chaining still defeated the subscript recognisers, an ordinary shape with 16 occurrences in the pinned clone | fixed in 82e7274 |
+| S3-R2-02 | low | scripts/ephoros.py | a whitespace-separated dotted chain scanned quadratically, 62.8 seconds at 100 KB and hours at the cap, inside the untrusted-read boundary; introduced by this step's range and missed in round 1 | fixed in 82e7274 |
+| S3-R2-03 | info | scripts/ephoros.py | a `//` pragma inside a block comment suppressed, against the documented line-comment grammar | fixed in 82e7274 |
+| S3-R2-04 | info | scripts/ephoros.py | a constant template-literal index value was missed while the quoted forms fired | fixed in 82e7274 |
+
+The scan fix is structural rather than a cap: chain parsing is anchored to
+bracket positions and runs once, backwards, per bracket, taking the
+adversarial 100 KB specimen from 58.7 seconds to 0.017 and the same content at
+the full 1 MiB cap to 0.177 seconds, with a normal 1 MiB file at 0.295
+seconds -- measured before and after through the real check path, as metron
+requires. Ten guard tests landed with the fixes, six observed red first and
+four pinning negatives, for 110 focused cases. After the fixes the clone run
+stays clean at exit 0 with zero pragmas and an empty porcelain, the tree lint
+exits 0, the Hexaemeron suite passes 704/704, the root suite 107/107, and
+phylax and hypomnema each exit 0.
+
+Leads not pursued: the Python `#` pragma matches inside a Python string, a
+line-based behaviour identical at the step-2 parent and outside this step's
+diff, belonging to a deliberate decision on that surface; the shared lexer's
+recursion defect stays carried forward for the owning surface; read and write
+subscripts both fire on both language sides alike, a parity-preserving rule
+decision nobody has asked to change; a constant backtick literal now counts
+as a string in every constant-key position, semantically identical to the
+quoted forms, with the self-lint and clone run clean under it.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7622,3 +7622,39 @@ name carrying both dashboard and log words reports the dashboard reading by
 deterministic precedence, contrived and consistent; wider fuzzing past four
 thousand cases, marginal after the corpus and clone differentials came back
 with zero unexpected deltas.
+
+## Ephoros wallet-address telemetry, step 3, round 4 -- 2026-08-21
+
+The round audited the tree at `7295cfe` with round 3's fix seams as its focus.
+Every seam held under the strongest equivalence evidence of the loop: a
+findings-tuple differential over all 882 clone TypeScript files, the 24
+committed fixtures, a 40-shape corpus of mismatched and cross-nested brackets
+and fourteen thousand seeded fuzz cases came back with zero deltas, line
+numbers pinned identically including on E000 paths, and every prior specimen
+kept its bound. The three lints and both suites were green; the finding below
+came from extending the adversarial shapes to sink-named nesting, which round
+3's unnamed-chain specimens could not reach.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R4-01 | medium | scripts/ephoros.py | overlapping spans that name a sink still paid per-span work behind the gates, 107 seconds at 160 KB and roughly 77 minutes at the cap on a nested `.labels(` shape | fixed in d21e5ea |
+
+The fix indexes each file once: both property regexes run a single pass over
+the whole mask with spans collecting their rows by bisection, depth-zero
+punctuation is attributed to its innermost matched pair in one scan, and key
+extraction reads a bounded window whose equivalence the grammar guarantees.
+Measured before and after through the real check path, the nested `.labels(`
+shape goes from an extrapolated 80 minutes at the cap to 1.16 seconds, the
+sink-named bracket nest from 12.2 to 1.08 seconds, and every earlier specimen
+keeps its bound with a normal 1 MiB file at 0.43 seconds. The fixer's own
+differential -- the clone, the fixtures and ten thousand seeded fuzz cases,
+10,906 ordered comparisons -- shows zero behaviour deltas. Four guard tests
+land the shapes with exact codes, counts and line numbers, for 116 focused
+cases; the Hexaemeron suite passes 710/710, the root suite 107/107, the tree
+lint exits 0 and the clone run stays clean at exit 0 in 0.86 seconds.
+
+Leads not pursued: shapes whose mandated output is itself quadratic, such as
+nested sinks each re-reporting their inner label containers, now run in
+output-proportional time and cannot be faster than what they must print; the
+shared lexer's recursion defect stays carried forward for the owning surface,
+unchanged since round 1.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7658,3 +7658,38 @@ nested sinks each re-reporting their inner label containers, now run in
 output-proportional time and cannot be faster than what they must print; the
 shared lexer's recursion defect stays carried forward for the owning surface,
 unchanged since round 1.
+
+## Ephoros wallet-address telemetry, step 3, round 5 -- 2026-08-21
+
+The closing round audited the tree at `d21e5ea` with round 4's span-index fix
+as its focus, on evidence independent of the fixer's own harness: a fresh
+differential with its own generators and seed over the 882 clone files, the 24
+fixtures and 5,400 fuzz cases biased at the fix's edges, 6,306 ordered
+comparisons with zero deltas, plus 43 hand-directed attacks derived from a
+static read of the diff. The bounded-window equivalence argument was attacked
+directly and holds: no truncating constant exists, the one numeric literal is
+an exact-length gate beside an anchored hex match, and 500 KB values with the
+address word at the far end fire identically on both sides. Performance holds
+with nothing over 1.13 seconds at the cap, including a fresh shape aimed at
+the new index's bisection. The three lints exit 0, the focused suite passes
+116/116, the Hexaemeron suite 710/710, the root suite 107/107, and the clone
+runs clean at exit 0 in 0.86 seconds with zero pragmas and an empty porcelain
+at start and end.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | No findings. | clean |
+
+The remaining lead set is stable and recorded: the shared lexer's recursion
+defect belongs to its owning surface and is contained at this checker's
+boundary by the unsuppressible E000 path, re-confirmed by 178 fail-closed fuzz
+cases; output-proportional shapes now do exactly the work their mandated
+output requires; the spec-accepted lexical misses are declared non-goals with
+parity across both language sides.
+
+Leads not pursued: fuzzing past the cumulative twenty-five thousand cases,
+marginal after two clone-wide differentials with zero unexpected deltas; two
+pre-existing hypomnema pointer hits inside historical Hermes entries of this
+log, outside this step's diff and outside the acceptance lint scope; the
+study's file-count note from round 1, resolved -- the pinned clone reads
+exactly 882 tracked TypeScript files today.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7454,3 +7454,44 @@ The review covered all 8 source-bound risks: `ts-lexer-input`,
 this documents-only step records them without implementing or weakening any.
 
 Leads not pursued: none.
+
+## Ephoros wallet-address telemetry, step 2, round 1 -- 2026-08-21
+
+The exact range `485023a30468f898068454fb92e10ae2b547a604..a88b649c1993c95babe2d848c220efc1e4f966bc`
+holds the E005 recognisers in Python and block-YAML, ten fixtures under
+`telemetry-keys/` and 21 new checker tests. No Solidity changed, so the
+recorded security-suite waiver applies and the Pashov pair did not run.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | No findings. | clean |
+
+Phylax, Ephoros and Hypomnema each exit 0. The focused checker suite passes
+67/67, the Hexaemeron suite 661/661 and the root suite 107/107. The step head
+has a valid local signature and exactly one of each required Shoggoth trailer.
+
+The review ran roughly seventy adversarial specimens against the checker
+beyond the committed tests. The register ids in this step's reach were each
+worked by execution: `e002-reassignment` (overlap labels such as
+`wallet_hash` and `address_url` yield exactly one code, E005; `tx_hash` keeps
+E002; a mixed label set yields one of each), `yaml-label-keys` (25 probes:
+block scalars, quoted keys, list forms, flow mappings, comment interruptions,
+alert-boundary containment and `annotations:` nesting all behave inside the
+E004 subset, and E004 and E005 co-fire where both apply), `suppression-parity`
+in its Python half (a reasoned pragma on the line and the line above
+suppresses all three shapes, a bare pragma suppresses none, and pragma-shaped
+text inside scalars is inert) and `fixture-exclusion` (the walk reaches zero
+`telemetry-keys/` files while an identical specimen outside a fixtures
+directory is caught, exit 1). A parent-to-head differential over every
+pre-existing fixture shows E001 to E004 unmoved; the one modified test is the
+sanctioned E002-to-E005 guard re-pin. `ts-lexer-input`, the TypeScript half of
+`suppression-parity`, `false-positive-cache-keys` and `walk-widening` are not
+applicable until step 3 opens that surface.
+
+Leads not pursued: the `s?` suffix shared by `ADDRESS_KEY` and the
+pre-existing `UNBOUNDED` regex misses `-es` plurals such as `addresses` and
+`hashes`, a checker-wide lexical gap that predates this commit and belongs to
+a deliberate rule-widening decision; the E005 message says wallet address for
+any `address`-fragment key such as `ip_address`, a wording the SKILL.md prose
+in step 4 should state; nested mappings under `labels:` pass silently because
+recognition is direct-children-only, worth a line in the same step 4 prose.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7587,3 +7587,38 @@ subscripts both fire on both language sides alike, a parity-preserving rule
 decision nobody has asked to change; a constant backtick literal now counts
 as a string in every constant-key position, semantically identical to the
 quoted forms, with the self-lint and clone run clean under it.
+
+## Ephoros wallet-address telemetry, step 3, round 3 -- 2026-08-21
+
+The round audited the tree at `82e7274` with round 2's fix seams as its
+focus and one converging sweep. All thirteen earlier fixes held: the backward
+chain parser was differentialed against the old grammar over a 65-shape
+corpus, four thousand seeded fuzz cases and a findings-level comparison across
+all 882 clone TypeScript files with zero unexpected deltas, and the pragma,
+backtick and regression seams each held under execution. The three lints and
+both suites were green; the findings below came from the sweep's mandated
+adversarial shapes.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R3-01 | medium | scripts/ephoros.py | deeply nested brackets scanned quadratically through `_matching`, extrapolating to roughly 1.9 hours at the 1 MiB cap, the `ts-lexer-input` register class | fixed in 7295cfe |
+| S3-R3-02 | low | scripts/ephoros.py | a findings-saturated file paid a per-finding newline count, 9.9 seconds for fifty thousand findings | fixed in 7295cfe |
+
+Both fixes are structural and measured before and after through the real
+check path, as metron requires: one linear stack pass maps every opening
+bracket to its closer and cheap sink-name gates precede all span work, taking
+the nested specimen at cap scale from an extrapolated 1.9 hours to 0.814
+seconds; a per-file newline table with bisect takes the saturated specimen
+from 9.877 to 0.526 seconds with line numbers pinned identical at the first,
+middle and last finding. Two guard tests land the specimens at runtime,
+asserting completion, exact counts and exact line numbers rather than
+wall-clock. After the fixes the focused suite passes 112, the Hexaemeron suite
+706/706, the root suite 107/107, the tree lint exits 0 and the clone run stays
+clean at exit 0 in 0.886 seconds with an empty porcelain.
+
+Leads not pursued: a generic-call type argument hides the chain from both the
+old and new grammars alike, a lexical depth the study declares a non-goal; a
+name carrying both dashboard and log words reports the dashboard reading by
+deterministic precedence, contrived and consistent; wider fuzzing past four
+thousand cases, marginal after the corpus and clone differentials came back
+with zero unexpected deltas.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7495,3 +7495,57 @@ a deliberate rule-widening decision; the E005 message says wallet address for
 any `address`-fragment key such as `ip_address`, a wording the SKILL.md prose
 in step 4 should state; nested mappings under `labels:` pass silently because
 recognition is direct-children-only, worth a line in the same step 4 prose.
+
+## Ephoros wallet-address telemetry, step 3, round 1 -- 2026-08-21
+
+The exact range `e78a3cac6d684e474dbf5d78c65bd8faa5d84417..41f5da1d637826851bdc8c647da3df3dc590d49f`
+opens the TypeScript surface: `check_typescript` through the shared masked
+lexer, the widened walk, and 20 new checker tests. No Solidity changed, so the
+recorded security-suite waiver applies and the Pashov pair did not run. The
+three lints and both suites were green; every finding below came from
+adversarial probes beyond the committed tests.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R1-01 | high | scripts/ephoros.py | a ~3 KB nested-template file raises RecursionError through the shared lexer, crashes the run and drops sibling findings, falsifying the E000 fail-closed claim | fixed in 2a464fe |
+| S3-R1-02 | medium | scripts/ephoros.py | pragma text inside a TS string or template suppresses a real E005; allow lines were read from raw text rather than comment spans | fixed in 2a464fe |
+| S3-R1-03 | medium | scripts/ephoros.py | TS E000 findings were suppressible, so a crafted unterminated file plus a pragma vanished with exit 0 | fixed in 2a464fe |
+| S3-R1-04 | medium | scripts/ephoros.py | the widened ALLOW grammar leaked `//` pragma semantics into Python files, changing parent behaviour out of step scope | fixed in 2a464fe |
+| S3-R1-05 | medium | scripts/ephoros.py | `index:` string-literal values were missed because the property regex ran over the blanked mask | fixed in 2a464fe |
+| S3-R1-06 | low | scripts/ephoros.py | canonical prom-client `labelNames:` spelling unrecognised | fixed in 2a464fe |
+| S3-R1-07 | low | scripts/ephoros.py | optional chaining `?.` defeated every recogniser | fixed in 2a464fe |
+| S3-R1-08 | low | tests/test_ephoros_checker.py | five YAML alert-label tests were absorbed into a TypeScript-named class | fixed in 2a464fe |
+| S3-R1-09 | info | scripts/ephoros.py | `#` pragmas suppressed inside `.ts` files under the same un-gated grammar | fixed in 2a464fe |
+
+Each fix landed under the guard-test convention, red observed then green: 13
+tests over the step head's 87, for 100 focused cases. After the fixes the
+clone run stays clean at exit 0 with zero pragmas and an empty porcelain, the
+tree lint exits 0, the Hexaemeron suite passes 694/694 and the root suite
+107/107. Phylax still exits 0 over the changed checker and over the clone's
+`src`, and a mixed secret-plus-address specimen draws exactly one code from
+each lint, so the boundary between the two holds. A parent-to-head
+differential over E001 to E003, the Python E005 shapes, Python suppression and
+the YAML shapes shows zero mismatches beyond the sanctioned fixes.
+
+The register ids this step opens were each worked by execution:
+`ts-lexer-input` (cap exact at 1 MiB and applied before lexing, 0.2 ms refusal
+on cap-plus-one; unterminated constructs, invalid UTF-8, BOM, CRLF, JSX and
+regex ambiguity all E000 or clean; no execution or import of inspected
+source), `false-positive-cache-keys` (the clone's five real address patterns
+stay clean while tags shorthand, statsd tags, instance labels, positional hex
+and attributes fire), `suppression-parity` in its TypeScript half (line and
+line-above suppress, bare and block-comment pragmas do not), `walk-widening`
+(`node_modules` excluded by test and probe, symlinked directories not
+traversed, and the walked `dist`/`build` question checked against both named
+trees, which hold no tracked build output today) and `rule-boundary-drift`
+(no P004 to P007 pattern duplicated or moved).
+
+Leads not pursued: the shared lexer's recursion defect itself stays in
+`plugins/hexaemeron/lib/typescript_lexer.py` and reproduces identically under
+phylax, which predates this run; ephoros now contains it at its own boundary,
+and the lexer fix belongs to a deliberate change on the owning surface,
+carried forward for the run report. Computed object keys and method-call
+dashboard access pass on both language sides alike, parity holds and widening
+either is a rule decision nobody has asked for. The study's count of 882
+tracked TypeScript files reads 875 at the pinned clone commit, a
+study-document discrepancy with no bearing on any acceptance command.

--- a/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
+++ b/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
@@ -8,6 +8,7 @@ reading intent. Everything else in SKILL.md stays a judgement.
   E002  a metric label drawn from an unbounded source
   E003  a duration summarised as a mean
   E004  a supported YAML alert entry has no local runbook annotation
+  E005  telemetry keyed by wallet address: a metric label, dashboard key or log index
 
 Exit 0 clean, 1 findings, 2 bad invocation.
 
@@ -35,6 +36,12 @@ UNBOUNDED = re.compile(
     re.IGNORECASE,
 )
 
+# One concern, one code: E005 claims the address-shaped labels, E002 keeps
+# every other unbounded fragment.
+ADDRESS_KEY = re.compile(r"(?:^|_)(?:address|wallet|addr)s?(?:_|$)", re.IGNORECASE)
+HEX_ADDRESS = re.compile(r"0x[0-9a-fA-F]{40}")
+DASHBOARD_NAME = re.compile(r"(?:^|_|\.)(?:dashboard|panel)s?$", re.IGNORECASE)
+
 DURATION = re.compile(
     r"(?:^|_)(?:duration|latency|elapsed|seconds|secs|millis|ms|runtime|response_?time"
     r"|took|wait|time)s?(?:_|$)",
@@ -47,6 +54,8 @@ YAML_SUFFIXES = {".yaml", ".yml"}
 MAX_YAML_BYTES = 1 << 20
 ALERT = re.compile(r"^-\s+alert\s*:")
 ANNOTATIONS = re.compile(r"^annotations\s*:\s*$")
+LABELS = re.compile(r"^labels\s*:\s*$")
+YAML_KEY = re.compile(r"^(?P<key>[^\s:#-][^:]*?)\s*:")
 RUNBOOK = re.compile(r"^runbook\s*:\s*(?P<path>.+?)\s*$", re.DOTALL)
 BLOCK_SCALAR = re.compile(
     r"^(?:[^:#][^:]*:\s*|-\s+)[|>](?:[+-]?\d?|\d[+-]?)\s*$")
@@ -84,6 +93,21 @@ def _name_of(node: ast.AST) -> str:
 
 def _is_str_literal(node: ast.AST) -> bool:
     return isinstance(node, ast.Constant) and isinstance(node.value, str)
+
+
+def _address_key(label: str) -> bool:
+    return bool(ADDRESS_KEY.search(label) or HEX_ADDRESS.fullmatch(label))
+
+
+def _address_shaped(node: ast.AST) -> str:
+    """Return the address-shaped name or literal in a key position, or ""."""
+    if isinstance(node, ast.Name) and ADDRESS_KEY.search(node.id):
+        return node.id
+    if isinstance(node, ast.Attribute) and ADDRESS_KEY.search(node.attr):
+        return node.attr
+    if _is_str_literal(node) and _address_key(node.value):
+        return node.value
+    return ""
 
 
 def _built_by_formatting(node: ast.AST) -> bool:
@@ -128,6 +152,11 @@ class Visitor(ast.NodeVisitor):
     def _add(self, node: ast.AST, code: str, message: str) -> None:
         self.findings.append(Finding(self.path, node.lineno, code, message))
 
+    def _keyed_by_address(self, node: ast.AST, position: str, key: str) -> None:
+        self._add(node, "E005",
+                  f"{position} `{key}` keys telemetry by wallet address; "
+                  "put it in an event")
+
     def visit_Call(self, node: ast.Call) -> None:
         func = node.func
         if isinstance(func, ast.Attribute) and func.attr in LOG_METHODS \
@@ -136,12 +165,39 @@ class Visitor(ast.NodeVisitor):
                 self._add(node, "E001",
                           "log message built by formatting; use a stable name and fields")
 
+        if isinstance(func, ast.Attribute):
+            if func.attr == "labels":
+                for keyword in node.keywords:
+                    if keyword.arg and ADDRESS_KEY.search(keyword.arg):
+                        self._keyed_by_address(node, "metric label", keyword.arg)
+                for arg in node.args:
+                    if _is_str_literal(arg) and HEX_ADDRESS.fullmatch(arg.value):
+                        self._keyed_by_address(node, "metric label", arg.value)
+            if LOGGER_NAME.search(_name_of(func.value)):
+                for keyword in node.keywords:
+                    if keyword.arg == "index":
+                        key = _address_shaped(keyword.value)
+                        if key:
+                            self._keyed_by_address(node, "log index", key)
+
         for keyword in node.keywords:
             if keyword.arg in LABEL_KWARGS:
                 for label in self._label_names(keyword.value):
-                    if UNBOUNDED.search(label):
+                    if _address_key(label):
+                        self._keyed_by_address(node, "metric label", label)
+                    elif UNBOUNDED.search(label):
                         self._add(node, "E002",
                                   f"metric label `{label}` is unbounded; put it in an event")
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        key = _address_shaped(node.slice)
+        if key:
+            target = _name_of(node.value)
+            if DASHBOARD_NAME.search(target):
+                self._keyed_by_address(node, "dashboard key", key)
+            elif LOGGER_NAME.search(target):
+                self._keyed_by_address(node, "log index", key)
         self.generic_visit(node)
 
     @staticmethod
@@ -332,6 +388,34 @@ def _relative_markdown(value: str) -> bool:
                 and "://" not in value)
 
 
+def _alert_label_findings(
+        path: Path, significant: list[tuple[int, int, str]], allowed: set[int],
+        index: int, end: int, child_indent: int | None) -> list[Finding]:
+    """Return E005 findings for address-named keys under one alert's labels."""
+    findings: list[Finding] = []
+    cursor = index + 1
+    while cursor < end:
+        _, labels_indent, nested = significant[cursor]
+        cursor += 1
+        if labels_indent != child_indent or not LABELS.match(nested):
+            continue
+        key_child_indent = significant[cursor][1] if cursor < end else None
+        while cursor < end:
+            number, key_indent, candidate = significant[cursor]
+            if key_indent <= labels_indent:
+                break
+            match = YAML_KEY.match(candidate)
+            if key_indent == key_child_indent and match \
+                    and _address_key(match.group("key")) \
+                    and number not in allowed and number - 1 not in allowed:
+                findings.append(Finding(
+                    path, number, "E005",
+                    f"alert label `{match.group('key')}` keys telemetry by "
+                    "wallet address; put it in an event"))
+            cursor += 1
+    return findings
+
+
 def _yaml_findings(path: Path, text: str) -> list[Finding]:
     lines = text.splitlines()
     significant = _yaml_lines(lines)
@@ -349,6 +433,8 @@ def _yaml_findings(path: Path, text: str) -> list[Finding]:
 
         alert_child_indent = (significant[index + 1][1]
                               if index + 1 < end else None)
+        findings.extend(_alert_label_findings(
+            path, significant, allowed, index, end, alert_child_indent))
         annotated = False
         cursor = index + 1
         while cursor < end:

--- a/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
+++ b/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
@@ -12,7 +12,8 @@ reading intent. Everything else in SKILL.md stays a judgement.
 
 Exit 0 clean, 1 findings, 2 bad invocation.
 
-Deliberate exceptions state a reason: `# ephoros: allow <why>`.
+Deliberate exceptions state a reason: `# ephoros: allow <why>` in Python and
+YAML, `// ephoros: allow <why>` in TypeScript.
 """
 
 from __future__ import annotations
@@ -23,6 +24,12 @@ import json
 import re
 import sys
 from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[3]
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))
+
+from lib.typescript_lexer import lex  # noqa: E402
 
 LOG_METHODS = {"debug", "info", "warning", "warn", "error", "critical", "exception", "log"}
 # A logger, not any object with an `info` method, and deliberately not `print`:
@@ -49,8 +56,30 @@ DURATION = re.compile(
 )
 MEAN_FUNCS = {"mean", "fmean", "average", "avg"}
 
-ALLOW = re.compile(r"#\s*ephoros:\s*allow\s+(?P<reason>\S.*)$")
+ALLOW = re.compile(r"(?:#|//)\s*ephoros:\s*allow\s+(?P<reason>\S.*)$")
 YAML_SUFFIXES = {".yaml", ".yml"}
+TYPESCRIPT_SUFFIXES = {".ts", ".tsx"}
+TYPESCRIPT_MAX_BYTES = 1 << 20
+
+# The TypeScript surface, read through the shared masked lexer the way phylax
+# reads it. Recognition splits identifiers on underscore and camel-case
+# boundaries, so `walletAddress` and `wallet_address` name the same key.
+TS_IDENTIFIER = r"[A-Za-z_$][\w$]*"
+TS_WORD = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
+TS_CHAIN = re.compile(
+    rf"(?<![\w$.])(?P<chain>{TS_IDENTIFIER}(?:\s*\.\s*{TS_IDENTIFIER})*)"
+    r"\s*(?P<open>[\[(])")
+TS_LABEL_PROPERTY = re.compile(
+    r"(?<![\w$])(?:labels|labelnames|label_names|tags|attributes)"
+    r"\s*:\s*(?P<open>[\[{])")
+TS_INDEX_PROPERTY = re.compile(r"(?<![\w$])index\s*:\s*")
+TS_ADDRESS_WORDS = frozenset({"address", "addresses", "addr", "addrs",
+                              "wallet", "wallets"})
+TS_METRIC_WORDS = frozenset({"metric", "metrics", "counter", "counters",
+                             "gauge", "gauges", "histogram", "histograms",
+                             "analytics", "telemetry", "statsd"})
+TS_DASHBOARD_WORDS = frozenset({"dashboard", "dashboards", "panel", "panels"})
+TS_LOG_WORDS = frozenset({"log", "logs", "logger", "logging"})
 MAX_YAML_BYTES = 1 << 20
 ALERT = re.compile(r"^-\s+alert\s*:")
 ANNOTATIONS = re.compile(r"^annotations\s*:\s*$")
@@ -464,7 +493,251 @@ def _yaml_findings(path: Path, text: str) -> list[Finding]:
                 "alert entry has no nested `annotations.runbook` Markdown path"))
     return findings
 
+def _line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _masked(text: str, spans) -> str:
+    """Blank comments, strings and other non-code while preserving offsets."""
+    parts = []
+    for kind, start, end in spans:
+        segment = text[start:end]
+        if kind == "code":
+            parts.append(segment)
+        else:
+            parts.append("".join(ch if ch == "\n" else " " for ch in segment))
+    return "".join(parts)
+
+
+def _matching(mask: str, opening: int) -> int | None:
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    if opening >= len(mask) or mask[opening] not in pairs:
+        return None
+    stack = [pairs[mask[opening]]]
+    for index in range(opening + 1, len(mask)):
+        current = mask[index]
+        if current in pairs:
+            stack.append(pairs[current])
+        elif stack and current == stack[-1]:
+            stack.pop()
+            if not stack:
+                return index
+    return None
+
+
+def _split_ranges(mask: str, start: int, end: int) -> list[tuple[int, int]]:
+    """Split a comma list at lexical depth zero, retaining source offsets."""
+    ranges = []
+    stack = []
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    item = start
+    for index in range(start, end):
+        current = mask[index]
+        if current in pairs:
+            stack.append(pairs[current])
+        elif stack and current == stack[-1]:
+            stack.pop()
+        elif current == "," and not stack:
+            ranges.append((item, index))
+            item = index + 1
+    ranges.append((item, end))
+    return ranges
+
+
+def _ts_words(name: str) -> set[str]:
+    return {word.lower() for word in TS_WORD.findall(name)}
+
+
+def _ts_address_name(name: str) -> bool:
+    return bool(_ts_words(name) & TS_ADDRESS_WORDS)
+
+
+def _ts_address_string(value: str) -> bool:
+    return bool(HEX_ADDRESS.fullmatch(value) or _ts_address_name(value))
+
+
+def _ts_string_value(expression: str) -> str | None:
+    expression = expression.strip()
+    if len(expression) >= 2 and expression[0] == expression[-1] \
+            and expression[0] in "'\"":
+        return expression[1:-1]
+    return None
+
+
+def _ts_address_expression(text: str, mask: str, start: int, end: int) -> str:
+    """Return the address-shaped name or literal in a key position, or ""."""
+    expression = mask[start:end].strip()
+    if re.fullmatch(rf"{TS_IDENTIFIER}(?:\s*\.\s*{TS_IDENTIFIER})*", expression):
+        last = re.split(r"\s*\.\s*", expression)[-1]
+        return last if _ts_address_name(last) else ""
+    value = _ts_string_value(text[start:end])
+    if value is not None and _ts_address_string(value):
+        return value
+    return ""
+
+
+def _ts_keyed_by_address(path: Path, text: str, offset: int,
+                         position: str, key: str) -> Finding:
+    return Finding(path, _line_of(text, offset), "E005",
+                   f"{position} `{key}` keys telemetry by wallet address; "
+                   "put it in an event")
+
+
+def _ts_object_keys(text: str, mask: str, opening: int,
+                    closing: int) -> list[tuple[int, str]]:
+    """Return (offset, key) for each address-shaped key of one object literal."""
+    keys = []
+    for start, end in _split_ranges(mask, opening + 1, closing):
+        colon = -1
+        stack = []
+        pairs = {"(": ")", "[": "]", "{": "}"}
+        for index in range(start, end):
+            current = mask[index]
+            if current in pairs:
+                stack.append(pairs[current])
+            elif stack and current == stack[-1]:
+                stack.pop()
+            elif current == ":" and not stack:
+                colon = index
+                break
+        key_end = colon if colon != -1 else end
+        key = _ts_address_expression(text, mask, start, key_end)
+        if key:
+            keys.append((start, key))
+    return keys
+
+
+def _ts_label_container(path: Path, text: str, mask: str, opening: int,
+                        closing: int) -> list[Finding]:
+    """E005 findings for address keys inside one label set container."""
+    findings = []
+    if mask[opening] == "{":
+        for offset, key in _ts_object_keys(text, mask, opening, closing):
+            findings.append(_ts_keyed_by_address(
+                path, text, offset, "metric label", key))
+    else:
+        for start, end in _split_ranges(mask, opening + 1, closing):
+            value = _ts_string_value(text[start:end])
+            if value is not None and _ts_address_string(value):
+                findings.append(_ts_keyed_by_address(
+                    path, text, start, "metric label", value))
+    return findings
+
+
+def _ts_label_properties(path: Path, text: str, mask: str, start: int,
+                         end: int) -> list[Finding]:
+    """Label/tag/attribute sets inside one telemetry sink call's arguments."""
+    findings = []
+    for match in TS_LABEL_PROPERTY.finditer(mask, start, end):
+        opening = match.start("open")
+        closing = _matching(mask, opening)
+        if closing is not None:
+            findings.extend(_ts_label_container(path, text, mask, opening, closing))
+    return findings
+
+
+def _ts_labels_call(path: Path, text: str, mask: str, start: int,
+                    end: int) -> list[Finding]:
+    """The Prometheus instance style: `.labels({...})` or a literal address."""
+    findings = []
+    for arg_start, arg_end in _split_ranges(mask, start, end):
+        argument = mask[arg_start:arg_end].strip()
+        if argument.startswith("{"):
+            opening = mask.index("{", arg_start, arg_end)
+            closing = _matching(mask, opening)
+            if closing is not None:
+                for offset, key in _ts_object_keys(text, mask, opening, closing):
+                    findings.append(_ts_keyed_by_address(
+                        path, text, offset, "metric label", key))
+        else:
+            value = _ts_string_value(text[arg_start:arg_end])
+            if value is not None and HEX_ADDRESS.fullmatch(value):
+                findings.append(_ts_keyed_by_address(
+                    path, text, arg_start, "metric label", value))
+    return findings
+
+
+def _ts_index_properties(path: Path, text: str, mask: str, start: int,
+                         end: int) -> list[Finding]:
+    """`index:` properties inside one logger or log-store call's arguments."""
+    findings = []
+    for match in TS_INDEX_PROPERTY.finditer(mask, start, end):
+        value_end = match.end()
+        stack = []
+        pairs = {"(": ")", "[": "]", "{": "}"}
+        for index in range(match.end(), end):
+            current = mask[index]
+            if current in pairs:
+                stack.append(pairs[current])
+            elif current in ")]}" and not stack:
+                value_end = index
+                break
+            elif stack and current == stack[-1]:
+                stack.pop()
+            elif current == "," and not stack:
+                value_end = index
+                break
+        else:
+            value_end = end
+        key = _ts_address_expression(text, mask, match.end(), value_end)
+        if key:
+            findings.append(_ts_keyed_by_address(
+                path, text, match.start(), "log index", key))
+    return findings
+
+
+def check_typescript(path: Path, text: str) -> list[Finding]:
+    spans, errors = lex(text)
+    if errors:
+        return [Finding(path, _line_of(text, offset), "E000",
+                        f"could not lex: {reason}")
+                for offset, reason in errors]
+    mask = _masked(text, spans)
+    findings: list[Finding] = []
+    for match in TS_CHAIN.finditer(mask):
+        segments = re.split(r"\s*\.\s*", match.group("chain"))
+        if segments[0] == "console":
+            continue  # command-line output is not telemetry
+        opening = match.start("open")
+        closing = _matching(mask, opening)
+        if closing is None:
+            continue
+        last_words = _ts_words(segments[-1])
+        if match.group("open") == "[":
+            key = _ts_address_expression(text, mask, opening + 1, closing)
+            if key and last_words & TS_DASHBOARD_WORDS:
+                findings.append(_ts_keyed_by_address(
+                    path, text, opening + 1, "dashboard key", key))
+            elif key and last_words & TS_LOG_WORDS:
+                findings.append(_ts_keyed_by_address(
+                    path, text, opening + 1, "log index", key))
+            continue
+        chain_words = set().union(*(_ts_words(s) for s in segments))
+        if chain_words & TS_METRIC_WORDS:
+            findings.extend(_ts_label_properties(
+                path, text, mask, opening + 1, closing))
+        if len(segments) >= 2 and segments[-1] == "labels":
+            findings.extend(_ts_labels_call(
+                path, text, mask, opening + 1, closing))
+        if len(segments) >= 2 and _ts_words(segments[-2]) & TS_LOG_WORDS:
+            findings.extend(_ts_index_properties(
+                path, text, mask, opening + 1, closing))
+    return findings
+
+
 def check(path: Path) -> list[Finding]:
+    if path.suffix in TYPESCRIPT_SUFFIXES:
+        try:
+            with path.open("rb") as source:
+                raw = source.read(TYPESCRIPT_MAX_BYTES + 1)
+            if len(raw) > TYPESCRIPT_MAX_BYTES:
+                return [Finding(path, 1, "E000",
+                                "unreadable: TypeScript exceeds 1 MiB")]
+            text = raw.decode("utf-8")
+        except (OSError, UnicodeDecodeError) as err:
+            return [Finding(path, 1, "E000", f"unreadable: {err}")]
+        return [f for f in check_typescript(path, text)
+                if not suppressed(text, f.line)]
     if path.suffix in YAML_SUFFIXES:
         try:
             with path.open("rb") as source:
@@ -495,11 +768,14 @@ def walk(paths: list[str]) -> list[Path]:
     for raw in paths:
         root = Path(raw)
         if root.is_dir():
-            found = (child for suffix in (".py", *sorted(YAML_SUFFIXES))
+            suffixes = (".py", *sorted(TYPESCRIPT_SUFFIXES),
+                        *sorted(YAML_SUFFIXES))
+            found = (child for suffix in suffixes
                      for child in root.rglob(f"*{suffix}"))
             out.extend(child for child in sorted(set(found))
                        if child.is_file()
                        and "__pycache__" not in child.parts
+                       and "node_modules" not in child.parts
                        and "fixtures" not in child.relative_to(root).parts[:-1])
         else:
             out.append(root)

--- a/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
+++ b/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
@@ -57,7 +57,7 @@ DURATION = re.compile(
 MEAN_FUNCS = {"mean", "fmean", "average", "avg"}
 
 # The pragma grammar is gated by surface: `#` belongs to Python and YAML,
-# `//` to TypeScript, where it is read from genuine comment spans only.
+# `//` to TypeScript, where it is read from genuine line-comment spans only.
 ALLOW = re.compile(r"#\s*ephoros:\s*allow\s+(?P<reason>\S.*)$")
 TS_ALLOW = re.compile(r"//\s*ephoros:\s*allow\s+(?P<reason>\S.*)$", re.MULTILINE)
 YAML_SUFFIXES = {".yaml", ".yml"}
@@ -72,9 +72,9 @@ TS_WORD = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
 # `?.` separates a chain the way `.` does: optional chaining names the same sink.
 TS_SEPARATOR = r"\s*\??\.\s*"
 TS_SPLIT = re.compile(TS_SEPARATOR)
-TS_CHAIN = re.compile(
-    rf"(?<![\w$.])(?P<chain>{TS_IDENTIFIER}(?:{TS_SEPARATOR}{TS_IDENTIFIER})*)"
-    r"\s*(?P<open>[\[(])")
+TS_OPEN = re.compile(r"[\[(]")
+TS_IDENT_CHAR = re.compile(r"[\w$]")
+TS_IDENT_START = re.compile(r"[A-Za-z_$]")
 TS_LABEL_PROPERTY = re.compile(
     r"(?<![\w$])(?:labels|labelNames|labelnames|label_names|tags|attributes)"
     r"\s*:\s*(?P<open>[\[{])")
@@ -556,6 +556,53 @@ def _ts_words(name: str) -> set[str]:
     return {word.lower() for word in TS_WORD.findall(name)}
 
 
+def _skip_ws(mask: str, index: int) -> int:
+    while index and mask[index - 1].isspace():
+        index -= 1
+    return index
+
+
+def _ts_chain_before(mask: str, opening: int) -> list[str] | None:
+    """Parse the dotted chain that ends at the bracket at `opening`, or None.
+
+    Scanning is anchored to the brackets: a chain is only ever read once,
+    backwards from its own bracket, so a dotted expression that never reaches
+    a bracket costs nothing.  A forward chain regex paid quadratically there —
+    every admitted start position rescanned the whole remaining chain before
+    failing at the bracket class.  `?.` separates segments the way `.` does,
+    including the bracket form `?.[` and `?.(`.
+    """
+    index = _skip_ws(mask, opening)
+    if mask[index - 2:index] == "?.":
+        index = _skip_ws(mask, index - 2)
+    segments: list[str] = []
+    while True:
+        end = index
+        while index and TS_IDENT_CHAR.match(mask[index - 1]):
+            index -= 1
+        if end == index or not TS_IDENT_START.match(mask[index]):
+            # No identifier here: the chain ends at the last good segment,
+            # and a separator already consumed is not part of it.
+            if not segments:
+                return None
+            index = start
+            break
+        segments.append(mask[index:end])
+        start = index
+        after = _skip_ws(mask, index)
+        if after and mask[after - 1] == ".":
+            dot = after - 1
+            if dot and mask[dot - 1] == "?":
+                dot -= 1
+            index = _skip_ws(mask, dot)
+            continue
+        break
+    if index and mask[index - 1] == ".":
+        return None  # a trailing property of something that is not a name
+    segments.reverse()
+    return segments
+
+
 def _ts_address_name(name: str) -> bool:
     return bool(_ts_words(name) & TS_ADDRESS_WORDS)
 
@@ -568,6 +615,11 @@ def _ts_string_value(expression: str) -> str | None:
     expression = expression.strip()
     if len(expression) >= 2 and expression[0] == expression[-1] \
             and expression[0] in "'\"":
+        return expression[1:-1]
+    # A template literal with no `${}` interpolation is a constant string;
+    # an interpolated one is not, and stays out of key recognition.
+    if len(expression) >= 2 and expression[0] == expression[-1] == "`" \
+            and "${" not in expression:
         return expression[1:-1]
     return None
 
@@ -696,10 +748,15 @@ def _ts_index_properties(path: Path, text: str, mask: str, start: int,
 
 
 def _ts_allow_lines(text: str, spans) -> set[int]:
-    """Return reasoned pragma lines that are genuine TypeScript comments."""
+    """Return reasoned pragma lines that are genuine `//` line comments.
+
+    The documented grammar is a `//` line comment, so block comments are
+    inert for suppression: `/* // ephoros: allow why */` states no reason
+    at the site it would excuse.
+    """
     allowed: set[int] = set()
     for kind, start, end in spans:
-        if kind not in ("line_comment", "block_comment"):
+        if kind != "line_comment":
             continue
         for match in TS_ALLOW.finditer(text, start, end):
             allowed.add(_line_of(text, match.start()))
@@ -723,16 +780,18 @@ def check_typescript(path: Path, text: str) -> list[Finding]:
     allowed = _ts_allow_lines(text, spans)
     mask = _masked(text, spans)
     findings: list[Finding] = []
-    for match in TS_CHAIN.finditer(mask):
-        segments = TS_SPLIT.split(match.group("chain"))
+    for bracket in TS_OPEN.finditer(mask):
+        opening = bracket.start()
+        segments = _ts_chain_before(mask, opening)
+        if not segments:
+            continue
         if segments[0] == "console":
             continue  # command-line output is not telemetry
-        opening = match.start("open")
         closing = _matching(mask, opening)
         if closing is None:
             continue
         last_words = _ts_words(segments[-1])
-        if match.group("open") == "[":
+        if mask[opening] == "[":
             key = _ts_address_expression(text, mask, opening + 1, closing)
             if key and last_words & TS_DASHBOARD_WORDS:
                 findings.append(_ts_keyed_by_address(

--- a/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
+++ b/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
@@ -23,6 +23,7 @@ import ast
 import json
 import re
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 PLUGIN_ROOT = Path(__file__).resolve().parents[3]
@@ -501,8 +502,22 @@ def _yaml_findings(path: Path, text: str) -> list[Finding]:
                 "alert entry has no nested `annotations.runbook` Markdown path"))
     return findings
 
-def _line_of(text: str, offset: int) -> int:
-    return text.count("\n", 0, offset) + 1
+def _newline_offsets(text: str) -> list[int]:
+    """Offsets of every newline, built once per file so lookups can bisect.
+
+    Counting from the top of the file for every finding cost quadratic time
+    on findings-saturated files; one table and a bisection keep it linear.
+    """
+    offsets = []
+    index = text.find("\n")
+    while index != -1:
+        offsets.append(index)
+        index = text.find("\n", index + 1)
+    return offsets
+
+
+def _line_of(newlines: list[int], offset: int) -> int:
+    return bisect_left(newlines, offset) + 1
 
 
 def _masked(text: str, spans) -> str:
@@ -517,20 +532,24 @@ def _masked(text: str, spans) -> str:
     return "".join(parts)
 
 
-def _matching(mask: str, opening: int) -> int | None:
+def _bracket_matches(mask: str) -> dict[int, int]:
+    """Map every opening bracket's offset to its closing offset, or nothing.
+
+    One linear stack pass per file: a closer pops only the innermost opener
+    it actually pairs with, and a mismatched closer is inert, exactly as the
+    old per-bracket forward scan behaved.  That scan restarted at every
+    bracket with a chain before it, so fully overlapping nested spans cost
+    quadratic time; the table answers every lookup in constant time.
+    """
     pairs = {"(": ")", "[": "]", "{": "}"}
-    if opening >= len(mask) or mask[opening] not in pairs:
-        return None
-    stack = [pairs[mask[opening]]]
-    for index in range(opening + 1, len(mask)):
-        current = mask[index]
+    matches: dict[int, int] = {}
+    stack: list[tuple[int, str]] = []
+    for index, current in enumerate(mask):
         if current in pairs:
-            stack.append(pairs[current])
-        elif stack and current == stack[-1]:
-            stack.pop()
-            if not stack:
-                return index
-    return None
+            stack.append((index, pairs[current]))
+        elif stack and current == stack[-1][1]:
+            matches[stack.pop()[0]] = index
+    return matches
 
 
 def _split_ranges(mask: str, start: int, end: int) -> list[tuple[int, int]]:
@@ -637,9 +656,9 @@ def _ts_address_expression(text: str, mask: str, start: int, end: int) -> str:
     return ""
 
 
-def _ts_keyed_by_address(path: Path, text: str, offset: int,
+def _ts_keyed_by_address(path: Path, newlines: list[int], offset: int,
                          position: str, key: str) -> Finding:
-    return Finding(path, _line_of(text, offset), "E005",
+    return Finding(path, _line_of(newlines, offset), "E005",
                    f"{position} `{key}` keys telemetry by wallet address; "
                    "put it in an event")
 
@@ -668,36 +687,39 @@ def _ts_object_keys(text: str, mask: str, opening: int,
     return keys
 
 
-def _ts_label_container(path: Path, text: str, mask: str, opening: int,
-                        closing: int) -> list[Finding]:
+def _ts_label_container(path: Path, text: str, mask: str, newlines: list[int],
+                        opening: int, closing: int) -> list[Finding]:
     """E005 findings for address keys inside one label set container."""
     findings = []
     if mask[opening] == "{":
         for offset, key in _ts_object_keys(text, mask, opening, closing):
             findings.append(_ts_keyed_by_address(
-                path, text, offset, "metric label", key))
+                path, newlines, offset, "metric label", key))
     else:
         for start, end in _split_ranges(mask, opening + 1, closing):
             value = _ts_string_value(text[start:end])
             if value is not None and _ts_address_string(value):
                 findings.append(_ts_keyed_by_address(
-                    path, text, start, "metric label", value))
+                    path, newlines, start, "metric label", value))
     return findings
 
 
-def _ts_label_properties(path: Path, text: str, mask: str, start: int,
+def _ts_label_properties(path: Path, text: str, mask: str, newlines: list[int],
+                         matches: dict[int, int], start: int,
                          end: int) -> list[Finding]:
     """Label/tag/attribute sets inside one telemetry sink call's arguments."""
     findings = []
     for match in TS_LABEL_PROPERTY.finditer(mask, start, end):
         opening = match.start("open")
-        closing = _matching(mask, opening)
+        closing = matches.get(opening)
         if closing is not None:
-            findings.extend(_ts_label_container(path, text, mask, opening, closing))
+            findings.extend(_ts_label_container(
+                path, text, mask, newlines, opening, closing))
     return findings
 
 
-def _ts_labels_call(path: Path, text: str, mask: str, start: int,
+def _ts_labels_call(path: Path, text: str, mask: str, newlines: list[int],
+                    matches: dict[int, int], start: int,
                     end: int) -> list[Finding]:
     """The Prometheus instance style: `.labels({...})` or a literal address."""
     findings = []
@@ -705,21 +727,21 @@ def _ts_labels_call(path: Path, text: str, mask: str, start: int,
         argument = mask[arg_start:arg_end].strip()
         if argument.startswith("{"):
             opening = mask.index("{", arg_start, arg_end)
-            closing = _matching(mask, opening)
+            closing = matches.get(opening)
             if closing is not None:
                 for offset, key in _ts_object_keys(text, mask, opening, closing):
                     findings.append(_ts_keyed_by_address(
-                        path, text, offset, "metric label", key))
+                        path, newlines, offset, "metric label", key))
         else:
             value = _ts_string_value(text[arg_start:arg_end])
             if value is not None and HEX_ADDRESS.fullmatch(value):
                 findings.append(_ts_keyed_by_address(
-                    path, text, arg_start, "metric label", value))
+                    path, newlines, arg_start, "metric label", value))
     return findings
 
 
-def _ts_index_properties(path: Path, text: str, mask: str, start: int,
-                         end: int) -> list[Finding]:
+def _ts_index_properties(path: Path, text: str, mask: str, newlines: list[int],
+                         start: int, end: int) -> list[Finding]:
     """`index:` properties inside one logger or log-store call's arguments."""
     findings = []
     for match in TS_INDEX_PROPERTY.finditer(mask, start, end):
@@ -743,11 +765,11 @@ def _ts_index_properties(path: Path, text: str, mask: str, start: int,
         key = _ts_address_expression(text, mask, match.end(), value_end)
         if key:
             findings.append(_ts_keyed_by_address(
-                path, text, match.start(), "log index", key))
+                path, newlines, match.start(), "log index", key))
     return findings
 
 
-def _ts_allow_lines(text: str, spans) -> set[int]:
+def _ts_allow_lines(text: str, spans, newlines: list[int]) -> set[int]:
     """Return reasoned pragma lines that are genuine `//` line comments.
 
     The documented grammar is a `//` line comment, so block comments are
@@ -759,7 +781,7 @@ def _ts_allow_lines(text: str, spans) -> set[int]:
         if kind != "line_comment":
             continue
         for match in TS_ALLOW.finditer(text, start, end):
-            allowed.add(_line_of(text, match.start()))
+            allowed.add(_line_of(newlines, match.start()))
     return allowed
 
 
@@ -773,12 +795,14 @@ def check_typescript(path: Path, text: str) -> list[Finding]:
         return [Finding(path, 1, "E000", "could not lex: recursion limit")]
     except Exception as err:  # noqa: BLE001 -- any lexer failure fails closed
         return [Finding(path, 1, "E000", f"could not lex: {err}")]
+    newlines = _newline_offsets(text)
     if errors:
-        return [Finding(path, _line_of(text, offset), "E000",
+        return [Finding(path, _line_of(newlines, offset), "E000",
                         f"could not lex: {reason}")
                 for offset, reason in errors]
-    allowed = _ts_allow_lines(text, spans)
+    allowed = _ts_allow_lines(text, spans, newlines)
     mask = _masked(text, spans)
+    matches = _bracket_matches(mask)
     findings: list[Finding] = []
     for bracket in TS_OPEN.finditer(mask):
         opening = bracket.start()
@@ -787,29 +811,42 @@ def check_typescript(path: Path, text: str) -> list[Finding]:
             continue
         if segments[0] == "console":
             continue  # command-line output is not telemetry
-        closing = _matching(mask, opening)
-        if closing is None:
-            continue
+        # The cheap sink-name gates come before any per-bracket span work:
+        # a bracket whose chain names no sink costs nothing further.
         last_words = _ts_words(segments[-1])
         if mask[opening] == "[":
+            if not last_words & (TS_DASHBOARD_WORDS | TS_LOG_WORDS):
+                continue
+            closing = matches.get(opening)
+            if closing is None:
+                continue
             key = _ts_address_expression(text, mask, opening + 1, closing)
             if key and last_words & TS_DASHBOARD_WORDS:
                 findings.append(_ts_keyed_by_address(
-                    path, text, opening + 1, "dashboard key", key))
+                    path, newlines, opening + 1, "dashboard key", key))
             elif key and last_words & TS_LOG_WORDS:
                 findings.append(_ts_keyed_by_address(
-                    path, text, opening + 1, "log index", key))
+                    path, newlines, opening + 1, "log index", key))
             continue
         chain_words = set().union(*(_ts_words(s) for s in segments))
-        if chain_words & TS_METRIC_WORDS:
+        metric_sink = bool(chain_words & TS_METRIC_WORDS)
+        labels_call = len(segments) >= 2 and segments[-1] == "labels"
+        log_call = len(segments) >= 2 and bool(
+            _ts_words(segments[-2]) & TS_LOG_WORDS)
+        if not (metric_sink or labels_call or log_call):
+            continue
+        closing = matches.get(opening)
+        if closing is None:
+            continue
+        if metric_sink:
             findings.extend(_ts_label_properties(
-                path, text, mask, opening + 1, closing))
-        if len(segments) >= 2 and segments[-1] == "labels":
+                path, text, mask, newlines, matches, opening + 1, closing))
+        if labels_call:
             findings.extend(_ts_labels_call(
-                path, text, mask, opening + 1, closing))
-        if len(segments) >= 2 and _ts_words(segments[-2]) & TS_LOG_WORDS:
+                path, text, mask, newlines, matches, opening + 1, closing))
+        if log_call:
             findings.extend(_ts_index_properties(
-                path, text, mask, opening + 1, closing))
+                path, text, mask, newlines, opening + 1, closing))
     return [finding for finding in findings
             if finding.line not in allowed and finding.line - 1 not in allowed]
 

--- a/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
+++ b/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
@@ -56,7 +56,10 @@ DURATION = re.compile(
 )
 MEAN_FUNCS = {"mean", "fmean", "average", "avg"}
 
-ALLOW = re.compile(r"(?:#|//)\s*ephoros:\s*allow\s+(?P<reason>\S.*)$")
+# The pragma grammar is gated by surface: `#` belongs to Python and YAML,
+# `//` to TypeScript, where it is read from genuine comment spans only.
+ALLOW = re.compile(r"#\s*ephoros:\s*allow\s+(?P<reason>\S.*)$")
+TS_ALLOW = re.compile(r"//\s*ephoros:\s*allow\s+(?P<reason>\S.*)$", re.MULTILINE)
 YAML_SUFFIXES = {".yaml", ".yml"}
 TYPESCRIPT_SUFFIXES = {".ts", ".tsx"}
 TYPESCRIPT_MAX_BYTES = 1 << 20
@@ -66,13 +69,18 @@ TYPESCRIPT_MAX_BYTES = 1 << 20
 # boundaries, so `walletAddress` and `wallet_address` name the same key.
 TS_IDENTIFIER = r"[A-Za-z_$][\w$]*"
 TS_WORD = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
+# `?.` separates a chain the way `.` does: optional chaining names the same sink.
+TS_SEPARATOR = r"\s*\??\.\s*"
+TS_SPLIT = re.compile(TS_SEPARATOR)
 TS_CHAIN = re.compile(
-    rf"(?<![\w$.])(?P<chain>{TS_IDENTIFIER}(?:\s*\.\s*{TS_IDENTIFIER})*)"
+    rf"(?<![\w$.])(?P<chain>{TS_IDENTIFIER}(?:{TS_SEPARATOR}{TS_IDENTIFIER})*)"
     r"\s*(?P<open>[\[(])")
 TS_LABEL_PROPERTY = re.compile(
-    r"(?<![\w$])(?:labels|labelnames|label_names|tags|attributes)"
+    r"(?<![\w$])(?:labels|labelNames|labelnames|label_names|tags|attributes)"
     r"\s*:\s*(?P<open>[\[{])")
-TS_INDEX_PROPERTY = re.compile(r"(?<![\w$])index\s*:\s*")
+# No trailing `\s*`: a blanked string in the mask is spaces, and the value
+# span must start at the colon so the raw literal can be read back.
+TS_INDEX_PROPERTY = re.compile(r"(?<![\w$])index\s*:")
 TS_ADDRESS_WORDS = frozenset({"address", "addresses", "addr", "addrs",
                               "wallet", "wallets"})
 TS_METRIC_WORDS = frozenset({"metric", "metrics", "counter", "counters",
@@ -567,8 +575,9 @@ def _ts_string_value(expression: str) -> str | None:
 def _ts_address_expression(text: str, mask: str, start: int, end: int) -> str:
     """Return the address-shaped name or literal in a key position, or ""."""
     expression = mask[start:end].strip()
-    if re.fullmatch(rf"{TS_IDENTIFIER}(?:\s*\.\s*{TS_IDENTIFIER})*", expression):
-        last = re.split(r"\s*\.\s*", expression)[-1]
+    if re.fullmatch(rf"{TS_IDENTIFIER}(?:{TS_SEPARATOR}{TS_IDENTIFIER})*",
+                    expression):
+        last = TS_SPLIT.split(expression)[-1]
         return last if _ts_address_name(last) else ""
     value = _ts_string_value(text[start:end])
     if value is not None and _ts_address_string(value):
@@ -686,16 +695,36 @@ def _ts_index_properties(path: Path, text: str, mask: str, start: int,
     return findings
 
 
+def _ts_allow_lines(text: str, spans) -> set[int]:
+    """Return reasoned pragma lines that are genuine TypeScript comments."""
+    allowed: set[int] = set()
+    for kind, start, end in spans:
+        if kind not in ("line_comment", "block_comment"):
+            continue
+        for match in TS_ALLOW.finditer(text, start, end):
+            allowed.add(_line_of(text, match.start()))
+    return allowed
+
+
 def check_typescript(path: Path, text: str) -> list[Finding]:
-    spans, errors = lex(text)
+    # The lexer boundary fails closed per file: a construct it cannot
+    # terminate reports E000 here rather than crashing the whole run, and
+    # E000 bypasses suppression, matching the Python and YAML semantics.
+    try:
+        spans, errors = lex(text)
+    except RecursionError:
+        return [Finding(path, 1, "E000", "could not lex: recursion limit")]
+    except Exception as err:  # noqa: BLE001 -- any lexer failure fails closed
+        return [Finding(path, 1, "E000", f"could not lex: {err}")]
     if errors:
         return [Finding(path, _line_of(text, offset), "E000",
                         f"could not lex: {reason}")
                 for offset, reason in errors]
+    allowed = _ts_allow_lines(text, spans)
     mask = _masked(text, spans)
     findings: list[Finding] = []
     for match in TS_CHAIN.finditer(mask):
-        segments = re.split(r"\s*\.\s*", match.group("chain"))
+        segments = TS_SPLIT.split(match.group("chain"))
         if segments[0] == "console":
             continue  # command-line output is not telemetry
         opening = match.start("open")
@@ -722,7 +751,8 @@ def check_typescript(path: Path, text: str) -> list[Finding]:
         if len(segments) >= 2 and _ts_words(segments[-2]) & TS_LOG_WORDS:
             findings.extend(_ts_index_properties(
                 path, text, mask, opening + 1, closing))
-    return findings
+    return [finding for finding in findings
+            if finding.line not in allowed and finding.line - 1 not in allowed]
 
 
 def check(path: Path) -> list[Finding]:
@@ -736,8 +766,7 @@ def check(path: Path) -> list[Finding]:
             text = raw.decode("utf-8")
         except (OSError, UnicodeDecodeError) as err:
             return [Finding(path, 1, "E000", f"unreadable: {err}")]
-        return [f for f in check_typescript(path, text)
-                if not suppressed(text, f.line)]
+        return check_typescript(path, text)
     if path.suffix in YAML_SUFFIXES:
         try:
             with path.open("rb") as source:

--- a/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
+++ b/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
@@ -72,8 +72,10 @@ TS_IDENTIFIER = r"[A-Za-z_$][\w$]*"
 TS_WORD = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
 # `?.` separates a chain the way `.` does: optional chaining names the same sink.
 TS_SEPARATOR = r"\s*\??\.\s*"
-TS_SPLIT = re.compile(TS_SEPARATOR)
+TS_IDENT = re.compile(TS_IDENTIFIER)
+TS_SEP = re.compile(TS_SEPARATOR)
 TS_OPEN = re.compile(r"[\[(]")
+TS_INTEREST = re.compile(r"[()\[\]{}:,]")
 TS_IDENT_CHAR = re.compile(r"[\w$]")
 TS_IDENT_START = re.compile(r"[A-Za-z_$]")
 TS_LABEL_PROPERTY = re.compile(
@@ -552,25 +554,6 @@ def _bracket_matches(mask: str) -> dict[int, int]:
     return matches
 
 
-def _split_ranges(mask: str, start: int, end: int) -> list[tuple[int, int]]:
-    """Split a comma list at lexical depth zero, retaining source offsets."""
-    ranges = []
-    stack = []
-    pairs = {"(": ")", "[": "]", "{": "}"}
-    item = start
-    for index in range(start, end):
-        current = mask[index]
-        if current in pairs:
-            stack.append(pairs[current])
-        elif stack and current == stack[-1]:
-            stack.pop()
-        elif current == "," and not stack:
-            ranges.append((item, index))
-            item = index + 1
-    ranges.append((item, end))
-    return ranges
-
-
 def _ts_words(name: str) -> set[str]:
     return {word.lower() for word in TS_WORD.findall(name)}
 
@@ -626,36 +609,6 @@ def _ts_address_name(name: str) -> bool:
     return bool(_ts_words(name) & TS_ADDRESS_WORDS)
 
 
-def _ts_address_string(value: str) -> bool:
-    return bool(HEX_ADDRESS.fullmatch(value) or _ts_address_name(value))
-
-
-def _ts_string_value(expression: str) -> str | None:
-    expression = expression.strip()
-    if len(expression) >= 2 and expression[0] == expression[-1] \
-            and expression[0] in "'\"":
-        return expression[1:-1]
-    # A template literal with no `${}` interpolation is a constant string;
-    # an interpolated one is not, and stays out of key recognition.
-    if len(expression) >= 2 and expression[0] == expression[-1] == "`" \
-            and "${" not in expression:
-        return expression[1:-1]
-    return None
-
-
-def _ts_address_expression(text: str, mask: str, start: int, end: int) -> str:
-    """Return the address-shaped name or literal in a key position, or ""."""
-    expression = mask[start:end].strip()
-    if re.fullmatch(rf"{TS_IDENTIFIER}(?:{TS_SEPARATOR}{TS_IDENTIFIER})*",
-                    expression):
-        last = TS_SPLIT.split(expression)[-1]
-        return last if _ts_address_name(last) else ""
-    value = _ts_string_value(text[start:end])
-    if value is not None and _ts_address_string(value):
-        return value
-    return ""
-
-
 def _ts_keyed_by_address(path: Path, newlines: list[int], offset: int,
                          position: str, key: str) -> Finding:
     return Finding(path, _line_of(newlines, offset), "E005",
@@ -663,110 +616,284 @@ def _ts_keyed_by_address(path: Path, newlines: list[int], offset: int,
                    "put it in an event")
 
 
-def _ts_object_keys(text: str, mask: str, opening: int,
-                    closing: int) -> list[tuple[int, str]]:
-    """Return (offset, key) for each address-shaped key of one object literal."""
-    keys = []
-    for start, end in _split_ranges(mask, opening + 1, closing):
-        colon = -1
-        stack = []
-        pairs = {"(": ")", "[": "]", "{": "}"}
-        for index in range(start, end):
-            current = mask[index]
-            if current in pairs:
-                stack.append(pairs[current])
-            elif stack and current == stack[-1]:
-                stack.pop()
-            elif current == ":" and not stack:
-                colon = index
-                break
-        key_end = colon if colon != -1 else end
-        key = _ts_address_expression(text, mask, start, key_end)
-        if key:
-            keys.append((start, key))
-    return keys
+class _TsSpanIndex:
+    """Per-file tables that keep sink-named overlapping spans near-linear.
 
+    Once a nested bracket chain named a sink, every enclosing bracket paid
+    its full span for the property scans, the comma splits and the key
+    expression reads, and fully overlapping spans made that quadratic --
+    about 77 minutes at the 1 MiB cap.  Each table here is built in one
+    pass over the file and consulted by bisection, so the total work
+    across all spans stays near-linear in the file plus the findings
+    actually reported.
 
-def _ts_label_container(path: Path, text: str, mask: str, newlines: list[int],
-                        opening: int, closing: int) -> list[Finding]:
-    """E005 findings for address keys inside one label set container."""
-    findings = []
-    if mask[opening] == "{":
-        for offset, key in _ts_object_keys(text, mask, opening, closing):
-            findings.append(_ts_keyed_by_address(
-                path, newlines, offset, "metric label", key))
-    else:
-        for start, end in _split_ranges(mask, opening + 1, closing):
-            value = _ts_string_value(text[start:end])
-            if value is not None and _ts_address_string(value):
-                findings.append(_ts_keyed_by_address(
-                    path, newlines, start, "metric label", value))
-    return findings
+    Every table keys events by the innermost *matched* bracket pair around
+    them, which reproduces the old local scans exactly: inside a matched
+    pair every opener is itself matched, so a scan's private stack mirrors
+    the file-wide one, and an inert closer is inert to both.
+    """
 
+    def __init__(self, path: Path, text: str, mask: str,
+                 newlines: list[int], matches: dict[int, int]) -> None:
+        self.path = path
+        self.text = text
+        self.mask = mask
+        self.newlines = newlines
+        self.matches = matches
+        self._commas: dict[int, list[int]] | None = None
+        self._colons: dict[int, list[int]] = {}
+        self._inerts: dict[int, list[int]] = {}
+        self._label_starts: list[int] = []
+        self._label_rows: list[list[Finding]] = []
+        self._index_starts: list[int] = []
+        self._index_rows: list[Finding] = []
+        self._word_starts: list[int] | None = None
+        self._interp_starts: list[int] | None = None
 
-def _ts_label_properties(path: Path, text: str, mask: str, newlines: list[int],
-                         matches: dict[int, int], start: int,
-                         end: int) -> list[Finding]:
-    """Label/tag/attribute sets inside one telemetry sink call's arguments."""
-    findings = []
-    for match in TS_LABEL_PROPERTY.finditer(mask, start, end):
-        opening = match.start("open")
-        closing = matches.get(opening)
-        if closing is not None:
-            findings.extend(_ts_label_container(
-                path, text, mask, newlines, opening, closing))
-    return findings
-
-
-def _ts_labels_call(path: Path, text: str, mask: str, newlines: list[int],
-                    matches: dict[int, int], start: int,
-                    end: int) -> list[Finding]:
-    """The Prometheus instance style: `.labels({...})` or a literal address."""
-    findings = []
-    for arg_start, arg_end in _split_ranges(mask, start, end):
-        argument = mask[arg_start:arg_end].strip()
-        if argument.startswith("{"):
-            opening = mask.index("{", arg_start, arg_end)
+    def _build(self) -> None:
+        """One pass over the punctuation, then one pass over the sinks."""
+        if self._commas is not None:
+            return
+        commas: dict[int, list[int]] = {}
+        self._commas = commas
+        colons, inerts = self._colons, self._inerts
+        mask, matches = self.mask, self.matches
+        index_matches = list(TS_INDEX_PROPERTY.finditer(mask))
+        queries = sorted({match.end() for match in index_matches})
+        enclosing: dict[int, int] = {}
+        stack: list[int] = []
+        cursor, total = 0, len(queries)
+        for event in TS_INTEREST.finditer(mask):
+            position = event.start()
+            while cursor < total and queries[cursor] <= position:
+                enclosing[queries[cursor]] = stack[-1] if stack else -1
+                cursor += 1
+            current = event.group()
+            if current in "([{":
+                if position in matches:
+                    stack.append(position)
+            elif current in ")]}":
+                if stack and matches[stack[-1]] == position:
+                    stack.pop()
+                else:
+                    inerts.setdefault(
+                        stack[-1] if stack else -1, []).append(position)
+            elif current == ",":
+                commas.setdefault(
+                    stack[-1] if stack else -1, []).append(position)
+            else:
+                colons.setdefault(
+                    stack[-1] if stack else -1, []).append(position)
+        while cursor < total:
+            enclosing[queries[cursor]] = stack[-1] if stack else -1
+            cursor += 1
+        # The property regexes run once over the whole mask, each closed
+        # container or value is analysed once, and only productive rows
+        # are kept: a span later collects its rows by position, so nested
+        # sinks still repeat findings the way the per-span scans did,
+        # without repeating the work.  Neither property can straddle a
+        # span boundary, because neither matches a closing bracket.
+        for match in TS_LABEL_PROPERTY.finditer(mask):
+            opening = match.start("open")
             closing = matches.get(opening)
-            if closing is not None:
-                for offset, key in _ts_object_keys(text, mask, opening, closing):
-                    findings.append(_ts_keyed_by_address(
-                        path, newlines, offset, "metric label", key))
-        else:
-            value = _ts_string_value(text[arg_start:arg_end])
-            if value is not None and HEX_ADDRESS.fullmatch(value):
+            if closing is None:
+                continue
+            row = self._label_container(opening, closing)
+            if row:
+                self._label_starts.append(match.start())
+                self._label_rows.append(row)
+        for match in index_matches:
+            begin = match.end()
+            value_end = self._value_end(enclosing[begin], begin)
+            key = self.address_expression(begin, value_end)
+            if key:
+                self._index_starts.append(match.start())
+                self._index_rows.append(_ts_keyed_by_address(
+                    self.path, self.newlines, match.start(),
+                    "log index", key))
+
+    def _value_end(self, opener: int, begin: int) -> int:
+        """Where an `index:` value ends: the old forward scan, replayed.
+
+        From `begin`, that scan's private stack saw exactly the depth-zero
+        commas and inert closers of the innermost enclosing pair, and then
+        the pair's own closer, whichever came first.
+        """
+        end = self.matches[opener] if opener != -1 else len(self.mask)
+        for positions in (self._commas.get(opener, []),
+                          self._inerts.get(opener, [])):
+            found = bisect_left(positions, begin)
+            if found < len(positions) and positions[found] < end:
+                end = positions[found]
+        return end
+
+    def ranges(self, opening: int, closing: int) -> list[tuple[int, int]]:
+        """Split one matched span at its depth-zero commas."""
+        self._build()
+        ranges = []
+        item = opening + 1
+        for comma in self._commas.get(opening, []):
+            ranges.append((item, comma))
+            item = comma + 1
+        ranges.append((item, closing))
+        return ranges
+
+    def _first_colon(self, opening: int, start: int, end: int) -> int:
+        positions = self._colons.get(opening, [])
+        found = bisect_left(positions, start)
+        if found < len(positions) and positions[found] < end:
+            return positions[found]
+        return end
+
+    def _object_keys(self, opening: int,
+                     closing: int) -> list[tuple[int, str]]:
+        """(offset, key) for each address-shaped key of one object literal."""
+        keys = []
+        for start, end in self.ranges(opening, closing):
+            key_end = self._first_colon(opening, start, end)
+            key = self.address_expression(start, key_end)
+            if key:
+                keys.append((start, key))
+        return keys
+
+    def _label_container(self, opening: int, closing: int) -> list[Finding]:
+        """E005 findings for address keys inside one label set container."""
+        findings = []
+        if self.mask[opening] == "{":
+            for offset, key in self._object_keys(opening, closing):
                 findings.append(_ts_keyed_by_address(
-                    path, newlines, arg_start, "metric label", value))
-    return findings
-
-
-def _ts_index_properties(path: Path, text: str, mask: str, newlines: list[int],
-                         start: int, end: int) -> list[Finding]:
-    """`index:` properties inside one logger or log-store call's arguments."""
-    findings = []
-    for match in TS_INDEX_PROPERTY.finditer(mask, start, end):
-        value_end = match.end()
-        stack = []
-        pairs = {"(": ")", "[": "]", "{": "}"}
-        for index in range(match.end(), end):
-            current = mask[index]
-            if current in pairs:
-                stack.append(pairs[current])
-            elif current in ")]}" and not stack:
-                value_end = index
-                break
-            elif stack and current == stack[-1]:
-                stack.pop()
-            elif current == "," and not stack:
-                value_end = index
-                break
+                    self.path, self.newlines, offset, "metric label", key))
         else:
-            value_end = end
-        key = _ts_address_expression(text, mask, match.end(), value_end)
-        if key:
-            findings.append(_ts_keyed_by_address(
-                path, newlines, match.start(), "log index", key))
-    return findings
+            for start, end in self.ranges(opening, closing):
+                bounds = self._string_bounds(start, end)
+                if bounds is not None and self._address_value(*bounds):
+                    findings.append(_ts_keyed_by_address(
+                        self.path, self.newlines, start, "metric label",
+                        self.text[bounds[0]:bounds[1]]))
+        return findings
+
+    def label_findings(self, start: int, end: int) -> list[Finding]:
+        """Label/tag/attribute sets inside one telemetry sink call."""
+        self._build()
+        findings: list[Finding] = []
+        found = bisect_left(self._label_starts, start)
+        while found < len(self._label_starts) \
+                and self._label_starts[found] < end:
+            findings.extend(self._label_rows[found])
+            found += 1
+        return findings
+
+    def index_findings(self, start: int, end: int) -> list[Finding]:
+        """`index:` properties inside one logger or log-store call."""
+        self._build()
+        found = bisect_left(self._index_starts, start)
+        findings: list[Finding] = []
+        while found < len(self._index_starts) \
+                and self._index_starts[found] < end:
+            findings.append(self._index_rows[found])
+            found += 1
+        return findings
+
+    def labels_call(self, opening: int, closing: int) -> list[Finding]:
+        """The Prometheus instance style: `.labels({...})` or a literal."""
+        findings = []
+        mask = self.mask
+        for arg_start, arg_end in self.ranges(opening, closing):
+            first = arg_start
+            while first < arg_end and mask[first].isspace():
+                first += 1
+            if first < arg_end and mask[first] == "{":
+                inner = self.matches.get(first)
+                if inner is not None:
+                    for offset, key in self._object_keys(first, inner):
+                        findings.append(_ts_keyed_by_address(
+                            self.path, self.newlines, offset,
+                            "metric label", key))
+            else:
+                bounds = self._string_bounds(arg_start, arg_end)
+                if bounds is not None and bounds[1] - bounds[0] == 42 \
+                        and HEX_ADDRESS.fullmatch(
+                            self.text, bounds[0], bounds[1]):
+                    findings.append(_ts_keyed_by_address(
+                        self.path, self.newlines, arg_start, "metric label",
+                        self.text[bounds[0]:bounds[1]]))
+        return findings
+
+    def address_expression(self, start: int, end: int) -> str:
+        """The address-shaped name or literal in a key position, or "".
+
+        Reads a bounded window instead of slicing the span: the dotted
+        chain is parsed forward from the key's own start and stops at the
+        first character outside the chain grammar, so fully overlapping
+        spans no longer pay their whole width for every key.
+        """
+        mask = self.mask
+        first, last = start, end
+        while first < last and mask[first].isspace():
+            first += 1
+        while last > first and mask[last - 1].isspace():
+            last -= 1
+        ident = TS_IDENT.match(mask, first, last) if first < last else None
+        while ident is not None and ident.end() < last:
+            separator = TS_SEP.match(mask, ident.end(), last)
+            ident = TS_IDENT.match(mask, separator.end(), last) \
+                if separator is not None else None
+        if ident is not None:
+            name = ident.group()
+            return name if _ts_address_name(name) else ""
+        bounds = self._string_bounds(start, end)
+        if bounds is not None and self._address_value(*bounds):
+            return self.text[bounds[0]:bounds[1]]
+        return ""
+
+    def _string_bounds(self, start: int, end: int) -> tuple[int, int] | None:
+        """Value bounds of a constant string literal, without slicing.
+
+        A template literal with no `${}` interpolation is a constant
+        string; an interpolated one is not, and stays out of key
+        recognition.
+        """
+        text = self.text
+        while start < end and text[start].isspace():
+            start += 1
+        while end > start and text[end - 1].isspace():
+            end -= 1
+        if end - start < 2 or text[start] != text[end - 1]:
+            return None
+        if text[start] in "'\"":
+            return start + 1, end - 1
+        if text[start] == "`" and not self._interpolated(start + 1, end - 1):
+            return start + 1, end - 1
+        return None
+
+    def _interpolated(self, start: int, end: int) -> bool:
+        if self._interp_starts is None:
+            starts = []
+            found = self.text.find("${")
+            while found != -1:
+                starts.append(found)
+                found = self.text.find("${", found + 1)
+            self._interp_starts = starts
+        starts = self._interp_starts
+        found = bisect_left(starts, start)
+        return found < len(starts) and starts[found] + 2 <= end
+
+    def _address_value(self, start: int, end: int) -> bool:
+        """An address-shaped string value, judged without slicing it.
+
+        The value sits between two quote characters, which no word token
+        can cross, so its word tokens are exactly the file's word tokens
+        inside it: found once for the whole file, then bisected.
+        """
+        if end - start == 42 and HEX_ADDRESS.fullmatch(self.text, start, end):
+            return True
+        if self._word_starts is None:
+            self._word_starts = [
+                match.start() for match in TS_WORD.finditer(self.text)
+                if match.group().lower() in TS_ADDRESS_WORDS]
+        starts = self._word_starts
+        found = bisect_left(starts, start)
+        return found < len(starts) and starts[found] < end
 
 
 def _ts_allow_lines(text: str, spans, newlines: list[int]) -> set[int]:
@@ -803,6 +930,7 @@ def check_typescript(path: Path, text: str) -> list[Finding]:
     allowed = _ts_allow_lines(text, spans, newlines)
     mask = _masked(text, spans)
     matches = _bracket_matches(mask)
+    span_index = _TsSpanIndex(path, text, mask, newlines, matches)
     findings: list[Finding] = []
     for bracket in TS_OPEN.finditer(mask):
         opening = bracket.start()
@@ -820,7 +948,7 @@ def check_typescript(path: Path, text: str) -> list[Finding]:
             closing = matches.get(opening)
             if closing is None:
                 continue
-            key = _ts_address_expression(text, mask, opening + 1, closing)
+            key = span_index.address_expression(opening + 1, closing)
             if key and last_words & TS_DASHBOARD_WORDS:
                 findings.append(_ts_keyed_by_address(
                     path, newlines, opening + 1, "dashboard key", key))
@@ -839,14 +967,11 @@ def check_typescript(path: Path, text: str) -> list[Finding]:
         if closing is None:
             continue
         if metric_sink:
-            findings.extend(_ts_label_properties(
-                path, text, mask, newlines, matches, opening + 1, closing))
+            findings.extend(span_index.label_findings(opening + 1, closing))
         if labels_call:
-            findings.extend(_ts_labels_call(
-                path, text, mask, newlines, matches, opening + 1, closing))
+            findings.extend(span_index.labels_call(opening, closing))
         if log_call:
-            findings.extend(_ts_index_properties(
-                path, text, mask, newlines, opening + 1, closing))
+            findings.extend(span_index.index_findings(opening + 1, closing))
     return [finding for finding in findings
             if finding.line not in allowed and finding.line - 1 not in allowed]
 

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/alert-labels.yaml
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/alert-labels.yaml
@@ -1,0 +1,9 @@
+groups:
+  - name: markets
+    rules:
+      - alert: DepositStalled
+        expr: pending_deposits > 5
+        labels:
+          wallet_address: "{{ $labels.wallet_address }}"
+        annotations:
+          runbook: runbooks/deposit-stalled.md

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/console-output.ts
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/console-output.ts
@@ -1,0 +1,3 @@
+// Command-line output is not telemetry.
+console.log("lender", walletAddress)
+console.log(event, { index: walletAddress })

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/dashboard-key.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/dashboard-key.py
@@ -1,0 +1,3 @@
+"""A dashboard panel selected by wallet address."""
+
+dashboard[wallet_address] = deposit_panel

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/dashboard-key.ts
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/dashboard-key.ts
@@ -1,0 +1,2 @@
+// A dashboard panel selected by wallet address.
+marketDashboard[walletAddress] = depositPanel

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/event-fields.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/event-fields.py
@@ -1,0 +1,3 @@
+"""An address inside an event's fields, the legal home."""
+
+logger.info("lender_checked", extra={"wallet_address": lender})

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/log-index-argument.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/log-index-argument.py
@@ -1,0 +1,3 @@
+"""A log write indexed by wallet address."""
+
+audit_log.write(event, index=wallet_address)

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/log-index-key.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/log-index-key.py
@@ -1,0 +1,3 @@
+"""A log store partitioned by wallet address."""
+
+event_log[wallet_address] = event

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/log-index.ts
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/log-index.ts
@@ -1,0 +1,2 @@
+// A log write indexed by wallet address.
+auditLog.write(event, { index: walletAddress })

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/logger-message.ts
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/logger-message.ts
@@ -1,0 +1,2 @@
+// An address interpolated into a message, not a key.
+logger.debug(`Retrieved market updates for lender ${walletAddress}`)

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/message-argument.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/message-argument.py
@@ -1,0 +1,3 @@
+"""An address passed as a message argument, not a key."""
+
+logger.info("lender skipped %s", wallet_address)

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/metric-label-constructor.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/metric-label-constructor.py
@@ -1,0 +1,3 @@
+"""An address-named label in the constructor style."""
+
+deposits = Histogram("deposit_size", labelnames=["wallet_address", "venue"])

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/metric-label-hex-literal.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/metric-label-hex-literal.py
@@ -1,0 +1,3 @@
+"""A literal address baked into a label."""
+
+withdrawals.labels("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef").inc()

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/metric-label-instance.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/metric-label-instance.py
@@ -1,0 +1,3 @@
+"""An address-named label in the instance-call style."""
+
+deposits.labels(wallet_address=depositor).inc()

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/metric-label-set.ts
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/metric-label-set.ts
@@ -1,0 +1,2 @@
+// An address-named key in a label set on a metric sink.
+metrics.increment("deposit_size", { tags: { wallet_address: depositor } })

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/print.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/print.py
@@ -1,0 +1,3 @@
+"""Command-line output is not telemetry."""
+
+print(f"lender {wallet_address}")

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/query-key.ts
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/query-key.ts
@@ -1,0 +1,6 @@
+// A react-query cache key is a cache key, not a telemetry sink.
+export const useLenders = (walletAddress: string) =>
+  useQuery({
+    queryKey: ["lenders", walletAddress],
+    queryFn: () => fetchLenders(walletAddress),
+  })

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/storage-key.ts
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/storage-key.ts
@@ -1,0 +1,2 @@
+// A storage key is a storage key, not a telemetry sink.
+localStorage.setItem(`${TIMESTAMP_KEY}_${address.toLowerCase()}`, String(Date.now()))

--- a/plugins/hexaemeron/tests/test_ephoros_checker.py
+++ b/plugins/hexaemeron/tests/test_ephoros_checker.py
@@ -154,7 +154,111 @@ class TelemetryKeys(unittest.TestCase):
             "c.labels(wallet_address=a).inc()  # ephoros: allow\n"))
 
 
-class AlertLabelKeys(unittest.TestCase):
+def ts_codes(source, name="sample.ts"):
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / name
+        path.write_text(source, encoding="utf-8")
+        return sorted(f.code for f in ephoros.check(path))
+
+
+class TypeScriptTelemetryKeys(unittest.TestCase):
+    def test_it_flags_an_address_key_on_a_metric_label_set(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "metric-label-set.ts")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_flags_an_address_key_on_a_dashboard_structure(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "dashboard-key.ts")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_flags_an_address_key_on_a_log_index_position(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "log-index.ts")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_flags_a_camel_case_label_key_on_an_analytics_sink(self):
+        self.assertEqual(["E005"], ts_codes(
+            'analytics.track("deposit", { labels: { walletAddress: depositor } })\n'))
+
+    def test_it_flags_a_forty_hex_literal_in_a_label_array(self):
+        self.assertEqual(["E005"], ts_codes(
+            'metrics.increment("m", '
+            '{ tags: ["0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"] })\n'))
+
+    def test_it_flags_the_labels_instance_call_style(self):
+        self.assertEqual(["E005"], ts_codes(
+            "deposits.labels({ walletAddress: depositor }).inc()\n"))
+
+    def test_it_flags_a_log_store_partitioned_by_address(self):
+        self.assertEqual(["E005"], ts_codes("eventLog[walletAddress] = event\n"))
+
+    def test_it_allows_a_query_key_array_carrying_an_address(self):
+        self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "query-key.ts"))
+
+    def test_it_allows_a_storage_key_built_from_an_address(self):
+        self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "storage-key.ts"))
+
+    def test_it_allows_a_logger_message_interpolating_an_address(self):
+        self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "logger-message.ts"))
+
+    def test_it_ignores_console_output_which_is_not_telemetry(self):
+        self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "console-output.ts"))
+
+    def test_an_address_key_on_an_unnamed_store_does_not_fire(self):
+        self.assertEqual([], ts_codes("cache[walletAddress] = market\n"))
+
+    def test_a_label_shaped_object_outside_a_telemetry_sink_does_not_fire(self):
+        self.assertEqual([], ts_codes(
+            "chip.render({ tags: { walletAddress: lender } })\n"))
+
+    def test_a_reasoned_slash_pragma_on_the_line_suppresses_e005(self):
+        self.assertEqual([], ts_codes(
+            "eventLog[walletAddress] = event"
+            "  // ephoros: allow one aggregate treasury row\n"))
+
+    def test_a_reasoned_slash_pragma_on_the_line_above_suppresses_e005(self):
+        self.assertEqual([], ts_codes(
+            "// ephoros: allow one aggregate treasury row\n"
+            "eventLog[walletAddress] = event\n"))
+
+    def test_a_bare_slash_pragma_does_not_suppress_e005(self):
+        self.assertEqual(["E005"], ts_codes(
+            "eventLog[walletAddress] = event  // ephoros: allow\n"))
+
+
+class TypeScriptBoundaries(unittest.TestCase):
+    def test_an_oversized_typescript_file_fails_visibly(self):
+        source = "//" + "x" * ephoros.TYPESCRIPT_MAX_BYTES
+        self.assertEqual(["E000"], ts_codes(source))
+
+    def test_typescript_read_requests_only_the_cap_plus_one_byte(self):
+        class RecordingReader(io.BytesIO):
+            requested = None
+
+            def read(self, size=-1):
+                self.requested = size
+                return super().read(size)
+
+        reader = RecordingReader(b"/" * (ephoros.TYPESCRIPT_MAX_BYTES + 1))
+        with mock.patch.object(Path, "open", return_value=reader), \
+                mock.patch.object(Path, "read_bytes", side_effect=AssertionError):
+            findings = ephoros.check(Path("bounded.ts"))
+        self.assertEqual(["E000"], [finding.code for finding in findings])
+        self.assertEqual(ephoros.TYPESCRIPT_MAX_BYTES + 1, reader.requested)
+
+    def test_a_lexer_failure_reports_e000(self):
+        self.assertEqual(["E000"], ts_codes("const s = `never terminated\n"))
+
+    def test_the_walk_skips_node_modules(self):
+        with tempfile.TemporaryDirectory() as base:
+            vendored = Path(base) / "node_modules" / "left-pad"
+            vendored.mkdir(parents=True)
+            (vendored / "index.ts").write_text(
+                "eventLog[walletAddress] = event\n", encoding="utf-8")
+            first_party = Path(base) / "src"
+            first_party.mkdir()
+            kept = first_party / "page.tsx"
+            kept.write_text("export default null\n", encoding="utf-8")
+            self.assertEqual([kept], ephoros.walk([base]))
+
     def test_an_address_named_key_under_alert_labels_reports_e005(self):
         findings = ephoros.check(TELEMETRY_FIXTURES / "alert-labels.yaml")
         self.assertEqual(["E005"], [finding.code for finding in findings])

--- a/plugins/hexaemeron/tests/test_ephoros_checker.py
+++ b/plugins/hexaemeron/tests/test_ephoros_checker.py
@@ -153,6 +153,16 @@ class TelemetryKeys(unittest.TestCase):
         self.assertIn("E005", codes(
             "c.labels(wallet_address=a).inc()  # ephoros: allow\n"))
 
+    def test_slash_pragma_text_in_a_python_string_does_not_suppress(self):
+        self.assertEqual(["E005"], codes(
+            's = "// ephoros: allow tracked elsewhere"\n'
+            "c.labels(wallet_address=a).inc()\n"))
+
+    def test_a_slash_pragma_mentioned_mid_comment_does_not_suppress(self):
+        self.assertEqual(["E005"], codes(
+            "c.labels(wallet_address=a).inc()"
+            "  # see // ephoros: allow foo for the shape\n"))
+
 
 def ts_codes(source, name="sample.ts"):
     with tempfile.TemporaryDirectory() as directory:
@@ -190,6 +200,32 @@ class TypeScriptTelemetryKeys(unittest.TestCase):
     def test_it_flags_a_log_store_partitioned_by_address(self):
         self.assertEqual(["E005"], ts_codes("eventLog[walletAddress] = event\n"))
 
+    def test_it_flags_a_string_literal_wallet_index(self):
+        self.assertEqual(["E005"], ts_codes(
+            "auditLog.write(event, { index: 'wallet_address' })\n"))
+
+    def test_it_flags_a_forty_hex_literal_index(self):
+        self.assertEqual(["E005"], ts_codes(
+            "auditLog.write(event, "
+            "{ index: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' })\n"))
+
+    def test_it_flags_the_camel_case_label_names_property(self):
+        self.assertEqual(["E005"], ts_codes(
+            'const c = new client.Counter({ name: "c", '
+            'labelNames: ["wallet_address"] })\n'))
+
+    def test_it_flags_an_optional_chained_metric_sink(self):
+        self.assertEqual(["E005"], ts_codes(
+            "metrics?.gauge('m', { tags: { walletAddress: w } })\n"))
+
+    def test_it_flags_an_optional_chain_inside_a_sink_chain(self):
+        self.assertEqual(["E005"], ts_codes(
+            "sink?.metrics.gauge('m', { tags: { walletAddress: w } })\n"))
+
+    def test_an_optional_chained_cache_key_does_not_fire(self):
+        self.assertEqual([], ts_codes(
+            "cache?.store[walletAddress] = market\n"))
+
     def test_it_allows_a_query_key_array_carrying_an_address(self):
         self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "query-key.ts"))
 
@@ -223,6 +259,20 @@ class TypeScriptTelemetryKeys(unittest.TestCase):
         self.assertEqual(["E005"], ts_codes(
             "eventLog[walletAddress] = event  // ephoros: allow\n"))
 
+    def test_pragma_text_in_a_string_does_not_suppress(self):
+        self.assertEqual(["E005"], ts_codes(
+            'eventLog[walletAddress] = "// ephoros: allow tracked elsewhere"\n'))
+
+    def test_pragma_text_in_a_template_does_not_suppress(self):
+        self.assertEqual(["E005"], ts_codes(
+            "const note = `// ephoros: allow tracked elsewhere`\n"
+            "eventLog[walletAddress] = event\n"))
+
+    def test_a_hash_pragma_does_not_suppress_in_typescript(self):
+        self.assertEqual(["E005"], ts_codes(
+            "// # ephoros: allow tracked elsewhere\n"
+            "eventLog[walletAddress] = event\n"))
+
 
 class TypeScriptBoundaries(unittest.TestCase):
     def test_an_oversized_typescript_file_fails_visibly(self):
@@ -247,6 +297,27 @@ class TypeScriptBoundaries(unittest.TestCase):
     def test_a_lexer_failure_reports_e000(self):
         self.assertEqual(["E000"], ts_codes("const s = `never terminated\n"))
 
+    def test_a_pragma_cannot_suppress_a_lexer_failure(self):
+        self.assertEqual(["E000"], ts_codes(
+            "// ephoros: allow crafted reason\n"
+            "const s = `never terminated\n"))
+
+    def test_a_lexer_recursion_failure_fails_closed_per_file(self):
+        with tempfile.TemporaryDirectory() as base:
+            nested = Path(base) / "nested.ts"
+            nested.write_text(
+                "const s = " + "`${" * 600 + "0" + "}`" * 600 + "\n",
+                encoding="utf-8")
+            sibling = Path(base) / "sibling.ts"
+            sibling.write_text("eventLog[walletAddress] = event\n",
+                               encoding="utf-8")
+            findings = [finding for path in ephoros.walk([base])
+                        for finding in ephoros.check(path)]
+            by_file = {Path(finding.path).name: finding for finding in findings}
+            self.assertEqual("E000", by_file["nested.ts"].code)
+            self.assertIn("recursion", by_file["nested.ts"].message)
+            self.assertEqual("E005", by_file["sibling.ts"].code)
+
     def test_the_walk_skips_node_modules(self):
         with tempfile.TemporaryDirectory() as base:
             vendored = Path(base) / "node_modules" / "left-pad"
@@ -259,6 +330,8 @@ class TypeScriptBoundaries(unittest.TestCase):
             kept.write_text("export default null\n", encoding="utf-8")
             self.assertEqual([kept], ephoros.walk([base]))
 
+
+class AlertLabelKeys(unittest.TestCase):
     def test_an_address_named_key_under_alert_labels_reports_e005(self):
         findings = ephoros.check(TELEMETRY_FIXTURES / "alert-labels.yaml")
         self.assertEqual(["E005"], [finding.code for finding in findings])

--- a/plugins/hexaemeron/tests/test_ephoros_checker.py
+++ b/plugins/hexaemeron/tests/test_ephoros_checker.py
@@ -377,6 +377,76 @@ class TypeScriptBoundaries(unittest.TestCase):
                                 encoding="utf-8")
             self.assertEqual([], ephoros.check(specimen))
 
+    def test_a_sink_named_labels_nest_keeps_its_single_exact_finding(self):
+        # Once every nested chain names `.labels`, the cheap unnamed-chain
+        # gate stops short-circuiting and each fully overlapping span paid
+        # a full-width comma split and key read: 28 seconds at this depth,
+        # about 77 minutes at the 1 MiB cap. The per-file position tables
+        # keep the walk near-linear, and only the innermost span carries
+        # the address-shaped key.
+        depth = 8192
+        source = ("// nested labels specimen\n"
+                  + "m.labels(" * depth + "{walletAddress: 1}" + ")" * depth)
+        with tempfile.TemporaryDirectory() as base:
+            specimen = Path(base) / "labels.ts"
+            specimen.write_text(source, encoding="utf-8")
+            findings = ephoros.check(specimen)
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+        self.assertEqual([2], [finding.line for finding in findings])
+        self.assertIn("metric label `walletAddress`", findings[0].message)
+
+    def test_a_sink_named_logger_nest_repeats_the_index_finding_per_span(self):
+        # Each of the nested `logger.info` spans contains the one `index:`
+        # property, so each span reports it, exactly as the old per-span
+        # scans did -- the findings repeat while the work does not (the
+        # same shape cost 7.3 seconds at this depth and quadratically more
+        # beyond it).
+        depth = 8192
+        source = ("// nested logger specimen\n"
+                  + "logger.info(" * depth
+                  + "{index: walletAddress}" + ")" * depth)
+        with tempfile.TemporaryDirectory() as base:
+            specimen = Path(base) / "logger.ts"
+            specimen.write_text(source, encoding="utf-8")
+            findings = ephoros.check(specimen)
+        self.assertEqual(["E005"] * depth,
+                         [finding.code for finding in findings])
+        self.assertEqual({2}, {finding.line for finding in findings})
+        self.assertIn("log index `walletAddress`", findings[0].message)
+
+    def test_a_sink_named_counter_nest_repeats_the_label_finding_per_span(self):
+        # The metric-sink reading of the same overlap: every nested
+        # `counter` span contains the one `labels:` container, so every
+        # span repeats its finding from the container analysed once.
+        depth = 8192
+        source = ("// nested counter specimen\n"
+                  + "counter(" * depth
+                  + "{labels: {walletAddress: 1}}" + ")" * depth)
+        with tempfile.TemporaryDirectory() as base:
+            specimen = Path(base) / "counter.ts"
+            specimen.write_text(source, encoding="utf-8")
+            findings = ephoros.check(specimen)
+        self.assertEqual(["E005"] * depth,
+                         [finding.code for finding in findings])
+        self.assertEqual({2}, {finding.line for finding in findings})
+        self.assertIn("metric label `walletAddress`", findings[0].message)
+
+    def test_a_log_named_bracket_nest_keeps_its_single_exact_finding(self):
+        # The subscript form of the same overlap: every `log[` span read
+        # its full width for a key expression (12.2 seconds at the 1 MiB
+        # cap); the bounded forward parse stops at the first character
+        # outside the chain grammar, and only the innermost span holds one.
+        depth = 150_000
+        source = ("// nested log store specimen\n"
+                  + "log[" * depth + "walletAddress" + "]" * depth)
+        with tempfile.TemporaryDirectory() as base:
+            specimen = Path(base) / "logstore.ts"
+            specimen.write_text(source, encoding="utf-8")
+            findings = ephoros.check(specimen)
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+        self.assertEqual([2], [finding.line for finding in findings])
+        self.assertIn("log index `walletAddress`", findings[0].message)
+
     def test_a_findings_saturated_file_keeps_every_line_number(self):
         # Counting newlines from the top of the file for every finding cost
         # quadratic time on findings-saturated files (10s at this size); a

--- a/plugins/hexaemeron/tests/test_ephoros_checker.py
+++ b/plugins/hexaemeron/tests/test_ephoros_checker.py
@@ -364,6 +364,37 @@ class TypeScriptBoundaries(unittest.TestCase):
             specimen.write_text("a . " * 25_000, encoding="utf-8")
             self.assertEqual([], ephoros.check(specimen))
 
+    def test_a_deeply_nested_bracket_chain_completes_with_zero_findings(self):
+        # Every bracket in a[a[a[...]]] carries a chain, and the old
+        # per-bracket forward scan to its closer re-read the fully
+        # overlapping nested spans quadratically: 28s at N=16000, hours at
+        # the 1 MiB cap. One linear stack pass now matches every bracket up
+        # front, and the unnamed chain yields nothing even at cap scale.
+        depth = 250_000
+        with tempfile.TemporaryDirectory() as base:
+            specimen = Path(base) / "nested.ts"
+            specimen.write_text("a[" * depth + "x" + "]" * depth,
+                                encoding="utf-8")
+            self.assertEqual([], ephoros.check(specimen))
+
+    def test_a_findings_saturated_file_keeps_every_line_number(self):
+        # Counting newlines from the top of the file for every finding cost
+        # quadratic time on findings-saturated files (10s at this size); a
+        # bisected newline table built once per file keeps it linear. The
+        # first, middle, and last findings pin the exact line numbers the
+        # counting implementation reported.
+        lines = 50_000
+        with tempfile.TemporaryDirectory() as base:
+            specimen = Path(base) / "saturated.ts"
+            specimen.write_text("log[walletAddress]\n" * lines,
+                                encoding="utf-8")
+            findings = ephoros.check(specimen)
+        self.assertEqual(["E005"] * lines,
+                         [finding.code for finding in findings])
+        self.assertEqual(1, findings[0].line)
+        self.assertEqual(25_001, findings[lines // 2].line)
+        self.assertEqual(50_000, findings[-1].line)
+
     def test_the_walk_skips_node_modules(self):
         with tempfile.TemporaryDirectory() as base:
             vendored = Path(base) / "node_modules" / "left-pad"

--- a/plugins/hexaemeron/tests/test_ephoros_checker.py
+++ b/plugins/hexaemeron/tests/test_ephoros_checker.py
@@ -16,6 +16,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "skills" / "ephoros" / "scripts" / "ephoros.py"
 ALERT_FIXTURES = ROOT / "tests" / "fixtures" / "ephoros" / "alert-rules"
+TELEMETRY_FIXTURES = ROOT / "tests" / "fixtures" / "ephoros" / "telemetry-keys"
 
 spec = importlib.util.spec_from_file_location("ephoros_lint", SCRIPT)
 ephoros = importlib.util.module_from_spec(spec)
@@ -61,8 +62,8 @@ class LogMessages(unittest.TestCase):
 
 
 class MetricLabels(unittest.TestCase):
-    def test_it_flags_an_address_label(self):
-        self.assertIn("E002", codes(
+    def test_it_flags_an_address_label_as_e005_since_the_subset_moved(self):
+        self.assertEqual(["E005"], codes(
             "h = Histogram('d', labels={'address': a, 'venue': v})\n"))
 
     def test_it_flags_a_hash_label_in_a_list(self):
@@ -88,6 +89,104 @@ class Durations(unittest.TestCase):
 
     def test_it_allows_a_mean_of_layout_positions(self):
         self.assertEqual([], codes("order = sum(positions) / len(positions)\n"))
+
+
+class TelemetryKeys(unittest.TestCase):
+    def test_it_flags_an_address_label_in_the_constructor_style(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "metric-label-constructor.py")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_flags_the_labels_instance_call_style(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "metric-label-instance.py")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_flags_a_forty_hex_literal_label_value(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "metric-label-hex-literal.py")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_flags_a_forty_hex_literal_in_a_constructor_label_set(self):
+        self.assertEqual(["E005"], codes(
+            "m = metric('m', tags=['0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'])\n"))
+
+    def test_it_flags_an_address_shaped_dashboard_key(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "dashboard-key.py")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_flags_an_address_shaped_log_index_key(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "log-index-key.py")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_flags_an_address_index_argument(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "log-index-argument.py")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_allows_an_address_in_an_events_fields(self):
+        self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "event-fields.py"))
+
+    def test_it_allows_an_address_in_a_message_argument(self):
+        self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "message-argument.py"))
+
+    def test_it_ignores_print_which_is_not_telemetry(self):
+        self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "print.py"))
+
+    def test_an_address_key_on_an_unnamed_store_does_not_fire(self):
+        self.assertEqual([], codes("cache[wallet_address] = market\n"))
+
+    def test_a_wallet_address_label_yields_e005_and_not_e002(self):
+        self.assertEqual(["E005"], codes(
+            "c = Counter('c', labelnames=['wallet_address'])\n"))
+
+    def test_a_hash_named_label_keeps_e002(self):
+        self.assertEqual(["E002"], codes("c = Counter('c', labelnames=['tx_hash'])\n"))
+
+    def test_a_reasoned_pragma_on_the_line_suppresses_e005(self):
+        self.assertEqual([], codes(
+            "c.labels(wallet_address=a).inc()"
+            "  # ephoros: allow one aggregate treasury row\n"))
+
+    def test_a_reasoned_pragma_on_the_line_above_suppresses_e005(self):
+        self.assertEqual([], codes(
+            "# ephoros: allow one aggregate treasury row\n"
+            "c.labels(wallet_address=a).inc()\n"))
+
+    def test_a_bare_pragma_does_not_suppress_e005(self):
+        self.assertIn("E005", codes(
+            "c.labels(wallet_address=a).inc()  # ephoros: allow\n"))
+
+
+class AlertLabelKeys(unittest.TestCase):
+    def test_an_address_named_key_under_alert_labels_reports_e005(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "alert-labels.yaml")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_a_bounded_label_key_is_clean(self):
+        source = ("- alert: Bounded\n"
+                  "  labels:\n"
+                  "    severity: page\n"
+                  "  annotations:\n"
+                  "    runbook: runbooks/bounded.md\n")
+        self.assertEqual([], yaml_findings(source))
+
+    def test_a_labels_mapping_outside_an_alert_entry_is_ignored(self):
+        source = "service:\n  labels:\n    wallet_address: primary\n"
+        self.assertEqual([], yaml_findings(source))
+
+    def test_a_reasoned_pragma_suppresses_an_alert_label_key(self):
+        source = ("- alert: Suppressed\n"
+                  "  labels:\n"
+                  "    # ephoros: allow one aggregate treasury row\n"
+                  "    wallet_address: treasury\n"
+                  "  annotations:\n"
+                  "    runbook: runbooks/suppressed.md\n")
+        self.assertEqual([], yaml_findings(source))
+
+    def test_a_bare_pragma_does_not_suppress_an_alert_label_key(self):
+        source = ("- alert: StillKeyed\n"
+                  "  labels:\n"
+                  "    wallet_address: treasury  # ephoros: allow\n"
+                  "  annotations:\n"
+                  "    runbook: runbooks/still-keyed.md\n")
+        self.assertEqual(["E005"], [finding.code for finding in yaml_findings(source)])
 
 
 class Suppression(unittest.TestCase):

--- a/plugins/hexaemeron/tests/test_ephoros_checker.py
+++ b/plugins/hexaemeron/tests/test_ephoros_checker.py
@@ -226,6 +226,33 @@ class TypeScriptTelemetryKeys(unittest.TestCase):
         self.assertEqual([], ts_codes(
             "cache?.store[walletAddress] = market\n"))
 
+    def test_it_flags_an_optional_chain_bracket_log_store(self):
+        self.assertEqual(["E005"], ts_codes(
+            "eventLog?.[walletAddress] = event\n"))
+
+    def test_it_flags_an_optional_chain_bracket_dashboard_key(self):
+        self.assertEqual(["E005"], ts_codes(
+            "dashboards?.[walletAddress] = panel\n"))
+
+    def test_it_flags_an_optional_chain_bracket_string_log_index(self):
+        self.assertEqual(["E005"], ts_codes(
+            "auditLog?.['walletAddress'].push(e)\n"))
+
+    def test_an_optional_chain_bracket_on_an_unnamed_store_does_not_fire(self):
+        self.assertEqual([], ts_codes("cache?.[walletAddress]\n"))
+
+    def test_an_optional_chain_bracket_after_a_subscript_does_not_fire(self):
+        self.assertEqual([], ts_codes(
+            "ADS_REGISTRY[chainId]?.[marketAddress.toLowerCase()]\n"))
+
+    def test_it_flags_a_template_literal_wallet_index(self):
+        self.assertEqual(["E005"], ts_codes(
+            "auditLog.write(e, { index: `wallet_address` })\n"))
+
+    def test_an_interpolated_template_index_does_not_fire(self):
+        self.assertEqual([], ts_codes(
+            "auditLog.write(e, { index: `${walletAddress}` })\n"))
+
     def test_it_allows_a_query_key_array_carrying_an_address(self):
         self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "query-key.ts"))
 
@@ -273,6 +300,16 @@ class TypeScriptTelemetryKeys(unittest.TestCase):
             "// # ephoros: allow tracked elsewhere\n"
             "eventLog[walletAddress] = event\n"))
 
+    def test_a_block_comment_pragma_does_not_suppress(self):
+        self.assertEqual(["E005"], ts_codes(
+            "/* // ephoros: allow smuggled reason */ "
+            "eventLog[walletAddress] = event\n"))
+
+    def test_a_block_comment_pragma_on_the_line_above_does_not_suppress(self):
+        self.assertEqual(["E005"], ts_codes(
+            "/* // ephoros: allow smuggled reason */\n"
+            "eventLog[walletAddress] = event\n"))
+
 
 class TypeScriptBoundaries(unittest.TestCase):
     def test_an_oversized_typescript_file_fails_visibly(self):
@@ -317,6 +354,15 @@ class TypeScriptBoundaries(unittest.TestCase):
             self.assertEqual("E000", by_file["nested.ts"].code)
             self.assertIn("recursion", by_file["nested.ts"].message)
             self.assertEqual("E005", by_file["sibling.ts"].code)
+
+    def test_an_adversarial_dotted_chain_completes_with_zero_findings(self):
+        # A whitespace-separated dotted chain that never reaches a bracket
+        # once cost quadratic rescans (about a minute at this size); the
+        # bracket-anchored scan reads it once and finds nothing.
+        with tempfile.TemporaryDirectory() as base:
+            specimen = Path(base) / "adversarial.ts"
+            specimen.write_text("a . " * 25_000, encoding="utf-8")
+            self.assertEqual([], ephoros.check(specimen))
 
     def test_the_walk_skips_node_modules(self):
         with tempfile.TemporaryDirectory() as base:


### PR DESCRIPTION
Step 3 of the run for
[skills#322](https://github.com/wildcat-finance/skills/issues/322). The
checker now reads `.ts`/`.tsx` through the shared masked lexer at
`plugins/hexaemeron/lib/typescript_lexer.py`, the architecture phylax already
audited: a 1 MiB cap enforced before lexing, every lexer failure fail-closed
as E000, and no execution or import of inspected source. The three E005
shapes mirror the Python pass -- an address key on a metric label set, on a
dashboard structure, and on a log-index position -- with `// ephoros: allow
<why>` suppressing beside the `#` form and a bare pragma suppressing nothing.
The walk gains the two suffixes and excludes `node_modules` the way it
excludes `__pycache__`. The pinned `wildcat-app-v2` clone, 882 tracked
TypeScript files, runs clean at exit 0 in 0.86 seconds with zero suppression
pragmas.

The audit loop ran five rounds and is the bulk of this diff's history:
sixteen findings, every one fixed under the guard-test convention with red
observed first. The largest were a RecursionError through the shared lexer
that could crash the run on a 3 KB crafted file, pragma text inside strings
suppressing real findings, and a family of four quadratic scan shapes inside
the untrusted-read boundary, the worst extrapolating to hours at the cap and
all now completing in about a second through structural fixes measured before
and after. Convergence was established by differential testing against each
prior head: over twenty-five thousand seeded cases and two clone-wide sweeps
with zero unexpected behaviour deltas, and a closing round with independent
generators that found nothing. Full record in `audit/AUDIT.md` under "Ephoros
wallet-address telemetry, step 3, rounds 1 through 5"; the fixes are folded
into this branch, so no separate fixes PR exists.

49 checker tests land over step 2's 67, for 116 focused cases. Proof:

```bash
python3 -m unittest plugins.hexaemeron.tests.test_ephoros_checker
python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py /home/user/wildcat-finance/wildcat-app-v2
python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests scripts
python3 plugins/hexaemeron/tests/run_tests.py
python3 -m unittest discover -s tests
```

This stacks on step 2,
`fiat/ephoros-catches-telemetry-keyed-by-wallet-addres-step-2-e005-in-python-and-block-yaml-wi`.

Wildcat-Origin: shoggoth. The usual marker is an HTML comment, and the tooling
this session posts through strips HTML comments from pull-request bodies, so
the provenance line is visible here instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_017bdMt9VHMvPLwAnXz8AYRD)_