### PR TITLE
Ephoros catches telemetry keyed by wallet address across Python and TypeScript

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7428,3 +7428,29 @@ Phylax, Ephoros and Hypomnema each exit 0. The diff check is clean. Mason head
 exactly one copy of each required Shoggoth trailer.
 
 Leads not pursued: none.
+
+## Ephoros wallet-address telemetry, step 1, round 1 -- 2026-08-21
+
+The exact range `6412c85d7cfd352e21fcc3dc0d8cef39a0649976..a1af4b888b1c181b2a0267b6feee2156abcee238`
+contains the two committed specification copies and nothing else. No product
+source or Solidity changed, so the recorded security-suite waiver applies and
+the Pashov pair did not run.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | No findings. | clean |
+
+Protasis accepts both tracked specifications, study mode and runbook mode each
+exiting 0. Imprimatur exits 0 on each document. Phylax, Ephoros and Hypomnema
+each exit 0 over the two changed files. The Hexaemeron suite passes 640/640 and
+the root suite 107/107. Promise Machine reports 14 plugins and 14 copies clean.
+The step head has a valid local signature and exactly one of each required
+Shoggoth trailer.
+
+The review covered all 8 source-bound risks: `ts-lexer-input`,
+`false-positive-cache-keys`, `rule-boundary-drift`, `e002-reassignment`,
+`suppression-parity`, `yaml-label-keys`, `fixture-exclusion` and
+`walk-widening`. Each names an implementation obligation of steps 2 through 4;
+this documents-only step records them without implementing or weakening any.
+
+Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7549,3 +7549,41 @@ dashboard access pass on both language sides alike, parity holds and widening
 either is a rule decision nobody has asked for. The study's count of 882
 tracked TypeScript files reads 875 at the pinned clone commit, a
 study-document discrepancy with no bearing on any acceptance command.
+
+## Ephoros wallet-address telemetry, step 3, round 2 -- 2026-08-21
+
+The round audited the fixed tree at `2a464fe` with the seams of round 1's nine
+fixes as its focus. All nine held: the recursion containment survives five
+other lexer stress paths and an exception-injection probe, the comment-span
+pragma collection holds under CRLF, JSX, template-expression and
+file-boundary edges, E000 stays unsuppressible without over-rotating real
+findings, and a three-way differential shows parent Python behaviour exactly
+restored. The three lints and both suites were green; the findings below came
+from fresh probes.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R2-01 | low | scripts/ephoros.py | the `?.[` bracket form of optional chaining still defeated the subscript recognisers, an ordinary shape with 16 occurrences in the pinned clone | fixed in 82e7274 |
+| S3-R2-02 | low | scripts/ephoros.py | a whitespace-separated dotted chain scanned quadratically, 62.8 seconds at 100 KB and hours at the cap, inside the untrusted-read boundary; introduced by this step's range and missed in round 1 | fixed in 82e7274 |
+| S3-R2-03 | info | scripts/ephoros.py | a `//` pragma inside a block comment suppressed, against the documented line-comment grammar | fixed in 82e7274 |
+| S3-R2-04 | info | scripts/ephoros.py | a constant template-literal index value was missed while the quoted forms fired | fixed in 82e7274 |
+
+The scan fix is structural rather than a cap: chain parsing is anchored to
+bracket positions and runs once, backwards, per bracket, taking the
+adversarial 100 KB specimen from 58.7 seconds to 0.017 and the same content at
+the full 1 MiB cap to 0.177 seconds, with a normal 1 MiB file at 0.295
+seconds -- measured before and after through the real check path, as metron
+requires. Ten guard tests landed with the fixes, six observed red first and
+four pinning negatives, for 110 focused cases. After the fixes the clone run
+stays clean at exit 0 with zero pragmas and an empty porcelain, the tree lint
+exits 0, the Hexaemeron suite passes 704/704, the root suite 107/107, and
+phylax and hypomnema each exit 0.
+
+Leads not pursued: the Python `#` pragma matches inside a Python string, a
+line-based behaviour identical at the step-2 parent and outside this step's
+diff, belonging to a deliberate decision on that surface; the shared lexer's
+recursion defect stays carried forward for the owning surface; read and write
+subscripts both fire on both language sides alike, a parity-preserving rule
+decision nobody has asked to change; a constant backtick literal now counts
+as a string in every constant-key position, semantically identical to the
+quoted forms, with the self-lint and clone run clean under it.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7622,3 +7622,39 @@ name carrying both dashboard and log words reports the dashboard reading by
 deterministic precedence, contrived and consistent; wider fuzzing past four
 thousand cases, marginal after the corpus and clone differentials came back
 with zero unexpected deltas.
+
+## Ephoros wallet-address telemetry, step 3, round 4 -- 2026-08-21
+
+The round audited the tree at `7295cfe` with round 3's fix seams as its focus.
+Every seam held under the strongest equivalence evidence of the loop: a
+findings-tuple differential over all 882 clone TypeScript files, the 24
+committed fixtures, a 40-shape corpus of mismatched and cross-nested brackets
+and fourteen thousand seeded fuzz cases came back with zero deltas, line
+numbers pinned identically including on E000 paths, and every prior specimen
+kept its bound. The three lints and both suites were green; the finding below
+came from extending the adversarial shapes to sink-named nesting, which round
+3's unnamed-chain specimens could not reach.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R4-01 | medium | scripts/ephoros.py | overlapping spans that name a sink still paid per-span work behind the gates, 107 seconds at 160 KB and roughly 77 minutes at the cap on a nested `.labels(` shape | fixed in d21e5ea |
+
+The fix indexes each file once: both property regexes run a single pass over
+the whole mask with spans collecting their rows by bisection, depth-zero
+punctuation is attributed to its innermost matched pair in one scan, and key
+extraction reads a bounded window whose equivalence the grammar guarantees.
+Measured before and after through the real check path, the nested `.labels(`
+shape goes from an extrapolated 80 minutes at the cap to 1.16 seconds, the
+sink-named bracket nest from 12.2 to 1.08 seconds, and every earlier specimen
+keeps its bound with a normal 1 MiB file at 0.43 seconds. The fixer's own
+differential -- the clone, the fixtures and ten thousand seeded fuzz cases,
+10,906 ordered comparisons -- shows zero behaviour deltas. Four guard tests
+land the shapes with exact codes, counts and line numbers, for 116 focused
+cases; the Hexaemeron suite passes 710/710, the root suite 107/107, the tree
+lint exits 0 and the clone run stays clean at exit 0 in 0.86 seconds.
+
+Leads not pursued: shapes whose mandated output is itself quadratic, such as
+nested sinks each re-reporting their inner label containers, now run in
+output-proportional time and cannot be faster than what they must print; the
+shared lexer's recursion defect stays carried forward for the owning surface,
+unchanged since round 1.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7658,3 +7658,38 @@ nested sinks each re-reporting their inner label containers, now run in
 output-proportional time and cannot be faster than what they must print; the
 shared lexer's recursion defect stays carried forward for the owning surface,
 unchanged since round 1.
+
+## Ephoros wallet-address telemetry, step 3, round 5 -- 2026-08-21
+
+The closing round audited the tree at `d21e5ea` with round 4's span-index fix
+as its focus, on evidence independent of the fixer's own harness: a fresh
+differential with its own generators and seed over the 882 clone files, the 24
+fixtures and 5,400 fuzz cases biased at the fix's edges, 6,306 ordered
+comparisons with zero deltas, plus 43 hand-directed attacks derived from a
+static read of the diff. The bounded-window equivalence argument was attacked
+directly and holds: no truncating constant exists, the one numeric literal is
+an exact-length gate beside an anchored hex match, and 500 KB values with the
+address word at the far end fire identically on both sides. Performance holds
+with nothing over 1.13 seconds at the cap, including a fresh shape aimed at
+the new index's bisection. The three lints exit 0, the focused suite passes
+116/116, the Hexaemeron suite 710/710, the root suite 107/107, and the clone
+runs clean at exit 0 in 0.86 seconds with zero pragmas and an empty porcelain
+at start and end.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | No findings. | clean |
+
+The remaining lead set is stable and recorded: the shared lexer's recursion
+defect belongs to its owning surface and is contained at this checker's
+boundary by the unsuppressible E000 path, re-confirmed by 178 fail-closed fuzz
+cases; output-proportional shapes now do exactly the work their mandated
+output requires; the spec-accepted lexical misses are declared non-goals with
+parity across both language sides.
+
+Leads not pursued: fuzzing past the cumulative twenty-five thousand cases,
+marginal after two clone-wide differentials with zero unexpected deltas; two
+pre-existing hypomnema pointer hits inside historical Hermes entries of this
+log, outside this step's diff and outside the acceptance lint scope; the
+study's file-count note from round 1, resolved -- the pinned clone reads
+exactly 882 tracked TypeScript files today.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7454,3 +7454,44 @@ The review covered all 8 source-bound risks: `ts-lexer-input`,
 this documents-only step records them without implementing or weakening any.
 
 Leads not pursued: none.
+
+## Ephoros wallet-address telemetry, step 2, round 1 -- 2026-08-21
+
+The exact range `485023a30468f898068454fb92e10ae2b547a604..a88b649c1993c95babe2d848c220efc1e4f966bc`
+holds the E005 recognisers in Python and block-YAML, ten fixtures under
+`telemetry-keys/` and 21 new checker tests. No Solidity changed, so the
+recorded security-suite waiver applies and the Pashov pair did not run.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | No findings. | clean |
+
+Phylax, Ephoros and Hypomnema each exit 0. The focused checker suite passes
+67/67, the Hexaemeron suite 661/661 and the root suite 107/107. The step head
+has a valid local signature and exactly one of each required Shoggoth trailer.
+
+The review ran roughly seventy adversarial specimens against the checker
+beyond the committed tests. The register ids in this step's reach were each
+worked by execution: `e002-reassignment` (overlap labels such as
+`wallet_hash` and `address_url` yield exactly one code, E005; `tx_hash` keeps
+E002; a mixed label set yields one of each), `yaml-label-keys` (25 probes:
+block scalars, quoted keys, list forms, flow mappings, comment interruptions,
+alert-boundary containment and `annotations:` nesting all behave inside the
+E004 subset, and E004 and E005 co-fire where both apply), `suppression-parity`
+in its Python half (a reasoned pragma on the line and the line above
+suppresses all three shapes, a bare pragma suppresses none, and pragma-shaped
+text inside scalars is inert) and `fixture-exclusion` (the walk reaches zero
+`telemetry-keys/` files while an identical specimen outside a fixtures
+directory is caught, exit 1). A parent-to-head differential over every
+pre-existing fixture shows E001 to E004 unmoved; the one modified test is the
+sanctioned E002-to-E005 guard re-pin. `ts-lexer-input`, the TypeScript half of
+`suppression-parity`, `false-positive-cache-keys` and `walk-widening` are not
+applicable until step 3 opens that surface.
+
+Leads not pursued: the `s?` suffix shared by `ADDRESS_KEY` and the
+pre-existing `UNBOUNDED` regex misses `-es` plurals such as `addresses` and
+`hashes`, a checker-wide lexical gap that predates this commit and belongs to
+a deliberate rule-widening decision; the E005 message says wallet address for
+any `address`-fragment key such as `ip_address`, a wording the SKILL.md prose
+in step 4 should state; nested mappings under `labels:` pass silently because
+recognition is direct-children-only, worth a line in the same step 4 prose.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7587,3 +7587,38 @@ subscripts both fire on both language sides alike, a parity-preserving rule
 decision nobody has asked to change; a constant backtick literal now counts
 as a string in every constant-key position, semantically identical to the
 quoted forms, with the self-lint and clone run clean under it.
+
+## Ephoros wallet-address telemetry, step 3, round 3 -- 2026-08-21
+
+The round audited the tree at `82e7274` with round 2's fix seams as its
+focus and one converging sweep. All thirteen earlier fixes held: the backward
+chain parser was differentialed against the old grammar over a 65-shape
+corpus, four thousand seeded fuzz cases and a findings-level comparison across
+all 882 clone TypeScript files with zero unexpected deltas, and the pragma,
+backtick and regression seams each held under execution. The three lints and
+both suites were green; the findings below came from the sweep's mandated
+adversarial shapes.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R3-01 | medium | scripts/ephoros.py | deeply nested brackets scanned quadratically through `_matching`, extrapolating to roughly 1.9 hours at the 1 MiB cap, the `ts-lexer-input` register class | fixed in 7295cfe |
+| S3-R3-02 | low | scripts/ephoros.py | a findings-saturated file paid a per-finding newline count, 9.9 seconds for fifty thousand findings | fixed in 7295cfe |
+
+Both fixes are structural and measured before and after through the real
+check path, as metron requires: one linear stack pass maps every opening
+bracket to its closer and cheap sink-name gates precede all span work, taking
+the nested specimen at cap scale from an extrapolated 1.9 hours to 0.814
+seconds; a per-file newline table with bisect takes the saturated specimen
+from 9.877 to 0.526 seconds with line numbers pinned identical at the first,
+middle and last finding. Two guard tests land the specimens at runtime,
+asserting completion, exact counts and exact line numbers rather than
+wall-clock. After the fixes the focused suite passes 112, the Hexaemeron suite
+706/706, the root suite 107/107, the tree lint exits 0 and the clone run stays
+clean at exit 0 in 0.886 seconds with an empty porcelain.
+
+Leads not pursued: a generic-call type argument hides the chain from both the
+old and new grammars alike, a lexical depth the study declares a non-goal; a
+name carrying both dashboard and log words reports the dashboard reading by
+deterministic precedence, contrived and consistent; wider fuzzing past four
+thousand cases, marginal after the corpus and clone differentials came back
+with zero unexpected deltas.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7693,3 +7693,40 @@ pre-existing hypomnema pointer hits inside historical Hermes entries of this
 log, outside this step's diff and outside the acceptance lint scope; the
 study's file-count note from round 1, resolved -- the pinned clone reads
 exactly 882 tracked TypeScript files today.
+
+## Ephoros wallet-address telemetry, step 4, round 1 -- 2026-08-21
+
+The exact range `fdd187a809d1aba0da0ef807b00dff3bbca13979..1fc0a2aaff4d2d216ada128da2ef098c21aabc51`
+holds documentation and records only: the E005 section of the ephoros
+SKILL.md with its three stated limits, the `ephoros-v1.2.0` evolution row,
+ADR-010, one phylax boundary sentence pointing at it, and the two re-pinned
+promise digests. No product source or Solidity changed, so the recorded
+security-suite waiver applies and the Pashov pair did not run.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | No findings. | clean |
+
+The review checked the prose against the run's measured evidence rather than
+against itself: every claimed behaviour in the new SKILL.md section -- the
+three surfaces, the cap and fail-closed path, the E002 subset move, both
+pragma grammars, bare-pragma inertness and the three stated limits -- was
+established by execution in the step 2 and step 3 rounds above, and the
+ledger row's successor job names a live specimen in the pinned clone. One
+correction is on the page rather than silent: the study and runbook wrote the
+completed-frontier label as `ephoros-v0.3.0`, and the versioning contract's
+own arithmetic, enforced by `tests.test_evolution_contract`, makes a
+completed frontier increment the first counter, so the recorded label is
+`ephoros-v1.2.0` with generation and epoch retained. The demo path from study
+item 1 ran green in order on the finished tree: the focused suite 116, both
+tree lints exit 0, the clone clean at exit 0, the Hexaemeron suite 710/710,
+the root suite 107/107 and the evolution contract 8 tests. Promise Machine
+reports 14 plugins and 14 copies clean after the digest re-pins, imprimatur
+scores 100 on each changed prose file, hypomnema exits 0 with every ADR
+pointer resolving, and the step head carries a valid local signature with
+exactly one of each required Shoggoth trailer.
+
+The register ids are prose-inapplicable here and each stands at its step 2
+and 3 disposition; this step records them without weakening any.
+
+Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7495,3 +7495,57 @@ a deliberate rule-widening decision; the E005 message says wallet address for
 any `address`-fragment key such as `ip_address`, a wording the SKILL.md prose
 in step 4 should state; nested mappings under `labels:` pass silently because
 recognition is direct-children-only, worth a line in the same step 4 prose.
+
+## Ephoros wallet-address telemetry, step 3, round 1 -- 2026-08-21
+
+The exact range `e78a3cac6d684e474dbf5d78c65bd8faa5d84417..41f5da1d637826851bdc8c647da3df3dc590d49f`
+opens the TypeScript surface: `check_typescript` through the shared masked
+lexer, the widened walk, and 20 new checker tests. No Solidity changed, so the
+recorded security-suite waiver applies and the Pashov pair did not run. The
+three lints and both suites were green; every finding below came from
+adversarial probes beyond the committed tests.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R1-01 | high | scripts/ephoros.py | a ~3 KB nested-template file raises RecursionError through the shared lexer, crashes the run and drops sibling findings, falsifying the E000 fail-closed claim | fixed in 2a464fe |
+| S3-R1-02 | medium | scripts/ephoros.py | pragma text inside a TS string or template suppresses a real E005; allow lines were read from raw text rather than comment spans | fixed in 2a464fe |
+| S3-R1-03 | medium | scripts/ephoros.py | TS E000 findings were suppressible, so a crafted unterminated file plus a pragma vanished with exit 0 | fixed in 2a464fe |
+| S3-R1-04 | medium | scripts/ephoros.py | the widened ALLOW grammar leaked `//` pragma semantics into Python files, changing parent behaviour out of step scope | fixed in 2a464fe |
+| S3-R1-05 | medium | scripts/ephoros.py | `index:` string-literal values were missed because the property regex ran over the blanked mask | fixed in 2a464fe |
+| S3-R1-06 | low | scripts/ephoros.py | canonical prom-client `labelNames:` spelling unrecognised | fixed in 2a464fe |
+| S3-R1-07 | low | scripts/ephoros.py | optional chaining `?.` defeated every recogniser | fixed in 2a464fe |
+| S3-R1-08 | low | tests/test_ephoros_checker.py | five YAML alert-label tests were absorbed into a TypeScript-named class | fixed in 2a464fe |
+| S3-R1-09 | info | scripts/ephoros.py | `#` pragmas suppressed inside `.ts` files under the same un-gated grammar | fixed in 2a464fe |
+
+Each fix landed under the guard-test convention, red observed then green: 13
+tests over the step head's 87, for 100 focused cases. After the fixes the
+clone run stays clean at exit 0 with zero pragmas and an empty porcelain, the
+tree lint exits 0, the Hexaemeron suite passes 694/694 and the root suite
+107/107. Phylax still exits 0 over the changed checker and over the clone's
+`src`, and a mixed secret-plus-address specimen draws exactly one code from
+each lint, so the boundary between the two holds. A parent-to-head
+differential over E001 to E003, the Python E005 shapes, Python suppression and
+the YAML shapes shows zero mismatches beyond the sanctioned fixes.
+
+The register ids this step opens were each worked by execution:
+`ts-lexer-input` (cap exact at 1 MiB and applied before lexing, 0.2 ms refusal
+on cap-plus-one; unterminated constructs, invalid UTF-8, BOM, CRLF, JSX and
+regex ambiguity all E000 or clean; no execution or import of inspected
+source), `false-positive-cache-keys` (the clone's five real address patterns
+stay clean while tags shorthand, statsd tags, instance labels, positional hex
+and attributes fire), `suppression-parity` in its TypeScript half (line and
+line-above suppress, bare and block-comment pragmas do not), `walk-widening`
+(`node_modules` excluded by test and probe, symlinked directories not
+traversed, and the walked `dist`/`build` question checked against both named
+trees, which hold no tracked build output today) and `rule-boundary-drift`
+(no P004 to P007 pattern duplicated or moved).
+
+Leads not pursued: the shared lexer's recursion defect itself stays in
+`plugins/hexaemeron/lib/typescript_lexer.py` and reproduces identically under
+phylax, which predates this run; ephoros now contains it at its own boundary,
+and the lexer fix belongs to a deliberate change on the owning surface,
+carried forward for the run report. Computed object keys and method-call
+dashboard access pass on both language sides alike, parity holds and widening
+either is a rule decision nobody has asked for. The study's count of 882
+tracked TypeScript files reads 875 at the pinned clone commit, a
+study-document discrepancy with no bearing on any acceptance command.

