### PR TITLE
Put volunteer work into the earliest open Wave

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7960,3 +7960,18 @@ terminal newline. Artwork and binary inspection remain obligations of step 3.
 
 Leads not pursued: SCG-S1-R1-02 changed no code and has no regression test; the
 exact failing and corrected invocations are recorded above.
+
+## Shoggoth contributor guide, step 1, round 2 -- 2026-08-22
+
+Reviewed the fixed tree and issue #447 readback against both round-1 findings
+and all eight study risks. The discussion record exists, stays open, carries
+the exact expected title and the `observation` and `origin:ai` labels, and its
+body differs from the preview only by GitHub's terminal newline. The three
+changed documents still contain no personal name or handle, and proposed
+syntax remains marked as not live.
+
+Phylax, Ephoros and Hypomnema each inspected the three changed documents and
+exited 0. The security-suite waiver still applies; no Solidity entered the
+tree. Zero findings.
+
+Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8018,3 +8018,22 @@ contributor". `scope-widening` remains closed. `mascot-identity` and
 `binary-review` remain Step 3 obligations.
 
 Leads not pursued: none.
+
+## Shoggoth contributor guide, step 2, round 2 -- 2026-08-22
+
+Re-reviewed the fixed tree, both immutable correction receipts and the exact
+issue #447 readback against the two round-1 findings. The selector first finds
+the earliest Wave with open issues, then applies eligibility inside that Wave.
+If none is eligible, it stops instead of advancing to another Wave or silently
+falling through to frontier work. The issue no longer carries a count that its
+own creation invalidates.
+
+Wave 3 remains the earliest open snapshot group. Issues #323 through #328 are
+still open, unassigned and free of issue-number branch or open-pull-request
+trails. Phylax, Ephoros and Hypomnema each exit 0 on the corrected scope. The
+root suite passes 109/109, the controller verifies its 16-entry receipt chain,
+and the exact-selection and no-personal-name assertions pass.
+
+No new findings.
+
+Leads not pursued: none.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7927,3 +7927,36 @@ commit performs no remote action and claims no upstream merge or issue
 closure. Issue 363 remains untouched.
 
 Leads not pursued: none.
+
+## Shoggoth contributor guide, step 1, round 1 -- 2026-08-22
+
+Reviewed the three new documents against the eight study risks and the
+non-Solidity phase gates. The security-suite waiver applies: this step adds no
+Solidity, so X-Ray, Solidity Auditor and Fizz did not run. Phylax, Ephoros and
+Hypomnema each inspected the changed paths and exited 0. Imprimatur, Brevitas,
+the document assertions and the 109-test root suite had already exited 0 on
+the exact implementation commit.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| SCG-S1-R1-01 | medium | `docs/how-to-help-shoggoth-study.md`; `docs/how-to-help-shoggoth-runbook.md` | Step 1 shipped the study before the planned framework observation existed. The study named that issue as the standing home for the volunteer-selector trade, so Hypomnema's record-placement rule had no existing record to inspect when implementation was receipted. | fixed by filing [issue #447](https://github.com/wildcat-finance/skills/issues/447), which carries the chosen intent-packet design, rejected inference boundary, claim-channel alternatives and unresolved questions; exact title and labels were read back from GitHub |
+| SCG-S1-R1-02 | low | audit invocation | The first Hypomnema command included `audit/AUDIT.md`, whose historical failure specimens deliberately name absent runbooks. It reproduced two H003 findings at lines 6119 and 6269; the reduced command over the three changed documents exited 0. | fixed by applying the pointer gate to the changed documentation scope named by the audit contract; no checker or shipped-document defect existed, so no code guard was added |
+
+`selection-overclaim` is closed for this step: every selector example is under
+"The selector we should discuss" and the following sentence says the commands
+are proposed, not live. `contributor-attribution` is closed by PR #445, issue
+#438 and the merged audit rounds; no personal name or handle appears in the
+three documents. `wave-drift` is bounded by the 22 August 2026 date and the
+sentence refusing a permanent priority claim. `duplicate-work` stays visible:
+the guide names assignment, branches and pull requests, and says the
+pre-pull-request claim channel remains open. `scope-widening` is closed by the
+diff, which contains only the guide, study and runbook.
+
+`mascot-identity`, `issue-authority` and `binary-review` are not applicable to
+the step-1 repository diff. The standing issue was filed as the audit fix under
+the user's explicit request, with only the existing `observation` and
+`origin:ai` labels; the exact body differs from the preview only by GitHub's
+terminal newline. Artwork and binary inspection remain obligations of step 3.
+
+Leads not pursued: SCG-S1-R1-02 changed no code and has no regression test; the
+exact failing and corrected invocations are recorded above.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -7975,3 +7975,46 @@ exited 0. The security-suite waiver still applies; no Solidity entered the
 tree. Zero findings.
 
 Leads not pursued: none.
+
+## Shoggoth contributor guide, step 2, round 1 -- 2026-08-22
+
+Reviewed implementation range
+`eeed036b4f994104c9c1e7b5c03f6cdaea71ac13..c35dda9d02b88b9f489eb7c380e7ce61bcca88e6`,
+the corrected issue #447 readback and the user correction receipts. The
+security-suite waiver applies because the step changes documentation and one
+discussion issue, not Solidity.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| SCG-S2-R1-01 | medium | `docs/how-to-help-shoggoth.md`; `docs/how-to-help-shoggoth-study.md`; `docs/how-to-help-shoggoth-runbook.md`; issue #447 | The first correction described the default as the earliest Wave with an eligible open issue. That narrows the user's rule: first choose the earliest Wave that still has open issues, then apply eligibility inside it. | fixed in this round; the tracked prose and issue now use the open-issue boundary, while the second immutable correction receipt records how eligibility applies inside the chosen Wave |
+| SCG-S2-R1-02 | low | issue #447 | The issue body counted ten open issues without Wave metadata. Filing the issue made that count stale immediately because the observation itself has no Wave metadata. | fixed in this round by keeping the relevant fact without a self-invalidating count |
+
+The dated live census finds Waves 3 through 12 with open work. Wave 3 is the
+earliest and contains issues #323 through #328. All six are open and
+unassigned, and none has an issue-number branch or open-pull-request trail.
+The guide therefore uses issue #323 as its present-day named-issue example.
+This snapshot does not assert that Wave 3 remains the default after its open
+issues close.
+
+The first requirements correction remains byte-for-byte intact at digest
+`2b1cee87ec199012030e286d0047945ca47ef133c244adf3e0a316d0dcaaabca`.
+The clarification at digest
+`06fefa4266fc2ade47efe05d4a8619424d441641903c4ce29be4a249a8e03605`
+supersedes only its narrower eligibility phrase. `hexctl verify` accepts the
+15-entry chain.
+
+Phylax, Ephoros and Hypomnema each inspect the changed guide, study, runbook,
+issue preview and clarification and exit 0. The GitHub readback matches the
+previewed body, title and labels after ignoring only its terminal newline.
+The exact-selection, no-personal-name and current Wave assertions pass.
+Imprimatur reports no defect, Brevitas exits 0 and the root suite passes
+109/109.
+
+All eight study risks were reviewed. `selection-overclaim`, `wave-drift`,
+`duplicate-work` and `issue-authority` are bounded by the proposed-not-live
+label, dated snapshot, public-claim discussion and exact issue readback.
+`contributor-attribution` is clean: the public text says only "an external
+contributor". `scope-widening` remains closed. `mascot-identity` and
+`binary-review` remain Step 3 obligations.
+
+Leads not pursued: none.

