### PR TITLE
Widen the ledger row gate to the compact shape

### DIFF
--- a/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
+++ b/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
@@ -707,15 +707,26 @@ LEDGER_ROW = re.compile(
     r"\| `(?P<revision>[^`]+)` \| `(?P<digest>[0-9a-f]{64})` "
     r"\| (?P<evidence>.*?) \| (?P<change>.*?) \|$"
 )
-"""One history row. Deliberately the same shape tests/test_evolution_contract.py
-matches, so the gate and the suite cannot disagree about what a row is."""
+LEDGER_ROW_COMPACT = re.compile(
+    r"^- `(?P<version>[^`]+)` \| (?P<axis>baseline|evolution|generation|epoch) "
+    r"\| `(?P<revision>[^`]+)` \| `(?P<digest>[0-9a-f]{64})` "
+    r"\| (?P<evidence>.*?) \| (?P<change>.*?)$"
+)
+"""One history row, in either spelling tests/test_evolution_contract.py
+accepts, so the gate and the suite cannot disagree about what a row is.
+Reading only the table shape counted a compact-list ledger as empty and
+refused a real completed frontier (skills#443)."""
 
 LEDGER_AXES = ("baseline", "evolution", "generation", "epoch")
 
 
 def ledger_rows(text: str) -> list[dict]:
-    return [m.groupdict() for m in
-            (LEDGER_ROW.fullmatch(line) for line in text.splitlines()) if m]
+    rows = []
+    for line in text.splitlines():
+        match = LEDGER_ROW.fullmatch(line) or LEDGER_ROW_COMPACT.fullmatch(line)
+        if match:
+            rows.append(match.groupdict())
+    return rows
 
 
 def ledger_field(text: str, name: str) -> str | None:
@@ -816,7 +827,16 @@ def frontier_close_fault(path: str, before: dict) -> str | None:
                 f"frontier job records one new row")
 
     rows = ledger_rows(text)
-    gained = len(rows) - before["rows"]
+    # Anchor on the init-time version rather than the stored count: a snapshot
+    # taken while the gate misread a ledger's row spelling counted a real
+    # history as empty, and the anchor survives that (skills#443).
+    anchor = before.get("version_at_init")
+    anchor_at = [i for i, r in enumerate(rows) if r["version"] == anchor]
+    if anchor is not None and not anchor_at:
+        return (f"{path} no longer carries the init-time version row "
+                f"{anchor!r}; history is append-only")
+    gained = (len(rows) - (anchor_at[-1] + 1) if anchor_at
+              else len(rows) - before["rows"])
     if gained != 1:
         return (f"{path} gained {gained} history row(s); the contract allows "
                 f"exactly one per completed frontier job")

--- a/plugins/hexaemeron/tests/test_hexctl.py
+++ b/plugins/hexaemeron/tests/test_hexctl.py
@@ -1,5 +1,6 @@
 """End-to-end tests for hexctl, run through the CLI the way the skill uses it."""
 
+import glob
 import json
 import hashlib
 import os
@@ -2682,3 +2683,157 @@ class FrontierGateTests(unittest.TestCase):
             held = json.load(fh)["frontier"]
         self.assertEqual(held["rows"], 1)
         self.assertEqual(held["sha256"], self.before["sha256"])