--- a/docs/decisions/ADR-010-split-address-telemetry-from-boundary-control.md
+++ b/docs/decisions/ADR-010-split-address-telemetry-from-boundary-control.md
@@ -1,0 +1,70 @@
+# ADR-010: Split address telemetry shape from boundary control over shared TypeScript files
+
+## Status
+
+Accepted, 2026-08-21. Superseded by a later numbered record once it stops being
+true.
+
+## Context
+
+Two lints now read the same TypeScript files. Phylax has read `.ts`/`.tsx`
+since its off-chain boundary work landed P005 through P007, through the
+attributed lexer vendored at `plugins/hexaemeron/lib/typescript_lexer.py`.
+The wallet-address telemetry run gave Ephoros the same surface for E005, an
+address used as a metric label, a dashboard key or a log index.
+
+The address rule could plausibly have lived in either skill. Phylax already
+owns the personal-data and address-linkage judgement, including caches that
+pair addresses with resolved names, and its checker already had the TypeScript
+machinery. Ephoros owns the prose rule the checker mechanises: do not index
+telemetry by wallet address, stated in its SKILL.md before any parser read it.
+A rule that two skills could claim ends up either duplicated or orphaned, and
+finding codes are interfaces other tools cite, so the claim had to be settled
+before E005 shipped.
+
+## Decision
+
+Telemetry shape belongs to Ephoros and boundary control belongs to Phylax,
+whatever language the file is written in. E005, the one address rule that is
+telemetry shape rather than boundary control, is an Ephoros code. Secrets in
+source or output (P004), raw HTML and sanitisers (P005), session credentials
+in persisted storage (P006), fetch hosts (P007), and the personal-data and
+address-linkage judgement including linkage caches stay Phylax. One concern
+carries one code, the same file may carry findings from both lints, and no
+pattern is owned by both.
+
+## Alternatives
+
+- **Folding the address rule into phylax.** The checker with the TypeScript
+  machinery would have gained one more pattern, cheaply. It lost because the
+  rule is about where an address sits in emitted telemetry, not about data
+  crossing a trust boundary, and because the prose rule it mechanises lives in
+  Ephoros's contract. A finding code enforcing one skill's rule from another
+  skill's checker leaves two ledgers each owning half a decision, and the two
+  skills evolve on separate frontiers.
+- **A shared rule engine both lints call.** One walk, one suppression grammar,
+  no duplication. It lost because it creates a third surface that evolves on
+  no ledger of its own, and the two checkers already share exactly the part
+  that is safe to share -- the masked lexer -- while their rules, walks and
+  pragma grammars stay citable per skill.
+- **Duplicating the pattern in both lints.** Nothing slips through. It lost
+  because the same line then draws two codes from two tools, a reasoned pragma
+  for one leaves the other firing, and every deliberate exception has to be
+  stated twice and kept in step. A double-reported finding trains people to
+  suppress rather than fix.
+
+## Consequences
+
+A TypeScript file can carry findings from both lints, and the audit evidence
+says the split holds in practice: a mixed secret-plus-address specimen draws
+exactly one code from each. The pragma namespaces stay distinct --
+`ephoros: allow` answers E005 and `phylax: allow` answers P-codes -- so an
+exception states its reason to the lint that owns the concern.
+
+Both checkers keep reading through the one vendored lexer, so a defect there
+is contained twice at each checker's own fail-closed boundary (`E000`, `P000`)
+and fixed once on the owning surface.
+
+Moving a rule across this line later is expensive by design: it changes
+recorded findings, so it takes an evolution row on both ledgers and a record
+superseding this one.

--- a/docs/ephoros-wallet-address-telemetry-runbook.md
+++ b/docs/ephoros-wallet-address-telemetry-runbook.md
@@ -1,0 +1,130 @@
+# Runbook: Ephoros catches telemetry keyed by wallet address across Python and TypeScript
+
+Derived from `.hexaemeron/study.md`, whose chosen design is option A: one rule,
+E005, inside `ephoros.py`, with the TypeScript surface read through the shared
+masked lexer. Four steps, dependency order, one pull request each. Every step
+ends with both suites green: `python3 plugins/hexaemeron/tests/run_tests.py`
+and `python3 -m unittest discover -s tests`, run from `/home/user/skills`.
+
+One allocation is corrected against the base rather than inherited: the
+study's item 12 named ADR-008 as the next free decision-record number, and
+`docs/decisions/` on the starting ref already holds ADR-008 and ADR-009. The
+decision and its home stand; its number is ADR-010.
+
+## Step 1: Scaffold: commit the study and runbook
+
+**Goal.** Land the reviewed spec documents in the repository the way every
+prior run in this tree has.
+**Entry.** Branch from `fiat/ephoros-catches-telemetry-keyed-by-wallet-addres`
+at `main`, `6412c85d7cfd352e21fcc3dc0d8cef39a0649976`.
+**Exit.** `docs/ephoros-wallet-address-telemetry-study.md` and
+`docs/ephoros-wallet-address-telemetry-runbook.md` committed;
+`python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py <each>`
+exits 0; `python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py
+--study docs/ephoros-wallet-address-telemetry-study.md` and
+`python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py
+docs/ephoros-wallet-address-telemetry-runbook.md` exit 0; both suites pass.
+**Files.** `docs/ephoros-wallet-address-telemetry-study.md`,
+`docs/ephoros-wallet-address-telemetry-runbook.md`.
+**Tests.** None written; both suites run as the regression gate.
+**Disciplines.** phylax: none, committing documents opens no boundary.
+ephoros: none, a document does not run unattended. metron: none, no
+performance claim. elenchus: none, no failure in hand. hypomnema: the spec
+documents are the shipped record of this phase; the two decision records the
+study names land in step 4, where their content exists.
+
+## Step 2: E005 in Python and block-YAML, with the E002 subset guard
+
+**Goal.** Report an address used as a metric label, a dashboard key or a log
+index in Python source and in supported block-YAML label mappings.
+**Entry.** Step 1's exit state, branched from its step branch.
+**Exit.** `python3 -m unittest plugins.hexaemeron.tests.test_ephoros_checker`
+passes with the new cases, each positive recogniser case having been observed
+red before its recogniser landed;
+`python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+scripts` exits 0; both suites pass.
+**Files.** `plugins/hexaemeron/skills/ephoros/scripts/ephoros.py`,
+`plugins/hexaemeron/tests/test_ephoros_checker.py`,
+`plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/` (new Python and
+YAML specimens).
+**Tests.** Positive: an address-named label in the `labels=[...]` constructor
+style, the `.labels(wallet_address=...)` instance style, a 40-hex literal
+label, an address-shaped dashboard key, an address-shaped log-index key or
+`index=` argument, and an address-named key under a supported block-YAML
+`labels:` mapping. Negative: an address in an event's fields, an address in a
+message argument, and `print`. Guards: the label `wallet_address` yields E005
+and not E002 while a `hash`-named label keeps E002; `# ephoros: allow <why>`
+suppresses on the line and the line above; a bare pragma suppresses nothing.
+Expected count: at least twelve new cases over the 46 existing.
+**Disciplines.** phylax: none, the checker reads the same trees it already
+reads. ephoros: none, the deliverable is a terminal lint (study item 8).
+metron: none, no performance claim. elenchus: every recogniser case follows
+the guard-test convention, red before the fix and kept green. hypomnema: the
+E005/E002 subset decision is incurred here and recorded in step 4, in the
+ledger row and the SKILL.md mechanical subset, the homes item 12 names.
+
+## Step 3: The TypeScript surface through the shared lexer
+
+**Goal.** E005 reads `.ts`/`.tsx` through
+`plugins/hexaemeron/lib/typescript_lexer.py` with phylax's audited input
+boundary, and the pinned application clone runs clean.
+**Entry.** Step 2's exit state, branched from its step branch.
+**Exit.** `python3 -m unittest plugins.hexaemeron.tests.test_ephoros_checker`
+passes with the TypeScript cases, positives observed red first;
+`python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
+/home/user/wildcat-finance/wildcat-app-v2` exits 0 with zero suppression
+pragmas added to that read-only clone;
+`python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+scripts` exits 0; both suites pass.
+**Files.** `plugins/hexaemeron/skills/ephoros/scripts/ephoros.py`,
+`plugins/hexaemeron/tests/test_ephoros_checker.py`,
+`plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/` (new TypeScript
+specimens).
+**Tests.** Positive: the three acceptance shapes in TypeScript -- an address
+key on a metric label set, on a dashboard structure, and on a log-index
+position of a logger or log-store call. Negative: a react-query `queryKey`
+array carrying an address, a storage key built from an address, a logger
+message interpolating an address, and `console.*`. Boundary: a file over 1 MiB
+reports E000, a lexer failure reports E000, no inspected source is executed or
+imported, the walk skips `node_modules` the way the Python walk skips
+`__pycache__`, and `// ephoros: allow <why>` suppresses while a bare pragma
+does not. Expected count: at least ten new cases.
+**Disciplines.** phylax: this step opens the untrusted-TypeScript read
+boundary; the control is the one phylax already audited -- the 1 MiB cap before
+lexing, E000 fail-closed, no execution -- feeding the `ts-lexer-input`
+register line. ephoros: none, the deliverable stays a terminal lint. metron:
+none, the per-file work is bounded by the cap and phylax runs the same shape
+over the same tree with no recorded budget (study item 10). elenchus: the
+guard-test convention holds for every fixture. hypomnema: the ephoros/phylax
+line over shared TypeScript files is exercised here and recorded in step 4's
+ADR-010.
+
+## Step 4: Say so everywhere, then demonstrate
+
+**Goal.** Document E005, record the two decisions, advance the ledger, honour
+the frontier run's prose reconciliation, and run the demo path.
+**Entry.** Step 3's exit state, branched from its step branch.
+**Exit.** The ephoros `SKILL.md` mechanical subset documents E005 and both
+pragma forms, with frontmatter version matching the ledger;
+`plugins/hexaemeron/skills/ephoros/EVOLUTION.md` carries exactly one new
+`ephoros-v0.3.0` row valid under the versioning contract, either recording one
+evidenced successor job or closing mature, decided on the evidence then in
+hand; `docs/decisions/ADR-010-split-address-telemetry-from-boundary-control.md`
+records the ephoros/phylax line and both SKILL.md boundary sentences point at
+it; the cold read of mutable first-party marketplace prose is done and every
+touched file is listed in the step's pull request body;
+`python3 -m unittest tests.test_evolution_contract` passes;
+`python3 scripts/promise_machine.py check` passes; the demo-path block from
+study item 1 runs green in order; both suites pass.
+**Files.** `plugins/hexaemeron/skills/ephoros/SKILL.md`,
+`plugins/hexaemeron/skills/ephoros/EVOLUTION.md`,
+`docs/decisions/ADR-010-split-address-telemetry-from-boundary-control.md`,
+`plugins/hexaemeron/skills/phylax/SKILL.md` (one boundary sentence pointing at
+the ADR), plus whatever files the cold read shows stale.
+**Tests.** `tests.test_evolution_contract` over the new row; both suites; no
+new test files expected.
+**Disciplines.** phylax: none, prose and records only. ephoros: none, prose
+and records only. metron: none, no performance claim. elenchus: none unless
+the demo path surfaces a failure, which then follows its triage order.
+hypomnema: this is the step where the ADR and the ledger row land; it owns
+their shape and homes.

