### PR TITLE
Audit #327 Step 1 report emitter

### DIFF
--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 1418
+    "files_walked": 1422
   },
   "entries": [
     {

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8152,3 +8152,66 @@ Leads not pursued: the residual check-to-use race between path validation and
 replacement requires a concurrent actor already able to mutate the worktree;
 the emitter does not claim protection from a hostile local writer, and the
 Fiat controller prevents concurrent state writers separately.
+
+## Elenchus guard verdict, step 1, round 2 -- 2026-08-22
+
+Re-reviewed the cumulative corrected tree at
+`b768992892b56b89c33762bbdb322c6c22c598f4` against all three round-1
+findings, all 12 study risks and adjacent ordinary Python failure modes. The
+recorded security-suite waiver still applies: this step ships no Solidity, so
+X-Ray, Solidity Auditor and Fizz did not run.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| EGV-S1-R2-01 | medium | `plugins/hexaemeron/tests/emit_unittest_report.py` | A test that changed the process working directory could retarget a relative report path outside the worktree from which the emitter was invoked. The emitter resolved the report root after discovery and execution instead of binding it at entry. | fixed in this round by capturing the canonical invocation root before loading selectors and using it for report confinement; the regression was observed red on the round-1 tree and green after the fix |
+
+All three round-1 regressions were replayed explicitly. Interrupted selector
+discovery writes an incomplete zero-test report and exits 130. In-worktree
+parent and final-file symlinks are refused without creating the destination.
+The complete committed Horos document equals a fresh canonical scan, and two
+consecutive writes retain SHA-256
+`8ed91d402cb83c886bb9f3c9696d5d88cfb7e87e498a16df5c96fb067a263513`
+with 1,422 walked files and 91 entries.
+
+Adjacent path, replacement, interruption and truthfulness cases were also
+reviewed. The invocation-root regression proves a repository test cannot
+redirect a relative output by calling `os.chdir`. Absolute and relative
+targets remain confined, lexical symlinks are refused before canonical
+containment, and temporary output is written in the destination directory,
+flushed, synced and atomically replaced. Existing output is replaced only
+after a complete bounded encoding; the size-refusal case preserves the prior
+file. Assertion failures, infrastructure errors, skips, clean and zero-test
+selections, invalid selectors, discovery interruption and execution
+interruption retain distinct truthful counts and completion state. The report
+continues to contain only the fixed schema and aggregate counters.
+
+The emitter focus passes 14/14 and the boundary focus passes 5/5. The root
+suite passes 114/114 and the Hexaemeron suite passes 755/755. Both Protasis
+checks are clean, Imprimatur scores the accepted study and runbook 100 with no
+defect, Brevitas is clean on the accepted runbook, Promise Machine reports 14
+plugins, 14 copies and all 67 coverage rows clean, and `git diff --check` is
+clean. Phylax, Ephoros and Hypomnema each exit 0.
+
+All 12 risk-register ids were dispositioned. `claim-omission` and
+`source-drift` remain closed by the exact tracked and receipted study and
+runbook copies and the accepted study digest; the formal guard declaration is
+still a Step 2 obligation. `command-injection` is closed within this step:
+selectors stay in the standard-library loader, no shell or new subprocess is
+introduced, and report confinement is now bound before selector code runs.
+`verdict-forgery`, `verdict-drift` and `ref-mismatch` remain Step 2
+obligations because this tree changes no controller receipt or verdict.
+
+`diagnostic-leak` remains closed by the fixed aggregate-only schema.
+`legacy-overclaim` is unchanged because Step 1 reads and writes no controller
+state. `later-issue-leak` remains closed because no synopsis or audit-close
+policy is added. `frontier-drift` is closed because neither evolution ledger
+changes. `package-staleness` remains assigned to Step 3 because Step 1 changes
+no installed controller behaviour. `self-hosting-gap` remains visible: these
+guards execute the checked-in report writer directly and make no claim about
+the older live controller.
+
+Leads not pursued: the residual check-to-use race between validation and
+replacement, including replacement of the invocation path itself, requires a
+concurrent or test-controlled actor already able to mutate the worktree. The
+emitter does not claim protection from a hostile local writer, and the Fiat
+controller separately prevents concurrent state writers.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8215,3 +8215,62 @@ replacement, including replacement of the invocation path itself, requires a
 concurrent or test-controlled actor already able to mutate the worktree. The
 emitter does not claim protection from a hostile local writer, and the Fiat
 controller separately prevents concurrent state writers.
+
+## Elenchus guard verdict, step 1, round 3 -- 2026-08-22
+
+Re-reviewed the cumulative corrected tree at
+`ad77bb0544612f402c3947c2f51ae2cb7c5d9612` against the four prior regression
+mechanisms, all 12 study risks and adjacent local reliability cases for the
+report writer and canonical Horos boundary. The recorded security-suite waiver
+still applies: this step ships no Solidity, so X-Ray, Solidity Auditor and Fizz
+did not run.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | No findings. | clean |
+
+The four prior mechanisms remain closed. Interrupted selector discovery writes
+an incomplete zero-test report and exits 130. In-worktree parent and final-file
+symlinks refuse without creating the destination. A fresh complete Horos
+document equals the committed record. A test changing process cwd cannot
+retarget a relative report outside the invocation root. These focused replays
+pass 5/5; the complete emitter focus passes 14/14 and the boundary focus passes
+5/5. This closes EGV-S1-R1-01, EGV-S1-R1-02, EGV-S1-R1-03 and EGV-S1-R2-01 on
+the cumulative tree.
+
+Adjacent probes also refuse the worktree root as a file, parent traversal, a
+regular-file parent, a final directory and a broken final symlink. Injected
+file-sync and replacement failures preserve the previous report and remove the
+temporary file. Two fresh Horos scans reproduce the same canonical bytes,
+schema 2, tracked universe, 1,422 walked files and 91 entries. The exact study
+and runbook copies match their receipts, both Protasis checks are clean, the
+root suite passes 114/114 and the Hexaemeron suite passes 755/755. Version,
+frontier, manifest and marketplace focus passes 41/41. Promise Machine reports
+14 plugins, 14 copies and all 67 coverage rows clean. Imprimatur scores both
+accepted documents 100 with no defect, Brevitas is clean, and Phylax, Ephoros
+and Hypomnema each exit 0.
+
+All 12 risk-register ids were dispositioned. `claim-omission` and
+`source-drift` remain closed for Step 1 by the exact tracked and receipted
+study and runbook bytes and the accepted study digest; the formal guard block
+remains a Step 2 obligation. `command-injection` remains closed within this
+step because selector loading adds no shell or subprocess and the output write
+is confined, symlink-refusing, bounded and atomic. `verdict-forgery`,
+`verdict-drift` and `ref-mismatch` remain assigned to Step 2 because this tree
+changes no controller field, accepted verdict set or implementation-ref
+binding.
+
+`diagnostic-leak` remains closed by the aggregate-only fixed report schema.
+`legacy-overclaim` is unchanged because Step 1 reads and writes no controller
+state. `later-issue-leak` remains closed because no synopsis or audit-close
+policy is added. `frontier-drift` remains closed because neither evolution
+ledger changes and the focused contracts pass. `package-staleness` remains a
+Step 3 publication obligation because Step 1 changes no installed controller
+behaviour. `self-hosting-gap` remains visible: the checked-in report writer and
+guards are direct test evidence and make no claim that the older live
+controller implements Step 2's future contract.
+
+Leads not pursued: the previously recorded check-to-use race requires a
+concurrent or test-controlled actor already able to mutate the worktree. The
+emitter does not claim protection from a hostile local writer, and the Fiat
+controller separately prevents concurrent state writers.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8099,3 +8099,56 @@ required-text and forbidden-name assertions pass. The controller verifies its
 No new findings.
 
 Leads not pursued: none.
+
+## Elenchus guard verdict, step 1, round 1 -- 2026-08-22
+
+Reviewed exact implementation range
+`cd48583be2caeace32b14638dbdd85692b73a004..2ef61f297394d64cd7fd3a88b271d30fef507f44`
+against the accepted study, runbook and all 12 risk-register rows. The recorded
+security-suite waiver applies because the step changes Python tests,
+documentation and the Horos boundary, and ships no Solidity. X-Ray, Solidity
+Auditor and Fizz did not run.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| EGV-S1-R1-01 | medium | `plugins/hexaemeron/tests/emit_unittest_report.py` | Unittest selector discovery ran outside the interruption guard. A module raising `KeyboardInterrupt` during import terminated the emitter with no fresh report, so the caller could not distinguish interrupted discovery from an absent or stale run. | fixed in this round by guarding discovery and writing an incomplete zero-test report with exit 130; the regression was observed red on the implementation tree and green after the fix |
+| EGV-S1-R1-02 | medium | `plugins/hexaemeron/tests/emit_unittest_report.py` | Resolving the supplied report path before checking its components erased in-worktree parent and final-file symlinks. Both forms were accepted and redirected the write to a different in-worktree file despite the stated no-symlink boundary. | fixed in this round by inspecting lexical components before canonical containment and retaining the final regular-file check; parent and file symlink regressions were observed red on the implementation tree and green after the fix |
+| EGV-S1-R1-03 | low | `.horos/boundary.json`; `tests/test_boundary_currency.py` | The committed boundary reported 1,418 walked files while a fresh tracked-tree scan reported 1,422. The existing currency test compared classified entries only, so stale canonical count metadata passed. | fixed in this round by regenerating the boundary to 1,422 and comparing the complete canonical document in the currency suite; two consecutive scans now render identical bytes |
+
+The report-writer focus passes 13/13. Its temporary-worktree cases cover
+assertion failure, infrastructure error, skip, clean and zero-test selection,
+runner and discovery interruption, an invalid selector, stale-output
+replacement, outside-worktree refusal, parent and final symlink refusal, the
+one-byte size limit preserving the previous file, and exact canonical JSON
+bytes. The boundary focus passes 5/5. The accepted study and runbook are
+byte-identical to their receipted sources, and both Protasis checks are clean.
+
+All 12 risk-register ids were dispositioned. `claim-omission` is closed for
+this step by the exact receipted and tracked runbook copies; the formal guard
+declaration remains in Step 2 rather than being inferred here. `source-drift`
+is closed by both byte comparisons and the accepted study digest.
+`command-injection` is closed within this step: selectors stay in the
+standard-library loader, no shell or subprocess is added, and the report write
+is confined, symlink-refusing, bounded and atomic. `verdict-forgery`,
+`verdict-drift` and `ref-mismatch` remain Step 2 obligations; this diff changes
+no controller field, accepted value or implementation-ref binding.
+
+`diagnostic-leak` is closed by the fixed report schema, which records counts
+and completion only. `legacy-overclaim` is unchanged because this step reads
+or writes no controller state. `later-issue-leak` remains closed: the study and
+runbook defer synopsis and audit-close policy to their named later issues.
+`frontier-drift` is closed because neither evolution ledger changes.
+`package-staleness` remains assigned to the Step 3 publication bump; Step 1
+changes no installed controller behaviour. `self-hosting-gap` remains visible:
+the report writer and its guards run directly from the checked-in tree and do
+not treat the live run's older controller as proof of Step 2's future contract.
+
+Phylax, Ephoros and Hypomnema each inspect the changed tree and exit 0.
+Imprimatur scores both accepted documents 100 with no defect, Brevitas is
+clean, Promise Machine reports 14 plugins, 14 copies and all 67 coverage rows
+clean, the root and Hexaemeron suites pass, and `git diff --check` is clean.
+
+Leads not pursued: the residual check-to-use race between path validation and
+replacement requires a concurrent actor already able to mutate the worktree;
+the emitter does not claim protection from a hostile local writer, and the
+Fiat controller prevents concurrent state writers separately.

--- a/plugins/hexaemeron/tests/emit_unittest_report.py
+++ b/plugins/hexaemeron/tests/emit_unittest_report.py
@@ -39,6 +39,23 @@ def _report_target(raw: str) -> Path:
 
     root = Path.cwd().resolve()
     lexical = supplied if supplied.is_absolute() else root / supplied
+
+    def inside_root(path: Path) -> bool:
+        try:
+            path.relative_to(root)
+        except ValueError:
+            return False
+        return True
+
+    current = Path(lexical.anchor)
+    for part in lexical.parts[1:]:
+        current /= part
+        if current.is_symlink() and (
+            inside_root(current.parent.resolve())
+            or inside_root(current.resolve(strict=False))
+        ):
+            raise ReportWriteError("the report path cannot contain a symlink")
+
     target = lexical.resolve(strict=False)
     try:
         relative = target.relative_to(root)
@@ -59,6 +76,7 @@ def _report_target(raw: str) -> Path:
         if not current.is_dir():
             raise ReportWriteError("the report parent is not a directory")
 
+    target = current / relative.parts[-1]
     if target.is_symlink() or (target.exists() and not target.is_file()):
         raise ReportWriteError("the report path must be a regular file")
     return target
@@ -115,10 +133,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     sys.path.insert(0, str(Path.cwd()))
-    suite = unittest.defaultTestLoader.loadTestsFromNames(args.selectors)
     runner = RecordingRunner(verbosity=1)
     interrupted = False
     try:
+        suite = unittest.defaultTestLoader.loadTestsFromNames(args.selectors)
         result = runner.run(suite)
     except BaseException:
         interrupted = True

--- a/plugins/hexaemeron/tests/emit_unittest_report.py
+++ b/plugins/hexaemeron/tests/emit_unittest_report.py
@@ -30,14 +30,14 @@ class RecordingRunner(unittest.TextTestRunner):
         return self.result
 
 
-def _report_target(raw: str) -> Path:
+def _report_target(raw: str, *, root: Path | None = None) -> Path:
     if not raw:
         raise ReportWriteError("the report path is empty")
     supplied = Path(raw)
     if ".." in supplied.parts:
         raise ReportWriteError("the report path must stay inside the worktree")
 
-    root = Path.cwd().resolve()
+    root = (root or Path.cwd()).resolve()
     lexical = supplied if supplied.is_absolute() else root / supplied
 
     def inside_root(path: Path) -> bool:
@@ -95,8 +95,13 @@ def _payload(result: unittest.TestResult, complete: bool) -> dict[str, object]:
     }
 
 
-def _write_report(raw_target: str, payload: dict[str, object]) -> None:
-    target = _report_target(raw_target)
+def _write_report(
+    raw_target: str,
+    payload: dict[str, object],
+    *,
+    root: Path | None = None,
+) -> None:
+    target = _report_target(raw_target, root=root)
     encoded = (
         json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
     ).encode("utf-8")
@@ -132,7 +137,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("selectors", nargs="+", help="named unittest selectors")
     args = parser.parse_args(argv)
 
-    sys.path.insert(0, str(Path.cwd()))
+    invocation_root = Path.cwd().resolve()
+    sys.path.insert(0, str(invocation_root))
     runner = RecordingRunner(verbosity=1)
     interrupted = False
     try:
@@ -143,7 +149,11 @@ def main(argv: list[str] | None = None) -> int:
         result = runner.result or unittest.TestResult()
 
     try:
-        _write_report(args.report, _payload(result, complete=not interrupted))
+        _write_report(
+            args.report,
+            _payload(result, complete=not interrupted),
+            root=invocation_root,
+        )
     except (OSError, ReportWriteError) as error:
         print(f"could not write unittest report: {error}", file=sys.stderr)
         return 2

--- a/plugins/hexaemeron/tests/test_emit_unittest_report.py
+++ b/plugins/hexaemeron/tests/test_emit_unittest_report.py
@@ -135,6 +135,43 @@ class EmitUnittestReportTests(unittest.TestCase):
         self.assertEqual(0, payload["testsRun"])
         self.assertFalse(payload["complete"])
 
+    def test_test_cannot_retarget_a_relative_report_by_changing_cwd(self):
+        shifted_root = Path(self.temporary.name)
+        (self.root / "change_directory.py").write_text(
+            textwrap.dedent(
+                f"""\
+                import os
+                import unittest
+
+
+                class ChangeDirectory(unittest.TestCase):
+                    def test_change_directory(self):
+                        os.chdir({str(shifted_root)!r})
+                """
+            ),
+            encoding="utf-8",
+        )
+        relative_report = Path(".elenchus") / "relative.json"
+        expected = self.root / relative_report
+        redirected = shifted_root / relative_report
+
+        run = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                str(relative_report),
+                "change_directory.ChangeDirectory.test_change_directory",
+            ],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(0, run.returncode)
+        self.assertTrue(expected.is_file())
+        self.assertFalse(redirected.exists())
+
     def test_invalid_selector_is_an_error_report(self):
         run, payload = self.run_emitter("test_outcomes.Outcomes.test_absent")
         self.assertEqual(1, run.returncode)