+
+
+def compact_row(version, axis, revision, digest, change="Did the thing."):
+    return f"- `{version}` | {axis} | `{revision}` | `{digest}` | [e](f) | {change}\n"
+
+
+class LedgerRowShapeTests(unittest.TestCase):
+    """The gate and the suite parse the same row set, whichever shape a
+    ledger spells its history in.
+
+    tests/test_evolution_contract.py accepts a table row and a compact bullet
+    row; the issue 322 run halted because the gate read only the first, saw a
+    two-row ledger as empty at init, and refused the one real new row at
+    integrate (skills#443).
+    """
+
+    def test_a_compact_bullet_row_parses(self):
+        digest = "a" * 64
+        rows = hexctl_module().ledger_rows(
+            compact_row("example-v0.1.0", "baseline", "held-job", digest))
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["version"], "example-v0.1.0")
+        self.assertEqual(rows[0]["digest"], digest)
+
+    def test_a_table_row_still_parses(self):
+        digest = "b" * 64
+        rows = hexctl_module().ledger_rows(
+            row("example-v0.1.0", "baseline", "held-job", digest))
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["version"], "example-v0.1.0")
+
+    def test_the_gate_parses_every_governed_ledger_in_the_tree(self):
+        repo = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+        ledgers = sorted(
+            glob.glob(os.path.join(repo, "plugins", "*", "skills", "*", "EVOLUTION.md")))
+        self.assertTrue(ledgers)
+        module = hexctl_module()
+        for ledger in ledgers:
+            with self.subTest(ledger=os.path.relpath(ledger, repo)):
+                with open(ledger, encoding="utf-8") as fh:
+                    text = fh.read()
+                self.assertTrue(
+                    module.ledger_rows(text),
+                    "a governed ledger parsed as having no history rows")
+
+
+class FrontierGateCompactTests(FrontierGateTests):
+    """The whole gate, over a ledger spelled in the compact bullet shape."""
+
+    def setUp(self):
+        super().setUp()
+        self.base_row = compact_row(
+            "widget-v1.1.0", "baseline", self.HELD[1], self.base_digest,
+            "Versioning starts here.")
+        widget_ledger(self.ledger, [self.base_row], version="widget-v1.1.0",
+                      status=self.HELD[0], revision=self.HELD[1],
+                      frontier=self.HELD[2], job=self.HELD[3])
+        with open(self.ledger, "rb") as handle:
+            self.before["sha256"] = hashlib.sha256(handle.read()).hexdigest()
+
+    def close_with(self, version, axis, header=None, digest=None, extra=()):
+        header = header or self.NEXT
+        widget_ledger(
+            self.ledger,
+            [self.base_row, compact_row(version, axis, header[1],
+                                        digest or frontier_digest(*header)),
+             *extra],
+            version=version, status=header[0], revision=header[1],
+            frontier=header[2], job=header[3])
+
+    def test_two_new_rows_are_refused(self):
+        self.close_with("widget-v2.1.0", "evolution",
+                        extra=[compact_row("widget-v3.1.0", "evolution",
+                                           self.NEXT[1],
+                                           frontier_digest(*self.NEXT))])
+        self.assertIn("gained 2 history row(s)", self.fault())
+
+    def test_a_header_row_mismatch_is_refused(self):
+        widget_ledger(
+            self.ledger,
+            [self.base_row, compact_row("widget-v2.1.0", "evolution",
+                                        self.NEXT[1],
+                                        frontier_digest(*self.NEXT))],
+            version="widget-v7.7.7", status=self.NEXT[0], revision=self.NEXT[1],
+            frontier=self.NEXT[2], job=self.NEXT[3])
+        self.assertIn("they have to be the same row", self.fault())
+
+
+class FrontierGateLegacySnapshotTests(unittest.TestCase):
+    """A snapshot taken while the gate could not see compact rows counted a
+    real history as empty. The gate anchors on the init-time version instead
+    of trusting that count, so such a run can still close honestly."""
+
+    HELD = FrontierGateTests.HELD
+    NEXT = FrontierGateTests.NEXT
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.ledger = os.path.join(
+            self.dir, "plugins", "demo", "skills", "widget", "EVOLUTION.md")
+        digest = frontier_digest(*self.HELD)
+        self.rows = [
+            compact_row("widget-v0.1.0", "baseline", self.HELD[1], digest,
+                        "Versioning starts here."),
+            compact_row("widget-v1.1.0", "evolution", self.HELD[1], digest),
+        ]
+        widget_ledger(self.ledger, self.rows, version="widget-v1.1.0",
+                      status=self.HELD[0], revision=self.HELD[1],
+                      frontier=self.HELD[2], job=self.HELD[3])
+        with open(self.ledger, "rb") as handle:
+            ledger_sha256 = hashlib.sha256(handle.read()).hexdigest()
+        self.before = {
+            "ledger": os.path.relpath(self.ledger, self.dir),
+            "sha256": ledger_sha256,
+            "rows": 0,
+            "version_at_init": "widget-v1.1.0",
+        }
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+    def fault(self):
+        return hexctl_module().frontier_close_fault(self.ledger, self.before)
+
+    def test_one_row_after_the_init_version_closes(self):
+        widget_ledger(
+            self.ledger,
+            [*self.rows, compact_row("widget-v2.1.0", "evolution", self.NEXT[1],
+                                     frontier_digest(*self.NEXT))],
+            version="widget-v2.1.0", status=self.NEXT[0], revision=self.NEXT[1],
+            frontier=self.NEXT[2], job=self.NEXT[3])
+        self.assertIsNone(self.fault())
+
+    def test_two_rows_after_the_init_version_are_refused(self):
+        widget_ledger(
+            self.ledger,
+            [*self.rows,
+             compact_row("widget-v2.1.0", "evolution", self.NEXT[1],
+                         frontier_digest(*self.NEXT)),
+             compact_row("widget-v3.1.0", "evolution", self.NEXT[1],
+                         frontier_digest(*self.NEXT))],
+            version="widget-v3.1.0", status=self.NEXT[0], revision=self.NEXT[1],
+            frontier=self.NEXT[2], job=self.NEXT[3])
+        self.assertIn("gained 2 history row(s)", self.fault())
+
+    def test_a_vanished_init_version_row_is_refused(self):
+        widget_ledger(
+            self.ledger,
+            [compact_row("widget-v2.1.0", "evolution", self.NEXT[1],
+                         frontier_digest(*self.NEXT))],
+            version="widget-v2.1.0", status=self.NEXT[0], revision=self.NEXT[1],
+            frontier=self.NEXT[2], job=self.NEXT[3])
+        self.assertIn("no longer carries the init-time version row", self.fault())

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -128,7 +128,7 @@
     },
     "fiat-final-integration": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "f8aa8214615ddcb6f329b5b78ed6469215ba12f0996d6381744d0253a53c84c3",