--- a/docs/ephoros-wallet-address-telemetry-study.md
+++ b/docs/ephoros-wallet-address-telemetry-study.md
@@ -1,0 +1,385 @@
+# Study: Ephoros catches telemetry keyed by wallet address across Python and TypeScript
+
+Assuming, unless corrected:
+
+1. The run starts from `main` at `6412c85d7cfd352e21fcc3dc0d8cef39a0649976`. The
+   TypeScript conformance corpus is the read-only shallow clone of
+   `wildcat-app-v2` at `/home/user/wildcat-finance/wildcat-app-v2`, HEAD
+   `564a189`. Neither that clone nor any vendored directory is edited.
+2. "Telemetry keyed by wallet address" means an address in a key position of a
+   telemetry sink: a metric label, a dashboard key, or a log index. An address
+   inside an event's fields or message stays legal, which is the line
+   `ephoros/SKILL.md` already draws in prose: where an address is genuinely
+   needed to diagnose, it goes in an event, never in a metric label or a
+   dashboard axis.
+3. E005 is the new finding code. E000 to E004 keep their numbers and firing
+   conditions, with one exception decided in item 4: a metric label whose name
+   is address-shaped reports E005 rather than E002, and a guard test pins the
+   move.
+4. Python 3.11 and the standard library remain the implementation boundary.
+   The TypeScript surface is read through the attributed Horos lexer already
+   vendored at `plugins/hexaemeron/lib/typescript_lexer.py`, the same way
+   `phylax.py` reads it. No Node invocation, no tree-sitter, no new
+   dependency.
+5. `console.*` in TypeScript is treated the way `print` is treated in Python:
+   command-line output rather than telemetry, outside the lint's claim.
+   Logger objects (the app's `@wildcatfi/wildcat-sdk` `logger`), metric
+   clients and analytics sinks are inside it.
+6. This is frontier work under
+   [skills#322](https://github.com/wildcat-finance/skills/issues/322).
+   Closing it moves the evolution counter, `ephoros-v0.2.0` to
+   `ephoros-v0.3.0`, replaces the held next job with a successor, and owes the
+   cold read of mutable first-party marketplace prose that the versioning
+   contract requires of every frontier run.
+7. Phylax is untouched: P000 to P007 keep their numbers, and nothing phylax
+   owns (secrets, session storage, fetch hosts, sanitisers, personal-data
+   linkage caches) moves into ephoros.
+
+I will proceed on these assumptions unless corrected.
+
+## 1. Problem statement
+
+`ephoros/SKILL.md` forbids indexing telemetry by wallet address, and today that
+rule is read by a person. The checker at
+`plugins/hexaemeron/skills/ephoros/scripts/ephoros.py` reads Python and a
+block-YAML subset, and nothing reads the TypeScript application at all. Build
+E005: a bounded rule that reports an address used as a metric label, a
+dashboard key or a log index, in Python and in TypeScript, for Wildcat
+contributors and for the Fiat gates that run the tree lints on every step.
+
+A working prototype is established by these commands:
+
+- `python3 -m unittest plugins.hexaemeron.tests.test_ephoros_checker` reports
+  one E005 for each of the three acceptance shapes -- an address as a metric
+  label, as a dashboard key, and as a log index -- each held by a fixture in
+  Python and by a fixture in TypeScript, and each observed red before the
+  recogniser lands. Negative fixtures prove an address inside an event's
+  fields or message, a react-query `queryKey`, and a plain storage key do not
+  fire.
+- `python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+  scripts` exits 0 over this marketplace.
+- `python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
+  /home/user/wildcat-finance/wildcat-app-v2` exits 0 over the pinned
+  application clone, now reading its 882 tracked `.ts`/`.tsx` files.
+- `python3 plugins/hexaemeron/tests/run_tests.py` passes: the Hexaemeron
+  plugin suite.
+- `python3 -m unittest discover -s tests` passes: the root suite of
+  `/home/user/skills`.
+- `python3 -m unittest tests.test_evolution_contract` accepts the
+  `ephoros-v0.3.0` row with its successor job.
+
+The demo path is that block of commands, run in order on the finished tree.
+
+## 2. Prior art
+
+**In this repository.** `ephoros.py` ships E000 to E004. E002 is the nearest
+neighbour and the reason this job is still unmet. Its `UNBOUNDED` identifier
+regex at `ephoros.py:33` already carries an `address|wallet` fragment, and it
+fires only when a call site passes a `labels`, `labelnames`, `label_names`,
+`tags` or `attributes` keyword whose value is a literal dict, list, tuple or
+set of string label names. It misses the Prometheus instance style
+`counter.labels(wallet_address=addr)`, says nothing about dashboard keys or
+log indexes, and reads no TypeScript, because the checker walks only `.py`,
+`.yaml` and `.yml` files. The held frontier in `ephoros/EVOLUTION.md` names
+exactly this gap. `phylax.py` is the architectural precedent for the missing
+language: P005 to P007 read `.ts`/`.tsx` through
+`plugins/hexaemeron/lib/typescript_lexer.py` (absorbed from Horos at commit
+`b95f332`, never executing inspected source), cap reads at 1 MiB with `P000`
+fail-closed, and honour `// phylax: allow <why>`.
+
+**The last two merged pull requests that changed ephoros, both read.**
+
+- [skills#426](https://github.com/wildcat-finance/skills/pull/426), "Drop the
+  sibling-handoff paragraph from every skill surface" (merged 2026-08-21).
+  It removed one paragraph from `ephoros/SKILL.md` among 34 files and
+  re-pinned four Promise Machine digests, ephoros among them. Carried forward
+  in its body: the unlabelled routing clause inside 118 marketplace-context
+  blocks was deliberately left as a separate decision. It stays open here by
+  name: it is a marketplace-wide prose decision, not ephoros lint work, and
+  this run's prose reconciliation touches ephoros context blocks only where
+  the frontier sentence moves.
+- [skills#356](https://github.com/wildcat-finance/skills/pull/356), "Require
+  local runbook annotations on alert rules" (merged 2026-08-21). It shipped
+  E004 and the generic block-YAML machinery across eight audit rounds plus
+  post-cap closure. Its body fixes the boundary this study keeps: ephoros owns
+  annotation presence, Hypomnema H003 and H007 own resolution and target
+  shape, and remote URLs and configuration dialects sit outside. Both remain
+  non-goals here, restated in item 3.
+
+**Audit records, read before the options below were drawn.** `audit/AUDIT.md`
+and `plugins/hexaemeron/audit/AUDIT.md`, every round touching ephoros, phylax
+or telemetry rules:
+
+- "Ephoros alert-runbook annotations" rounds `E319-S2-R1` through `E319-S2-R8`
+  and two post-cap closures resolved sixteen findings, nearly all in the
+  hand-rolled YAML lexing boundary: suppression state inside quoted and block
+  scalars, cross-line quote state, plain-scalar continuations and folds. That
+  history is design evidence here: scanning unmasked text is where those
+  defects lived, so the TypeScript pass rides the existing masked lexer
+  rather than raw regex (option D below is rejected on it).
+- Accepted-not-pursued leads carried forward by name: **non-HTTP URI schemes**
+  and **unquoted hashes in plain scalar paths** remain outside the documented
+  relative-path prototype (`E319-S2-R1` leads). They stay outside here too:
+  E005 adds no pointer handling, so neither lead is reopened.
+- "Phylax TypeScript boundaries" (2026-08-19) added the 1 MiB TypeScript read
+  cap with `P000` fail-closed because the checker had read untrusted files
+  whole. E005's TypeScript pass inherits the same bound, as a register entry.
+- "Receipted lint rounds", integrate note (2026-08-19): no CI workflow runs
+  the Hexaemeron suite, so lint and suite evidence is local. Still true;
+  touching CI stays ask-first and this run does not claim it.
+- `plugins/hexaemeron/audit/AUDIT.md` holds no ephoros finding; its F-01 to
+  F-10 concern `hexctl.py`, `hook_gate.py` and the vendored prose lint, and
+  its accepted leads (`os.replace` atomicity, concurrent `hexctl`, ANSI
+  passthrough) do not touch this job.
+
+**The real telemetry surfaces, surveyed rather than assumed.**
+
+- This marketplace's Python: the tree lints run clean today
+  (`ephoros.py plugins tests scripts` exits 0, verified on the starting ref).
+  Ariadne, Tabularium and Lazarus handle addresses as data -- captures,
+  witnesses, releases -- and none of them keys a metric, dashboard or log
+  store by one. The only label-kwarg vocabulary in tree is the checker's own.
+- `wildcat-app-v2` at `564a189`, 882 tracked TypeScript files: its telemetry
+  is Hotjar (`Hotjar.init` in `src/components/HotjarConsent/index.tsx`,
+  consent-gated, with no identify or event call), the SDK logger imported from
+  `@wildcatfi/wildcat-sdk/dist/utils/logger` used as `logger.debug(...)`
+  template messages, and 164 `console.*` lines including address-bearing
+  templates in `src/app/api/mla/[market]/route.ts:72`. One logger call,
+  `src/app/[locale]/borrower/market/[address]/hooks/useGetLenders.ts:30`,
+  interpolates lender addresses into a message: an event-shaped use E005
+  leaves alone under assumption 2. `package.json` names no prom-client,
+  Sentry, PostHog, Datadog or Mixpanel. react-query `queryKey` arrays carry
+  addresses throughout (`src/config/query-keys.ts`), and
+  `src/utils/timestamp.ts` keys localStorage by `${TIMESTAMP_KEY}_${address}`:
+  cache and storage keys, not telemetry sinks, so the recognisers are scoped
+  to sinks and neither fires. The three workflow YAMLs carry no alert entries
+  and no address keys.
+
+The three acceptance shapes therefore exist in neither tree today: the
+fixtures supply them, and the clean-run criterion over the read-only clone is
+satisfiable without a single suppression pragma.
+
+## 3. Constraints and non-goals
+
+- Starting ref: `main` at `6412c85d7cfd352e21fcc3dc0d8cef39a0649976`.
+  `wildcat-app-v2` pinned at `564a189`, read-only.
+- Python 3.11, standard library only. The TypeScript lexer already in
+  `plugins/hexaemeron/lib/` is the one permitted reader; this repository's
+  plugins run on stdlib by convention (`phylax/SKILL.md` states it as the
+  house default, and Lazarus's four pinned packages are the stated exception),
+  verified against the tree: no ephoros or phylax script imports outside the
+  standard library and the plugin `lib`.
+- Finding codes are stable interfaces. E000 to E004 keep their numbers and
+  behaviour, except the address-named metric-label subset of E002, which E005
+  claims (item 4). P000 to P007 are untouched.
+- The rule boundary: ephoros stops at the presence and shape of telemetry;
+  phylax owns secrets, session storage, fetch hosts, sanitisers and the
+  personal-data linkage section. Item 9 draws the line once.
+- Non-goals, each deliberate: a TypeScript analogue of E001 (message built by
+  formatting); any `console.*` discipline (assumption 5); the `lenders-name`
+  address-to-name cache in the application, which is phylax's personal-data
+  linkage concern, not telemetry shape; remote runbook URLs and configuration
+  dialects (carried from skills#356); dataflow or rename tracking -- the rule
+  is lexical, like every other rule in this checker, so an address flowing
+  through an innocently named variable passes; CI changes.
+- **Always.** Both suites (`python3 -m unittest discover -s tests`,
+  `python3 plugins/hexaemeron/tests/run_tests.py`) before a commit; the
+  imprimatur lint on every shipped document; the focused checker tests, the
+  evolution and version-propagation gates, Promise Machine, and the Phylax,
+  Ephoros and Hypomnema tree lints before each step closes.
+- **Ask first.** Adding a dependency (tree-sitter or any YAML/TS parser);
+  touching CI; changing a public checker interface beyond adding E005;
+  widening the walk to new suffixes beyond `.ts`/`.tsx`; editing anything in
+  the application clone.
+- **Never.** Edit vendored directories or the read-only clone; weaken an
+  existing rule to make a tree pass; delete a failing test; commit a
+  credential; claim a command ran when it did not.
+
+## 4. Design options
+
+**A. One rule, one checker, the shared lexer (chosen).** Add E005 inside
+`ephoros.py`. Python: extend the existing `ast.NodeVisitor` with three
+recognisers -- an address-named or 40-hex-literal metric label (both the
+`labels=[...]` constructor style E002 sees and the `.labels(wallet=...)`
+instance style it misses), an address-shaped key on a dashboard-named target,
+and an address-shaped key or `index=` argument on a log-named target.
+TypeScript: add `check_typescript` importing `lib.typescript_lexer` exactly as
+`phylax.py:27-31` does, mask comments and strings, and recognise the mirrored
+three shapes over the masked source, with the 1 MiB cap, `E000` fail-closed on
+lexer errors, and `// ephoros: allow <why>` beside the existing `#` form.
+YAML: an address-named key under a `labels:` mapping of a supported alert
+entry rides the block-YAML pass E004 already owns. The trade: lexical
+recognition sees named shapes only, so a renamed address passes -- accepted,
+because every rule in this checker (and in phylax) makes the same trade, and
+the fixtures pin exactly what is claimed.
+
+**B. A separate TypeScript scanner.** A second script (Python, or Node running
+the TypeScript compiler API) invoked beside `ephoros.py`. Rejected: executing
+Node against inspected source breaks the precedent phylax states in its own
+SKILL.md (the lint never invokes Node or loads the target's dependencies), and
+a second entry point splits one gate into two invocations that can drift apart
+in walks, caps and suppression rules.
+
+**C. tree-sitter for a real TypeScript AST.** Deeper recognition, fewer
+lexical misses. Rejected: an ask-first native dependency against the stdlib
+convention, a grammar to vendor and pin, and a comprehension cost the whole
+plugin has so far refused to pay. Nothing in the acceptance needs more than
+key-position recognition.
+
+**D. Raw regex over unmasked TypeScript text.** Cheapest to write. Rejected on
+this run's own audit evidence: the sixteen `E319` findings were almost all
+unmasked-text boundary defects, and the masked lexer that avoids the class
+already sits in `plugins/hexaemeron/lib/`.
+
+A is the pick: it is the cheapest to comprehend that meets the acceptance --
+one checker, one walk, one suppression grammar, and an architecture the
+repository has already audited once in phylax.
+
+One sub-decision rides the pick. An address-named metric label matches both
+E002's `UNBOUNDED` regex and E005. One concern gets one code: E005 claims the
+address-shaped subset (`address`, `wallet`, `addr` fragments and 40-hex
+literals), E002 keeps every other unbounded fragment (`hash`, `tx`, `url`,
+`error` and the rest), and a guard test pins that the label `wallet_address`
+now yields E005 and not E002. No consumer's output changes in practice: both
+trees are clean of address labels today, so no existing finding moves. The
+decision is recorded where item 12 puts it.
+
+## 5. Risk register seed
+
+The audit loop should look hardest at the checker's own input boundary and at
+the two clean-run claims, because those are where this run can fail quietly.
+The `E319` rounds spent sixteen findings on exactly the first class.
+
+```risk-register
+ts-lexer-input | untrusted TypeScript read by the shared lexer | the 1 MiB cap applies before lexing, lexer errors fail closed as E000, and no inspected source is executed or imported
+false-positive-cache-keys | react-query queryKey arrays and storage keys in the read-only clone | the recognisers are scoped to telemetry sinks, and the clone run exits 0 with zero suppression pragmas
+rule-boundary-drift | the ephoros and phylax line over the same TypeScript files | E005 reads telemetry shape only, and no P004 to P007 pattern or personal-data concern is duplicated or moved
+e002-reassignment | call sites whose label names are address-shaped | a guard test pins E005 claiming the subset and E002 keeping the rest, observed red before the change
+suppression-parity | the TypeScript pragma beside the Python one | a reasoned ephoros allow comment suppresses in both comment styles and a bare pragma suppresses nothing, each tested
+yaml-label-keys | address-named keys in supported block-YAML label mappings | the recogniser stays inside the E004 block-YAML subset and the accepted URI and hash leads stay outside
+fixture-exclusion | fixture trees under the tree-lint walks | the caught specimens live under fixtures directories the walk already skips, so the clean-run criteria stay honest
+walk-widening | node_modules or build output under a scanned root | the TypeScript walk excludes node_modules the way the Python walk excludes __pycache__, held by a test
+```
+
+The prose the block cannot carry: `false-positive-cache-keys` is the risk that
+decides whether this design survives contact with the application. The survey
+in item 2 says the clone's address flows are messages, cache keys and storage
+keys; if a recogniser drafted in the runbook fires on any of them, the fix is
+narrowing the recogniser, never a pragma in a read-only tree and never a
+weaker fixture.
+
+## 6. Glossary seeds
+
+- Address key: a wallet address, or an identifier naming one (`address`,
+  `wallet`, `addr` fragments, or a `0x` 40-hex literal), in a key position.
+- Telemetry sink: a call surface that stores or emits operational signals: a
+  logger object, a metric client, an analytics client, a dashboard or panel
+  structure, a log store.
+- Metric label: a name in a bounded label set on a metric series (`labels=`,
+  `labelnames=`, `tags=`, `attributes=`, or `.labels(...)`).
+- Dashboard key: a key that selects a dashboard axis, panel or series.
+- Log index: a key by which a log store is partitioned or looked up, as
+  opposed to a field inside one event.
+- Masked source: TypeScript text with comments and string bodies blanked by
+  the shared lexer, so recognisers cannot match inside either.
+- Event field: a queryable key-value inside one emitted event; the legal home
+  for an address that diagnosis genuinely needs.
+- Reasoned pragma: `# ephoros: allow <why>` or `// ephoros: allow <why>` on
+  the finding line or the line above; a bare pragma suppresses nothing.
+
+## 7. Sources
+
+- `plugins/hexaemeron/skills/ephoros/SKILL.md`, `EVOLUTION.md`,
+  `scripts/ephoros.py`, `agents/openai.yaml` -- the skill, its held job, the
+  checker.
+- `plugins/hexaemeron/skills/phylax/SKILL.md`, `scripts/phylax.py`,
+  `plugins/hexaemeron/lib/typescript_lexer.py` -- the boundary owner and the
+  TypeScript precedent.
+- `plugins/hexaemeron/tests/test_ephoros_checker.py`,
+  `tests/fixtures/ephoros/` -- the fixture and test conventions E005 extends.
+- [skills#322](https://github.com/wildcat-finance/skills/issues/322) -- the
+  held job and acceptance.
+- [skills#356](https://github.com/wildcat-finance/skills/pull/356) and
+  [skills#426](https://github.com/wildcat-finance/skills/pull/426) -- the last
+  two merged pull requests that changed ephoros.
+- `audit/AUDIT.md` -- the `E319` rounds, "Phylax TypeScript boundaries" and
+  "Receipted lint rounds"; `plugins/hexaemeron/audit/AUDIT.md` -- the plugin's
+  own two rounds.
+- `docs/ephoros-alert-runbook-annotations-study.md` -- the E004 study whose
+  boundary decisions this study inherits.
+- `/home/user/wildcat-finance/wildcat-app-v2` at `564a189`: `package.json`,
+  `src/components/HotjarConsent/index.tsx`, `src/config/query-keys.ts`,
+  `src/utils/timestamp.ts`, `src/app/api/mla/[market]/route.ts`,
+  `src/app/[locale]/borrower/market/[address]/hooks/useGetLenders.ts`.
+
+## 8. Signals, and the questions behind them
+
+None, and here is why: the deliverable is a lint invoked from a terminal and
+from Fiat gates, and a terminal lint has no three-in-the-morning question --
+it runs, prints findings, and exits. Its visibility contract is its exit code
+and finding lines, which the receipted rounds already record.
+[ephoros](../plugins/hexaemeron/skills/ephoros/SKILL.md) owns what a signal
+must carry, and this run changes what that skill enforces, not what this run
+itself must emit.
+
+## 9. Boundaries, per capability
+
+This step opens one boundary: the checker now reads untrusted TypeScript from
+an outside repository. What is worth taking at it is the checker's own
+runtime -- memory, time, or a crafted file that wedges the lexer -- and the
+control is the one phylax already audited: a 1 MiB read cap enforced before
+lexing, `E000` fail-closed on any construct the lexer cannot terminate, and no
+execution or import of inspected source. That feeds the `ts-lexer-input`
+register line rather than replacing it.
+
+The boundary between the two lints, drawn once as the issue asks:
+[phylax](../plugins/hexaemeron/skills/phylax/SKILL.md) owns what crosses trust
+boundaries -- secrets in source or output (P004), raw HTML and sanitisers
+(P005), session credentials in persisted storage (P006), fetch hosts (P007),
+and the personal-data and address-linkage judgement sections, including caches
+that pair addresses with names. Ephoros owns the presence and shape of the
+telemetry a step leaves behind -- and E005 is the one address rule that is
+telemetry shape rather than boundary control: an address used as a metric
+label, dashboard key or log index. The same `.ts` file may carry findings from
+both lints; no pattern is owned by both.
+
+## 10. The budget, or its absence
+
+None is set, and here is why: the checker gains one AST pass and one lexical
+pass whose per-file work is bounded by the 1 MiB cap, the same shape phylax
+already runs over the identical 882-file tree with no recorded budget and no
+complaint in any receipted round. A budget without a recorded baseline would
+be taste, which [metron](../plugins/hexaemeron/skills/metron/SKILL.md) --
+owner of what a budget carries and how it is checked -- refuses; if a tree-run
+ever feels slow, the first act is metron's baseline of
+`python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py <tree>`, not a
+number invented here.
+
+## 11. The fail-closed posture
+
+The lint stops rather than guesses: an unreadable file, an oversized file, an
+unparseable Python module or a TypeScript construct the lexer cannot terminate
+each report `E000` and fail the run; findings exit 1; a bad invocation exits
+2. A bare pragma suppresses nothing. During the audit loop, every fix follows
+the guard-test convention this run's prior art already practises: the failing
+case lands as a test observed red before the fix and kept green after, the way
+all sixteen `E319` resolutions were evidenced.
+[elenchus](../plugins/hexaemeron/skills/elenchus/SKILL.md) owns the triage
+order and the guard rule; this study only names where they will apply.
+
+## 12. Decisions and their homes
+
+Two decisions here are expensive to reverse, and
+[hypomnema](../plugins/hexaemeron/skills/hypomnema/SKILL.md) owns which
+decisions earn a record and where each lives.
+
+- **E005's scope and the E002 subset move.** Once published, other tools cite
+  the codes, so reassigning the address-shaped labels later would change
+  recorded findings. Home: the `ephoros-v0.3.0` evolution row in
+  `plugins/hexaemeron/skills/ephoros/EVOLUTION.md` and the mechanical-subset
+  section of its `SKILL.md`, which is where E004's equivalent decision lives.
+- **The ephoros/phylax line over shared TypeScript files.** It binds two
+  skills that evolve on separate ledgers, so it outlives both checkers'
+  internals. Home: an architecture decision record under `docs/decisions/`
+  (next free number ADR-008), pointed at from both SKILL.md boundary
+  sentences rather than restated in them.

--- a/plugins/hexaemeron/skills/ephoros/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/ephoros/EVOLUTION.md
@@ -4,16 +4,17 @@ Policy: [../VERSIONING.md](../VERSIONING.md)
 
 ## Held frontier
 
-- Current version: `ephoros-v0.2.0`
+- Current version: `ephoros-v1.2.0`
 - Frontier status: `open`
-- Frontier revision: `emitted-signal-contract`
-- Current frontier: Three Python rules are executable and run clean over this marketplace, while the TypeScript surface, the alert rules and the address-linkage rule remain read by a person.
-- Next Fiat job: Extend the lint to catch telemetry keyed by wallet address, the one rule this skill owns that phylax does not, across both Python and the TypeScript surface. Accepted when an address used as a metric label, a dashboard key and a log index are each caught in a fixture, the lint runs clean over this marketplace and wildcat-app-v2, and both suites pass.
+- Frontier revision: `typescript-rule-parity`
+- Current frontier: Five rules are executable: E001 to E003 read Python only, E004 reads the supported block-YAML subset, and E005 reads Python, supported block-YAML label keys and the TypeScript surface through the shared masked lexer, running clean over this marketplace and the pinned application clone.
+- Next Fiat job: Extend E001, E002 and E003 to the TypeScript surface the checker already reads, so a log message built by interpolation, an unbounded metric label and a mean-summarised duration are caught in the language the application ships in. Accepted when each of the three is caught by a TypeScript fixture observed red before its recogniser lands, the verdict over the pinned wildcat-app-v2 clone is decided on its own evidence rather than assumed clean -- its known interpolated logger message either fires truly or is excluded by a stated rule -- the lint stays clean over this marketplace, and both suites pass.
 
 ## History
 
 - `ephoros-v0.1.0` | baseline | `emitted-signal-contract` | `84e954fec8e47067179c8005120b0d5b689f5c89d0216ecfe4d56c0978f885ab` | [phylax secrets rule](../phylax/SKILL.md) | Ephoros starts here, holding the telemetry a step leaves behind once it runs unattended.
 - `ephoros-v0.2.0` | generation | `emitted-signal-contract` | `84e954fec8e47067179c8005120b0d5b689f5c89d0216ecfe4d56c0978f885ab` | [alert annotation study](../../../../docs/ephoros-alert-runbook-annotations-study.md), [skills#319](https://github.com/wildcat-finance/skills/issues/319) | E004 now reports each supported block-YAML alert list entry without its own nested `annotations.runbook` Markdown path. Comments, block scalars, top-level pointers and neighbouring entries do not create or satisfy the annotation, and the existing reasoned pragma remains the only exception. Ephoros stops at presence: Hypomnema owns resolution and target shape. The held frontier revision, digest, status and next job are unchanged.
+- `ephoros-v1.2.0` | evolution | `typescript-rule-parity` | `02ce0a73818c7a6c3bd9ff967c217b0172312b64a0f7b1776c4c1649bbe66fd7` | [wallet-address telemetry study](../../../../docs/ephoros-wallet-address-telemetry-study.md), [skills#322](https://github.com/wildcat-finance/skills/issues/322) | Closes the emitted-signal-contract frontier. E005 reports an address used as a metric label, a dashboard key or a log index, in Python, in supported block-YAML label mappings and in TypeScript read through the shared masked lexer under phylax's audited input boundary: the 1 MiB cap before lexing, E000 fail-closed, no execution of inspected source. Address-shaped metric labels move from E002 to E005 under a guard test, so one concern carries one code, and the reasoned pragma gains its `//` line-comment form. The ephoros/phylax line over shared TypeScript files is recorded in [ADR-010](../../../../docs/decisions/ADR-010-split-address-telemetry-from-boundary-control.md). Three limits are stated with the rule: the message says wallet address for any address-fragment key such as `ip_address`, recognition under a YAML `labels:` mapping is direct-children-only, and the `s?` suffix family shared with E002 misses `-es` plurals such as `addresses`. The successor is the parity gap this run leaves in hand: the TypeScript surface is read for one rule while E001 to E003 read Python only, and the pinned clone holds a live interpolated logger message an E001 analogue would have to judge.
 
 ## Ledger boundary
 

--- a/plugins/hexaemeron/skills/ephoros/SKILL.md
+++ b/plugins/hexaemeron/skills/ephoros/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   which belongs to elenchus, and do not use it to measure something slow, which
   belongs to metron.
 metadata:
-  version: "0.2.0"
+  version: "1.2.0"
 ---
 
 # Ephoros
@@ -163,7 +163,7 @@ credential or an address that should not be there.
 
 ## The mechanical subset
 
-Four of these rules are settled by a parser. Run the lint over the paths a
+Five of these rules are settled by a parser. Run the lint over the paths a
 step touched, and require exit 0.
 
 ```bash
@@ -176,17 +176,38 @@ block-YAML list entry starting with `alert:` that lacks its own nested
 `annotations.runbook` Markdown path. Comments, block scalars, top-level keys
 and neighbouring alert entries do not satisfy E004. The YAML pass establishes
 presence only: Hypomnema H003 resolves the path and H007 checks the target's
-answers. The other three rules read Python, and the lint says nothing about
-the TypeScript surface.
+answers. E001 to E003 read Python only.
 
-Two things it deliberately leaves alone. A `print` is command-line output
-rather than telemetry, and this marketplace writes a great deal of it. A mean
-of something that is not a duration is arithmetic, so sentence lengths and
-layout positions pass untouched.
+E005 reports telemetry keyed by wallet address: an address-shaped name or a
+40-hex literal used as a metric label, a dashboard key or a log index. It
+reads Python, address-named keys directly under a supported block-YAML
+`labels:` mapping, and `.ts`/`.tsx` source through the shared masked lexer
+phylax already uses, with the same input boundary: at most 1 MiB per
+TypeScript file, and a file the lexer cannot read or terminate reports E000
+and fails the run. Address-shaped metric labels that E002 used to claim now
+report E005, so one concern carries one code; every other unbounded fragment
+keeps E002. Where the line between this lint and phylax runs over the same
+TypeScript files is decided once, in
+[ADR-010](../../../../docs/decisions/ADR-010-split-address-telemetry-from-boundary-control.md).
 
-Deliberate exceptions state a reason: `# ephoros: allow <why>`, on the line or
-the one above it. A bare pragma suppresses nothing. Everything else here stays
-judgement, and a clean exit says only that these four found nothing.
+Three limits are part of the rule rather than defects in it. The finding
+message says wallet address for any address-fragment key, so `ip_address`
+draws the same words. Recognition under a YAML `labels:` mapping is
+direct-children-only, so a key nested one mapping deeper passes silently. And
+the `s?` suffix family E005 shares with E002 misses `-es` plurals, so
+`addresses` passes where `address` fires.
+
+Two things it deliberately leaves alone. A `print` in Python and `console.*`
+in TypeScript are command-line output rather than telemetry, and this
+marketplace writes a great deal of the first. A mean of something that is not
+a duration is arithmetic, so sentence lengths and layout positions pass
+untouched.
+
+Deliberate exceptions state a reason: `# ephoros: allow <why>` in Python and
+YAML, `// ephoros: allow <why>` as a genuine line comment in TypeScript, on
+the finding line or the one above it. A bare pragma suppresses nothing, in
+either form. Everything else here stays judgement, and a clean exit says only
+that these five found nothing.
 
 ## Rationalisations
 
@@ -247,10 +268,10 @@ signal behind it, or the sampled output someone should read.
 
 ### ephoros-mechanical-gate
 
-- Promise: A zero-exit Ephoros lint establishes that the bounded parser found none of its specified formatted-log, unbounded-metric-label or mean-duration patterns in the selected Python paths, and no supported block-YAML alert entry without its own nested runbook annotation.
+- Promise: A zero-exit Ephoros lint establishes that the bounded parser found none of its specified formatted-log, unbounded-metric-label or mean-duration patterns in the selected Python paths, no supported block-YAML alert entry without its own nested runbook annotation, and no wallet-address key on a metric label, dashboard key or log index in the selected Python, TypeScript and supported block-YAML label surfaces.
 - Evidence: The exact lint version, arguments, selected paths, structured findings and zero exit status.
 - Evidence classes: checked
-- Boundary: A clean lint covers only the three implemented Python rules and E004 annotation presence in the supported block-YAML subset; it does not prove useful observability, safe output, correct alerting, a resolving or useful runbook, general YAML semantics or conformance of another language.
+- Boundary: A clean lint covers only the four implemented Python rules, E004 annotation presence and E005 address-key recognition in the supported block-YAML subset, and E005 alone on the TypeScript surface; it does not prove useful observability, safe output, correct alerting, a resolving or useful runbook, general YAML semantics or any other rule in another language.
 - Authorises: Passing the mechanical Ephoros gate for the exact paths and checker version recorded.
 - Consequence: 1
 - Refuses: Unreadable or oversized input, an unexplained suppression, a non-zero result or any broader observability claim.

--- a/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
+++ b/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
@@ -8,6 +8,7 @@ reading intent. Everything else in SKILL.md stays a judgement.
   E002  a metric label drawn from an unbounded source
   E003  a duration summarised as a mean
   E004  a supported YAML alert entry has no local runbook annotation
+  E005  telemetry keyed by wallet address: a metric label, dashboard key or log index
 
 Exit 0 clean, 1 findings, 2 bad invocation.
 
@@ -35,6 +36,12 @@ UNBOUNDED = re.compile(
     re.IGNORECASE,
 )
 
+# One concern, one code: E005 claims the address-shaped labels, E002 keeps
+# every other unbounded fragment.
+ADDRESS_KEY = re.compile(r"(?:^|_)(?:address|wallet|addr)s?(?:_|$)", re.IGNORECASE)
+HEX_ADDRESS = re.compile(r"0x[0-9a-fA-F]{40}")
+DASHBOARD_NAME = re.compile(r"(?:^|_|\.)(?:dashboard|panel)s?$", re.IGNORECASE)
+
 DURATION = re.compile(
     r"(?:^|_)(?:duration|latency|elapsed|seconds|secs|millis|ms|runtime|response_?time"
     r"|took|wait|time)s?(?:_|$)",
@@ -47,6 +54,8 @@ YAML_SUFFIXES = {".yaml", ".yml"}
 MAX_YAML_BYTES = 1 << 20
 ALERT = re.compile(r"^-\s+alert\s*:")
 ANNOTATIONS = re.compile(r"^annotations\s*:\s*$")
+LABELS = re.compile(r"^labels\s*:\s*$")
+YAML_KEY = re.compile(r"^(?P<key>[^\s:#-][^:]*?)\s*:")
 RUNBOOK = re.compile(r"^runbook\s*:\s*(?P<path>.+?)\s*$", re.DOTALL)
 BLOCK_SCALAR = re.compile(
     r"^(?:[^:#][^:]*:\s*|-\s+)[|>](?:[+-]?\d?|\d[+-]?)\s*$")
@@ -84,6 +93,21 @@ def _name_of(node: ast.AST) -> str:
 
 def _is_str_literal(node: ast.AST) -> bool:
     return isinstance(node, ast.Constant) and isinstance(node.value, str)
+
+
+def _address_key(label: str) -> bool:
+    return bool(ADDRESS_KEY.search(label) or HEX_ADDRESS.fullmatch(label))
+
+
+def _address_shaped(node: ast.AST) -> str:
+    """Return the address-shaped name or literal in a key position, or ""."""
+    if isinstance(node, ast.Name) and ADDRESS_KEY.search(node.id):
+        return node.id
+    if isinstance(node, ast.Attribute) and ADDRESS_KEY.search(node.attr):
+        return node.attr
+    if _is_str_literal(node) and _address_key(node.value):
+        return node.value
+    return ""
 
 
 def _built_by_formatting(node: ast.AST) -> bool:
@@ -128,6 +152,11 @@ class Visitor(ast.NodeVisitor):
     def _add(self, node: ast.AST, code: str, message: str) -> None:
         self.findings.append(Finding(self.path, node.lineno, code, message))
 
+    def _keyed_by_address(self, node: ast.AST, position: str, key: str) -> None:
+        self._add(node, "E005",
+                  f"{position} `{key}` keys telemetry by wallet address; "
+                  "put it in an event")
+
     def visit_Call(self, node: ast.Call) -> None:
         func = node.func
         if isinstance(func, ast.Attribute) and func.attr in LOG_METHODS \
@@ -136,12 +165,39 @@ class Visitor(ast.NodeVisitor):
                 self._add(node, "E001",
                           "log message built by formatting; use a stable name and fields")
 
+        if isinstance(func, ast.Attribute):
+            if func.attr == "labels":
+                for keyword in node.keywords:
+                    if keyword.arg and ADDRESS_KEY.search(keyword.arg):
+                        self._keyed_by_address(node, "metric label", keyword.arg)
+                for arg in node.args:
+                    if _is_str_literal(arg) and HEX_ADDRESS.fullmatch(arg.value):
+                        self._keyed_by_address(node, "metric label", arg.value)
+            if LOGGER_NAME.search(_name_of(func.value)):
+                for keyword in node.keywords:
+                    if keyword.arg == "index":
+                        key = _address_shaped(keyword.value)
+                        if key:
+                            self._keyed_by_address(node, "log index", key)
+
         for keyword in node.keywords:
             if keyword.arg in LABEL_KWARGS:
                 for label in self._label_names(keyword.value):
-                    if UNBOUNDED.search(label):
+                    if _address_key(label):
+                        self._keyed_by_address(node, "metric label", label)
+                    elif UNBOUNDED.search(label):
                         self._add(node, "E002",
                                   f"metric label `{label}` is unbounded; put it in an event")
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        key = _address_shaped(node.slice)
+        if key:
+            target = _name_of(node.value)
+            if DASHBOARD_NAME.search(target):
+                self._keyed_by_address(node, "dashboard key", key)
+            elif LOGGER_NAME.search(target):
+                self._keyed_by_address(node, "log index", key)
         self.generic_visit(node)
 
     @staticmethod
@@ -332,6 +388,34 @@ def _relative_markdown(value: str) -> bool:
                 and "://" not in value)
 
 
+def _alert_label_findings(
+        path: Path, significant: list[tuple[int, int, str]], allowed: set[int],
+        index: int, end: int, child_indent: int | None) -> list[Finding]:
+    """Return E005 findings for address-named keys under one alert's labels."""
+    findings: list[Finding] = []
+    cursor = index + 1
+    while cursor < end:
+        _, labels_indent, nested = significant[cursor]
+        cursor += 1
+        if labels_indent != child_indent or not LABELS.match(nested):
+            continue
+        key_child_indent = significant[cursor][1] if cursor < end else None
+        while cursor < end:
+            number, key_indent, candidate = significant[cursor]
+            if key_indent <= labels_indent:
+                break
+            match = YAML_KEY.match(candidate)
+            if key_indent == key_child_indent and match \
+                    and _address_key(match.group("key")) \
+                    and number not in allowed and number - 1 not in allowed:
+                findings.append(Finding(
+                    path, number, "E005",
+                    f"alert label `{match.group('key')}` keys telemetry by "
+                    "wallet address; put it in an event"))
+            cursor += 1
+    return findings
+
+
 def _yaml_findings(path: Path, text: str) -> list[Finding]:
     lines = text.splitlines()
     significant = _yaml_lines(lines)
@@ -349,6 +433,8 @@ def _yaml_findings(path: Path, text: str) -> list[Finding]:
 
         alert_child_indent = (significant[index + 1][1]
                               if index + 1 < end else None)
+        findings.extend(_alert_label_findings(
+            path, significant, allowed, index, end, alert_child_indent))
         annotated = False
         cursor = index + 1
         while cursor < end:

--- a/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
+++ b/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
@@ -12,7 +12,8 @@ reading intent. Everything else in SKILL.md stays a judgement.
 
 Exit 0 clean, 1 findings, 2 bad invocation.
 
-Deliberate exceptions state a reason: `# ephoros: allow <why>`.
+Deliberate exceptions state a reason: `# ephoros: allow <why>` in Python and
+YAML, `// ephoros: allow <why>` in TypeScript.
 """
 
 from __future__ import annotations
@@ -23,6 +24,12 @@ import json
 import re
 import sys
 from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[3]
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))
+
+from lib.typescript_lexer import lex  # noqa: E402
 
 LOG_METHODS = {"debug", "info", "warning", "warn", "error", "critical", "exception", "log"}
 # A logger, not any object with an `info` method, and deliberately not `print`:
@@ -49,8 +56,30 @@ DURATION = re.compile(
 )
 MEAN_FUNCS = {"mean", "fmean", "average", "avg"}
 
-ALLOW = re.compile(r"#\s*ephoros:\s*allow\s+(?P<reason>\S.*)$")
+ALLOW = re.compile(r"(?:#|//)\s*ephoros:\s*allow\s+(?P<reason>\S.*)$")
 YAML_SUFFIXES = {".yaml", ".yml"}
+TYPESCRIPT_SUFFIXES = {".ts", ".tsx"}
+TYPESCRIPT_MAX_BYTES = 1 << 20
+
+# The TypeScript surface, read through the shared masked lexer the way phylax
+# reads it. Recognition splits identifiers on underscore and camel-case
+# boundaries, so `walletAddress` and `wallet_address` name the same key.
+TS_IDENTIFIER = r"[A-Za-z_$][\w$]*"
+TS_WORD = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
+TS_CHAIN = re.compile(
+    rf"(?<![\w$.])(?P<chain>{TS_IDENTIFIER}(?:\s*\.\s*{TS_IDENTIFIER})*)"
+    r"\s*(?P<open>[\[(])")
+TS_LABEL_PROPERTY = re.compile(
+    r"(?<![\w$])(?:labels|labelnames|label_names|tags|attributes)"
+    r"\s*:\s*(?P<open>[\[{])")
+TS_INDEX_PROPERTY = re.compile(r"(?<![\w$])index\s*:\s*")
+TS_ADDRESS_WORDS = frozenset({"address", "addresses", "addr", "addrs",
+                              "wallet", "wallets"})
+TS_METRIC_WORDS = frozenset({"metric", "metrics", "counter", "counters",
+                             "gauge", "gauges", "histogram", "histograms",
+                             "analytics", "telemetry", "statsd"})
+TS_DASHBOARD_WORDS = frozenset({"dashboard", "dashboards", "panel", "panels"})
+TS_LOG_WORDS = frozenset({"log", "logs", "logger", "logging"})
 MAX_YAML_BYTES = 1 << 20
 ALERT = re.compile(r"^-\s+alert\s*:")
 ANNOTATIONS = re.compile(r"^annotations\s*:\s*$")
@@ -464,7 +493,251 @@ def _yaml_findings(path: Path, text: str) -> list[Finding]:
                 "alert entry has no nested `annotations.runbook` Markdown path"))
     return findings
 
+def _line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _masked(text: str, spans) -> str:
+    """Blank comments, strings and other non-code while preserving offsets."""
+    parts = []
+    for kind, start, end in spans:
+        segment = text[start:end]
+        if kind == "code":
+            parts.append(segment)
+        else:
+            parts.append("".join(ch if ch == "\n" else " " for ch in segment))
+    return "".join(parts)
+
+
+def _matching(mask: str, opening: int) -> int | None:
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    if opening >= len(mask) or mask[opening] not in pairs:
+        return None
+    stack = [pairs[mask[opening]]]
+    for index in range(opening + 1, len(mask)):
+        current = mask[index]
+        if current in pairs:
+            stack.append(pairs[current])
+        elif stack and current == stack[-1]:
+            stack.pop()
+            if not stack:
+                return index
+    return None
+
+
+def _split_ranges(mask: str, start: int, end: int) -> list[tuple[int, int]]:
+    """Split a comma list at lexical depth zero, retaining source offsets."""
+    ranges = []
+    stack = []
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    item = start
+    for index in range(start, end):
+        current = mask[index]
+        if current in pairs:
+            stack.append(pairs[current])
+        elif stack and current == stack[-1]:
+            stack.pop()
+        elif current == "," and not stack:
+            ranges.append((item, index))
+            item = index + 1
+    ranges.append((item, end))
+    return ranges
+
+
+def _ts_words(name: str) -> set[str]:
+    return {word.lower() for word in TS_WORD.findall(name)}
+
+
+def _ts_address_name(name: str) -> bool:
+    return bool(_ts_words(name) & TS_ADDRESS_WORDS)
+
+
+def _ts_address_string(value: str) -> bool:
+    return bool(HEX_ADDRESS.fullmatch(value) or _ts_address_name(value))
+
+
+def _ts_string_value(expression: str) -> str | None:
+    expression = expression.strip()
+    if len(expression) >= 2 and expression[0] == expression[-1] \
+            and expression[0] in "'\"":
+        return expression[1:-1]
+    return None
+
+
+def _ts_address_expression(text: str, mask: str, start: int, end: int) -> str:
+    """Return the address-shaped name or literal in a key position, or ""."""
+    expression = mask[start:end].strip()
+    if re.fullmatch(rf"{TS_IDENTIFIER}(?:\s*\.\s*{TS_IDENTIFIER})*", expression):
+        last = re.split(r"\s*\.\s*", expression)[-1]
+        return last if _ts_address_name(last) else ""
+    value = _ts_string_value(text[start:end])
+    if value is not None and _ts_address_string(value):
+        return value
+    return ""
+
+
+def _ts_keyed_by_address(path: Path, text: str, offset: int,
+                         position: str, key: str) -> Finding:
+    return Finding(path, _line_of(text, offset), "E005",
+                   f"{position} `{key}` keys telemetry by wallet address; "
+                   "put it in an event")
+
+
+def _ts_object_keys(text: str, mask: str, opening: int,
+                    closing: int) -> list[tuple[int, str]]:
+    """Return (offset, key) for each address-shaped key of one object literal."""
+    keys = []
+    for start, end in _split_ranges(mask, opening + 1, closing):
+        colon = -1
+        stack = []
+        pairs = {"(": ")", "[": "]", "{": "}"}
+        for index in range(start, end):
+            current = mask[index]
+            if current in pairs:
+                stack.append(pairs[current])
+            elif stack and current == stack[-1]:
+                stack.pop()
+            elif current == ":" and not stack:
+                colon = index
+                break
+        key_end = colon if colon != -1 else end
+        key = _ts_address_expression(text, mask, start, key_end)
+        if key:
+            keys.append((start, key))
+    return keys
+
+
+def _ts_label_container(path: Path, text: str, mask: str, opening: int,
+                        closing: int) -> list[Finding]:
+    """E005 findings for address keys inside one label set container."""
+    findings = []
+    if mask[opening] == "{":
+        for offset, key in _ts_object_keys(text, mask, opening, closing):
+            findings.append(_ts_keyed_by_address(
+                path, text, offset, "metric label", key))
+    else:
+        for start, end in _split_ranges(mask, opening + 1, closing):
+            value = _ts_string_value(text[start:end])
+            if value is not None and _ts_address_string(value):
+                findings.append(_ts_keyed_by_address(
+                    path, text, start, "metric label", value))
+    return findings
+
+
+def _ts_label_properties(path: Path, text: str, mask: str, start: int,
+                         end: int) -> list[Finding]:
+    """Label/tag/attribute sets inside one telemetry sink call's arguments."""
+    findings = []
+    for match in TS_LABEL_PROPERTY.finditer(mask, start, end):
+        opening = match.start("open")
+        closing = _matching(mask, opening)
+        if closing is not None:
+            findings.extend(_ts_label_container(path, text, mask, opening, closing))
+    return findings
+
+
+def _ts_labels_call(path: Path, text: str, mask: str, start: int,
+                    end: int) -> list[Finding]:
+    """The Prometheus instance style: `.labels({...})` or a literal address."""
+    findings = []
+    for arg_start, arg_end in _split_ranges(mask, start, end):
+        argument = mask[arg_start:arg_end].strip()
+        if argument.startswith("{"):
+            opening = mask.index("{", arg_start, arg_end)
+            closing = _matching(mask, opening)
+            if closing is not None:
+                for offset, key in _ts_object_keys(text, mask, opening, closing):
+                    findings.append(_ts_keyed_by_address(
+                        path, text, offset, "metric label", key))
+        else:
+            value = _ts_string_value(text[arg_start:arg_end])
+            if value is not None and HEX_ADDRESS.fullmatch(value):
+                findings.append(_ts_keyed_by_address(
+                    path, text, arg_start, "metric label", value))
+    return findings
+
+
+def _ts_index_properties(path: Path, text: str, mask: str, start: int,
+                         end: int) -> list[Finding]:
+    """`index:` properties inside one logger or log-store call's arguments."""
+    findings = []
+    for match in TS_INDEX_PROPERTY.finditer(mask, start, end):
+        value_end = match.end()
+        stack = []
+        pairs = {"(": ")", "[": "]", "{": "}"}
+        for index in range(match.end(), end):
+            current = mask[index]
+            if current in pairs:
+                stack.append(pairs[current])
+            elif current in ")]}" and not stack:
+                value_end = index
+                break
+            elif stack and current == stack[-1]:
+                stack.pop()
+            elif current == "," and not stack:
+                value_end = index
+                break
+        else:
+            value_end = end
+        key = _ts_address_expression(text, mask, match.end(), value_end)
+        if key:
+            findings.append(_ts_keyed_by_address(
+                path, text, match.start(), "log index", key))
+    return findings
+
+
+def check_typescript(path: Path, text: str) -> list[Finding]:
+    spans, errors = lex(text)
+    if errors:
+        return [Finding(path, _line_of(text, offset), "E000",
+                        f"could not lex: {reason}")
+                for offset, reason in errors]
+    mask = _masked(text, spans)
+    findings: list[Finding] = []
+    for match in TS_CHAIN.finditer(mask):
+        segments = re.split(r"\s*\.\s*", match.group("chain"))
+        if segments[0] == "console":
+            continue  # command-line output is not telemetry
+        opening = match.start("open")
+        closing = _matching(mask, opening)
+        if closing is None:
+            continue
+        last_words = _ts_words(segments[-1])
+        if match.group("open") == "[":
+            key = _ts_address_expression(text, mask, opening + 1, closing)
+            if key and last_words & TS_DASHBOARD_WORDS:
+                findings.append(_ts_keyed_by_address(
+                    path, text, opening + 1, "dashboard key", key))
+            elif key and last_words & TS_LOG_WORDS:
+                findings.append(_ts_keyed_by_address(
+                    path, text, opening + 1, "log index", key))
+            continue
+        chain_words = set().union(*(_ts_words(s) for s in segments))
+        if chain_words & TS_METRIC_WORDS:
+            findings.extend(_ts_label_properties(
+                path, text, mask, opening + 1, closing))
+        if len(segments) >= 2 and segments[-1] == "labels":
+            findings.extend(_ts_labels_call(
+                path, text, mask, opening + 1, closing))
+        if len(segments) >= 2 and _ts_words(segments[-2]) & TS_LOG_WORDS:
+            findings.extend(_ts_index_properties(
+                path, text, mask, opening + 1, closing))
+    return findings
+
+
 def check(path: Path) -> list[Finding]:
+    if path.suffix in TYPESCRIPT_SUFFIXES:
+        try:
+            with path.open("rb") as source:
+                raw = source.read(TYPESCRIPT_MAX_BYTES + 1)
+            if len(raw) > TYPESCRIPT_MAX_BYTES:
+                return [Finding(path, 1, "E000",
+                                "unreadable: TypeScript exceeds 1 MiB")]
+            text = raw.decode("utf-8")
+        except (OSError, UnicodeDecodeError) as err:
+            return [Finding(path, 1, "E000", f"unreadable: {err}")]
+        return [f for f in check_typescript(path, text)
+                if not suppressed(text, f.line)]
     if path.suffix in YAML_SUFFIXES:
         try:
             with path.open("rb") as source:
@@ -495,11 +768,14 @@ def walk(paths: list[str]) -> list[Path]:
     for raw in paths:
         root = Path(raw)
         if root.is_dir():
-            found = (child for suffix in (".py", *sorted(YAML_SUFFIXES))
+            suffixes = (".py", *sorted(TYPESCRIPT_SUFFIXES),
+                        *sorted(YAML_SUFFIXES))
+            found = (child for suffix in suffixes
                      for child in root.rglob(f"*{suffix}"))
             out.extend(child for child in sorted(set(found))
                        if child.is_file()
                        and "__pycache__" not in child.parts
+                       and "node_modules" not in child.parts
                        and "fixtures" not in child.relative_to(root).parts[:-1])
         else:
             out.append(root)

--- a/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
+++ b/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
@@ -57,7 +57,7 @@ DURATION = re.compile(
 MEAN_FUNCS = {"mean", "fmean", "average", "avg"}
 
 # The pragma grammar is gated by surface: `#` belongs to Python and YAML,
-# `//` to TypeScript, where it is read from genuine comment spans only.
+# `//` to TypeScript, where it is read from genuine line-comment spans only.
 ALLOW = re.compile(r"#\s*ephoros:\s*allow\s+(?P<reason>\S.*)$")
 TS_ALLOW = re.compile(r"//\s*ephoros:\s*allow\s+(?P<reason>\S.*)$", re.MULTILINE)
 YAML_SUFFIXES = {".yaml", ".yml"}
@@ -72,9 +72,9 @@ TS_WORD = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
 # `?.` separates a chain the way `.` does: optional chaining names the same sink.
 TS_SEPARATOR = r"\s*\??\.\s*"
 TS_SPLIT = re.compile(TS_SEPARATOR)
-TS_CHAIN = re.compile(
-    rf"(?<![\w$.])(?P<chain>{TS_IDENTIFIER}(?:{TS_SEPARATOR}{TS_IDENTIFIER})*)"
-    r"\s*(?P<open>[\[(])")
+TS_OPEN = re.compile(r"[\[(]")
+TS_IDENT_CHAR = re.compile(r"[\w$]")
+TS_IDENT_START = re.compile(r"[A-Za-z_$]")
 TS_LABEL_PROPERTY = re.compile(
     r"(?<![\w$])(?:labels|labelNames|labelnames|label_names|tags|attributes)"
     r"\s*:\s*(?P<open>[\[{])")
@@ -556,6 +556,53 @@ def _ts_words(name: str) -> set[str]:
     return {word.lower() for word in TS_WORD.findall(name)}
 
 
+def _skip_ws(mask: str, index: int) -> int:
+    while index and mask[index - 1].isspace():
+        index -= 1
+    return index
+
+
+def _ts_chain_before(mask: str, opening: int) -> list[str] | None:
+    """Parse the dotted chain that ends at the bracket at `opening`, or None.
+
+    Scanning is anchored to the brackets: a chain is only ever read once,
+    backwards from its own bracket, so a dotted expression that never reaches
+    a bracket costs nothing.  A forward chain regex paid quadratically there —
+    every admitted start position rescanned the whole remaining chain before
+    failing at the bracket class.  `?.` separates segments the way `.` does,
+    including the bracket form `?.[` and `?.(`.
+    """
+    index = _skip_ws(mask, opening)
+    if mask[index - 2:index] == "?.":
+        index = _skip_ws(mask, index - 2)
+    segments: list[str] = []
+    while True:
+        end = index
+        while index and TS_IDENT_CHAR.match(mask[index - 1]):
+            index -= 1
+        if end == index or not TS_IDENT_START.match(mask[index]):
+            # No identifier here: the chain ends at the last good segment,
+            # and a separator already consumed is not part of it.
+            if not segments:
+                return None
+            index = start
+            break
+        segments.append(mask[index:end])
+        start = index
+        after = _skip_ws(mask, index)
+        if after and mask[after - 1] == ".":
+            dot = after - 1
+            if dot and mask[dot - 1] == "?":
+                dot -= 1
+            index = _skip_ws(mask, dot)
+            continue
+        break
+    if index and mask[index - 1] == ".":
+        return None  # a trailing property of something that is not a name
+    segments.reverse()
+    return segments
+
+
 def _ts_address_name(name: str) -> bool:
     return bool(_ts_words(name) & TS_ADDRESS_WORDS)
 
@@ -568,6 +615,11 @@ def _ts_string_value(expression: str) -> str | None:
     expression = expression.strip()
     if len(expression) >= 2 and expression[0] == expression[-1] \
             and expression[0] in "'\"":
+        return expression[1:-1]
+    # A template literal with no `${}` interpolation is a constant string;
+    # an interpolated one is not, and stays out of key recognition.
+    if len(expression) >= 2 and expression[0] == expression[-1] == "`" \
+            and "${" not in expression:
         return expression[1:-1]
     return None
 
@@ -696,10 +748,15 @@ def _ts_index_properties(path: Path, text: str, mask: str, start: int,
 
 
 def _ts_allow_lines(text: str, spans) -> set[int]:
-    """Return reasoned pragma lines that are genuine TypeScript comments."""
+    """Return reasoned pragma lines that are genuine `//` line comments.
+
+    The documented grammar is a `//` line comment, so block comments are
+    inert for suppression: `/* // ephoros: allow why */` states no reason
+    at the site it would excuse.
+    """
     allowed: set[int] = set()
     for kind, start, end in spans:
-        if kind not in ("line_comment", "block_comment"):
+        if kind != "line_comment":
             continue
         for match in TS_ALLOW.finditer(text, start, end):
             allowed.add(_line_of(text, match.start()))
@@ -723,16 +780,18 @@ def check_typescript(path: Path, text: str) -> list[Finding]:
     allowed = _ts_allow_lines(text, spans)
     mask = _masked(text, spans)
     findings: list[Finding] = []
-    for match in TS_CHAIN.finditer(mask):
-        segments = TS_SPLIT.split(match.group("chain"))
+    for bracket in TS_OPEN.finditer(mask):
+        opening = bracket.start()
+        segments = _ts_chain_before(mask, opening)
+        if not segments:
+            continue
         if segments[0] == "console":
             continue  # command-line output is not telemetry
-        opening = match.start("open")
         closing = _matching(mask, opening)
         if closing is None:
             continue
         last_words = _ts_words(segments[-1])
-        if match.group("open") == "[":
+        if mask[opening] == "[":
             key = _ts_address_expression(text, mask, opening + 1, closing)
             if key and last_words & TS_DASHBOARD_WORDS:
                 findings.append(_ts_keyed_by_address(

--- a/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
+++ b/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
@@ -23,6 +23,7 @@ import ast
 import json
 import re
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 PLUGIN_ROOT = Path(__file__).resolve().parents[3]
@@ -501,8 +502,22 @@ def _yaml_findings(path: Path, text: str) -> list[Finding]:
                 "alert entry has no nested `annotations.runbook` Markdown path"))
     return findings
 
-def _line_of(text: str, offset: int) -> int:
-    return text.count("\n", 0, offset) + 1
+def _newline_offsets(text: str) -> list[int]:
+    """Offsets of every newline, built once per file so lookups can bisect.
+
+    Counting from the top of the file for every finding cost quadratic time
+    on findings-saturated files; one table and a bisection keep it linear.
+    """
+    offsets = []
+    index = text.find("\n")
+    while index != -1:
+        offsets.append(index)
+        index = text.find("\n", index + 1)
+    return offsets
+
+
+def _line_of(newlines: list[int], offset: int) -> int:
+    return bisect_left(newlines, offset) + 1
 
 
 def _masked(text: str, spans) -> str:
@@ -517,20 +532,24 @@ def _masked(text: str, spans) -> str:
     return "".join(parts)
 
 
-def _matching(mask: str, opening: int) -> int | None:
+def _bracket_matches(mask: str) -> dict[int, int]:
+    """Map every opening bracket's offset to its closing offset, or nothing.
+
+    One linear stack pass per file: a closer pops only the innermost opener
+    it actually pairs with, and a mismatched closer is inert, exactly as the
+    old per-bracket forward scan behaved.  That scan restarted at every
+    bracket with a chain before it, so fully overlapping nested spans cost
+    quadratic time; the table answers every lookup in constant time.
+    """
     pairs = {"(": ")", "[": "]", "{": "}"}
-    if opening >= len(mask) or mask[opening] not in pairs:
-        return None
-    stack = [pairs[mask[opening]]]
-    for index in range(opening + 1, len(mask)):
-        current = mask[index]
+    matches: dict[int, int] = {}
+    stack: list[tuple[int, str]] = []
+    for index, current in enumerate(mask):
         if current in pairs:
-            stack.append(pairs[current])
-        elif stack and current == stack[-1]:
-            stack.pop()
-            if not stack:
-                return index
-    return None
+            stack.append((index, pairs[current]))
+        elif stack and current == stack[-1][1]:
+            matches[stack.pop()[0]] = index
+    return matches
 
 
 def _split_ranges(mask: str, start: int, end: int) -> list[tuple[int, int]]:
@@ -637,9 +656,9 @@ def _ts_address_expression(text: str, mask: str, start: int, end: int) -> str:
     return ""
 
 
-def _ts_keyed_by_address(path: Path, text: str, offset: int,
+def _ts_keyed_by_address(path: Path, newlines: list[int], offset: int,
                          position: str, key: str) -> Finding:
-    return Finding(path, _line_of(text, offset), "E005",
+    return Finding(path, _line_of(newlines, offset), "E005",
                    f"{position} `{key}` keys telemetry by wallet address; "
                    "put it in an event")
 
@@ -668,36 +687,39 @@ def _ts_object_keys(text: str, mask: str, opening: int,
     return keys
 
 
-def _ts_label_container(path: Path, text: str, mask: str, opening: int,
-                        closing: int) -> list[Finding]:
+def _ts_label_container(path: Path, text: str, mask: str, newlines: list[int],
+                        opening: int, closing: int) -> list[Finding]:
     """E005 findings for address keys inside one label set container."""
     findings = []
     if mask[opening] == "{":
         for offset, key in _ts_object_keys(text, mask, opening, closing):
             findings.append(_ts_keyed_by_address(
-                path, text, offset, "metric label", key))
+                path, newlines, offset, "metric label", key))
     else:
         for start, end in _split_ranges(mask, opening + 1, closing):
             value = _ts_string_value(text[start:end])
             if value is not None and _ts_address_string(value):
                 findings.append(_ts_keyed_by_address(
-                    path, text, start, "metric label", value))
+                    path, newlines, start, "metric label", value))
     return findings
 
 
-def _ts_label_properties(path: Path, text: str, mask: str, start: int,
+def _ts_label_properties(path: Path, text: str, mask: str, newlines: list[int],
+                         matches: dict[int, int], start: int,
                          end: int) -> list[Finding]:
     """Label/tag/attribute sets inside one telemetry sink call's arguments."""
     findings = []
     for match in TS_LABEL_PROPERTY.finditer(mask, start, end):
         opening = match.start("open")
-        closing = _matching(mask, opening)
+        closing = matches.get(opening)
         if closing is not None:
-            findings.extend(_ts_label_container(path, text, mask, opening, closing))
+            findings.extend(_ts_label_container(
+                path, text, mask, newlines, opening, closing))
     return findings
 
 
-def _ts_labels_call(path: Path, text: str, mask: str, start: int,
+def _ts_labels_call(path: Path, text: str, mask: str, newlines: list[int],
+                    matches: dict[int, int], start: int,
                     end: int) -> list[Finding]:
     """The Prometheus instance style: `.labels({...})` or a literal address."""
     findings = []
@@ -705,21 +727,21 @@ def _ts_labels_call(path: Path, text: str, mask: str, start: int,
         argument = mask[arg_start:arg_end].strip()
         if argument.startswith("{"):
             opening = mask.index("{", arg_start, arg_end)
-            closing = _matching(mask, opening)
+            closing = matches.get(opening)
             if closing is not None:
                 for offset, key in _ts_object_keys(text, mask, opening, closing):
                     findings.append(_ts_keyed_by_address(
-                        path, text, offset, "metric label", key))
+                        path, newlines, offset, "metric label", key))
         else:
             value = _ts_string_value(text[arg_start:arg_end])
             if value is not None and HEX_ADDRESS.fullmatch(value):
                 findings.append(_ts_keyed_by_address(
-                    path, text, arg_start, "metric label", value))
+                    path, newlines, arg_start, "metric label", value))
     return findings
 
 
-def _ts_index_properties(path: Path, text: str, mask: str, start: int,
-                         end: int) -> list[Finding]:
+def _ts_index_properties(path: Path, text: str, mask: str, newlines: list[int],
+                         start: int, end: int) -> list[Finding]:
     """`index:` properties inside one logger or log-store call's arguments."""
     findings = []
     for match in TS_INDEX_PROPERTY.finditer(mask, start, end):
@@ -743,11 +765,11 @@ def _ts_index_properties(path: Path, text: str, mask: str, start: int,
         key = _ts_address_expression(text, mask, match.end(), value_end)
         if key:
             findings.append(_ts_keyed_by_address(
-                path, text, match.start(), "log index", key))
+                path, newlines, match.start(), "log index", key))
     return findings
 
 
-def _ts_allow_lines(text: str, spans) -> set[int]:
+def _ts_allow_lines(text: str, spans, newlines: list[int]) -> set[int]:
     """Return reasoned pragma lines that are genuine `//` line comments.
 
     The documented grammar is a `//` line comment, so block comments are
@@ -759,7 +781,7 @@ def _ts_allow_lines(text: str, spans) -> set[int]:
         if kind != "line_comment":
             continue
         for match in TS_ALLOW.finditer(text, start, end):
-            allowed.add(_line_of(text, match.start()))
+            allowed.add(_line_of(newlines, match.start()))
     return allowed
 
 
@@ -773,12 +795,14 @@ def check_typescript(path: Path, text: str) -> list[Finding]:
         return [Finding(path, 1, "E000", "could not lex: recursion limit")]
     except Exception as err:  # noqa: BLE001 -- any lexer failure fails closed
         return [Finding(path, 1, "E000", f"could not lex: {err}")]
+    newlines = _newline_offsets(text)
     if errors:
-        return [Finding(path, _line_of(text, offset), "E000",
+        return [Finding(path, _line_of(newlines, offset), "E000",
                         f"could not lex: {reason}")
                 for offset, reason in errors]
-    allowed = _ts_allow_lines(text, spans)
+    allowed = _ts_allow_lines(text, spans, newlines)
     mask = _masked(text, spans)
+    matches = _bracket_matches(mask)
     findings: list[Finding] = []
     for bracket in TS_OPEN.finditer(mask):
         opening = bracket.start()
@@ -787,29 +811,42 @@ def check_typescript(path: Path, text: str) -> list[Finding]:
             continue
         if segments[0] == "console":
             continue  # command-line output is not telemetry
-        closing = _matching(mask, opening)
-        if closing is None:
-            continue
+        # The cheap sink-name gates come before any per-bracket span work:
+        # a bracket whose chain names no sink costs nothing further.
         last_words = _ts_words(segments[-1])
         if mask[opening] == "[":
+            if not last_words & (TS_DASHBOARD_WORDS | TS_LOG_WORDS):
+                continue
+            closing = matches.get(opening)
+            if closing is None:
+                continue
             key = _ts_address_expression(text, mask, opening + 1, closing)
             if key and last_words & TS_DASHBOARD_WORDS:
                 findings.append(_ts_keyed_by_address(
-                    path, text, opening + 1, "dashboard key", key))
+                    path, newlines, opening + 1, "dashboard key", key))
             elif key and last_words & TS_LOG_WORDS:
                 findings.append(_ts_keyed_by_address(
-                    path, text, opening + 1, "log index", key))
+                    path, newlines, opening + 1, "log index", key))
             continue
         chain_words = set().union(*(_ts_words(s) for s in segments))
-        if chain_words & TS_METRIC_WORDS:
+        metric_sink = bool(chain_words & TS_METRIC_WORDS)
+        labels_call = len(segments) >= 2 and segments[-1] == "labels"
+        log_call = len(segments) >= 2 and bool(
+            _ts_words(segments[-2]) & TS_LOG_WORDS)
+        if not (metric_sink or labels_call or log_call):
+            continue
+        closing = matches.get(opening)
+        if closing is None:
+            continue
+        if metric_sink:
             findings.extend(_ts_label_properties(
-                path, text, mask, opening + 1, closing))
-        if len(segments) >= 2 and segments[-1] == "labels":
+                path, text, mask, newlines, matches, opening + 1, closing))
+        if labels_call:
             findings.extend(_ts_labels_call(
-                path, text, mask, opening + 1, closing))
-        if len(segments) >= 2 and _ts_words(segments[-2]) & TS_LOG_WORDS:
+                path, text, mask, newlines, matches, opening + 1, closing))
+        if log_call:
             findings.extend(_ts_index_properties(
-                path, text, mask, opening + 1, closing))
+                path, text, mask, newlines, opening + 1, closing))
     return [finding for finding in findings
             if finding.line not in allowed and finding.line - 1 not in allowed]
 

--- a/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
+++ b/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
@@ -56,7 +56,10 @@ DURATION = re.compile(
 )
 MEAN_FUNCS = {"mean", "fmean", "average", "avg"}
 
-ALLOW = re.compile(r"(?:#|//)\s*ephoros:\s*allow\s+(?P<reason>\S.*)$")
+# The pragma grammar is gated by surface: `#` belongs to Python and YAML,
+# `//` to TypeScript, where it is read from genuine comment spans only.
+ALLOW = re.compile(r"#\s*ephoros:\s*allow\s+(?P<reason>\S.*)$")
+TS_ALLOW = re.compile(r"//\s*ephoros:\s*allow\s+(?P<reason>\S.*)$", re.MULTILINE)
 YAML_SUFFIXES = {".yaml", ".yml"}
 TYPESCRIPT_SUFFIXES = {".ts", ".tsx"}
 TYPESCRIPT_MAX_BYTES = 1 << 20
@@ -66,13 +69,18 @@ TYPESCRIPT_MAX_BYTES = 1 << 20
 # boundaries, so `walletAddress` and `wallet_address` name the same key.
 TS_IDENTIFIER = r"[A-Za-z_$][\w$]*"
 TS_WORD = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
+# `?.` separates a chain the way `.` does: optional chaining names the same sink.
+TS_SEPARATOR = r"\s*\??\.\s*"
+TS_SPLIT = re.compile(TS_SEPARATOR)
 TS_CHAIN = re.compile(
-    rf"(?<![\w$.])(?P<chain>{TS_IDENTIFIER}(?:\s*\.\s*{TS_IDENTIFIER})*)"
+    rf"(?<![\w$.])(?P<chain>{TS_IDENTIFIER}(?:{TS_SEPARATOR}{TS_IDENTIFIER})*)"
     r"\s*(?P<open>[\[(])")
 TS_LABEL_PROPERTY = re.compile(
-    r"(?<![\w$])(?:labels|labelnames|label_names|tags|attributes)"
+    r"(?<![\w$])(?:labels|labelNames|labelnames|label_names|tags|attributes)"
     r"\s*:\s*(?P<open>[\[{])")
-TS_INDEX_PROPERTY = re.compile(r"(?<![\w$])index\s*:\s*")
+# No trailing `\s*`: a blanked string in the mask is spaces, and the value
+# span must start at the colon so the raw literal can be read back.
+TS_INDEX_PROPERTY = re.compile(r"(?<![\w$])index\s*:")
 TS_ADDRESS_WORDS = frozenset({"address", "addresses", "addr", "addrs",
                               "wallet", "wallets"})
 TS_METRIC_WORDS = frozenset({"metric", "metrics", "counter", "counters",
@@ -567,8 +575,9 @@ def _ts_string_value(expression: str) -> str | None:
 def _ts_address_expression(text: str, mask: str, start: int, end: int) -> str:
     """Return the address-shaped name or literal in a key position, or ""."""
     expression = mask[start:end].strip()
-    if re.fullmatch(rf"{TS_IDENTIFIER}(?:\s*\.\s*{TS_IDENTIFIER})*", expression):
-        last = re.split(r"\s*\.\s*", expression)[-1]
+    if re.fullmatch(rf"{TS_IDENTIFIER}(?:{TS_SEPARATOR}{TS_IDENTIFIER})*",
+                    expression):
+        last = TS_SPLIT.split(expression)[-1]
         return last if _ts_address_name(last) else ""
     value = _ts_string_value(text[start:end])
     if value is not None and _ts_address_string(value):
@@ -686,16 +695,36 @@ def _ts_index_properties(path: Path, text: str, mask: str, start: int,
     return findings
 
 
+def _ts_allow_lines(text: str, spans) -> set[int]:
+    """Return reasoned pragma lines that are genuine TypeScript comments."""
+    allowed: set[int] = set()
+    for kind, start, end in spans:
+        if kind not in ("line_comment", "block_comment"):
+            continue
+        for match in TS_ALLOW.finditer(text, start, end):
+            allowed.add(_line_of(text, match.start()))
+    return allowed
+
+
 def check_typescript(path: Path, text: str) -> list[Finding]:
-    spans, errors = lex(text)
+    # The lexer boundary fails closed per file: a construct it cannot
+    # terminate reports E000 here rather than crashing the whole run, and
+    # E000 bypasses suppression, matching the Python and YAML semantics.
+    try:
+        spans, errors = lex(text)
+    except RecursionError:
+        return [Finding(path, 1, "E000", "could not lex: recursion limit")]
+    except Exception as err:  # noqa: BLE001 -- any lexer failure fails closed
+        return [Finding(path, 1, "E000", f"could not lex: {err}")]
     if errors:
         return [Finding(path, _line_of(text, offset), "E000",
                         f"could not lex: {reason}")
                 for offset, reason in errors]
+    allowed = _ts_allow_lines(text, spans)
     mask = _masked(text, spans)
     findings: list[Finding] = []
     for match in TS_CHAIN.finditer(mask):
-        segments = re.split(r"\s*\.\s*", match.group("chain"))
+        segments = TS_SPLIT.split(match.group("chain"))
         if segments[0] == "console":
             continue  # command-line output is not telemetry
         opening = match.start("open")
@@ -722,7 +751,8 @@ def check_typescript(path: Path, text: str) -> list[Finding]:
         if len(segments) >= 2 and _ts_words(segments[-2]) & TS_LOG_WORDS:
             findings.extend(_ts_index_properties(
                 path, text, mask, opening + 1, closing))
-    return findings
+    return [finding for finding in findings
+            if finding.line not in allowed and finding.line - 1 not in allowed]
 
 
 def check(path: Path) -> list[Finding]:
@@ -736,8 +766,7 @@ def check(path: Path) -> list[Finding]:
             text = raw.decode("utf-8")
         except (OSError, UnicodeDecodeError) as err:
             return [Finding(path, 1, "E000", f"unreadable: {err}")]
-        return [f for f in check_typescript(path, text)
-                if not suppressed(text, f.line)]
+        return check_typescript(path, text)
     if path.suffix in YAML_SUFFIXES:
         try:
             with path.open("rb") as source:

--- a/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
+++ b/plugins/hexaemeron/skills/ephoros/scripts/ephoros.py
@@ -72,8 +72,10 @@ TS_IDENTIFIER = r"[A-Za-z_$][\w$]*"
 TS_WORD = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
 # `?.` separates a chain the way `.` does: optional chaining names the same sink.
 TS_SEPARATOR = r"\s*\??\.\s*"
-TS_SPLIT = re.compile(TS_SEPARATOR)
+TS_IDENT = re.compile(TS_IDENTIFIER)
+TS_SEP = re.compile(TS_SEPARATOR)
 TS_OPEN = re.compile(r"[\[(]")
+TS_INTEREST = re.compile(r"[()\[\]{}:,]")
 TS_IDENT_CHAR = re.compile(r"[\w$]")
 TS_IDENT_START = re.compile(r"[A-Za-z_$]")
 TS_LABEL_PROPERTY = re.compile(
@@ -552,25 +554,6 @@ def _bracket_matches(mask: str) -> dict[int, int]:
     return matches
 
 
-def _split_ranges(mask: str, start: int, end: int) -> list[tuple[int, int]]:
-    """Split a comma list at lexical depth zero, retaining source offsets."""
-    ranges = []
-    stack = []
-    pairs = {"(": ")", "[": "]", "{": "}"}
-    item = start
-    for index in range(start, end):
-        current = mask[index]
-        if current in pairs:
-            stack.append(pairs[current])
-        elif stack and current == stack[-1]:
-            stack.pop()
-        elif current == "," and not stack:
-            ranges.append((item, index))
-            item = index + 1
-    ranges.append((item, end))
-    return ranges
-
-
 def _ts_words(name: str) -> set[str]:
     return {word.lower() for word in TS_WORD.findall(name)}
 
@@ -626,36 +609,6 @@ def _ts_address_name(name: str) -> bool:
     return bool(_ts_words(name) & TS_ADDRESS_WORDS)
 
 
-def _ts_address_string(value: str) -> bool:
-    return bool(HEX_ADDRESS.fullmatch(value) or _ts_address_name(value))
-
-
-def _ts_string_value(expression: str) -> str | None:
-    expression = expression.strip()
-    if len(expression) >= 2 and expression[0] == expression[-1] \
-            and expression[0] in "'\"":
-        return expression[1:-1]
-    # A template literal with no `${}` interpolation is a constant string;
-    # an interpolated one is not, and stays out of key recognition.
-    if len(expression) >= 2 and expression[0] == expression[-1] == "`" \
-            and "${" not in expression:
-        return expression[1:-1]
-    return None
-
-
-def _ts_address_expression(text: str, mask: str, start: int, end: int) -> str:
-    """Return the address-shaped name or literal in a key position, or ""."""
-    expression = mask[start:end].strip()
-    if re.fullmatch(rf"{TS_IDENTIFIER}(?:{TS_SEPARATOR}{TS_IDENTIFIER})*",
-                    expression):
-        last = TS_SPLIT.split(expression)[-1]
-        return last if _ts_address_name(last) else ""
-    value = _ts_string_value(text[start:end])
-    if value is not None and _ts_address_string(value):
-        return value
-    return ""
-
-
 def _ts_keyed_by_address(path: Path, newlines: list[int], offset: int,
                          position: str, key: str) -> Finding:
     return Finding(path, _line_of(newlines, offset), "E005",
@@ -663,110 +616,284 @@ def _ts_keyed_by_address(path: Path, newlines: list[int], offset: int,
                    "put it in an event")
 
 
-def _ts_object_keys(text: str, mask: str, opening: int,
-                    closing: int) -> list[tuple[int, str]]:
-    """Return (offset, key) for each address-shaped key of one object literal."""
-    keys = []
-    for start, end in _split_ranges(mask, opening + 1, closing):
-        colon = -1
-        stack = []
-        pairs = {"(": ")", "[": "]", "{": "}"}
-        for index in range(start, end):
-            current = mask[index]
-            if current in pairs:
-                stack.append(pairs[current])
-            elif stack and current == stack[-1]:
-                stack.pop()
-            elif current == ":" and not stack:
-                colon = index
-                break
-        key_end = colon if colon != -1 else end
-        key = _ts_address_expression(text, mask, start, key_end)
-        if key:
-            keys.append((start, key))
-    return keys
+class _TsSpanIndex:
+    """Per-file tables that keep sink-named overlapping spans near-linear.
 
+    Once a nested bracket chain named a sink, every enclosing bracket paid
+    its full span for the property scans, the comma splits and the key
+    expression reads, and fully overlapping spans made that quadratic --
+    about 77 minutes at the 1 MiB cap.  Each table here is built in one
+    pass over the file and consulted by bisection, so the total work
+    across all spans stays near-linear in the file plus the findings
+    actually reported.
 
-def _ts_label_container(path: Path, text: str, mask: str, newlines: list[int],
-                        opening: int, closing: int) -> list[Finding]:
-    """E005 findings for address keys inside one label set container."""
-    findings = []
-    if mask[opening] == "{":
-        for offset, key in _ts_object_keys(text, mask, opening, closing):
-            findings.append(_ts_keyed_by_address(
-                path, newlines, offset, "metric label", key))
-    else:
-        for start, end in _split_ranges(mask, opening + 1, closing):
-            value = _ts_string_value(text[start:end])
-            if value is not None and _ts_address_string(value):
-                findings.append(_ts_keyed_by_address(
-                    path, newlines, start, "metric label", value))
-    return findings
+    Every table keys events by the innermost *matched* bracket pair around
+    them, which reproduces the old local scans exactly: inside a matched
+    pair every opener is itself matched, so a scan's private stack mirrors
+    the file-wide one, and an inert closer is inert to both.
+    """
 
+    def __init__(self, path: Path, text: str, mask: str,
+                 newlines: list[int], matches: dict[int, int]) -> None:
+        self.path = path
+        self.text = text
+        self.mask = mask
+        self.newlines = newlines
+        self.matches = matches
+        self._commas: dict[int, list[int]] | None = None
+        self._colons: dict[int, list[int]] = {}
+        self._inerts: dict[int, list[int]] = {}
+        self._label_starts: list[int] = []
+        self._label_rows: list[list[Finding]] = []
+        self._index_starts: list[int] = []
+        self._index_rows: list[Finding] = []
+        self._word_starts: list[int] | None = None
+        self._interp_starts: list[int] | None = None
 
-def _ts_label_properties(path: Path, text: str, mask: str, newlines: list[int],
-                         matches: dict[int, int], start: int,
-                         end: int) -> list[Finding]:
-    """Label/tag/attribute sets inside one telemetry sink call's arguments."""
-    findings = []
-    for match in TS_LABEL_PROPERTY.finditer(mask, start, end):
-        opening = match.start("open")
-        closing = matches.get(opening)
-        if closing is not None:
-            findings.extend(_ts_label_container(
-                path, text, mask, newlines, opening, closing))
-    return findings
-
-
-def _ts_labels_call(path: Path, text: str, mask: str, newlines: list[int],
-                    matches: dict[int, int], start: int,
-                    end: int) -> list[Finding]:
-    """The Prometheus instance style: `.labels({...})` or a literal address."""
-    findings = []
-    for arg_start, arg_end in _split_ranges(mask, start, end):
-        argument = mask[arg_start:arg_end].strip()
-        if argument.startswith("{"):
-            opening = mask.index("{", arg_start, arg_end)
+    def _build(self) -> None:
+        """One pass over the punctuation, then one pass over the sinks."""
+        if self._commas is not None:
+            return
+        commas: dict[int, list[int]] = {}
+        self._commas = commas
+        colons, inerts = self._colons, self._inerts
+        mask, matches = self.mask, self.matches
+        index_matches = list(TS_INDEX_PROPERTY.finditer(mask))
+        queries = sorted({match.end() for match in index_matches})
+        enclosing: dict[int, int] = {}
+        stack: list[int] = []
+        cursor, total = 0, len(queries)
+        for event in TS_INTEREST.finditer(mask):
+            position = event.start()
+            while cursor < total and queries[cursor] <= position:
+                enclosing[queries[cursor]] = stack[-1] if stack else -1
+                cursor += 1
+            current = event.group()
+            if current in "([{":
+                if position in matches:
+                    stack.append(position)
+            elif current in ")]}":
+                if stack and matches[stack[-1]] == position:
+                    stack.pop()
+                else:
+                    inerts.setdefault(
+                        stack[-1] if stack else -1, []).append(position)
+            elif current == ",":
+                commas.setdefault(
+                    stack[-1] if stack else -1, []).append(position)
+            else:
+                colons.setdefault(
+                    stack[-1] if stack else -1, []).append(position)
+        while cursor < total:
+            enclosing[queries[cursor]] = stack[-1] if stack else -1
+            cursor += 1
+        # The property regexes run once over the whole mask, each closed
+        # container or value is analysed once, and only productive rows
+        # are kept: a span later collects its rows by position, so nested
+        # sinks still repeat findings the way the per-span scans did,
+        # without repeating the work.  Neither property can straddle a
+        # span boundary, because neither matches a closing bracket.
+        for match in TS_LABEL_PROPERTY.finditer(mask):
+            opening = match.start("open")
             closing = matches.get(opening)
-            if closing is not None:
-                for offset, key in _ts_object_keys(text, mask, opening, closing):
-                    findings.append(_ts_keyed_by_address(
-                        path, newlines, offset, "metric label", key))
-        else:
-            value = _ts_string_value(text[arg_start:arg_end])
-            if value is not None and HEX_ADDRESS.fullmatch(value):
+            if closing is None:
+                continue
+            row = self._label_container(opening, closing)
+            if row:
+                self._label_starts.append(match.start())
+                self._label_rows.append(row)
+        for match in index_matches:
+            begin = match.end()
+            value_end = self._value_end(enclosing[begin], begin)
+            key = self.address_expression(begin, value_end)
+            if key:
+                self._index_starts.append(match.start())
+                self._index_rows.append(_ts_keyed_by_address(
+                    self.path, self.newlines, match.start(),
+                    "log index", key))
+
+    def _value_end(self, opener: int, begin: int) -> int:
+        """Where an `index:` value ends: the old forward scan, replayed.
+
+        From `begin`, that scan's private stack saw exactly the depth-zero
+        commas and inert closers of the innermost enclosing pair, and then
+        the pair's own closer, whichever came first.
+        """
+        end = self.matches[opener] if opener != -1 else len(self.mask)
+        for positions in (self._commas.get(opener, []),
+                          self._inerts.get(opener, [])):
+            found = bisect_left(positions, begin)
+            if found < len(positions) and positions[found] < end:
+                end = positions[found]
+        return end
+
+    def ranges(self, opening: int, closing: int) -> list[tuple[int, int]]:
+        """Split one matched span at its depth-zero commas."""
+        self._build()
+        ranges = []
+        item = opening + 1
+        for comma in self._commas.get(opening, []):
+            ranges.append((item, comma))
+            item = comma + 1
+        ranges.append((item, closing))
+        return ranges
+
+    def _first_colon(self, opening: int, start: int, end: int) -> int:
+        positions = self._colons.get(opening, [])
+        found = bisect_left(positions, start)
+        if found < len(positions) and positions[found] < end:
+            return positions[found]
+        return end
+
+    def _object_keys(self, opening: int,
+                     closing: int) -> list[tuple[int, str]]:
+        """(offset, key) for each address-shaped key of one object literal."""
+        keys = []
+        for start, end in self.ranges(opening, closing):
+            key_end = self._first_colon(opening, start, end)
+            key = self.address_expression(start, key_end)
+            if key:
+                keys.append((start, key))
+        return keys
+
+    def _label_container(self, opening: int, closing: int) -> list[Finding]:
+        """E005 findings for address keys inside one label set container."""
+        findings = []
+        if self.mask[opening] == "{":
+            for offset, key in self._object_keys(opening, closing):
                 findings.append(_ts_keyed_by_address(
-                    path, newlines, arg_start, "metric label", value))
-    return findings
-
-
-def _ts_index_properties(path: Path, text: str, mask: str, newlines: list[int],
-                         start: int, end: int) -> list[Finding]:
-    """`index:` properties inside one logger or log-store call's arguments."""
-    findings = []
-    for match in TS_INDEX_PROPERTY.finditer(mask, start, end):
-        value_end = match.end()
-        stack = []
-        pairs = {"(": ")", "[": "]", "{": "}"}
-        for index in range(match.end(), end):
-            current = mask[index]
-            if current in pairs:
-                stack.append(pairs[current])
-            elif current in ")]}" and not stack:
-                value_end = index
-                break
-            elif stack and current == stack[-1]:
-                stack.pop()
-            elif current == "," and not stack:
-                value_end = index
-                break
+                    self.path, self.newlines, offset, "metric label", key))
         else:
-            value_end = end
-        key = _ts_address_expression(text, mask, match.end(), value_end)
-        if key:
-            findings.append(_ts_keyed_by_address(
-                path, newlines, match.start(), "log index", key))
-    return findings
+            for start, end in self.ranges(opening, closing):
+                bounds = self._string_bounds(start, end)
+                if bounds is not None and self._address_value(*bounds):
+                    findings.append(_ts_keyed_by_address(
+                        self.path, self.newlines, start, "metric label",
+                        self.text[bounds[0]:bounds[1]]))
+        return findings
+
+    def label_findings(self, start: int, end: int) -> list[Finding]:
+        """Label/tag/attribute sets inside one telemetry sink call."""
+        self._build()
+        findings: list[Finding] = []
+        found = bisect_left(self._label_starts, start)
+        while found < len(self._label_starts) \
+                and self._label_starts[found] < end:
+            findings.extend(self._label_rows[found])
+            found += 1
+        return findings
+
+    def index_findings(self, start: int, end: int) -> list[Finding]:
+        """`index:` properties inside one logger or log-store call."""
+        self._build()
+        found = bisect_left(self._index_starts, start)
+        findings: list[Finding] = []
+        while found < len(self._index_starts) \
+                and self._index_starts[found] < end:
+            findings.append(self._index_rows[found])
+            found += 1
+        return findings
+
+    def labels_call(self, opening: int, closing: int) -> list[Finding]:
+        """The Prometheus instance style: `.labels({...})` or a literal."""
+        findings = []
+        mask = self.mask
+        for arg_start, arg_end in self.ranges(opening, closing):
+            first = arg_start
+            while first < arg_end and mask[first].isspace():
+                first += 1
+            if first < arg_end and mask[first] == "{":
+                inner = self.matches.get(first)
+                if inner is not None:
+                    for offset, key in self._object_keys(first, inner):
+                        findings.append(_ts_keyed_by_address(
+                            self.path, self.newlines, offset,
+                            "metric label", key))
+            else:
+                bounds = self._string_bounds(arg_start, arg_end)
+                if bounds is not None and bounds[1] - bounds[0] == 42 \
+                        and HEX_ADDRESS.fullmatch(
+                            self.text, bounds[0], bounds[1]):
+                    findings.append(_ts_keyed_by_address(
+                        self.path, self.newlines, arg_start, "metric label",
+                        self.text[bounds[0]:bounds[1]]))
+        return findings
+
+    def address_expression(self, start: int, end: int) -> str:
+        """The address-shaped name or literal in a key position, or "".
+
+        Reads a bounded window instead of slicing the span: the dotted
+        chain is parsed forward from the key's own start and stops at the
+        first character outside the chain grammar, so fully overlapping
+        spans no longer pay their whole width for every key.
+        """
+        mask = self.mask
+        first, last = start, end
+        while first < last and mask[first].isspace():
+            first += 1
+        while last > first and mask[last - 1].isspace():
+            last -= 1
+        ident = TS_IDENT.match(mask, first, last) if first < last else None
+        while ident is not None and ident.end() < last:
+            separator = TS_SEP.match(mask, ident.end(), last)
+            ident = TS_IDENT.match(mask, separator.end(), last) \
+                if separator is not None else None
+        if ident is not None:
+            name = ident.group()
+            return name if _ts_address_name(name) else ""
+        bounds = self._string_bounds(start, end)
+        if bounds is not None and self._address_value(*bounds):
+            return self.text[bounds[0]:bounds[1]]
+        return ""
+
+    def _string_bounds(self, start: int, end: int) -> tuple[int, int] | None:
+        """Value bounds of a constant string literal, without slicing.
+
+        A template literal with no `${}` interpolation is a constant
+        string; an interpolated one is not, and stays out of key
+        recognition.
+        """
+        text = self.text
+        while start < end and text[start].isspace():
+            start += 1
+        while end > start and text[end - 1].isspace():
+            end -= 1
+        if end - start < 2 or text[start] != text[end - 1]:
+            return None
+        if text[start] in "'\"":
+            return start + 1, end - 1
+        if text[start] == "`" and not self._interpolated(start + 1, end - 1):
+            return start + 1, end - 1
+        return None
+
+    def _interpolated(self, start: int, end: int) -> bool:
+        if self._interp_starts is None:
+            starts = []
+            found = self.text.find("${")
+            while found != -1:
+                starts.append(found)
+                found = self.text.find("${", found + 1)
+            self._interp_starts = starts
+        starts = self._interp_starts
+        found = bisect_left(starts, start)
+        return found < len(starts) and starts[found] + 2 <= end
+
+    def _address_value(self, start: int, end: int) -> bool:
+        """An address-shaped string value, judged without slicing it.
+
+        The value sits between two quote characters, which no word token
+        can cross, so its word tokens are exactly the file's word tokens
+        inside it: found once for the whole file, then bisected.
+        """
+        if end - start == 42 and HEX_ADDRESS.fullmatch(self.text, start, end):
+            return True
+        if self._word_starts is None:
+            self._word_starts = [
+                match.start() for match in TS_WORD.finditer(self.text)
+                if match.group().lower() in TS_ADDRESS_WORDS]
+        starts = self._word_starts
+        found = bisect_left(starts, start)
+        return found < len(starts) and starts[found] < end
 
 
 def _ts_allow_lines(text: str, spans, newlines: list[int]) -> set[int]:
@@ -803,6 +930,7 @@ def check_typescript(path: Path, text: str) -> list[Finding]:
     allowed = _ts_allow_lines(text, spans, newlines)
     mask = _masked(text, spans)
     matches = _bracket_matches(mask)
+    span_index = _TsSpanIndex(path, text, mask, newlines, matches)
     findings: list[Finding] = []
     for bracket in TS_OPEN.finditer(mask):
         opening = bracket.start()
@@ -820,7 +948,7 @@ def check_typescript(path: Path, text: str) -> list[Finding]:
             closing = matches.get(opening)
             if closing is None:
                 continue
-            key = _ts_address_expression(text, mask, opening + 1, closing)
+            key = span_index.address_expression(opening + 1, closing)
             if key and last_words & TS_DASHBOARD_WORDS:
                 findings.append(_ts_keyed_by_address(
                     path, newlines, opening + 1, "dashboard key", key))
@@ -839,14 +967,11 @@ def check_typescript(path: Path, text: str) -> list[Finding]:
         if closing is None:
             continue
         if metric_sink:
-            findings.extend(_ts_label_properties(
-                path, text, mask, newlines, matches, opening + 1, closing))
+            findings.extend(span_index.label_findings(opening + 1, closing))
         if labels_call:
-            findings.extend(_ts_labels_call(
-                path, text, mask, newlines, matches, opening + 1, closing))
+            findings.extend(span_index.labels_call(opening, closing))
         if log_call:
-            findings.extend(_ts_index_properties(
-                path, text, mask, newlines, opening + 1, closing))
+            findings.extend(span_index.index_findings(opening + 1, closing))
     return [finding for finding in findings
             if finding.line not in allowed and finding.line - 1 not in allowed]
 

--- a/plugins/hexaemeron/skills/phylax/SKILL.md
+++ b/plugins/hexaemeron/skills/phylax/SKILL.md
@@ -259,6 +259,11 @@ that joins declared holdings to an external profile each creates the thing the
 marketplace refuses to produce. Keep only what the source supports, and say
 what could not be established.
 
+The one address rule that is telemetry shape rather than boundary control
+belongs to ephoros, and
+[ADR-010](../../../../docs/decisions/ADR-010-split-address-telemetry-from-boundary-control.md)
+draws that line once, over the same TypeScript files both lints read.
+
 ## The mechanical subset
 
 Seven of these rules are settled by a parser rather than by reading. Run the

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/alert-labels.yaml
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/alert-labels.yaml
@@ -1,0 +1,9 @@
+groups:
+  - name: markets
+    rules:
+      - alert: DepositStalled
+        expr: pending_deposits > 5
+        labels:
+          wallet_address: "{{ $labels.wallet_address }}"
+        annotations:
+          runbook: runbooks/deposit-stalled.md

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/console-output.ts
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/console-output.ts
@@ -1,0 +1,3 @@
+// Command-line output is not telemetry.
+console.log("lender", walletAddress)
+console.log(event, { index: walletAddress })

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/dashboard-key.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/dashboard-key.py
@@ -1,0 +1,3 @@
+"""A dashboard panel selected by wallet address."""
+
+dashboard[wallet_address] = deposit_panel

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/dashboard-key.ts
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/dashboard-key.ts
@@ -1,0 +1,2 @@
+// A dashboard panel selected by wallet address.
+marketDashboard[walletAddress] = depositPanel

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/event-fields.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/event-fields.py
@@ -1,0 +1,3 @@
+"""An address inside an event's fields, the legal home."""
+
+logger.info("lender_checked", extra={"wallet_address": lender})

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/log-index-argument.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/log-index-argument.py
@@ -1,0 +1,3 @@
+"""A log write indexed by wallet address."""
+
+audit_log.write(event, index=wallet_address)

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/log-index-key.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/log-index-key.py
@@ -1,0 +1,3 @@
+"""A log store partitioned by wallet address."""
+
+event_log[wallet_address] = event

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/log-index.ts
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/log-index.ts
@@ -1,0 +1,2 @@
+// A log write indexed by wallet address.
+auditLog.write(event, { index: walletAddress })

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/logger-message.ts
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/logger-message.ts
@@ -1,0 +1,2 @@
+// An address interpolated into a message, not a key.
+logger.debug(`Retrieved market updates for lender ${walletAddress}`)

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/message-argument.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/message-argument.py
@@ -1,0 +1,3 @@
+"""An address passed as a message argument, not a key."""
+
+logger.info("lender skipped %s", wallet_address)

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/metric-label-constructor.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/metric-label-constructor.py
@@ -1,0 +1,3 @@
+"""An address-named label in the constructor style."""
+
+deposits = Histogram("deposit_size", labelnames=["wallet_address", "venue"])

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/metric-label-hex-literal.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/metric-label-hex-literal.py
@@ -1,0 +1,3 @@
+"""A literal address baked into a label."""
+
+withdrawals.labels("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef").inc()

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/metric-label-instance.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/metric-label-instance.py
@@ -1,0 +1,3 @@
+"""An address-named label in the instance-call style."""
+
+deposits.labels(wallet_address=depositor).inc()

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/metric-label-set.ts
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/metric-label-set.ts
@@ -1,0 +1,2 @@
+// An address-named key in a label set on a metric sink.
+metrics.increment("deposit_size", { tags: { wallet_address: depositor } })

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/print.py
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/print.py
@@ -1,0 +1,3 @@
+"""Command-line output is not telemetry."""
+
+print(f"lender {wallet_address}")

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/query-key.ts
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/query-key.ts
@@ -1,0 +1,6 @@
+// A react-query cache key is a cache key, not a telemetry sink.
+export const useLenders = (walletAddress: string) =>
+  useQuery({
+    queryKey: ["lenders", walletAddress],
+    queryFn: () => fetchLenders(walletAddress),
+  })

--- a/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/storage-key.ts
+++ b/plugins/hexaemeron/tests/fixtures/ephoros/telemetry-keys/storage-key.ts
@@ -1,0 +1,2 @@
+// A storage key is a storage key, not a telemetry sink.
+localStorage.setItem(`${TIMESTAMP_KEY}_${address.toLowerCase()}`, String(Date.now()))

--- a/plugins/hexaemeron/tests/test_ephoros_checker.py
+++ b/plugins/hexaemeron/tests/test_ephoros_checker.py
@@ -154,7 +154,111 @@ class TelemetryKeys(unittest.TestCase):
             "c.labels(wallet_address=a).inc()  # ephoros: allow\n"))
 
 
-class AlertLabelKeys(unittest.TestCase):
+def ts_codes(source, name="sample.ts"):
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / name
+        path.write_text(source, encoding="utf-8")
+        return sorted(f.code for f in ephoros.check(path))
+
+
+class TypeScriptTelemetryKeys(unittest.TestCase):
+    def test_it_flags_an_address_key_on_a_metric_label_set(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "metric-label-set.ts")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_flags_an_address_key_on_a_dashboard_structure(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "dashboard-key.ts")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_flags_an_address_key_on_a_log_index_position(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "log-index.ts")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_flags_a_camel_case_label_key_on_an_analytics_sink(self):
+        self.assertEqual(["E005"], ts_codes(
+            'analytics.track("deposit", { labels: { walletAddress: depositor } })\n'))
+
+    def test_it_flags_a_forty_hex_literal_in_a_label_array(self):
+        self.assertEqual(["E005"], ts_codes(
+            'metrics.increment("m", '
+            '{ tags: ["0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"] })\n'))
+
+    def test_it_flags_the_labels_instance_call_style(self):
+        self.assertEqual(["E005"], ts_codes(
+            "deposits.labels({ walletAddress: depositor }).inc()\n"))
+
+    def test_it_flags_a_log_store_partitioned_by_address(self):
+        self.assertEqual(["E005"], ts_codes("eventLog[walletAddress] = event\n"))
+
+    def test_it_allows_a_query_key_array_carrying_an_address(self):
+        self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "query-key.ts"))
+
+    def test_it_allows_a_storage_key_built_from_an_address(self):
+        self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "storage-key.ts"))
+
+    def test_it_allows_a_logger_message_interpolating_an_address(self):
+        self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "logger-message.ts"))
+
+    def test_it_ignores_console_output_which_is_not_telemetry(self):
+        self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "console-output.ts"))
+
+    def test_an_address_key_on_an_unnamed_store_does_not_fire(self):
+        self.assertEqual([], ts_codes("cache[walletAddress] = market\n"))
+
+    def test_a_label_shaped_object_outside_a_telemetry_sink_does_not_fire(self):
+        self.assertEqual([], ts_codes(
+            "chip.render({ tags: { walletAddress: lender } })\n"))
+
+    def test_a_reasoned_slash_pragma_on_the_line_suppresses_e005(self):
+        self.assertEqual([], ts_codes(
+            "eventLog[walletAddress] = event"
+            "  // ephoros: allow one aggregate treasury row\n"))
+
+    def test_a_reasoned_slash_pragma_on_the_line_above_suppresses_e005(self):
+        self.assertEqual([], ts_codes(
+            "// ephoros: allow one aggregate treasury row\n"
+            "eventLog[walletAddress] = event\n"))
+
+    def test_a_bare_slash_pragma_does_not_suppress_e005(self):
+        self.assertEqual(["E005"], ts_codes(
+            "eventLog[walletAddress] = event  // ephoros: allow\n"))
+
+
+class TypeScriptBoundaries(unittest.TestCase):
+    def test_an_oversized_typescript_file_fails_visibly(self):
+        source = "//" + "x" * ephoros.TYPESCRIPT_MAX_BYTES
+        self.assertEqual(["E000"], ts_codes(source))
+
+    def test_typescript_read_requests_only_the_cap_plus_one_byte(self):
+        class RecordingReader(io.BytesIO):
+            requested = None
+
+            def read(self, size=-1):
+                self.requested = size
+                return super().read(size)
+
+        reader = RecordingReader(b"/" * (ephoros.TYPESCRIPT_MAX_BYTES + 1))
+        with mock.patch.object(Path, "open", return_value=reader), \
+                mock.patch.object(Path, "read_bytes", side_effect=AssertionError):
+            findings = ephoros.check(Path("bounded.ts"))
+        self.assertEqual(["E000"], [finding.code for finding in findings])
+        self.assertEqual(ephoros.TYPESCRIPT_MAX_BYTES + 1, reader.requested)
+
+    def test_a_lexer_failure_reports_e000(self):
+        self.assertEqual(["E000"], ts_codes("const s = `never terminated\n"))
+
+    def test_the_walk_skips_node_modules(self):
+        with tempfile.TemporaryDirectory() as base:
+            vendored = Path(base) / "node_modules" / "left-pad"
+            vendored.mkdir(parents=True)
+            (vendored / "index.ts").write_text(
+                "eventLog[walletAddress] = event\n", encoding="utf-8")
+            first_party = Path(base) / "src"
+            first_party.mkdir()
+            kept = first_party / "page.tsx"
+            kept.write_text("export default null\n", encoding="utf-8")
+            self.assertEqual([kept], ephoros.walk([base]))
+
     def test_an_address_named_key_under_alert_labels_reports_e005(self):
         findings = ephoros.check(TELEMETRY_FIXTURES / "alert-labels.yaml")
         self.assertEqual(["E005"], [finding.code for finding in findings])