--- a/plugins/hexaemeron/tests/test_emit_unittest_report.py
+++ b/plugins/hexaemeron/tests/test_emit_unittest_report.py
@@ -107,6 +107,12 @@ class EmitUnittestReportTests(unittest.TestCase):
             },
             payload,
         )
+        self.assertEqual(
+            '{"complete":true,"errors":0,"expectedFailures":0,'
+            '"failures":0,"schema":"elenchus.unittest.v1","skipped":0,'
+            '"testsRun":1,"unexpectedSuccesses":0}\n',
+            self.report.read_text(encoding="utf-8"),
+        )
 
     def test_zero_test_selector_is_recorded(self):
         run, payload = self.run_emitter("empty_module")
@@ -118,6 +124,15 @@ class EmitUnittestReportTests(unittest.TestCase):
         run, payload = self.run_emitter("test_outcomes.Outcomes.test_interrupt")
         self.assertEqual(130, run.returncode)
         self.assertEqual(1, payload["testsRun"])
+        self.assertFalse(payload["complete"])
+
+    def test_interrupted_selector_discovery_is_incomplete(self):
+        (self.root / "interrupt_import.py").write_text(
+            "raise KeyboardInterrupt()\n", encoding="utf-8"
+        )
+        run, payload = self.run_emitter("interrupt_import")
+        self.assertEqual(130, run.returncode)
+        self.assertEqual(0, payload["testsRun"])
         self.assertFalse(payload["complete"])
 
     def test_invalid_selector_is_an_error_report(self):