--- a/docs/how-to-help-shoggoth-runbook.md
+++ b/docs/how-to-help-shoggoth-runbook.md
@@ -1,0 +1,43 @@
+# Runbook: help an external contributor evolve the Shoggoth
+
+## Step 1: Publish the contributor path and its evidence
+
+**Goal.** Commit the accepted study and runbook beside a plain-language guide that explains the present contribution path and the three proposed volunteer lanes.
+
+**Entry.** Run branch `fiat/explain-how-contributors-help-evolve-shoggoth-an` at `98d0cded34bc559ba7ed2466988c40f0c3e28937`, with the study receipt recorded and no tracked run changes.
+
+**Exit.** `docs/how-to-help-shoggoth-study.md` and `docs/how-to-help-shoggoth-runbook.md` match the receipted artefacts; `docs/how-to-help-shoggoth.md` names the current named-issue route, the external-contributor case, the proposed `wave`, `frontier` and `maintenance` lanes, the no-literal-cat mascot rule and the current/proposed boundary. Prove it with `cmp`, required-term assertions, Imprimatur, Brevitas and `python3 -m unittest discover -s tests`.
+
+**Files.** Create `docs/how-to-help-shoggoth-study.md`, `docs/how-to-help-shoggoth-runbook.md` and `docs/how-to-help-shoggoth.md`.
+
+**Tests.** Add a small document assertion script under `tmp/` only for the run; it checks the required headings, contribution facts, current/proposed labels and absence of personal naming. Run the root suite; its expected count is whatever the synced base reports, with zero failures.
+
+**Disciplines.** phylax: the guide consumes GitHub facts, controlled by exact links and a dated snapshot. ephoros: none, no unattended process is added. metron: none, no performance claim. elenchus: any factual or lint failure stops publication and is corrected at the source. hypomnema: the committed study holds the design trade and the guide holds the public path.
+
+## Step 2: Open the volunteer-selector discussion
+
+**Goal.** File one framework observation that asks the repository to settle volunteer intent, default Wave selection, frontier opt-in, maintenance scope and the public claim signal.
+
+**Entry.** Step 1's branch and guide, with no issue URL yet recorded in the guide.
+
+**Exit.** One open issue exists in `wildcat-finance/skills`, labelled `observation` and `origin:ai`; its body opens by giving Protasis ownership of skill selection, includes the proposed intent packet, records the current Wave 12 snapshot, names the read-only issue boundary, and asks the unresolved questions. `docs/how-to-help-shoggoth.md` links the exact issue and a `gh issue view` readback matches the previewed title and body.
+
+**Files.** Update `docs/how-to-help-shoggoth.md`. Keep the exact issue preview in `.hexaemeron/` as run evidence; do not commit a second copy.
+
+**Tests.** Run required-term assertions, Imprimatur, Brevitas and `python3 -m unittest discover -s tests`; read the created issue back with `gh issue view --json` and compare title, labels and body.
+
+**Disciplines.** phylax: this step opens a GitHub write boundary, controlled by exact preview, existing labels and readback. ephoros: none, the issue does not run unattended. metron: none, no performance claim. elenchus: a mismatched issue readback stops the step and is repaired before the guide is committed. hypomnema: the issue is the durable home for the unresolved selector decision.
+
+## Step 3: Ship and inspect the mascot field guide
+
+**Goal.** Produce the final wide-page PDF and infographic in the V2 visual system, using a humanoid faceted-head Shoggoth and no literal cat.
+
+**Entry.** Step 2's branch, linked guide and verified discussion issue.
+
+**Exit.** `docs/assets/how-to-help-shoggoth-infographic.png` and the final `output/pdf/how-to-help-shoggoth.pdf` exist. The PDF is no more than six pages, names the external contribution, distinguishes live and proposed routes, includes the discussion URL, uses the cream/black/blue/yellow field-guide system, and passes text extraction, page-count, file-reopen and rendered-page inspection. `python3 plugins/horos/skills/horos/scripts/horos.py scan . --write`, the prose lints, required-term assertions and `python3 -m unittest discover -s tests` exit zero.
+
+**Files.** Create `docs/assets/how-to-help-shoggoth-infographic.png` and `output/pdf/how-to-help-shoggoth.pdf`; update `.horos/boundary.json` if the tracked infographic earns an entry. Keep builders and page renders under `tmp/`.
+
+**Tests.** Assert the generated image dimensions and readable file format; use `pdfinfo`, PyPDF text extraction and page-count checks; render every PDF page with Poppler and inspect the latest render; run the root suite and all lints covering changed files.
+
+**Disciplines.** phylax: image generation and PDF authoring consume local reference files and write bounded outputs. ephoros: none, no unattended process ships. metron: none, page count is an editorial limit rather than a speed claim. elenchus: identity drift, clipping, overlap or missing text blocks delivery and causes one targeted regeneration or layout correction. hypomnema: the guide and issue remain the sources of meaning; the PDF is a derived public explanation.