--- a/plugins/hexaemeron/tests/test_ephoros_checker.py
+++ b/plugins/hexaemeron/tests/test_ephoros_checker.py
@@ -153,6 +153,16 @@ class TelemetryKeys(unittest.TestCase):
         self.assertIn("E005", codes(
             "c.labels(wallet_address=a).inc()  # ephoros: allow\n"))
 
+    def test_slash_pragma_text_in_a_python_string_does_not_suppress(self):
+        self.assertEqual(["E005"], codes(
+            's = "// ephoros: allow tracked elsewhere"\n'
+            "c.labels(wallet_address=a).inc()\n"))
+
+    def test_a_slash_pragma_mentioned_mid_comment_does_not_suppress(self):
+        self.assertEqual(["E005"], codes(
+            "c.labels(wallet_address=a).inc()"
+            "  # see // ephoros: allow foo for the shape\n"))
+
 
 def ts_codes(source, name="sample.ts"):
     with tempfile.TemporaryDirectory() as directory:
@@ -190,6 +200,32 @@ class TypeScriptTelemetryKeys(unittest.TestCase):
     def test_it_flags_a_log_store_partitioned_by_address(self):
         self.assertEqual(["E005"], ts_codes("eventLog[walletAddress] = event\n"))
 
+    def test_it_flags_a_string_literal_wallet_index(self):
+        self.assertEqual(["E005"], ts_codes(
+            "auditLog.write(event, { index: 'wallet_address' })\n"))
+
+    def test_it_flags_a_forty_hex_literal_index(self):
+        self.assertEqual(["E005"], ts_codes(
+            "auditLog.write(event, "
+            "{ index: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' })\n"))
+
+    def test_it_flags_the_camel_case_label_names_property(self):
+        self.assertEqual(["E005"], ts_codes(
+            'const c = new client.Counter({ name: "c", '
+            'labelNames: ["wallet_address"] })\n'))
+
+    def test_it_flags_an_optional_chained_metric_sink(self):
+        self.assertEqual(["E005"], ts_codes(
+            "metrics?.gauge('m', { tags: { walletAddress: w } })\n"))
+
+    def test_it_flags_an_optional_chain_inside_a_sink_chain(self):
+        self.assertEqual(["E005"], ts_codes(
+            "sink?.metrics.gauge('m', { tags: { walletAddress: w } })\n"))
+
+    def test_an_optional_chained_cache_key_does_not_fire(self):
+        self.assertEqual([], ts_codes(
+            "cache?.store[walletAddress] = market\n"))
+
     def test_it_allows_a_query_key_array_carrying_an_address(self):
         self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "query-key.ts"))
 