@@ -153,6 +168,28 @@ class EmitUnittestReportTests(unittest.TestCase):
         self.assertEqual(2, run.returncode)
         self.assertIsNone(payload)
         self.assertFalse(outside.exists())
+
+    def test_output_parent_cannot_be_a_symlink(self):
+        actual = self.root / "actual"
+        actual.mkdir()
+        alias = self.root / "alias"
+        alias.symlink_to(actual, target_is_directory=True)
+        target = alias / "report.json"
+        run, payload = self.run_emitter(
+            "test_outcomes.Outcomes.test_clean", report=target
+        )
+        self.assertEqual(2, run.returncode)
+        self.assertIsNone(payload)
+        self.assertFalse((actual / "report.json").exists())
+
+    def test_output_file_cannot_be_a_symlink(self):
+        self.report.parent.mkdir()
+        destination = self.report.parent / "destination.json"
+        self.report.symlink_to(destination)
+        run, payload = self.run_emitter("test_outcomes.Outcomes.test_clean")
+        self.assertEqual(2, run.returncode)
+        self.assertIsNone(payload)
+        self.assertFalse(destination.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_boundary_currency.py
+++ b/tests/test_boundary_currency.py
@@ -38,13 +38,19 @@ REFRESH = (
 def drifted_paths(root):
     """Every path where the committed boundary and a fresh scan disagree."""
     committed = horos.load_boundary(str(root))
-    fresh = horos.boundary_document(
+    fresh = fresh_boundary(root, committed)
+    return [path for path, _ in horos.diff_documents(committed, fresh)]
+
+
+def fresh_boundary(root, committed=None):
+    """The canonical boundary document for the committed universe."""
+    committed = committed or horos.load_boundary(str(root))
+    return horos.boundary_document(
         horos.scan_tree(
             str(root),
             include_untracked=committed.get("universe") == "tracked+untracked",
         )
     )
-    return [path for path, _ in horos.diff_documents(committed, fresh)]
 
 
 def write(root, relpath, content):
@@ -67,6 +73,10 @@ def git(root, *args):
 class BoundaryCurrencyTests(unittest.TestCase):
     def test_the_committed_boundary_matches_a_fresh_scan(self):
         self.assertEqual(drifted_paths(ROOT), [], REFRESH)
+
+    def test_the_committed_boundary_metadata_matches_a_fresh_scan(self):
+        committed = horos.load_boundary(str(ROOT))
+        self.assertEqual(committed, fresh_boundary(ROOT, committed), REFRESH)
 
 
 @unittest.skipIf(GIT is None, "git unavailable")


### PR DESCRIPTION
This PR records three review rounds for issue #327 Step 1. Rounds 1 and 2 fixed
four findings in the unittest report writer and canonical Horos record. Round 3
found nothing further. The full evidence is under the three
`Elenchus guard verdict, step 1` headings in `audit/AUDIT.md`.

Proof:

```bash
python3 -m unittest plugins.hexaemeron.tests.test_emit_unittest_report -v
```

<!-- wildcat-origin: shoggoth -->