--- a/docs/how-to-help-shoggoth-runbook.md
+++ b/docs/how-to-help-shoggoth-runbook.md
@@ -20,7 +20,7 @@
 
 **Entry.** Step 1's branch and guide, with no issue URL yet recorded in the guide.
 
-**Exit.** One open issue exists in `wildcat-finance/skills`, labelled `observation` and `origin:ai`; its body opens by giving Protasis ownership of skill selection, includes the proposed intent packet, records the Wave 3 snapshot as the earliest Wave with eligible open issues, names the read-only issue boundary, and asks the unresolved questions. `docs/how-to-help-shoggoth.md` links the exact issue and a `gh issue view` readback matches the previewed title and body.
+**Exit.** One open issue exists in `wildcat-finance/skills`, labelled `observation` and `origin:ai`; its body opens by giving Protasis ownership of skill selection, includes the proposed intent packet, records the Wave 3 snapshot as the earliest Wave with open issues, names the read-only issue boundary, and asks the unresolved questions. `docs/how-to-help-shoggoth.md` links the exact issue and a `gh issue view` readback matches the previewed title and body.
 
 **Files.** Update `docs/how-to-help-shoggoth.md`. Keep the exact issue preview in `.hexaemeron/` as run evidence; do not commit a second copy.
 

--- a/docs/how-to-help-shoggoth-runbook.md
+++ b/docs/how-to-help-shoggoth-runbook.md
@@ -20,7 +20,7 @@
 
 **Entry.** Step 1's branch and guide, with no issue URL yet recorded in the guide.
 
-**Exit.** One open issue exists in `wildcat-finance/skills`, labelled `observation` and `origin:ai`; its body opens by giving Protasis ownership of skill selection, includes the proposed intent packet, records the current Wave 12 snapshot, names the read-only issue boundary, and asks the unresolved questions. `docs/how-to-help-shoggoth.md` links the exact issue and a `gh issue view` readback matches the previewed title and body.
+**Exit.** One open issue exists in `wildcat-finance/skills`, labelled `observation` and `origin:ai`; its body opens by giving Protasis ownership of skill selection, includes the proposed intent packet, records the Wave 3 snapshot as the earliest Wave with eligible open issues, names the read-only issue boundary, and asks the unresolved questions. `docs/how-to-help-shoggoth.md` links the exact issue and a `gh issue view` readback matches the previewed title and body.
 
 **Files.** Update `docs/how-to-help-shoggoth.md`. Keep the exact issue preview in `.hexaemeron/` as run evidence; do not commit a second copy.
 