@@ -223,6 +259,20 @@ class TypeScriptTelemetryKeys(unittest.TestCase):
         self.assertEqual(["E005"], ts_codes(
             "eventLog[walletAddress] = event  // ephoros: allow\n"))
 
+    def test_pragma_text_in_a_string_does_not_suppress(self):
+        self.assertEqual(["E005"], ts_codes(
+            'eventLog[walletAddress] = "// ephoros: allow tracked elsewhere"\n'))
+
+    def test_pragma_text_in_a_template_does_not_suppress(self):
+        self.assertEqual(["E005"], ts_codes(
+            "const note = `// ephoros: allow tracked elsewhere`\n"
+            "eventLog[walletAddress] = event\n"))
+
+    def test_a_hash_pragma_does_not_suppress_in_typescript(self):
+        self.assertEqual(["E005"], ts_codes(
+            "// # ephoros: allow tracked elsewhere\n"
+            "eventLog[walletAddress] = event\n"))
+
 
 class TypeScriptBoundaries(unittest.TestCase):
     def test_an_oversized_typescript_file_fails_visibly(self):
@@ -247,6 +297,27 @@ class TypeScriptBoundaries(unittest.TestCase):
     def test_a_lexer_failure_reports_e000(self):
         self.assertEqual(["E000"], ts_codes("const s = `never terminated\n"))
 