+      "sha256": "49cba6e5a93c453b0a65b5fbf4777d60cd5bd69fd1873f5ce71da4adba4cdc07",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "run branch, base, integration head and merge commit",
@@ -142,7 +142,7 @@
     },
     "fiat-receipted-delivery": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "f8aa8214615ddcb6f329b5b78ed6469215ba12f0996d6381744d0253a53c84c3",
+      "sha256": "49cba6e5a93c453b0a65b5fbf4777d60cd5bd69fd1873f5ce71da4adba4cdc07",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "validated state, topic, run branch, step branch and head commit",


### PR DESCRIPTION
Fixes [skills#443](https://github.com/wildcat-finance/skills/issues/443).

The controller's `LEDGER_ROW` regex read only Markdown table history rows,
while `tests/test_evolution_contract.py` deliberately accepts a second
spelling, the compact bullet row most skill ledgers actually use. The gate
therefore counted the two-row ephoros ledger as empty at init and refused the
issue 322 run's one real new row at `done integrate`, after the delivery had
merged (PR #442).

Two changes, both mirrored from the suite rather than invented:

- `ledger_rows` accepts both spellings, byte-for-byte the same patterns the
  suite matches, so the gate and the suite cannot disagree about what a row
  is -- now in fact rather than in a docstring.
- `frontier_close_fault` anchors "gained exactly one row" on the init-time
  `version_at_init` row instead of trusting the stored count: a snapshot
  taken while the gate misread a ledger's spelling counted a real history as
  empty, and the anchor survives that. A ledger that no longer carries the
  init-time version row is refused by name, since history is append-only.

The runtime binding digests for the two fiat promises are re-pinned; the
receipt's result surface is unchanged.

20 new tests, observed red first: both row spellings parse, every governed
ledger in the tree parses as non-empty, the whole frontier gate passes over a
compact-shaped ledger, and a legacy zero-row snapshot closes on exactly one
anchored new row while two rows or a vanished anchor are refused. Proof:

```bash
python3 -m unittest plugins.hexaemeron.tests.test_hexctl
python3 plugins/hexaemeron/tests/run_tests.py
python3 -m unittest discover -s tests
python3 scripts/promise_machine.py check
```

Wildcat-Origin: shoggoth. The usual marker is an HTML comment, and the tooling
this session posts through strips HTML comments from pull-request bodies, so
the provenance line is visible here instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_017bdMt9VHMvPLwAnXz8AYRD)_

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: https://github.com/wildcat-finance/skills/issues/443
Root-Issue-Successor: none-recorded
Root-Issue-Fiat-Required: 0
Root-Issue-Route: pr-only
Root-Issue-Classification-Source: live-contract
<!-- root-issue-analytics:v1:end -->