--- a/docs/how-to-help-shoggoth-study.md
+++ b/docs/how-to-help-shoggoth-study.md
@@ -1,0 +1,140 @@
+# Study: a clear contributor path into the Shoggoth
+
+Assuming, unless corrected:
+
+1. The public audience is an intelligent contributor who can use GitHub but does not need to understand the controller internals.
+2. The explainer describes what works now and labels the volunteer selector as a proposal; it must not present an unimplemented command as live.
+3. The highest numbered open `**Wave:**` block in issue metadata is the current wave. On 2026-08-22 that is Wave 12, with six open, unassigned issues.
+4. A named issue URL overrides every inferred selection. Without one, ordinary volunteer help should prefer the current wave rather than a skill frontier.
+5. Frontier work remains opt-in and subject to the owning skill's maturity gate. Maintenance may instead refresh Horos, census issues, or produce a new ranking proposal without claiming a frontier advance.
+6. The PDF follows the Promise Machine field-guide V2 design and uses the Wildcat Shoggoth as a humanoid figure with a faceted geometric head. It must not depict a literal cat.
+7. The run starts from `98d0cded34bc559ba7ed2466988c40f0c3e28937`, the merge of external-contributor PR #445.
+
+## 1. Problem statement
+
+Build a short contributor guide for someone outside the core team and a discussion issue for the missing volunteer-intent signal. The guide explains how a person can choose useful work, announce it, let Fiat turn it into a receipted delivery, and contribute maintenance without pretending every contribution advances a skill frontier.
+
+A working prototype has four parts:
+
+- a repository Markdown guide grounded in an external contributor's 2026-08-22 delivery;
+- a wide-page PDF and infographic in the established field-guide style, using repository mascot references;
+- a filed framework observation that proposes an explicit volunteer selector and public claim boundary; and
+- evidence that the prose lints, repository tests, PDF text checks and rendered-page inspection pass.
+
+The demo path is: read the guide, follow its present-day named-issue route, inspect the proposed three-lane selector, open the PDF, and follow the linked discussion issue.
+
+## 2. Prior art
+
+An external contributor supplied the live example. Their prompt was `/fiat how do i help evolve you`. The resulting work landed in [PR #445](https://github.com/wildcat-finance/skills/pull/445), which closed [issue #438](https://github.com/wildcat-finance/skills/issues/438). The run produced three fork pull requests, added issue-aware Fiat branch names, fixed a malformed task-issue URL parser finding, published Fiat 5.10.1 and Hexaemeron 1.5.4, and merged upstream as `98d0cded34bc559ba7ed2466988c40f0c3e28937`. This is evidence that an external contributor can complete a real, audited Fiat delivery.
+
+The last two merged pull requests changing the controller were read before options were drawn:
+
+- [PR #445](https://github.com/wildcat-finance/skills/pull/445) made a known task issue visible in every automatic run and step branch. It carried Fiat's held job, issue #363, forward unchanged. Its previously unfinished maintainer merge and issue closure are now complete.
+- [PR #444](https://github.com/wildcat-finance/skills/pull/444) repaired the evolution-ledger gate after it disagreed with the repository's accepted compact ledger shape. It carried no volunteer-selection design.
+
+The relevant audit record was read. PR #445's step 2 round 1 found that the task-issue parser accepted relative, hostless and non-HTTP inputs. Commit `63861895b98585cf597ae1fb3a2ec749ae3c9ef7` added raw-control, scheme, hostname and canonical positive-number checks; round 2 closed the finding. The guide may therefore say that the issue URL is bound and validated. It may not say that branch visibility prevents duplicate work on its own.
+
+The Shoggoth Interceptor protocol already fetches open issues, excludes assigned work, ranks candidates, resolves the implementation repository and sends one issue through Fiat. It detects issue trails in branches and pull requests. It has no explicit volunteer lane and its issue reader is deliberately read-only. Those constraints matter: a volunteer signal cannot silently assign, label or comment without separate authority.
+
+The issue corpus carries `**Wave:**` metadata. On the study snapshot, Waves 3 through 12 remain open; Wave 12 is the latest and contains issues #418 through #423, all six open and unassigned. Ten other open issues have no wave metadata, including later observations and Fiat wishes. Kronos already supports recorded rank-only passes over held frontier jobs, but that is a different candidate universe from the Wave backlog.
+
+## 3. Constraints and non-goals
+
+- Starting ref: `98d0cded34bc559ba7ed2466988c40f0c3e28937` on `main`.
+- Toolchain: repository Python tests and bundled prose lints; ReportLab/Pillow/PyPDF and Poppler for the derived PDF; built-in image generation with repository reference art.
+- The guide must distinguish present behaviour from proposed behaviour.
+- The mascot is a humanoid with a geometric mask-like head. No fur, paws, whiskers, tail, domestic-cat anatomy or cyber-cat substitute.
+- The issue is a discussion artefact, not an implementation of the selector.
+- No skill frontier, evolution ledger, package version, controller receipt shape or Shoggoth write policy changes in this run.
+- No automatic issue assignment, label, comment or closure is added.
+- No claim that the highest wave is objectively the most important work; it is the default backlog slice selected by stated metadata.
+- No performance claim or new runtime dependency.
+
+Always: run the root tests before each implementation receipt, lint every shipped prose file, validate the PDF text and page count, and inspect rendered pages. Ask first: adding a dependency, changing issue metadata, implementing write access, or changing a public command. Never: edit protected Shoggoth guardrails, present a proposed selector as live, invent the contributor's results, mutate unrelated issue metadata, or claim a check ran when it did not.
+
+## 4. Design options
+
+### Option A: keep natural-language inference
+
+Interpret words such as “evolve”, “help” and “next” to choose a job. This is frictionless, but the external contribution also demonstrates the defect: small wording changes can steer the candidate universe, and the same friendly prompt may repeatedly consume a frontier or old Fiat-adjacent job.
+
+### Option B: an explicit volunteer intent packet
+
+Propose one visible volunteer signal with three lanes: `wave`, `frontier` and `maintenance`. A named issue wins. With no issue and no lane, `wave` is the default and selects from the highest open Wave metadata. `frontier` invokes the owning ledgers and maturity gates. `maintenance` names a bounded task such as refreshing Horos or producing a census/ranking proposal. This is cheapest to explain and preserves current specialist boundaries.
+
+Trade: it adds a small grammar and requires a decision about where volunteer intent becomes publicly visible before a pull request exists.
+
+### Option C: GitHub assignment or label only
+
+Treat assignment or a new label as the entire signal. It is public and easy to inspect, but outside contributors may not have permission, and the Shoggoth issue path currently has no write authority. It also says who claimed work without saying whether they volunteered for a Wave, frontier or maintenance lane.
+
+### Option D: run a full census and Kronos-style ranking every time
+
+Recompute all issues and held jobs before every volunteer run. This adapts to drift, but is slow, mixes two candidate universes, and turns “I can help” into a planning exercise. A census is valuable maintenance when requested or when the snapshot is stale, not a mandatory prelude to every contribution.
+
+### Chosen design
+
+Use Option B in the discussion issue and explainer, while describing the present safe route as a named issue URL. Keep assignment, issue comments, branches and pull requests as possible public claim channels to be settled in discussion. This trades automatic magic for one explicit choice and refuses to infer frontier intent from the word “evolve”.
+
+## 5. Risk register seed
+
+```risk-register
+selection-overclaim | the guide's proposed command examples | proposed syntax is visibly marked as not implemented
+mascot-identity | the generated artwork and PDF composition | every figure is checked against the humanoid geometric-head references and carries no literal-cat anatomy
+contributor-attribution | the external contribution summary | dates links commits findings and outcomes match GitHub and the merged audit record
+wave-drift | the issue snapshot behind the default lane | the PDF dates the Wave 12 snapshot and does not claim it remains current forever
+duplicate-work | the gap between local volunteer intent and public visibility | the proposal names assignment branch PR and comment boundaries without claiming any is already automatic
+issue-authority | filing the discussion issue | the issue requests design discussion and performs no assignment label or metadata mutation beyond the authorised observation label
+binary-review | the generated PDF and infographic | source prose remains reviewable and the final binary is rendered text-extracted and page-count checked
+scope-widening | the temptation to implement the selector during documentation work | no controller interceptor ledger or version files change
+```
+
+## 6. Glossary seeds
+
+- **Fiat:** the receipted delivery controller that turns a scoped job into study, runbook, implementation, audit, prose and publication steps.
+- **Shoggoth:** the issue-selection and delivery operator that chooses work, invokes Fiat and leaves evidence.
+- **Wave:** a backlog grouping written in issue-body metadata, such as `Wave 12 - voice`.
+- **Frontier:** a skill's own held next improvement, governed by its evolution ledger and maturity gate.
+- **Maintenance:** bounded upkeep or planning that need not advance a frontier, such as a Horos refresh or issue census.
+- **Volunteer intent:** an explicit statement that a person is offering to run Fiat and which candidate lane they mean.
+- **Claim signal:** the visible evidence that a specific issue is already being worked, such as assignment, an issue-number branch or an open pull request.
+
+## 7. Sources
+
+- `AGENTS.md`, especially the four issue queues and repository checks.
+- `PROMISE_MACHINE.md`.
+- `plugins/hexaemeron/skills/fiat/SKILL.md` and `EVOLUTION.md` at the starting ref.
+- `plugins/hexaemeron/skills/kronos/SKILL.md` and `docs/kronos-rank-only/study.md`.
+- `audit/AUDIT.md`, “Fiat task-issue branch names” rounds.
+- [wildcat-finance/skills issue #438](https://github.com/wildcat-finance/skills/issues/438).
+- [wildcat-finance/skills PR #445](https://github.com/wildcat-finance/skills/pull/445).
+- [wildcat-finance/skills PR #444](https://github.com/wildcat-finance/skills/pull/444).
+- GitHub issue snapshot taken 2026-08-22 for Wave metadata and assignment state.
+- Shoggoth Interceptor `CLAUDE.md`, `README.md`, `bin/shoggoth.py` and `bin/console.py`.
+- Wildcat mascot references: `mascot-imagegen-kit/skill-characters/shoggoth.png`, `skill-characters/hexaemeron.png`, `skill-characters/kronos.png`, and the brand guideline corpus.
+
+## 8. Signals, and the questions behind them
+
+[Ephoros](../plugins/hexaemeron/skills/ephoros/SKILL.md) owns signal design. This run adds no unattended process, so it emits no runtime telemetry. The human-facing artefacts must still answer: “Which lane did the volunteer mean?”, “Which exact issue, snapshot or maintenance scope was selected?”, “Is anybody already working it?”, and “Did this delivery finish or only produce a discussion proposal?” The guide and issue answer those questions through explicit lane, issue URL, dated snapshot, claim-channel and status fields.
+
+## 9. Boundaries, per capability
+
+[Phylax](../plugins/hexaemeron/skills/phylax/SKILL.md) owns the boundary controls.
+
+- GitHub reads: take issue, pull request and assignment metadata; control with authenticated read-only queries and exact URLs.
+- Issue creation: take only the authorised discussion body; control by previewing the exact title/body, applying the existing `observation` and `origin:ai` labels, and reading the created issue back.
+- Image generation: take only approved repository references; control by visual identity review and the no-literal-cat constraint.
+- PDF creation: take local prose and approved artwork; control with stable output path, text extraction, page-count assertion and rendered-page inspection.
+- Repository mutation: take only the contributor guide, study/runbook copies and final reviewable assets; control with the Fiat branch stack, tests and signed commits.
+
+## 10. The budget, or its absence
+
+[Metron](../plugins/hexaemeron/skills/metron/SKILL.md) owns performance evidence. There is no performance change and no runtime budget. The practical size boundary is editorial: no more than six wide pages, with a one-page quick-start path. Page count is checked with `pdfinfo`; this is a presentation constraint, not a speed claim.
+
+## 11. The fail-closed posture
+
+[Elenchus](../plugins/hexaemeron/skills/elenchus/SKILL.md) owns failure work. Stop the dependent transition if the external contribution cannot be verified, proposed syntax reads as live, the mascot becomes a literal cat, an issue write differs from the preview, a prose lint fails, repository tests fail, or the PDF render shows clipping or overlap. A fix gets a guard where mechanical: text assertions for current/proposed labels, PDF term and page-count checks, and visual reinspection after any layout or image change.
+
+## 12. Decisions and their homes
+
+[Hypomnema](../plugins/hexaemeron/skills/hypomnema/SKILL.md) owns record placement. The current guide lives under `docs/` and keeps the dated external-contributor case study. The volunteer selector is expensive to reverse only after it becomes a public command, so this run files a framework observation rather than an ADR or implementation. The issue is the durable home for lane grammar, default selection, claim-channel and census-trigger discussion. The study records why natural-language inference and mandatory full census were rejected for this prototype.

--- a/docs/how-to-help-shoggoth-study.md
+++ b/docs/how-to-help-shoggoth-study.md
@@ -4,7 +4,7 @@ Assuming, unless corrected:
 
 1. The public audience is an intelligent contributor who can use GitHub but does not need to understand the controller internals.
 2. The explainer describes what works now and labels the volunteer selector as a proposal; it must not present an unimplemented command as live.
-3. The earliest `**Wave:**` block that still has an eligible open issue is the default Wave. On 2026-08-22 that is Wave 3, with six open, unassigned issues.
+3. The earliest `**Wave:**` block that still has an open issue is the default Wave. On 2026-08-22 that is Wave 3, with six open, unassigned issues.
 4. A named issue URL overrides every inferred selection. Without one, ordinary volunteer help should prefer the earliest open Wave rather than a skill frontier.
 5. Frontier work remains opt-in and subject to the owning skill's maturity gate. Maintenance may instead refresh Horos, census issues, or produce a new ranking proposal without claiming a frontier advance.
 6. The PDF follows the Promise Machine field-guide V2 design and uses the Wildcat Shoggoth as a humanoid figure with a faceted geometric head. It must not depict a literal cat.
@@ -60,7 +60,7 @@ Interpret words such as “evolve”, “help” and “next” to choose a job.
 
 ### Option B: an explicit volunteer intent packet
 
-Propose one visible volunteer signal with three lanes: `wave`, `frontier` and `maintenance`. A named issue wins. With no issue and no lane, `wave` is the default and selects from the earliest Wave that still has an eligible open issue. `frontier` invokes the owning ledgers and maturity gates. `maintenance` names a bounded task such as refreshing Horos or producing a census/ranking proposal. This is cheapest to explain and preserves current specialist boundaries.
+Propose one visible volunteer signal with three lanes: `wave`, `frontier` and `maintenance`. A named issue wins. With no issue and no lane, `wave` is the default and selects from the earliest Wave that still has an open issue. `frontier` invokes the owning ledgers and maturity gates. `maintenance` names a bounded task such as refreshing Horos or producing a census/ranking proposal. This is cheapest to explain and preserves current specialist boundaries.
 
 Trade: it adds a small grammar and requires a decision about where volunteer intent becomes publicly visible before a pull request exists.
 

--- a/docs/how-to-help-shoggoth-study.md
+++ b/docs/how-to-help-shoggoth-study.md
@@ -4,8 +4,8 @@ Assuming, unless corrected:
 
 1. The public audience is an intelligent contributor who can use GitHub but does not need to understand the controller internals.
 2. The explainer describes what works now and labels the volunteer selector as a proposal; it must not present an unimplemented command as live.
-3. The highest numbered open `**Wave:**` block in issue metadata is the current wave. On 2026-08-22 that is Wave 12, with six open, unassigned issues.
-4. A named issue URL overrides every inferred selection. Without one, ordinary volunteer help should prefer the current wave rather than a skill frontier.
+3. The earliest `**Wave:**` block that still has an eligible open issue is the default Wave. On 2026-08-22 that is Wave 3, with six open, unassigned issues.
+4. A named issue URL overrides every inferred selection. Without one, ordinary volunteer help should prefer the earliest open Wave rather than a skill frontier.
 5. Frontier work remains opt-in and subject to the owning skill's maturity gate. Maintenance may instead refresh Horos, census issues, or produce a new ranking proposal without claiming a frontier advance.
 6. The PDF follows the Promise Machine field-guide V2 design and uses the Wildcat Shoggoth as a humanoid figure with a faceted geometric head. It must not depict a literal cat.
 7. The run starts from `98d0cded34bc559ba7ed2466988c40f0c3e28937`, the merge of external-contributor PR #445.
@@ -36,7 +36,7 @@ The relevant audit record was read. PR #445's step 2 round 1 found that the task
 
 The Shoggoth Interceptor protocol already fetches open issues, excludes assigned work, ranks candidates, resolves the implementation repository and sends one issue through Fiat. It detects issue trails in branches and pull requests. It has no explicit volunteer lane and its issue reader is deliberately read-only. Those constraints matter: a volunteer signal cannot silently assign, label or comment without separate authority.
 
-The issue corpus carries `**Wave:**` metadata. On the study snapshot, Waves 3 through 12 remain open; Wave 12 is the latest and contains issues #418 through #423, all six open and unassigned. Ten other open issues have no wave metadata, including later observations and Fiat wishes. Kronos already supports recorded rank-only passes over held frontier jobs, but that is a different candidate universe from the Wave backlog.
+The issue corpus carries `**Wave:**` metadata. On the study snapshot, Waves 3 through 12 remain open; Wave 3 is the earliest and contains issues #323 through #328, all six open and unassigned. Ten other open issues have no wave metadata, including later observations and Fiat wishes. Kronos already supports recorded rank-only passes over held frontier jobs, but that is a different candidate universe from the Wave backlog.
 
 ## 3. Constraints and non-goals
 
@@ -47,7 +47,7 @@ The issue corpus carries `**Wave:**` metadata. On the study snapshot, Waves 3 th
 - The issue is a discussion artefact, not an implementation of the selector.
 - No skill frontier, evolution ledger, package version, controller receipt shape or Shoggoth write policy changes in this run.
 - No automatic issue assignment, label, comment or closure is added.
-- No claim that the highest wave is objectively the most important work; it is the default backlog slice selected by stated metadata.
+- No claim that the earliest open Wave is objectively the most important work; it is the default backlog slice selected by stated metadata.
 - No performance claim or new runtime dependency.
 
 Always: run the root tests before each implementation receipt, lint every shipped prose file, validate the PDF text and page count, and inspect rendered pages. Ask first: adding a dependency, changing issue metadata, implementing write access, or changing a public command. Never: edit protected Shoggoth guardrails, present a proposed selector as live, invent the contributor's results, mutate unrelated issue metadata, or claim a check ran when it did not.
@@ -60,7 +60,7 @@ Interpret words such as “evolve”, “help” and “next” to choose a job.
 
 ### Option B: an explicit volunteer intent packet
 
-Propose one visible volunteer signal with three lanes: `wave`, `frontier` and `maintenance`. A named issue wins. With no issue and no lane, `wave` is the default and selects from the highest open Wave metadata. `frontier` invokes the owning ledgers and maturity gates. `maintenance` names a bounded task such as refreshing Horos or producing a census/ranking proposal. This is cheapest to explain and preserves current specialist boundaries.
+Propose one visible volunteer signal with three lanes: `wave`, `frontier` and `maintenance`. A named issue wins. With no issue and no lane, `wave` is the default and selects from the earliest Wave that still has an eligible open issue. `frontier` invokes the owning ledgers and maturity gates. `maintenance` names a bounded task such as refreshing Horos or producing a census/ranking proposal. This is cheapest to explain and preserves current specialist boundaries.
 
 Trade: it adds a small grammar and requires a decision about where volunteer intent becomes publicly visible before a pull request exists.
 
@@ -82,7 +82,7 @@ Use Option B in the discussion issue and explainer, while describing the present
 selection-overclaim | the guide's proposed command examples | proposed syntax is visibly marked as not implemented
 mascot-identity | the generated artwork and PDF composition | every figure is checked against the humanoid geometric-head references and carries no literal-cat anatomy
 contributor-attribution | the external contribution summary | dates links commits findings and outcomes match GitHub and the merged audit record
-wave-drift | the issue snapshot behind the default lane | the PDF dates the Wave 12 snapshot and does not claim it remains current forever
+wave-drift | the issue snapshot behind the default lane | the PDF dates the Wave 3 snapshot and does not claim it remains current forever
 duplicate-work | the gap between local volunteer intent and public visibility | the proposal names assignment branch PR and comment boundaries without claiming any is already automatic
 issue-authority | filing the discussion issue | the issue requests design discussion and performs no assignment label or metadata mutation beyond the authorised observation label
 binary-review | the generated PDF and infographic | source prose remains reviewable and the final binary is rendered text-extracted and page-count checked

--- a/docs/how-to-help-shoggoth.md
+++ b/docs/how-to-help-shoggoth.md
@@ -79,7 +79,7 @@ The suggested selection order is simple:
 4. If that Wave has no eligible issue, stop and explain why. Do not fall through to a frontier silently.
 5. Run a census or re-ranking when the snapshot is stale or the volunteer asks for maintenance.
 
-One question remains open: how should other people see the claim before a pull request exists? Assignment is clear but may require maintainer permission. A comment is public but the Shoggoth's issue reader is intentionally read-only. PR #445 makes the issue-number branch an early signal once the run starts. The discussion issue linked from this guide is where that boundary should be settled.
+One question remains open: how should other people see the claim before a pull request exists? Assignment is clear but may require maintainer permission. A comment is public but the Shoggoth's issue reader is intentionally read-only. PR #445 makes the issue-number branch an early signal once the run starts. [Issue #447](https://github.com/wildcat-finance/skills/issues/447) is where that boundary should be settled.
 
 ## What Fiat does with your offer
 

--- a/docs/how-to-help-shoggoth.md
+++ b/docs/how-to-help-shoggoth.md
@@ -32,7 +32,7 @@ There are three useful lanes. They should be explicit because they draw work fro
 
 | Lane | Use it for | Example |
 | --- | --- | --- |
-| Wave | The earliest backlog group that still has eligible open issues | Take one open, unassigned issue from Wave 3 |
+| Wave | The earliest backlog group that still has open issues | Take one open, unassigned issue from Wave 3 |
 | Frontier | A skill's held next improvement | Advance Fiat's recorded next job, after its maturity gate passes |
 | Maintenance | Upkeep or planning that need not move a frontier | Refresh Horos, census issues or propose a revised ranking |
 
@@ -75,7 +75,7 @@ The suggested selection order is simple:
 
 1. An explicit issue URL always wins.
 2. An explicit lane selects only from that lane.
-3. A bare volunteer offer defaults to the earliest Wave that still has an eligible open issue.
+3. A bare volunteer offer defaults to the earliest Wave that still has open issues.
 4. If that Wave has no eligible issue, stop and explain why. Do not fall through to a frontier silently.
 5. Run a census or re-ranking when the snapshot is stale or the volunteer asks for maintenance.
 

--- a/docs/how-to-help-shoggoth.md
+++ b/docs/how-to-help-shoggoth.md
@@ -1,0 +1,112 @@
+# How to help evolve the Shoggoth
+
+You do not need to understand the whole skills suite. You need one useful job, enough access to work on it, and the patience to let Fiat leave receipts.
+
+## The sixty-second version
+
+1. Pick an open, unassigned issue you can finish.
+2. Name the exact issue URL when you invoke Fiat.
+3. Fiat writes the study and runbook before implementation starts.
+4. Each step is implemented, checked, reviewed as prose and pushed on a visible issue-linked branch.
+5. A maintainer reviews the pull request. The evidence says what ran and what remains open.
+
+The named issue matters. Friendly wording such as `/fiat how do i help evolve you` can suggest a useful direction, but it does not state whether you meant the current Wave, a skill frontier or maintenance. Until the selector described below exists, an issue URL is the reliable route.
+
+## An external contributor has already done it
+
+On 22 August 2026, an external contributor used `/fiat how do i help evolve you` and delivered [PR #445](https://github.com/wildcat-finance/skills/pull/445) against [issue #438](https://github.com/wildcat-finance/skills/issues/438).
+
+The run:
+
+- wrote and reviewed a study and runbook;
+- added issue-aware Fiat run and step branch names;
+- found one malformed task-issue URL case during audit and fixed it;
+- published Fiat 5.10.1 and Hexaemeron 1.5.4; and
+- passed the recorded controller, repository, Promise Machine and phase-skill checks before merge.
+
+That is the contribution model in miniature. The contributor supplied time and judgement. Fiat supplied order, checks and a record a maintainer could inspect.
+
+## What you can volunteer for
+
+There are three useful lanes. They should be explicit because they draw work from different queues.
+
+| Lane | Use it for | Example |
+| --- | --- | --- |
+| Wave | The most recent backlog group named by issue metadata | Take one open, unassigned issue from Wave 12 |
+| Frontier | A skill's held next improvement | Advance Fiat's recorded next job, after its maturity gate passes |
+| Maintenance | Upkeep or planning that need not move a frontier | Refresh Horos, census issues or propose a revised ranking |
+
+As of the 22 August 2026 snapshot, the latest open group is **Wave 12 - voice**. It contains six open, unassigned issues, #418 through #423. That is a dated observation, not a permanent priority claim.
+
+Frontier is not a grander word for ordinary work. It means the exact next job held in a skill's evolution ledger. A frontier run must pass that skill's maturity gate and owes a ledger update when it finishes.
+
+Maintenance can still be valuable. A clean Horos boundary lowers future reading cost. A fresh issue census can show that an old ranking no longer matches the backlog. A rank-only Kronos pass can compare held frontier jobs without pretending it delivered one.
+
+## The route that works today
+
+Choose an issue before invoking Fiat:
+
+```text
+/fiat https://github.com/wildcat-finance/skills/issues/418
+```
+
+Before you begin:
+
+- confirm the issue is open and unassigned;
+- check for an issue-number branch or open pull request;
+- read the issue body as requirements, not as permission for unrelated actions; and
+- state any access or decision you do not have.
+
+The controller can bind that issue during initialization. Automatic branches then begin `fiat/<issue>-...`, so other people can see what the work belongs to. The pull request links the issue and carries the run's evidence.
+
+## The selector we should discuss
+
+The proposed signal makes the offer explicit:
+
+```text
+/fiat volunteer --lane wave
+/fiat volunteer --lane frontier --skill fiat
+/fiat volunteer --lane maintenance --task "refresh the Horos boundary"
+```
+
+These commands are **proposed, not live**.
+
+The suggested selection order is simple:
+
+1. An explicit issue URL always wins.
+2. An explicit lane selects only from that lane.
+3. A bare volunteer offer defaults to the latest open Wave.
+4. If that Wave has no eligible issue, stop and explain why. Do not fall through to a frontier silently.
+5. Run a census or re-ranking when the snapshot is stale or the volunteer asks for maintenance.
+
+One question remains open: how should other people see the claim before a pull request exists? Assignment is clear but may require maintainer permission. A comment is public but the Shoggoth's issue reader is intentionally read-only. PR #445 makes the issue-number branch an early signal once the run starts. The discussion issue linked from this guide is where that boundary should be settled.
+
+## What Fiat does with your offer
+
+Fiat is the delivery controller. It does not decide that an issue is true or important. Once the job is selected, it keeps the work in order:
+
+```text
+study -> runbook -> implement -> audit -> prose -> push -> integrate
+```
+
+The domain skill does the specialist work. The phase skills govern how the work moves. The Promise Machine limits every claim to its evidence. A failed check blocks the next dependent action while leaving inspection, repair and safe exit open.
+
+The useful output is not merely a code diff. It is a reviewable branch, the tests that ran, the findings that were fixed or carried forward, and a pull request that says what has not been established.
+
+## A good first contribution
+
+Choose work that fits inside one Fiat run. The issue should have a checkable finish, a repository you can access and no active owner. Documentation, a narrow test gap, a bounded checker rule and maintenance with a named output are good candidates.
+
+Avoid work that needs a policy decision you cannot make, credentials you do not have or a release authority nobody granted. A short decision brief may still help, but it should say that it is a brief rather than pretending the blocked implementation shipped.
+
+The simplest useful opening is still:
+
+```text
+I can take this issue through a Fiat run: <exact issue URL>.
+```
+
+That sentence names the offer, the delivery method and the work. Everything after it can be made orderly.
+
+## Artwork boundary
+
+The Wildcat Shoggoth is a humanoid figure with a faceted geometric head or mask. It is not a literal cat. Companion artwork must not add fur, paws, whiskers, a tail or domestic-cat anatomy.

--- a/docs/how-to-help-shoggoth.md
+++ b/docs/how-to-help-shoggoth.md
@@ -91,7 +91,7 @@ study -> runbook -> implement -> audit -> prose -> push -> integrate
 
 The domain skill does the specialist work. The phase skills govern how the work moves. The Promise Machine limits every claim to its evidence. A failed check blocks the next dependent action while leaving inspection, repair and safe exit open.
 
-The useful output is not merely a code diff. It is a reviewable branch, the tests that ran, the findings that were fixed or carried forward, and a pull request that says what has not been established.
+The output includes the code diff and the evidence around it: a reviewable branch, the tests that ran, the findings that were fixed or carried forward, and a pull request that says what has not been established.
 
 ## A good first contribution
 

--- a/docs/how-to-help-shoggoth.md
+++ b/docs/how-to-help-shoggoth.md
@@ -10,7 +10,7 @@ You do not need to understand the whole skills suite. You need one useful job, e
 4. Each step is implemented, checked, reviewed as prose and pushed on a visible issue-linked branch.
 5. A maintainer reviews the pull request. The evidence says what ran and what remains open.
 
-The named issue matters. Friendly wording such as `/fiat how do i help evolve you` can suggest a useful direction, but it does not state whether you meant the current Wave, a skill frontier or maintenance. Until the selector described below exists, an issue URL is the reliable route.
+The named issue matters. Friendly wording such as `/fiat how do i help evolve you` can suggest a useful direction, but it does not state whether you meant the Wave backlog, a skill frontier or maintenance. Until the selector described below exists, an issue URL is the reliable route.
 
 ## An external contributor has already done it
 
@@ -32,11 +32,11 @@ There are three useful lanes. They should be explicit because they draw work fro
 
 | Lane | Use it for | Example |
 | --- | --- | --- |
-| Wave | The most recent backlog group named by issue metadata | Take one open, unassigned issue from Wave 12 |
+| Wave | The earliest backlog group that still has eligible open issues | Take one open, unassigned issue from Wave 3 |
 | Frontier | A skill's held next improvement | Advance Fiat's recorded next job, after its maturity gate passes |
 | Maintenance | Upkeep or planning that need not move a frontier | Refresh Horos, census issues or propose a revised ranking |
 
-As of the 22 August 2026 snapshot, the latest open group is **Wave 12 - voice**. It contains six open, unassigned issues, #418 through #423. That is a dated observation, not a permanent priority claim.
+As of the 22 August 2026 snapshot, Waves 3 through 12 still contain open work. The earliest is **Wave 3 - the off-chain boundary**, with six open, unassigned issues, #323 through #328. That is a dated observation, not a permanent priority claim.
 
 Frontier is not a grander word for ordinary work. It means the exact next job held in a skill's evolution ledger. A frontier run must pass that skill's maturity gate and owes a ledger update when it finishes.
 
@@ -47,7 +47,7 @@ Maintenance can still be valuable. A clean Horos boundary lowers future reading 
 Choose an issue before invoking Fiat:
 
 ```text
-/fiat https://github.com/wildcat-finance/skills/issues/418
+/fiat https://github.com/wildcat-finance/skills/issues/323
 ```
 
 Before you begin:
@@ -75,7 +75,7 @@ The suggested selection order is simple:
 
 1. An explicit issue URL always wins.
 2. An explicit lane selects only from that lane.
-3. A bare volunteer offer defaults to the latest open Wave.
+3. A bare volunteer offer defaults to the earliest Wave that still has an eligible open issue.
 4. If that Wave has no eligible issue, stop and explain why. Do not fall through to a frontier silently.
 5. Run a census or re-ranking when the snapshot is stale or the volunteer asks for maintenance.
 


### PR DESCRIPTION
# Put volunteer work into the earliest open Wave

## Discussion

This step links the contributor guide to [issue #447](https://github.com/wildcat-finance/skills/issues/447), the open discussion about how a Fiat volunteer should state their intent and show that work has been claimed.

It is stacked on [PR #448](https://github.com/wildcat-finance/skills/pull/448), which adds the guide and its supporting study and runbook.

The proposed selector has three lanes: Wave, frontier and maintenance. A named issue still wins. A bare volunteer offer starts with the earliest Wave that still has open issues, then looks for eligible work inside that Wave. It stops if none is eligible instead of moving to another Wave or silently choosing a frontier.

The 22 August 2026 snapshot puts Wave 3 first. Its six issues, #323 through #328, were open, unassigned and had no issue-number branch or open pull-request trail when checked. The snapshot is dated because that ordering will change as issues close.

## Audit

The record is in `audit/AUDIT.md` under “Shoggoth contributor guide, step 2”. Round 1 fixed the distinction between an open Wave and eligibility inside that Wave. It also removed an issue count that became stale as soon as issue #447 was filed. Round 2 found nothing further.

The audit commits are folded into this step before push. The local review branch is `fiat/explain-how-contributors-help-evolve-shoggoth-an-step-2-open-the-volunteer-selector-disc--audit`.

## Proof

```bash
python3 -m unittest discover -s tests
python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/how-to-help-shoggoth.md docs/how-to-help-shoggoth-study.md docs/how-to-help-shoggoth-runbook.md
python3 plugins/brevitas/skills/brevitas/scripts/brevitas.py docs/how-to-help-shoggoth.md --mode report
python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py docs/how-to-help-shoggoth.md docs/how-to-help-shoggoth-study.md docs/how-to-help-shoggoth-runbook.md
python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py docs/how-to-help-shoggoth.md docs/how-to-help-shoggoth-study.md docs/how-to-help-shoggoth-runbook.md
python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py docs/how-to-help-shoggoth.md docs/how-to-help-shoggoth-study.md docs/how-to-help-shoggoth-runbook.md
```

The root suite passes 109/109. Imprimatur, Brevitas, Phylax, Ephoros and Hypomnema exit 0 on their named scopes. The live issue readback matches the reviewed title, labels and body.

<!-- wildcat-origin: shoggoth -->