+    def test_a_pragma_cannot_suppress_a_lexer_failure(self):
+        self.assertEqual(["E000"], ts_codes(
+            "// ephoros: allow crafted reason\n"
+            "const s = `never terminated\n"))
+
+    def test_a_lexer_recursion_failure_fails_closed_per_file(self):
+        with tempfile.TemporaryDirectory() as base:
+            nested = Path(base) / "nested.ts"
+            nested.write_text(
+                "const s = " + "`${" * 600 + "0" + "}`" * 600 + "\n",
+                encoding="utf-8")
+            sibling = Path(base) / "sibling.ts"
+            sibling.write_text("eventLog[walletAddress] = event\n",
+                               encoding="utf-8")
+            findings = [finding for path in ephoros.walk([base])
+                        for finding in ephoros.check(path)]
+            by_file = {Path(finding.path).name: finding for finding in findings}
+            self.assertEqual("E000", by_file["nested.ts"].code)
+            self.assertIn("recursion", by_file["nested.ts"].message)
+            self.assertEqual("E005", by_file["sibling.ts"].code)
+
     def test_the_walk_skips_node_modules(self):
         with tempfile.TemporaryDirectory() as base:
             vendored = Path(base) / "node_modules" / "left-pad"
@@ -259,6 +330,8 @@ class TypeScriptBoundaries(unittest.TestCase):
             kept.write_text("export default null\n", encoding="utf-8")
             self.assertEqual([kept], ephoros.walk([base]))
 
+
+class AlertLabelKeys(unittest.TestCase):
     def test_an_address_named_key_under_alert_labels_reports_e005(self):
         findings = ephoros.check(TELEMETRY_FIXTURES / "alert-labels.yaml")
         self.assertEqual(["E005"], [finding.code for finding in findings])

--- a/plugins/hexaemeron/tests/test_ephoros_checker.py
+++ b/plugins/hexaemeron/tests/test_ephoros_checker.py
@@ -377,6 +377,76 @@ class TypeScriptBoundaries(unittest.TestCase):
                                 encoding="utf-8")
             self.assertEqual([], ephoros.check(specimen))
 
+    def test_a_sink_named_labels_nest_keeps_its_single_exact_finding(self):
+        # Once every nested chain names `.labels`, the cheap unnamed-chain
+        # gate stops short-circuiting and each fully overlapping span paid
+        # a full-width comma split and key read: 28 seconds at this depth,
+        # about 77 minutes at the 1 MiB cap. The per-file position tables
+        # keep the walk near-linear, and only the innermost span carries
+        # the address-shaped key.
+        depth = 8192
+        source = ("// nested labels specimen\n"
+                  + "m.labels(" * depth + "{walletAddress: 1}" + ")" * depth)
+        with tempfile.TemporaryDirectory() as base:
+            specimen = Path(base) / "labels.ts"
+            specimen.write_text(source, encoding="utf-8")
+            findings = ephoros.check(specimen)
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+        self.assertEqual([2], [finding.line for finding in findings])
+        self.assertIn("metric label `walletAddress`", findings[0].message)
+
+    def test_a_sink_named_logger_nest_repeats_the_index_finding_per_span(self):
+        # Each of the nested `logger.info` spans contains the one `index:`
+        # property, so each span reports it, exactly as the old per-span
+        # scans did -- the findings repeat while the work does not (the
+        # same shape cost 7.3 seconds at this depth and quadratically more
+        # beyond it).
+        depth = 8192
+        source = ("// nested logger specimen\n"
+                  + "logger.info(" * depth
+                  + "{index: walletAddress}" + ")" * depth)
+        with tempfile.TemporaryDirectory() as base:
+            specimen = Path(base) / "logger.ts"
+            specimen.write_text(source, encoding="utf-8")
+            findings = ephoros.check(specimen)
+        self.assertEqual(["E005"] * depth,
+                         [finding.code for finding in findings])
+        self.assertEqual({2}, {finding.line for finding in findings})
+        self.assertIn("log index `walletAddress`", findings[0].message)
+
+    def test_a_sink_named_counter_nest_repeats_the_label_finding_per_span(self):
+        # The metric-sink reading of the same overlap: every nested
+        # `counter` span contains the one `labels:` container, so every
+        # span repeats its finding from the container analysed once.
+        depth = 8192
+        source = ("// nested counter specimen\n"
+                  + "counter(" * depth
+                  + "{labels: {walletAddress: 1}}" + ")" * depth)
+        with tempfile.TemporaryDirectory() as base:
+            specimen = Path(base) / "counter.ts"
+            specimen.write_text(source, encoding="utf-8")
+            findings = ephoros.check(specimen)
+        self.assertEqual(["E005"] * depth,
+                         [finding.code for finding in findings])
+        self.assertEqual({2}, {finding.line for finding in findings})
+        self.assertIn("metric label `walletAddress`", findings[0].message)
+
+    def test_a_log_named_bracket_nest_keeps_its_single_exact_finding(self):
+        # The subscript form of the same overlap: every `log[` span read
+        # its full width for a key expression (12.2 seconds at the 1 MiB
+        # cap); the bounded forward parse stops at the first character
+        # outside the chain grammar, and only the innermost span holds one.
+        depth = 150_000
+        source = ("// nested log store specimen\n"
+                  + "log[" * depth + "walletAddress" + "]" * depth)
+        with tempfile.TemporaryDirectory() as base:
+            specimen = Path(base) / "logstore.ts"
+            specimen.write_text(source, encoding="utf-8")
+            findings = ephoros.check(specimen)
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+        self.assertEqual([2], [finding.line for finding in findings])
+        self.assertIn("log index `walletAddress`", findings[0].message)
+
     def test_a_findings_saturated_file_keeps_every_line_number(self):
         # Counting newlines from the top of the file for every finding cost
         # quadratic time on findings-saturated files (10s at this size); a

--- a/plugins/hexaemeron/tests/test_ephoros_checker.py
+++ b/plugins/hexaemeron/tests/test_ephoros_checker.py
@@ -364,6 +364,37 @@ class TypeScriptBoundaries(unittest.TestCase):
             specimen.write_text("a . " * 25_000, encoding="utf-8")
             self.assertEqual([], ephoros.check(specimen))
 
+    def test_a_deeply_nested_bracket_chain_completes_with_zero_findings(self):
+        # Every bracket in a[a[a[...]]] carries a chain, and the old
+        # per-bracket forward scan to its closer re-read the fully
+        # overlapping nested spans quadratically: 28s at N=16000, hours at
+        # the 1 MiB cap. One linear stack pass now matches every bracket up
+        # front, and the unnamed chain yields nothing even at cap scale.
+        depth = 250_000
+        with tempfile.TemporaryDirectory() as base:
+            specimen = Path(base) / "nested.ts"
+            specimen.write_text("a[" * depth + "x" + "]" * depth,
+                                encoding="utf-8")
+            self.assertEqual([], ephoros.check(specimen))
+
+    def test_a_findings_saturated_file_keeps_every_line_number(self):
+        # Counting newlines from the top of the file for every finding cost
+        # quadratic time on findings-saturated files (10s at this size); a
+        # bisected newline table built once per file keeps it linear. The
+        # first, middle, and last findings pin the exact line numbers the
+        # counting implementation reported.
+        lines = 50_000
+        with tempfile.TemporaryDirectory() as base:
+            specimen = Path(base) / "saturated.ts"
+            specimen.write_text("log[walletAddress]\n" * lines,
+                                encoding="utf-8")
+            findings = ephoros.check(specimen)
+        self.assertEqual(["E005"] * lines,
+                         [finding.code for finding in findings])
+        self.assertEqual(1, findings[0].line)
+        self.assertEqual(25_001, findings[lines // 2].line)
+        self.assertEqual(50_000, findings[-1].line)
+
     def test_the_walk_skips_node_modules(self):
         with tempfile.TemporaryDirectory() as base:
             vendored = Path(base) / "node_modules" / "left-pad"

--- a/plugins/hexaemeron/tests/test_ephoros_checker.py
+++ b/plugins/hexaemeron/tests/test_ephoros_checker.py
@@ -16,6 +16,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "skills" / "ephoros" / "scripts" / "ephoros.py"
 ALERT_FIXTURES = ROOT / "tests" / "fixtures" / "ephoros" / "alert-rules"
+TELEMETRY_FIXTURES = ROOT / "tests" / "fixtures" / "ephoros" / "telemetry-keys"
 
 spec = importlib.util.spec_from_file_location("ephoros_lint", SCRIPT)
 ephoros = importlib.util.module_from_spec(spec)
@@ -61,8 +62,8 @@ class LogMessages(unittest.TestCase):
 
 
 class MetricLabels(unittest.TestCase):
-    def test_it_flags_an_address_label(self):
-        self.assertIn("E002", codes(
+    def test_it_flags_an_address_label_as_e005_since_the_subset_moved(self):
+        self.assertEqual(["E005"], codes(
             "h = Histogram('d', labels={'address': a, 'venue': v})\n"))
 
     def test_it_flags_a_hash_label_in_a_list(self):
@@ -88,6 +89,104 @@ class Durations(unittest.TestCase):
 
     def test_it_allows_a_mean_of_layout_positions(self):
         self.assertEqual([], codes("order = sum(positions) / len(positions)\n"))
+
+
+class TelemetryKeys(unittest.TestCase):
+    def test_it_flags_an_address_label_in_the_constructor_style(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "metric-label-constructor.py")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_flags_the_labels_instance_call_style(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "metric-label-instance.py")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_flags_a_forty_hex_literal_label_value(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "metric-label-hex-literal.py")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_flags_a_forty_hex_literal_in_a_constructor_label_set(self):
+        self.assertEqual(["E005"], codes(
+            "m = metric('m', tags=['0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'])\n"))
+
+    def test_it_flags_an_address_shaped_dashboard_key(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "dashboard-key.py")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_flags_an_address_shaped_log_index_key(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "log-index-key.py")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_flags_an_address_index_argument(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "log-index-argument.py")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_it_allows_an_address_in_an_events_fields(self):
+        self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "event-fields.py"))
+
+    def test_it_allows_an_address_in_a_message_argument(self):
+        self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "message-argument.py"))
+
+    def test_it_ignores_print_which_is_not_telemetry(self):
+        self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "print.py"))
+
+    def test_an_address_key_on_an_unnamed_store_does_not_fire(self):
+        self.assertEqual([], codes("cache[wallet_address] = market\n"))
+
+    def test_a_wallet_address_label_yields_e005_and_not_e002(self):
+        self.assertEqual(["E005"], codes(
+            "c = Counter('c', labelnames=['wallet_address'])\n"))
+
+    def test_a_hash_named_label_keeps_e002(self):
+        self.assertEqual(["E002"], codes("c = Counter('c', labelnames=['tx_hash'])\n"))
+
+    def test_a_reasoned_pragma_on_the_line_suppresses_e005(self):
+        self.assertEqual([], codes(
+            "c.labels(wallet_address=a).inc()"
+            "  # ephoros: allow one aggregate treasury row\n"))
+
+    def test_a_reasoned_pragma_on_the_line_above_suppresses_e005(self):
+        self.assertEqual([], codes(
+            "# ephoros: allow one aggregate treasury row\n"
+            "c.labels(wallet_address=a).inc()\n"))
+
+    def test_a_bare_pragma_does_not_suppress_e005(self):
+        self.assertIn("E005", codes(
+            "c.labels(wallet_address=a).inc()  # ephoros: allow\n"))
+
+
+class AlertLabelKeys(unittest.TestCase):
+    def test_an_address_named_key_under_alert_labels_reports_e005(self):
+        findings = ephoros.check(TELEMETRY_FIXTURES / "alert-labels.yaml")
+        self.assertEqual(["E005"], [finding.code for finding in findings])
+
+    def test_a_bounded_label_key_is_clean(self):
+        source = ("- alert: Bounded\n"
+                  "  labels:\n"
+                  "    severity: page\n"
+                  "  annotations:\n"
+                  "    runbook: runbooks/bounded.md\n")
+        self.assertEqual([], yaml_findings(source))
+
+    def test_a_labels_mapping_outside_an_alert_entry_is_ignored(self):
+        source = "service:\n  labels:\n    wallet_address: primary\n"
+        self.assertEqual([], yaml_findings(source))
+
+    def test_a_reasoned_pragma_suppresses_an_alert_label_key(self):
+        source = ("- alert: Suppressed\n"
+                  "  labels:\n"
+                  "    # ephoros: allow one aggregate treasury row\n"
+                  "    wallet_address: treasury\n"
+                  "  annotations:\n"
+                  "    runbook: runbooks/suppressed.md\n")
+        self.assertEqual([], yaml_findings(source))
+
+    def test_a_bare_pragma_does_not_suppress_an_alert_label_key(self):
+        source = ("- alert: StillKeyed\n"
+                  "  labels:\n"
+                  "    wallet_address: treasury  # ephoros: allow\n"
+                  "  annotations:\n"
+                  "    runbook: runbooks/still-keyed.md\n")
+        self.assertEqual(["E005"], [finding.code for finding in yaml_findings(source)])
 
 
 class Suppression(unittest.TestCase):

--- a/plugins/hexaemeron/tests/test_ephoros_checker.py
+++ b/plugins/hexaemeron/tests/test_ephoros_checker.py
@@ -226,6 +226,33 @@ class TypeScriptTelemetryKeys(unittest.TestCase):
         self.assertEqual([], ts_codes(
             "cache?.store[walletAddress] = market\n"))
 
+    def test_it_flags_an_optional_chain_bracket_log_store(self):
+        self.assertEqual(["E005"], ts_codes(
+            "eventLog?.[walletAddress] = event\n"))
+
+    def test_it_flags_an_optional_chain_bracket_dashboard_key(self):
+        self.assertEqual(["E005"], ts_codes(
+            "dashboards?.[walletAddress] = panel\n"))
+
+    def test_it_flags_an_optional_chain_bracket_string_log_index(self):
+        self.assertEqual(["E005"], ts_codes(
+            "auditLog?.['walletAddress'].push(e)\n"))
+
+    def test_an_optional_chain_bracket_on_an_unnamed_store_does_not_fire(self):
+        self.assertEqual([], ts_codes("cache?.[walletAddress]\n"))
+
+    def test_an_optional_chain_bracket_after_a_subscript_does_not_fire(self):
+        self.assertEqual([], ts_codes(
+            "ADS_REGISTRY[chainId]?.[marketAddress.toLowerCase()]\n"))
+
+    def test_it_flags_a_template_literal_wallet_index(self):
+        self.assertEqual(["E005"], ts_codes(
+            "auditLog.write(e, { index: `wallet_address` })\n"))
+
+    def test_an_interpolated_template_index_does_not_fire(self):
+        self.assertEqual([], ts_codes(
+            "auditLog.write(e, { index: `${walletAddress}` })\n"))
+
     def test_it_allows_a_query_key_array_carrying_an_address(self):
         self.assertEqual([], ephoros.check(TELEMETRY_FIXTURES / "query-key.ts"))
 
@@ -273,6 +300,16 @@ class TypeScriptTelemetryKeys(unittest.TestCase):
             "// # ephoros: allow tracked elsewhere\n"
             "eventLog[walletAddress] = event\n"))
 
+    def test_a_block_comment_pragma_does_not_suppress(self):
+        self.assertEqual(["E005"], ts_codes(
+            "/* // ephoros: allow smuggled reason */ "
+            "eventLog[walletAddress] = event\n"))
+
+    def test_a_block_comment_pragma_on_the_line_above_does_not_suppress(self):
+        self.assertEqual(["E005"], ts_codes(
+            "/* // ephoros: allow smuggled reason */\n"
+            "eventLog[walletAddress] = event\n"))
+
 
 class TypeScriptBoundaries(unittest.TestCase):
     def test_an_oversized_typescript_file_fails_visibly(self):
@@ -317,6 +354,15 @@ class TypeScriptBoundaries(unittest.TestCase):
             self.assertEqual("E000", by_file["nested.ts"].code)
             self.assertIn("recursion", by_file["nested.ts"].message)
             self.assertEqual("E005", by_file["sibling.ts"].code)
+
+    def test_an_adversarial_dotted_chain_completes_with_zero_findings(self):
+        # A whitespace-separated dotted chain that never reaches a bracket
+        # once cost quadratic rescans (about a minute at this size); the
+        # bracket-anchored scan reads it once and finds nothing.
+        with tempfile.TemporaryDirectory() as base:
+            specimen = Path(base) / "adversarial.ts"
+            specimen.write_text("a . " * 25_000, encoding="utf-8")
+            self.assertEqual([], ephoros.check(specimen))
 
     def test_the_walk_skips_node_modules(self):
         with tempfile.TemporaryDirectory() as base:

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -114,7 +114,7 @@
     },
     "ephoros-observability-review": {
       "source": "plugins/hexaemeron/skills/ephoros/SKILL.md",
-      "sha256": "547f7c241af77a04e26d8df6284230c402c9d3da7ffe83e26b708ab510285f84",
+      "sha256": "54a4953fce631b2191d72ac70e527a9de864c7da2df70d5dd5c1783f0c55ff25",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "reviewed step and build identity",
@@ -380,7 +380,7 @@
     },
     "phylax-boundary-review": {
       "source": "plugins/hexaemeron/skills/phylax/SKILL.md",
-      "sha256": "cb5dbd5a82b72cc06c3629c5cde1fc771a7e611ef1f88136b97d08f71802e85b",
+      "sha256": "4ec03afb88700211ef0679b368ec509fab9ee1c182f8ee0011f1333e1e6b92cf",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "reviewed step, source tree and external-input boundary",


### PR DESCRIPTION
This run completes the held frontier job in
[skills#322](https://github.com/wildcat-finance/skills/issues/322). The
ephoros checker gains E005: an address used in a key position of a telemetry
sink -- a metric label, a dashboard key or a log index -- reported in Python,
in supported block-YAML label mappings, and in TypeScript read through the
shared masked lexer under phylax's audited input boundary. The address-shaped
subset of E002 moves to E005 under a guard test so one concern carries one
code, the reasoned pragma gains its `//` line-comment form, and the walk
gains `.ts`/`.tsx` while excluding `node_modules`. The pinned
`wildcat-app-v2` clone, 882 tracked TypeScript files, runs clean at exit 0 in
under a second with zero suppression pragmas. The ledger advances to
`ephoros-v1.2.0` with a successor job recorded, ADR-010 draws the
ephoros/phylax line once, and the audit trail -- seven rounds across four
steps, sixteen findings each fixed under the guard-test convention with over
twenty-five thousand differential cases at zero unexpected deltas -- lives in
`audit/AUDIT.md` under "Ephoros wallet-address telemetry".

The four stacked steps, merged in order: the committed study and runbook, the
Python and block-YAML recognisers with the E002 subset guard, the TypeScript
surface through the shared lexer, and the records above.

## Carried forward

- The shared TypeScript lexer at `plugins/hexaemeron/lib/typescript_lexer.py`
  recurses once per template-nesting level and a crafted 3 KB file exceeds the
  recursion limit; ephoros contains it at its boundary with an unsuppressible
  E000 and phylax reproduces the crash, so the fix belongs to the owning
  surface. Evidence: audit log, step 3 rounds 1 and 5.
- The `s?` suffix family shared by E005's address words and E002's unbounded
  fragments misses `-es` plurals such as `addresses` and `hashes`; recorded
  as a stated limit in the ephoros SKILL.md, and widening it is a rule
  decision for both codes at once. Evidence: step 2 round 1, step 3 log.
- A `#` pragma inside a Python string suppresses, because Python suppression
  is line-based; identical at this run's parent and outside its diff, a
  deliberate decision for that surface. Evidence: step 3 round 2 leads.
- The successor frontier job is recorded on the ledger rather than left
  implicit: extend E001 to E003 to the TypeScript surface, with the pinned
  clone's interpolated logger message as the live specimen an E001 analogue
  must judge.
- Two pre-existing hypomnema pointer findings sit inside historical Hermes
  entries of `audit/AUDIT.md`, and six historical imprimatur defects sit in
  entries from earlier runs; the log is append-only and they predate this
  run. Evidence: step 3 round 5 leads, step 1 and 2 prose passes.
- The marketplace-wide unlabelled routing clause inside 118 context blocks,
  deliberately left open by [skills#426](https://github.com/wildcat-finance/skills/pull/426),
  stays open by name.

Wildcat-Origin: shoggoth. The usual marker is an HTML comment, and the tooling
this session posts through strips HTML comments from pull-request bodies, so
the provenance line is visible here instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_017bdMt9VHMvPLwAnXz8AYRD)_

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: https://github.com/wildcat-finance/skills/issues/322
Root-Issue-Successor: none-recorded
Root-Issue-Fiat-Required: 1
Root-Issue-Route: fiat-required
Root-Issue-Classification-Source: live-contract
<!-- root-issue-analytics:v1:end -->
