### PR TITLE
Add the guard-verdict unittest report path

### DIFF
--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 1418
+    "files_walked": 1422
   },
   "entries": [
     {

--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 1415
+    "files_walked": 1418
   },
   "entries": [
     {

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8152,3 +8152,66 @@ Leads not pursued: the residual check-to-use race between path validation and
 replacement requires a concurrent actor already able to mutate the worktree;
 the emitter does not claim protection from a hostile local writer, and the
 Fiat controller prevents concurrent state writers separately.
+
+## Elenchus guard verdict, step 1, round 2 -- 2026-08-22
+
+Re-reviewed the cumulative corrected tree at
+`b768992892b56b89c33762bbdb322c6c22c598f4` against all three round-1
+findings, all 12 study risks and adjacent ordinary Python failure modes. The
+recorded security-suite waiver still applies: this step ships no Solidity, so
+X-Ray, Solidity Auditor and Fizz did not run.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| EGV-S1-R2-01 | medium | `plugins/hexaemeron/tests/emit_unittest_report.py` | A test that changed the process working directory could retarget a relative report path outside the worktree from which the emitter was invoked. The emitter resolved the report root after discovery and execution instead of binding it at entry. | fixed in this round by capturing the canonical invocation root before loading selectors and using it for report confinement; the regression was observed red on the round-1 tree and green after the fix |
+
+All three round-1 regressions were replayed explicitly. Interrupted selector
+discovery writes an incomplete zero-test report and exits 130. In-worktree
+parent and final-file symlinks are refused without creating the destination.
+The complete committed Horos document equals a fresh canonical scan, and two
+consecutive writes retain SHA-256
+`8ed91d402cb83c886bb9f3c9696d5d88cfb7e87e498a16df5c96fb067a263513`
+with 1,422 walked files and 91 entries.
+
+Adjacent path, replacement, interruption and truthfulness cases were also
+reviewed. The invocation-root regression proves a repository test cannot
+redirect a relative output by calling `os.chdir`. Absolute and relative
+targets remain confined, lexical symlinks are refused before canonical
+containment, and temporary output is written in the destination directory,
+flushed, synced and atomically replaced. Existing output is replaced only
+after a complete bounded encoding; the size-refusal case preserves the prior
+file. Assertion failures, infrastructure errors, skips, clean and zero-test
+selections, invalid selectors, discovery interruption and execution
+interruption retain distinct truthful counts and completion state. The report
+continues to contain only the fixed schema and aggregate counters.
+
+The emitter focus passes 14/14 and the boundary focus passes 5/5. The root
+suite passes 114/114 and the Hexaemeron suite passes 755/755. Both Protasis
+checks are clean, Imprimatur scores the accepted study and runbook 100 with no
+defect, Brevitas is clean on the accepted runbook, Promise Machine reports 14
+plugins, 14 copies and all 67 coverage rows clean, and `git diff --check` is
+clean. Phylax, Ephoros and Hypomnema each exit 0.
+
+All 12 risk-register ids were dispositioned. `claim-omission` and
+`source-drift` remain closed by the exact tracked and receipted study and
+runbook copies and the accepted study digest; the formal guard declaration is
+still a Step 2 obligation. `command-injection` is closed within this step:
+selectors stay in the standard-library loader, no shell or new subprocess is
+introduced, and report confinement is now bound before selector code runs.
+`verdict-forgery`, `verdict-drift` and `ref-mismatch` remain Step 2
+obligations because this tree changes no controller receipt or verdict.
+
+`diagnostic-leak` remains closed by the fixed aggregate-only schema.
+`legacy-overclaim` is unchanged because Step 1 reads and writes no controller
+state. `later-issue-leak` remains closed because no synopsis or audit-close
+policy is added. `frontier-drift` is closed because neither evolution ledger
+changes. `package-staleness` remains assigned to Step 3 because Step 1 changes
+no installed controller behaviour. `self-hosting-gap` remains visible: these
+guards execute the checked-in report writer directly and make no claim about
+the older live controller.
+
+Leads not pursued: the residual check-to-use race between validation and
+replacement, including replacement of the invocation path itself, requires a
+concurrent or test-controlled actor already able to mutate the worktree. The
+emitter does not claim protection from a hostile local writer, and the Fiat
+controller separately prevents concurrent state writers.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8215,3 +8215,62 @@ replacement, including replacement of the invocation path itself, requires a
 concurrent or test-controlled actor already able to mutate the worktree. The
 emitter does not claim protection from a hostile local writer, and the Fiat
 controller separately prevents concurrent state writers.
+
+## Elenchus guard verdict, step 1, round 3 -- 2026-08-22
+
+Re-reviewed the cumulative corrected tree at
+`ad77bb0544612f402c3947c2f51ae2cb7c5d9612` against the four prior regression
+mechanisms, all 12 study risks and adjacent local reliability cases for the
+report writer and canonical Horos boundary. The recorded security-suite waiver
+still applies: this step ships no Solidity, so X-Ray, Solidity Auditor and Fizz
+did not run.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | No findings. | clean |
+
+The four prior mechanisms remain closed. Interrupted selector discovery writes
+an incomplete zero-test report and exits 130. In-worktree parent and final-file
+symlinks refuse without creating the destination. A fresh complete Horos
+document equals the committed record. A test changing process cwd cannot
+retarget a relative report outside the invocation root. These focused replays
+pass 5/5; the complete emitter focus passes 14/14 and the boundary focus passes
+5/5. This closes EGV-S1-R1-01, EGV-S1-R1-02, EGV-S1-R1-03 and EGV-S1-R2-01 on
+the cumulative tree.
+
+Adjacent probes also refuse the worktree root as a file, parent traversal, a
+regular-file parent, a final directory and a broken final symlink. Injected
+file-sync and replacement failures preserve the previous report and remove the
+temporary file. Two fresh Horos scans reproduce the same canonical bytes,
+schema 2, tracked universe, 1,422 walked files and 91 entries. The exact study
+and runbook copies match their receipts, both Protasis checks are clean, the
+root suite passes 114/114 and the Hexaemeron suite passes 755/755. Version,
+frontier, manifest and marketplace focus passes 41/41. Promise Machine reports
+14 plugins, 14 copies and all 67 coverage rows clean. Imprimatur scores both
+accepted documents 100 with no defect, Brevitas is clean, and Phylax, Ephoros
+and Hypomnema each exit 0.
+
+All 12 risk-register ids were dispositioned. `claim-omission` and
+`source-drift` remain closed for Step 1 by the exact tracked and receipted
+study and runbook bytes and the accepted study digest; the formal guard block
+remains a Step 2 obligation. `command-injection` remains closed within this
+step because selector loading adds no shell or subprocess and the output write
+is confined, symlink-refusing, bounded and atomic. `verdict-forgery`,
+`verdict-drift` and `ref-mismatch` remain assigned to Step 2 because this tree
+changes no controller field, accepted verdict set or implementation-ref
+binding.
+
+`diagnostic-leak` remains closed by the aggregate-only fixed report schema.
+`legacy-overclaim` is unchanged because Step 1 reads and writes no controller
+state. `later-issue-leak` remains closed because no synopsis or audit-close
+policy is added. `frontier-drift` remains closed because neither evolution
+ledger changes and the focused contracts pass. `package-staleness` remains a
+Step 3 publication obligation because Step 1 changes no installed controller
+behaviour. `self-hosting-gap` remains visible: the checked-in report writer and
+guards are direct test evidence and make no claim that the older live
+controller implements Step 2's future contract.
+
+Leads not pursued: the previously recorded check-to-use race requires a
+concurrent or test-controlled actor already able to mutate the worktree. The
+emitter does not claim protection from a hostile local writer, and the Fiat
+controller separately prevents concurrent state writers.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8099,3 +8099,56 @@ required-text and forbidden-name assertions pass. The controller verifies its
 No new findings.
 
 Leads not pursued: none.
+
+## Elenchus guard verdict, step 1, round 1 -- 2026-08-22
+
+Reviewed exact implementation range
+`cd48583be2caeace32b14638dbdd85692b73a004..2ef61f297394d64cd7fd3a88b271d30fef507f44`
+against the accepted study, runbook and all 12 risk-register rows. The recorded
+security-suite waiver applies because the step changes Python tests,
+documentation and the Horos boundary, and ships no Solidity. X-Ray, Solidity
+Auditor and Fizz did not run.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| EGV-S1-R1-01 | medium | `plugins/hexaemeron/tests/emit_unittest_report.py` | Unittest selector discovery ran outside the interruption guard. A module raising `KeyboardInterrupt` during import terminated the emitter with no fresh report, so the caller could not distinguish interrupted discovery from an absent or stale run. | fixed in this round by guarding discovery and writing an incomplete zero-test report with exit 130; the regression was observed red on the implementation tree and green after the fix |
+| EGV-S1-R1-02 | medium | `plugins/hexaemeron/tests/emit_unittest_report.py` | Resolving the supplied report path before checking its components erased in-worktree parent and final-file symlinks. Both forms were accepted and redirected the write to a different in-worktree file despite the stated no-symlink boundary. | fixed in this round by inspecting lexical components before canonical containment and retaining the final regular-file check; parent and file symlink regressions were observed red on the implementation tree and green after the fix |
+| EGV-S1-R1-03 | low | `.horos/boundary.json`; `tests/test_boundary_currency.py` | The committed boundary reported 1,418 walked files while a fresh tracked-tree scan reported 1,422. The existing currency test compared classified entries only, so stale canonical count metadata passed. | fixed in this round by regenerating the boundary to 1,422 and comparing the complete canonical document in the currency suite; two consecutive scans now render identical bytes |
+
+The report-writer focus passes 13/13. Its temporary-worktree cases cover
+assertion failure, infrastructure error, skip, clean and zero-test selection,
+runner and discovery interruption, an invalid selector, stale-output
+replacement, outside-worktree refusal, parent and final symlink refusal, the
+one-byte size limit preserving the previous file, and exact canonical JSON
+bytes. The boundary focus passes 5/5. The accepted study and runbook are
+byte-identical to their receipted sources, and both Protasis checks are clean.
+
+All 12 risk-register ids were dispositioned. `claim-omission` is closed for
+this step by the exact receipted and tracked runbook copies; the formal guard
+declaration remains in Step 2 rather than being inferred here. `source-drift`
+is closed by both byte comparisons and the accepted study digest.
+`command-injection` is closed within this step: selectors stay in the
+standard-library loader, no shell or subprocess is added, and the report write
+is confined, symlink-refusing, bounded and atomic. `verdict-forgery`,
+`verdict-drift` and `ref-mismatch` remain Step 2 obligations; this diff changes
+no controller field, accepted value or implementation-ref binding.
+
+`diagnostic-leak` is closed by the fixed report schema, which records counts
+and completion only. `legacy-overclaim` is unchanged because this step reads
+or writes no controller state. `later-issue-leak` remains closed: the study and
+runbook defer synopsis and audit-close policy to their named later issues.
+`frontier-drift` is closed because neither evolution ledger changes.
+`package-staleness` remains assigned to the Step 3 publication bump; Step 1
+changes no installed controller behaviour. `self-hosting-gap` remains visible:
+the report writer and its guards run directly from the checked-in tree and do
+not treat the live run's older controller as proof of Step 2's future contract.
+
+Phylax, Ephoros and Hypomnema each inspect the changed tree and exit 0.
+Imprimatur scores both accepted documents 100 with no defect, Brevitas is
+clean, Promise Machine reports 14 plugins, 14 copies and all 67 coverage rows
+clean, the root and Hexaemeron suites pass, and `git diff --check` is clean.
+
+Leads not pursued: the residual check-to-use race between path validation and
+replacement requires a concurrent actor already able to mutate the worktree;
+the emitter does not claim protection from a hostile local writer, and the
+Fiat controller prevents concurrent state writers separately.

--- a/docs/elenchus-guard-verdict-runbook.md
+++ b/docs/elenchus-guard-verdict-runbook.md
@@ -1,0 +1,216 @@
+# Runbook: carry the Elenchus guard verdict into Fiat audit rounds
+
+This generation run starts at
+`cd48583be2caeace32b14638dbdd85692b73a004` on
+`fiat/327-elenchus-2-feed-the-guard-verdict-into-fiat`. The installed
+controller created the run before it understood guard declarations. Fresh
+fixtures and the receipted runbook bytes prove the new behaviour.
+
+Every step starts from the exact ref emitted by `hexctl next`. Every step ends
+with its focused and repository checks green. The implementation phase records
+the red-before-fix result before production code changes. Every Fiat-created
+commit uses `git commit -S`, passes `git verify-commit`, and contains exactly
+one of each required trailer:
+
+```text
+Co-authored-by: Shoggoth <shoggoth@wildcat.finance>
+Wildcat-Origin: shoggoth
+```
+
+After a push or GitHub merge, GitHub must report `verified: true` and
+`reason: valid` for every new commit.
+
+## Step 1: Install the guard-report test path and accepted specification
+
+**Goal.** Commit exact copies of the accepted study and runbook, then add the
+repository-owned unittest report emitter needed to test guard declarations in
+the next step.
+
+**Entry.** Exact base `cd48583be2caeace32b14638dbdd85692b73a004`; the
+study and runbook receipts are accepted; no product source has changed.
+
+**Exit.** The tracked study and runbook match their receipted sources byte for
+byte. A standard-library emitter runs named unittest selectors and writes one
+fresh `unittest-json-v1` report to the caller's exact path. Its own tests cover
+assertion failure, error, skip, clean execution, zero tests, interrupted
+completion, invalid selectors, output replacement and bounded writes. The
+emitter does not import or change `hexctl.py`. A Horos scan is stable on its
+second run. Focused tests, both repository suites, Promise Machine, prose,
+tree, diff, signature and trailer checks pass.
+
+```bash
+cmp .hexaemeron/study.md docs/elenchus-guard-verdict-study.md
+cmp .hexaemeron/runbook.md docs/elenchus-guard-verdict-runbook.md
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/elenchus-guard-verdict-study.md
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/elenchus-guard-verdict-runbook.md
+python3 -m unittest plugins.hexaemeron.tests.test_emit_unittest_report -v
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/elenchus-guard-verdict-study.md docs/elenchus-guard-verdict-runbook.md
+python3 plugins/brevitas/skills/brevitas/scripts/brevitas.py docs/elenchus-guard-verdict-runbook.md
+python3 plugins/horos/skills/horos/scripts/horos.py scan . --write
+python3 -m unittest tests.test_boundary_currency
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 scripts/promise_machine.py check
+python3 scripts/promise_machine.py coverage --check
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs
+git diff --check
+git verify-commit <commit-sha>
+```
+
+**Files.** `docs/elenchus-guard-verdict-study.md`;
+`docs/elenchus-guard-verdict-runbook.md`;
+`plugins/hexaemeron/tests/emit_unittest_report.py`;
+`plugins/hexaemeron/tests/test_emit_unittest_report.py`;
+`.horos/boundary.json`; `audit/AUDIT.md` only when audit rounds append to it.
+
+**Tests.** Add the emitter tests before changing the controller. Run the
+emitter-focused test, both repository suites, Promise Machine checks, exact
+document comparisons, Horos stability, prose, tree, diff, signature and
+trailer gates. Expected focused count is at least eight new cases.
+
+**Disciplines.** protasis: tracked copies preserve the accepted contract.
+phylax: the emitter accepts selectors and a report path, so it must use no
+shell and must confine and bound its write. ephoros: the fresh structured
+report is the bounded signal. metron: none, no performance claim. elenchus:
+the emitter makes later red-before-fix evidence machine-readable. hypomnema:
+the study and runbook preserve the design; the durable interface record lands
+in step 2.
+
+## Step 2: Bind the guard declaration to Warden and audit-round
+
+**Goal.** Parse one source-bound guard declaration, carry it in the Warden
+packet, and preserve the reported Elenchus verdict in the audit-round receipt.
+
+**Entry.** Step 1's signed and audited head; the repository-owned report
+emitter and its tests pass; tracked specifications match their receipts; the
+controller still has no guard field.
+
+**Exit.** One exact `elenchus-guard` block in a receipted runbook step formally
+declares a bug-fix step. `next` refuses malformed, duplicate, ambiguous,
+missing-after-declaration or digest-drifted source. Its Warden packet contains
+the exact command fields, step identity, source and command digests, and the
+signed implementation ref. It names `--guard-status` as owed. `audit-round`
+accepts and stores exactly `guarded`, `unguarded`, `passed` or `inconclusive`
+for a declared step, refuses a missing or unknown value, and refuses the flag
+for an ordinary step. Legacy runs remain readable and acquire no claim. The
+three lint exits and clean-close rules keep their current meaning. The ADR,
+Fiat audit instructions and Warden role describe the new boundary without
+adding issue #453's closure policy. Focused red-before-fix evidence and all
+complete gates pass.
+
+```elenchus-guard
+{
+  "test_command": "python3 plugins/hexaemeron/tests/emit_unittest_report.py {report} plugins.hexaemeron.tests.test_hexctl.GuardVerdictReceiptTests",
+  "report_format": "unittest-json-v1",
+  "report_file": ".elenchus/issue-327-step-2.json"
+}
+```
+
+```bash
+python3 plugins/hexaemeron/skills/elenchus/scripts/elenchus.py --ref HEAD --test-command "python3 plugins/hexaemeron/tests/emit_unittest_report.py {report} plugins.hexaemeron.tests.test_hexctl.GuardVerdictReceiptTests" --report-format unittest-json-v1 --report-file .elenchus/issue-327-step-2.json --require-guard
+python3 -m unittest plugins.hexaemeron.tests.test_hexctl.GuardVerdictReceiptTests -v
+python3 -m unittest plugins.hexaemeron.tests.test_elenchus_checker plugins.hexaemeron.tests.test_hexctl plugins.hexaemeron.tests.test_fiat_skill
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 scripts/promise_machine.py check
+python3 scripts/promise_machine.py coverage --check
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/decisions/ADR-012-bind-fiat-guard-verdicts-to-runbook-source.md plugins/hexaemeron/skills/fiat/references/audit-loop.md plugins/hexaemeron/agents/warden.md
+python3 plugins/brevitas/skills/brevitas/scripts/brevitas.py docs/decisions/ADR-012-bind-fiat-guard-verdicts-to-runbook-source.md
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs
+git diff --check
+git verify-commit <commit-sha>
+```
+
+**Files.** `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`;
+`plugins/hexaemeron/tests/test_hexctl.py`;
+`plugins/hexaemeron/tests/test_fiat_skill.py`;
+`plugins/hexaemeron/skills/fiat/references/audit-loop.md`;
+`plugins/hexaemeron/agents/warden.md`;
+`docs/decisions/ADR-012-bind-fiat-guard-verdicts-to-runbook-source.md`;
+`tests/promise_machine_coverage.json`; `audit/AUDIT.md` for audit rounds.
+
+**Tests.** Before editing `hexctl.py`, add the focused class and record its
+failures for absent packet fields, absent receipt validation and source drift.
+Keep each case as a regression test. Cover all four accepted verdicts, every
+declared-source refusal, an ordinary step, a legacy state, lint coexistence,
+state/ledger round trips, two byte-identical `next` calls and raw-output
+exclusion. Use the step's guard block to prove those changed tests fail on the
+unfixed parent and pass on the fixed tree.
+
+**Disciplines.** protasis: implement only the accepted block, packet and
+receipt contract. phylax: Markdown, JSON, command text and paths are untrusted;
+retain bounded reads, exact selectors and argv execution without a shell.
+ephoros: directive and ledger fields answer the operator questions; no new
+service telemetry is warranted. metron: none, no speed claim. elenchus: the
+block above owns the exact detached-parent guard command. hypomnema: ADR-012
+owns the durable source-binding decision and rejected alternatives.
+
+## Step 3: Publish the generations and demonstrate the four verdicts
+
+**Goal.** Publish the Elenchus and Fiat generation changes, reconcile every
+mutable surface, and demonstrate a complete guarded and ordinary audit path.
+
+**Entry.** Step 2's signed and audited head; guard declaration, packet and
+receipt tests pass; Elenchus still reads `elenchus-v1.1.0`, Fiat still reads
+`fiat-v5.10.1`, and both frontier digests are unchanged.
+
+**Exit.** Elenchus is `elenchus-v1.2.0` and Fiat is `fiat-v5.11.1`, each with
+one generation row. Elenchus remains mature at revision
+`observed-failure-root-cause` with digest
+`08e77bae576b3351d6f38e60ce9da88327014bcaa7459e319b8e51d79caeda8b`.
+Fiat retains revision `state-shape-validation`, issue #363 as its held target,
+and digest
+`e413d6041edb34b3807a54019489605814a591f60547755f8f66f01830f643aa`.
+Hexaemeron package `1.5.5`, both manifests, both marketplaces, instructions,
+README text, Promise Machine bindings and version tests agree. A fresh
+temporary run demonstrates each stored verdict, required and forbidden flags,
+source-drift refusal, an ordinary audit close, and legacy readability. No demo
+claims that a caller-reported value proves execution. Horos is stable on a
+second scan. All focused, complete, publication, prose, tree, diff, signature
+and GitHub verification gates pass.
+
+```bash
+python3 -m unittest plugins.hexaemeron.tests.test_elenchus_checker plugins.hexaemeron.tests.test_emit_unittest_report plugins.hexaemeron.tests.test_hexctl plugins.hexaemeron.tests.test_fiat_skill plugins.hexaemeron.tests.test_evolution tests.test_evolution_contract tests.test_marketplace_prose tests.test_version_propagation
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 scripts/promise_machine.py check
+python3 scripts/promise_machine.py coverage --check
+python3 plugins/horos/skills/horos/scripts/horos.py scan . --write
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py <all-changed-prose>
+python3 plugins/brevitas/skills/brevitas/scripts/brevitas.py <each-applicable-prose-file>
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs
+git diff --check
+git verify-commit <commit-sha>
+gh api repos/wildcat-finance/skills/commits/<pushed-sha> --jq '.commit.verification | select(.verified == true and .reason == "valid")'
+```
+
+**Files.** `plugins/hexaemeron/skills/elenchus/EVOLUTION.md`;
+`plugins/hexaemeron/skills/elenchus/SKILL.md`;
+`plugins/hexaemeron/skills/fiat/EVOLUTION.md`;
+`plugins/hexaemeron/skills/fiat/SKILL.md`;
+`plugins/hexaemeron/README.md`; both Hexaemeron manifests; both marketplace
+manifests; version, evolution and marketplace tests;
+`tests/promise_machine_coverage.json`; `.horos/boundary.json`;
+`audit/AUDIT.md`.
+
+**Tests.** Run a fresh checked-in-controller demo that records all four enum
+values without changing their meaning. Recheck every Step 2 refusal and the
+ordinary and legacy paths. Verify version arithmetic, one new generation row
+per skill, byte-exact frontier preservation, package propagation, marketplace
+text, Promise Machine digests and a stable Horos scan. Run the full suites and
+all applicable prose, tree, diff, signature, trailer and remote-verification
+gates.
+
+**Disciplines.** protasis: publish only the accepted generation changes and
+defer #429, #369, #453 and #363. phylax: the demo opens no path beyond the
+bounded interfaces proven in step 2. ephoros: the demo proves the CLI and
+ledger signals; no log, metric, trace or alert is added. metron: none, no
+performance claim. elenchus: replay the detached-parent guard and all
+compatibility specimens on the publication tree. hypomnema: the two ledger
+rows record the generation decisions while both held frontiers stay intact.

--- a/docs/elenchus-guard-verdict-study.md
+++ b/docs/elenchus-guard-verdict-study.md
@@ -1,0 +1,339 @@
+# Study: carry the Elenchus guard verdict into Fiat audit rounds
+
+Assuming, unless corrected:
+
+1. A step makes a formal bug-fix claim by placing one `elenchus-guard` block
+   inside its exact receipted runbook step. Fiat will not infer that claim from
+   a title, prose keywords or the diff.
+2. The block owns the test command and report adapter inputs. The controller
+   records the Elenchus verdict reported by the Warden; it does not execute the
+   test command itself or claim that a reported value proves the command ran.
+3. `guarded`, `unguarded`, `passed` and `inconclusive` remain observations, not
+   a new audit-close policy. Requiring a known failing guard before production
+   work belongs to issue #453 and is outside this run.
+4. A legacy runbook with no guard block is an ordinary step and owes no guard
+   field. Existing states and audit rounds remain readable and gain no claim
+   they did not record.
+5. This is generation work for Elenchus and Fiat. It does not reopen or advance
+   either held frontier.
+
+## 1. Problem statement
+
+Elenchus already classifies a changed test against its parent as exactly one of
+`guarded`, `unguarded`, `passed` or `inconclusive`. Fiat's Warden can read the
+result, but `audit-round` has nowhere to preserve it. An unguarded bug fix is
+therefore carried into `Leads not pursued` by hand, and a later reader cannot
+recover the verdict from controller state.
+
+Build a source-bound route for maintainers running Fiat over a bug-fix step.
+The runbook declares the Elenchus command, the Warden runs that command against
+the implementation commit, and the audit-round receipt stores the returned
+status beside the three existing lint exits. A working prototype satisfies all
+of these checks:
+
+- `python3 -m unittest plugins.hexaemeron.tests.test_elenchus_checker -v`
+  continues to prove all four verdicts and the structured-report refusals.
+- Focused controller tests create a bug-fix runbook, show that `hexctl next`
+  carries the exact command, source digest and implementation ref, show that a
+  missing `--guard-status` is refused, and show that each of the four values is
+  stored unchanged on an audit round.
+- The same tests mutate, remove and duplicate the receipted block and require
+  `next` to refuse before emitting a Warden packet.
+- A non-bug-fix step reaches and closes audit without a guard flag, and a
+  legacy state carrying no guard data remains readable.
+- `python3 -m unittest discover -s tests` and
+  `python3 plugins/hexaemeron/tests/run_tests.py` pass, followed by
+  `python3 scripts/promise_machine.py check`,
+  `python3 scripts/promise_machine.py coverage --check` and
+  `git diff --check`.
+
+Those checks establish receipt shape, source binding and preservation of the
+reported category. They do not establish that every bug fix is guarded, that a
+caller reported honestly, or that the surrounding system has no other fault.
+
+## 2. Prior art
+
+The target starts at `cd48583be2caeace32b14638dbdd85692b73a004` on
+`main`. `plugins/hexaemeron/skills/elenchus/scripts/elenchus.py` hashes to
+`9069e2a4266bf349c963aaad6e22cf2966d14bb34d05d025b72c9e77017d39c5`.
+Its `check()` result and CLI JSON contain `status`; `audit_line()` renders that
+status for a person. The classifier reads runner-owned structure and treats
+diagnostics and ordinary exit codes as non-classifying evidence. An unguarded
+result is non-fatal unless the caller selects `--require-guard`.
+
+`plugins/hexaemeron/skills/fiat/scripts/hexctl.py` hashes to
+`adf0fc24d650fdbb9d38b5b7ccb52320e5d76c1fbed0f3e9f303fa79a4d48167`.
+`done runbook` currently registers titles from `.hexaemeron/steps.json` and
+binds the Markdown artefact by SHA-256. `source_runbook_step()` later selects
+one exact, unfenced `## Step N: <title>` block. The Warden packet carries the
+risk register but not the runbook step. `audit-round` accepts the three lint
+exits, checks their consistency with the findings count, and stores them under
+`lints`. It records no guard field.
+
+The two latest merged pull requests that changed the controller were read.
+[PR #445](https://github.com/wildcat-finance/skills/pull/445) bound task issues
+to run and step branches and carried issue #363 forward untouched. That issue
+stays outside this run. [PR #444](https://github.com/wildcat-finance/skills/pull/444)
+made the frontier ledger gate accept both history-row spellings; it carried no
+unfinished guard work.
+
+The behaviour origins were also read. [PR #195](https://github.com/wildcat-finance/skills/pull/195)
+introduced the four Elenchus outcomes and fixed report ownership and bounded
+reads. [PR #206](https://github.com/wildcat-finance/skills/pull/206) added the
+three receipted lint exits and states the relevant limit: the controller
+records what the caller reports and cannot know that a check ran. Its package
+publication repair in [PR #207](https://github.com/wildcat-finance/skills/pull/207)
+shows that changed installed behaviour also needs a Hexaemeron package bump.
+The two latest merged pull requests touching the Elenchus skill text,
+[PR #426](https://github.com/wildcat-finance/skills/pull/426) and
+[PR #288](https://github.com/wildcat-finance/skills/pull/288), removed a
+duplicated routing paragraph and added Promise Machine declarations. Neither
+left guard-to-audit work open. PR #195 was read as the last merged behavioural
+change to Elenchus.
+
+The current audit records were read before drawing options. `audit/AUDIT.md`
+sections `Elenchus structured reports, step 1, rounds 1-2` preserve the two
+fixed report-boundary findings and a clean second round. Sections `Receipted
+lint rounds, steps 1-3` preserve the structured-field precedent, its
+caller-reporting limit, its backward-compatibility checks and its clean-close
+composition. `plugins/hexaemeron/audit/AUDIT.md` contains only the older plugin
+baseline audit; it adds no later Elenchus or lint-receipt decision. No relevant
+lead from those records is silently reopened here.
+
+Issue #429 depends on this result. Its future audit schema and synopsis must
+preserve the four-value verdict. This study supplies that structured value and
+stops. It does not build #429's schema, timestamp or synopsis.
+
+## 3. Constraints and non-goals
+
+The starting ref is the exact SHA above. The observed tools are Python 3.14.6,
+Forge 1.7.1, Node 26.6.0, Git 2.50.1 and GitHub CLI 2.96.0. Use Python's
+standard library and the existing Elenchus adapters; add no dependency, shell
+execution or new report format. No Solidity changes are planned.
+
+The formal runbook extension is a single fenced block inside the step that
+claims a bug fix:
+
+````markdown
+```elenchus-guard
+{
+  "test_command": "python3 tests/emit_unittest_report.py {report}",
+  "report_format": "unittest-json-v1",
+  "report_file": ".elenchus/unittest.json"
+}
+```
+````
+
+The command has one exact `{report}` argument. `report_format` is one of the
+three existing Elenchus formats, and `report_file` stays under the existing
+Elenchus report-path rules. The block's presence is the claim; no block means
+the step does not claim a bug fix. This run does not guess from words such as
+"repair", inspect commit-message intent, or classify the diff.
+
+The Warden runs the block against the signed implementation commit stored by
+`done implement`. Audit-fix commits are separate findings work and do not
+replace the ref whose changed tests are being checked. The controller adds no
+`--require-guard` policy. It stores an unguarded, passed or inconclusive result
+without recasting it as guarded or clean.
+
+Out of scope: #429's audit-log schema and synopsis, #369's synopsis reader,
+#453's pre-change known-failure injection, #363's delegated-task identity,
+rewriting historical audit entries, changing Elenchus classification, running
+the test command inside `hexctl`, and changing CI.
+
+Boundaries for the run:
+
+- **Always.** Run the focused Elenchus, controller and delegation-packet tests;
+  both repository suites; Promise Machine checks; all lints required by the
+  changed tree; version, manifest and frontier checks; and `git diff --check`
+  before a commit.
+- **Ask first.** Adding a dependency, changing CI, making an unguarded result
+  block audit closure, changing any public Elenchus report format, changing a
+  held frontier, or widening the subprocess trust boundary.
+- **Never.** Run the guard command through a shell, copy its diagnostics into
+  controller state, edit a vendored directory, alter an old audit entry, delete
+  a failing test, claim an unrun command ran, or change key or credential
+  handling.
+
+## 4. Design options
+
+**A. Add a free `--guard-status` flag.** This copies the lint-exit surface with
+the fewest lines. It gives the caller a value even when no runbook command
+exists, so the receipt cannot say which fix or command the status describes.
+Rejected because it preserves a word without its source.
+
+**B. Infer bug-fix steps from titles, prose or changed files.** This avoids a
+new runbook marker. The vocabulary is open, refactors can change tests, and a
+bug fix can touch no conventionally named file. The inference would be both
+easy to evade and hard to explain. Rejected.
+
+**C. Put the command in an expanded `steps.json` object.** The sidecar is
+already read during the runbook receipt and could carry the whole declaration.
+It would duplicate the human-readable `**Tests.**` contract and create a second
+source whose bytes are not currently retained by the receipt. Rejected in
+favour of one visible source.
+
+**D. Parse one bounded `elenchus-guard` block from the exact runbook step.**
+Chosen. The current runbook SHA and exact-step selector already provide most of
+the source boundary. The controller adds one block parser, includes the block
+and implementation ref in the Warden brief, requires `--guard-status` only for
+that step, and stores the value with the runbook and command digests. This is
+the cheapest construction that binds the status to an inspectable command.
+It trades away implicit discovery: a prose bug-fix claim without the block is
+a malformed Fiat specification and must be corrected at runbook review rather
+than guessed during audit.
+
+The block parser accepts exactly one block per exact step, a JSON object with
+the three fields shown above and no empty value. It rejects a missing field, a
+duplicate or nested decoy, an unknown report format, a command without one
+exact `{report}`, and source bytes that no longer match the receipted runbook.
+The Warden packet gains `guard`, containing the command fields, source path and
+SHA-256, step number and title, command SHA-256, and the implementation ref.
+`next` names `--guard-status` as owed. The receipt accepts only the four
+existing values, refuses the flag on a step with no guard block, and stores a
+structured guard record on every audit round for the declared step. Legacy
+rounds retain an absent field.
+
+## 5. Risk register seed
+
+```risk-register
+claim-omission | the boundary between a prose bug-fix claim and the formal runbook block | review and tests refuse a claimed fix whose exact step lacks the declaration
+source-drift | the receipted runbook bytes used to build a Warden packet | mutation removal and duplicate-block specimens refuse before packet emission
+command-injection | the repository-owned test command executed by Elenchus | one report placeholder is split without a shell and existing path and timeout controls remain active
+verdict-forgery | the value reported back to audit-round | the receipt states it is caller-reported and accepts only the four Elenchus values
+verdict-drift | the duplicated status vocabulary at the Elenchus and Fiat boundary | a test derives or compares the accepted set so a new Elenchus value cannot be dropped silently
+ref-mismatch | the commit whose changed tests Elenchus overlays onto its parent | the packet and stored guard record name the signed implementation receipt commit
+diagnostic-leak | bounded test output at the Warden-to-controller boundary | only status source digests and ref enter state or ledger
+legacy-overclaim | states and runbooks written before the guard field existed | legacy reads remain valid and never synthesise a status or source binding
+later-issue-leak | the boundary between verdict preservation and later consumption policy | tests preserve all four values without adding schema synopsis injection or closure policy
+frontier-drift | the mature Elenchus ledger and open Fiat held target | generation rows retain both frontier revisions and digests byte for byte
+package-staleness | the installed Hexaemeron copy after controller behaviour changes | version-propagation tests require one package bump across every manifest and marketplace
+self-hosting-gap | the live run began under the controller it changes | acceptance uses fresh checked-in-controller fixtures and does not treat old initialization as proof of the new contract
+```
+
+## 6. Glossary seeds
+
+- **Bug-fix step.** A runbook step containing one valid `elenchus-guard`
+  block; this is a formal Fiat claim, not a guess from prose or diff content.
+- **Guard declaration.** The source-bound test command, report format and
+  report file inside that block.
+- **Guard verdict.** Exactly `guarded`, `unguarded`, `passed` or
+  `inconclusive`, with the meanings already owned by Elenchus.
+- **Guard ref.** The signed implementation commit recorded by `done implement`
+  and supplied to Elenchus as `--ref`.
+- **Reported verdict.** A value the Warden says Elenchus returned. Fiat checks
+  its shape and source relation; it does not independently rerun the command.
+- **Legacy step.** A receipted step from before this contract, with no formal
+  guard declaration and no guard verdict owed.
+
+## 7. Sources
+
+- Issue #327: <https://github.com/wildcat-finance/skills/issues/327>.
+- Dependent issue #429: <https://github.com/wildcat-finance/skills/issues/429>.
+- Elenchus contract and checker:
+  `plugins/hexaemeron/skills/elenchus/SKILL.md`,
+  `plugins/hexaemeron/skills/elenchus/scripts/elenchus.py`, and
+  `plugins/hexaemeron/tests/test_elenchus_checker.py`.
+- Fiat contract, controller and role:
+  `plugins/hexaemeron/skills/fiat/SKILL.md`,
+  `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`,
+  `plugins/hexaemeron/skills/fiat/references/audit-loop.md`,
+  `plugins/hexaemeron/agents/warden.md`,
+  `plugins/hexaemeron/tests/test_hexctl.py`, and
+  `plugins/hexaemeron/tests/test_fiat_skill.py`.
+- Version law and ledgers: `plugins/hexaemeron/skills/VERSIONING.md`,
+  `plugins/hexaemeron/skills/elenchus/EVOLUTION.md`, and
+  `plugins/hexaemeron/skills/fiat/EVOLUTION.md`.
+- Current audit records: `audit/AUDIT.md` and
+  `plugins/hexaemeron/audit/AUDIT.md`.
+- Merged change records: PRs
+  [#195](https://github.com/wildcat-finance/skills/pull/195),
+  [#206](https://github.com/wildcat-finance/skills/pull/206),
+  [#207](https://github.com/wildcat-finance/skills/pull/207),
+  [#288](https://github.com/wildcat-finance/skills/pull/288),
+  [#426](https://github.com/wildcat-finance/skills/pull/426),
+  [#444](https://github.com/wildcat-finance/skills/pull/444), and
+  [#445](https://github.com/wildcat-finance/skills/pull/445).
+- Suite law: `PROMISE_MACHINE.md`; specification contract:
+  `plugins/hexaemeron/skills/protasis/SKILL.md`; prose gate:
+  `plugins/hexaemeron/skills/imprimatur/SKILL.md`.
+
+## 8. Signals, and the questions behind them
+
+The controller is local and does not add an unattended service, metric or
+alert. It still needs inspectable state for resumption. “Does this round owe a
+guard verdict?” is answered by `next` naming `--guard-status` and by the guard
+object in the Warden brief. “Which command and commit does it describe?” is
+answered by the runbook SHA-256, command SHA-256 and guard ref in that object.
+“What did the Warden report?” is answered by the structured round field in
+state and the hash-chained ledger transition. “Why did reconstruction stop?”
+is answered by a named missing, malformed, ambiguous or drifted-source refusal.
+No new telemetry is warranted; [Ephoros](../plugins/hexaemeron/skills/ephoros/SKILL.md)
+remains the owner if this becomes an unattended path later.
+
+## 9. Boundaries, per capability
+
+Runbook parsing reads untrusted Markdown under existing size, path and digest
+limits. The new parser selects only the exact step and one top-level block;
+fenced decoys, duplicates and changed bytes refuse. Test execution crosses a
+subprocess and filesystem boundary, but the capability stays inside existing
+Elenchus: `shlex` parsing, argv execution without a shell, one substituted
+report path, a timeout, a detached parent worktree and bounded report and
+diagnostic reads. The Warden-to-controller boundary accepts a reported enum,
+not raw output. The controller records only the enum, source digests and ref.
+Repository mutation stays inside the existing signed Fiat stack. See
+[Phylax](../plugins/hexaemeron/skills/phylax/SKILL.md) for the controls owned by
+those boundaries.
+
+## 10. The budget, or its absence
+
+There is no performance claim and therefore no Metron before-and-after budget.
+The implementation must preserve the existing bounded source reads and
+Elenchus timeout. The relevant acceptance is functional and is measured by the
+focused and full test commands in item 1, not by elapsed-time improvement. See
+[Metron](../plugins/hexaemeron/skills/metron/SKILL.md) if a later change is
+proposed for speed.
+
+## 11. The fail-closed posture
+
+A malformed, duplicate, ambiguous, missing-after-declaration or digest-drifted
+guard source stops packet construction. A declared bug-fix step without
+`--guard-status`, an unknown status, or a status supplied for an ordinary step
+stops the audit receipt. Elenchus's own missing, stale, mixed, empty or unsafe
+report cases remain `inconclusive`; Fiat preserves that value and never turns
+it into `guarded`. Red-before-fix tests cover every new refusal and all four
+accepted values, while the existing Elenchus fixtures remain the guard for
+classification. See [Elenchus](../plugins/hexaemeron/skills/elenchus/SKILL.md)
+for the triage and guard rules.
+
+## 12. Decisions and their homes
+
+The formal runbook block, Warden packet field and receipt semantics are an
+interface that later issues will consume. Record the reason and rejected
+sidecar and inference options in
+`docs/decisions/ADR-012-bind-fiat-guard-verdicts-to-runbook-source.md` and keep
+the operating rule in `plugins/hexaemeron/skills/fiat/SKILL.md`,
+`plugins/hexaemeron/skills/fiat/references/audit-loop.md` and
+`plugins/hexaemeron/agents/warden.md`. Elenchus keeps the verdict meanings in
+its own `SKILL.md`; Fiat cites rather than restates them.
+
+The Elenchus skill moves from `elenchus-v1.1.0` to `elenchus-v1.2.0` on the
+generation axis while retaining frontier status `mature`, revision
+`observed-failure-root-cause` and digest
+`08e77bae576b3351d6f38e60ce9da88327014bcaa7459e319b8e51d79caeda8b`
+byte for byte. Fiat moves from `fiat-v5.10.1` to `fiat-v5.11.1` on the
+generation axis while retaining revision `state-shape-validation`, its held
+issue #363 target and digest
+`e413d6041edb34b3807a54019489605814a591f60547755f8f66f01830f643aa`
+byte for byte. Hexaemeron package publication moves from `1.5.4` to `1.5.5`
+across every manifest and marketplace so installations can receive the new
+controller. Promise Machine bindings and the Horos boundary are regenerated
+only where their governed bytes require it. See
+[Hypomnema](../plugins/hexaemeron/skills/hypomnema/SKILL.md) for record
+placement.
+
+Unknowns left visible: the runbook has not yet selected the repository-owned
+report emitter used for this delivery's own guard declaration, and the runbook
+must name that exact command before implementation. No evidence supports
+turning non-`guarded` values into a controller halt in #327; that policy remains
+deferred to #453.

--- a/plugins/hexaemeron/tests/emit_unittest_report.py
+++ b/plugins/hexaemeron/tests/emit_unittest_report.py
@@ -39,6 +39,23 @@ def _report_target(raw: str) -> Path:
 
     root = Path.cwd().resolve()
     lexical = supplied if supplied.is_absolute() else root / supplied
+
+    def inside_root(path: Path) -> bool:
+        try:
+            path.relative_to(root)
+        except ValueError:
+            return False
+        return True
+
+    current = Path(lexical.anchor)
+    for part in lexical.parts[1:]:
+        current /= part
+        if current.is_symlink() and (
+            inside_root(current.parent.resolve())
+            or inside_root(current.resolve(strict=False))
+        ):
+            raise ReportWriteError("the report path cannot contain a symlink")
+
     target = lexical.resolve(strict=False)
     try:
         relative = target.relative_to(root)
@@ -59,6 +76,7 @@ def _report_target(raw: str) -> Path:
         if not current.is_dir():
             raise ReportWriteError("the report parent is not a directory")
 
+    target = current / relative.parts[-1]
     if target.is_symlink() or (target.exists() and not target.is_file()):
         raise ReportWriteError("the report path must be a regular file")
     return target
@@ -115,10 +133,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     sys.path.insert(0, str(Path.cwd()))
-    suite = unittest.defaultTestLoader.loadTestsFromNames(args.selectors)
     runner = RecordingRunner(verbosity=1)
     interrupted = False
     try:
+        suite = unittest.defaultTestLoader.loadTestsFromNames(args.selectors)
         result = runner.run(suite)
     except BaseException:
         interrupted = True

--- a/plugins/hexaemeron/tests/emit_unittest_report.py
+++ b/plugins/hexaemeron/tests/emit_unittest_report.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Run named unittest selectors and atomically write an Elenchus report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+SCHEMA = "elenchus.unittest.v1"
+MAX_REPORT_BYTES = 1024 * 1024
+
+
+class ReportWriteError(ValueError):
+    """The requested report target or encoded payload is unsafe."""
+
+
+class RecordingRunner(unittest.TextTestRunner):
+    """Keep the result available if a test interrupts the runner."""
+
+    result: unittest.TestResult | None = None
+
+    def _makeResult(self) -> unittest.TestResult:
+        self.result = super()._makeResult()
+        return self.result
+
+
+def _report_target(raw: str) -> Path:
+    if not raw:
+        raise ReportWriteError("the report path is empty")
+    supplied = Path(raw)
+    if ".." in supplied.parts:
+        raise ReportWriteError("the report path must stay inside the worktree")
+
+    root = Path.cwd().resolve()
+    lexical = supplied if supplied.is_absolute() else root / supplied
+    target = lexical.resolve(strict=False)
+    try:
+        relative = target.relative_to(root)
+    except ValueError as error:
+        raise ReportWriteError("the report path must stay inside the worktree") from error
+    if not relative.parts:
+        raise ReportWriteError("the report path must name a file")
+
+    current = root
+    for part in relative.parts[:-1]:
+        current /= part
+        if current.is_symlink():
+            raise ReportWriteError("the report path cannot contain a symlink")
+        try:
+            current.mkdir(exist_ok=True)
+        except OSError as error:
+            raise ReportWriteError("the report directory could not be created") from error
+        if not current.is_dir():
+            raise ReportWriteError("the report parent is not a directory")
+
+    if target.is_symlink() or (target.exists() and not target.is_file()):
+        raise ReportWriteError("the report path must be a regular file")
+    return target
+
+
+def _payload(result: unittest.TestResult, complete: bool) -> dict[str, object]:
+    return {
+        "schema": SCHEMA,
+        "complete": complete,
+        "testsRun": result.testsRun,
+        "failures": len(result.failures),
+        "errors": len(result.errors),
+        "skipped": len(result.skipped),
+        "expectedFailures": len(result.expectedFailures),
+        "unexpectedSuccesses": len(result.unexpectedSuccesses),
+    }
+
+
+def _write_report(raw_target: str, payload: dict[str, object]) -> None:
+    target = _report_target(raw_target)
+    encoded = (
+        json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode("utf-8")
+    if len(encoded) > MAX_REPORT_BYTES:
+        raise ReportWriteError("the report exceeds the size limit")
+
+    handle = tempfile.NamedTemporaryFile(
+        mode="wb",
+        dir=target.parent,
+        prefix=".unittest-report-",
+        suffix=".tmp",
+        delete=False,
+    )
+    try:
+        with handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(handle.name, target)
+    except BaseException:
+        try:
+            os.unlink(handle.name)
+        except OSError:
+            pass
+        raise
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run named unittest selectors and write unittest-json-v1."
+    )
+    parser.add_argument("report", help="report path inside the current worktree")
+    parser.add_argument("selectors", nargs="+", help="named unittest selectors")
+    args = parser.parse_args(argv)
+
+    sys.path.insert(0, str(Path.cwd()))
+    suite = unittest.defaultTestLoader.loadTestsFromNames(args.selectors)
+    runner = RecordingRunner(verbosity=1)
+    interrupted = False
+    try:
+        result = runner.run(suite)
+    except BaseException:
+        interrupted = True
+        result = runner.result or unittest.TestResult()
+
+    try:
+        _write_report(args.report, _payload(result, complete=not interrupted))
+    except (OSError, ReportWriteError) as error:
+        print(f"could not write unittest report: {error}", file=sys.stderr)
+        return 2
+
+    if interrupted:
+        return 130
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/hexaemeron/tests/emit_unittest_report.py
+++ b/plugins/hexaemeron/tests/emit_unittest_report.py
@@ -30,14 +30,14 @@ class RecordingRunner(unittest.TextTestRunner):
         return self.result
 
 
-def _report_target(raw: str) -> Path:
+def _report_target(raw: str, *, root: Path | None = None) -> Path:
     if not raw:
         raise ReportWriteError("the report path is empty")
     supplied = Path(raw)
     if ".." in supplied.parts:
         raise ReportWriteError("the report path must stay inside the worktree")
 
-    root = Path.cwd().resolve()
+    root = (root or Path.cwd()).resolve()
     lexical = supplied if supplied.is_absolute() else root / supplied
 
     def inside_root(path: Path) -> bool:
@@ -95,8 +95,13 @@ def _payload(result: unittest.TestResult, complete: bool) -> dict[str, object]:
     }
 
 
-def _write_report(raw_target: str, payload: dict[str, object]) -> None:
-    target = _report_target(raw_target)
+def _write_report(
+    raw_target: str,
+    payload: dict[str, object],
+    *,
+    root: Path | None = None,
+) -> None:
+    target = _report_target(raw_target, root=root)
     encoded = (
         json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
     ).encode("utf-8")
@@ -132,7 +137,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("selectors", nargs="+", help="named unittest selectors")
     args = parser.parse_args(argv)
 
-    sys.path.insert(0, str(Path.cwd()))
+    invocation_root = Path.cwd().resolve()
+    sys.path.insert(0, str(invocation_root))
     runner = RecordingRunner(verbosity=1)
     interrupted = False
     try:
@@ -143,7 +149,11 @@ def main(argv: list[str] | None = None) -> int:
         result = runner.result or unittest.TestResult()
 
     try:
-        _write_report(args.report, _payload(result, complete=not interrupted))
+        _write_report(
+            args.report,
+            _payload(result, complete=not interrupted),
+            root=invocation_root,
+        )
     except (OSError, ReportWriteError) as error:
         print(f"could not write unittest report: {error}", file=sys.stderr)
         return 2

--- a/plugins/hexaemeron/tests/test_emit_unittest_report.py
+++ b/plugins/hexaemeron/tests/test_emit_unittest_report.py
@@ -135,6 +135,43 @@ class EmitUnittestReportTests(unittest.TestCase):
         self.assertEqual(0, payload["testsRun"])
         self.assertFalse(payload["complete"])
 
+    def test_test_cannot_retarget_a_relative_report_by_changing_cwd(self):
+        shifted_root = Path(self.temporary.name)
+        (self.root / "change_directory.py").write_text(
+            textwrap.dedent(
+                f"""\
+                import os
+                import unittest
+
+
+                class ChangeDirectory(unittest.TestCase):
+                    def test_change_directory(self):
+                        os.chdir({str(shifted_root)!r})
+                """
+            ),
+            encoding="utf-8",
+        )
+        relative_report = Path(".elenchus") / "relative.json"
+        expected = self.root / relative_report
+        redirected = shifted_root / relative_report
+
+        run = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                str(relative_report),
+                "change_directory.ChangeDirectory.test_change_directory",
+            ],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(0, run.returncode)
+        self.assertTrue(expected.is_file())
+        self.assertFalse(redirected.exists())
+
     def test_invalid_selector_is_an_error_report(self):
         run, payload = self.run_emitter("test_outcomes.Outcomes.test_absent")
         self.assertEqual(1, run.returncode)

--- a/plugins/hexaemeron/tests/test_emit_unittest_report.py
+++ b/plugins/hexaemeron/tests/test_emit_unittest_report.py
@@ -1,0 +1,159 @@
+"""The repository-owned unittest emitter produces bounded fresh reports."""
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from unittest import mock
+
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE / "emit_unittest_report.py"
+
+SPEC = importlib.util.spec_from_file_location("emit_unittest_report", SCRIPT)
+emitter = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(emitter)
+
+
+FIXTURE = """\
+import unittest
+
+
+class Outcomes(unittest.TestCase):
+    def test_assertion_failure(self):
+        self.assertEqual(1, 2)
+
+    def test_error(self):
+        raise RuntimeError("broken fixture")
+
+    @unittest.skip("fixture skip")
+    def test_skip(self):
+        pass
+
+    def test_clean(self):
+        self.assertEqual(1 + 1, 2)
+
+    def test_interrupt(self):
+        raise KeyboardInterrupt()
+"""
+
+
+class EmitUnittestReportTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="unittest-emitter-")
+        self.root = Path(self.temporary.name) / "worktree"
+        self.root.mkdir()
+        (self.root / "test_outcomes.py").write_text(
+            textwrap.dedent(FIXTURE), encoding="utf-8"
+        )
+        (self.root / "empty_module.py").write_text("VALUE = 1\n", encoding="utf-8")
+        self.report = self.root / ".elenchus" / "report.json"
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def run_emitter(self, *selectors: str, report: Path | None = None):
+        target = report or self.report
+        run = subprocess.run(
+            [sys.executable, str(SCRIPT), str(target), *selectors],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        payload = json.loads(target.read_text(encoding="utf-8")) if target.exists() else None
+        return run, payload
+
+    def test_assertion_failure_is_counted(self):
+        run, payload = self.run_emitter(
+            "test_outcomes.Outcomes.test_assertion_failure"
+        )
+        self.assertEqual(1, run.returncode)
+        self.assertEqual(1, payload["testsRun"])
+        self.assertEqual(1, payload["failures"])
+        self.assertEqual(0, payload["errors"])
+        self.assertTrue(payload["complete"])
+
+    def test_infrastructure_error_is_counted(self):
+        run, payload = self.run_emitter("test_outcomes.Outcomes.test_error")
+        self.assertEqual(1, run.returncode)
+        self.assertEqual(1, payload["testsRun"])
+        self.assertEqual(0, payload["failures"])
+        self.assertEqual(1, payload["errors"])
+
+    def test_skip_is_counted(self):
+        run, payload = self.run_emitter("test_outcomes.Outcomes.test_skip")
+        self.assertEqual(0, run.returncode)
+        self.assertEqual(1, payload["testsRun"])
+        self.assertEqual(1, payload["skipped"])
+
+    def test_clean_selector_writes_the_exact_schema(self):
+        run, payload = self.run_emitter("test_outcomes.Outcomes.test_clean")
+        self.assertEqual(0, run.returncode)
+        self.assertEqual(
+            {
+                "schema": "elenchus.unittest.v1",
+                "complete": True,
+                "testsRun": 1,
+                "failures": 0,
+                "errors": 0,
+                "skipped": 0,
+                "expectedFailures": 0,
+                "unexpectedSuccesses": 0,
+            },
+            payload,
+        )
+
+    def test_zero_test_selector_is_recorded(self):
+        run, payload = self.run_emitter("empty_module")
+        self.assertEqual(0, run.returncode)
+        self.assertEqual(0, payload["testsRun"])
+        self.assertTrue(payload["complete"])
+
+    def test_interrupted_completion_is_incomplete(self):
+        run, payload = self.run_emitter("test_outcomes.Outcomes.test_interrupt")
+        self.assertEqual(130, run.returncode)
+        self.assertEqual(1, payload["testsRun"])
+        self.assertFalse(payload["complete"])
+
+    def test_invalid_selector_is_an_error_report(self):
+        run, payload = self.run_emitter("test_outcomes.Outcomes.test_absent")
+        self.assertEqual(1, run.returncode)
+        self.assertEqual(1, payload["testsRun"])
+        self.assertEqual(1, payload["errors"])
+        self.assertTrue(payload["complete"])
+
+    def test_existing_output_is_replaced(self):
+        self.report.parent.mkdir()
+        self.report.write_text("stale report", encoding="utf-8")
+        run, payload = self.run_emitter("test_outcomes.Outcomes.test_clean")
+        self.assertEqual(0, run.returncode)
+        self.assertEqual("elenchus.unittest.v1", payload["schema"])
+        self.assertNotIn("stale report", self.report.read_text(encoding="utf-8"))
+
+    def test_write_is_bounded_and_preserves_the_previous_file(self):
+        self.report.parent.mkdir()
+        self.report.write_text("previous\n", encoding="utf-8")
+        with mock.patch.object(emitter, "MAX_REPORT_BYTES", 1), mock.patch(
+            "pathlib.Path.cwd", return_value=self.root
+        ):
+            with self.assertRaises(emitter.ReportWriteError):
+                emitter._write_report(str(self.report), {"large": "payload"})
+        self.assertEqual("previous\n", self.report.read_text(encoding="utf-8"))
+
+    def test_output_is_confined_to_the_current_worktree(self):
+        outside = Path(self.temporary.name) / "outside.json"
+        run, payload = self.run_emitter(
+            "test_outcomes.Outcomes.test_clean", report=outside
+        )
+        self.assertEqual(2, run.returncode)
+        self.assertIsNone(payload)
+        self.assertFalse(outside.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/hexaemeron/tests/test_emit_unittest_report.py
+++ b/plugins/hexaemeron/tests/test_emit_unittest_report.py
@@ -107,6 +107,12 @@ class EmitUnittestReportTests(unittest.TestCase):
             },
             payload,
         )
+        self.assertEqual(
+            '{"complete":true,"errors":0,"expectedFailures":0,'
+            '"failures":0,"schema":"elenchus.unittest.v1","skipped":0,'
+            '"testsRun":1,"unexpectedSuccesses":0}\n',
+            self.report.read_text(encoding="utf-8"),
+        )
 
     def test_zero_test_selector_is_recorded(self):
         run, payload = self.run_emitter("empty_module")
@@ -118,6 +124,15 @@ class EmitUnittestReportTests(unittest.TestCase):
         run, payload = self.run_emitter("test_outcomes.Outcomes.test_interrupt")
         self.assertEqual(130, run.returncode)
         self.assertEqual(1, payload["testsRun"])
+        self.assertFalse(payload["complete"])
+
+    def test_interrupted_selector_discovery_is_incomplete(self):
+        (self.root / "interrupt_import.py").write_text(
+            "raise KeyboardInterrupt()\n", encoding="utf-8"
+        )
+        run, payload = self.run_emitter("interrupt_import")
+        self.assertEqual(130, run.returncode)
+        self.assertEqual(0, payload["testsRun"])
         self.assertFalse(payload["complete"])
 
     def test_invalid_selector_is_an_error_report(self):
@@ -153,6 +168,28 @@ class EmitUnittestReportTests(unittest.TestCase):
         self.assertEqual(2, run.returncode)
         self.assertIsNone(payload)
         self.assertFalse(outside.exists())
+
+    def test_output_parent_cannot_be_a_symlink(self):
+        actual = self.root / "actual"
+        actual.mkdir()
+        alias = self.root / "alias"
+        alias.symlink_to(actual, target_is_directory=True)
+        target = alias / "report.json"
+        run, payload = self.run_emitter(
+            "test_outcomes.Outcomes.test_clean", report=target
+        )
+        self.assertEqual(2, run.returncode)
+        self.assertIsNone(payload)
+        self.assertFalse((actual / "report.json").exists())
+
+    def test_output_file_cannot_be_a_symlink(self):
+        self.report.parent.mkdir()
+        destination = self.report.parent / "destination.json"
+        self.report.symlink_to(destination)
+        run, payload = self.run_emitter("test_outcomes.Outcomes.test_clean")
+        self.assertEqual(2, run.returncode)
+        self.assertIsNone(payload)
+        self.assertFalse(destination.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_boundary_currency.py
+++ b/tests/test_boundary_currency.py
@@ -38,13 +38,19 @@ REFRESH = (
 def drifted_paths(root):
     """Every path where the committed boundary and a fresh scan disagree."""
     committed = horos.load_boundary(str(root))
-    fresh = horos.boundary_document(
+    fresh = fresh_boundary(root, committed)
+    return [path for path, _ in horos.diff_documents(committed, fresh)]
+
+
+def fresh_boundary(root, committed=None):
+    """The canonical boundary document for the committed universe."""
+    committed = committed or horos.load_boundary(str(root))
+    return horos.boundary_document(
         horos.scan_tree(
             str(root),
             include_untracked=committed.get("universe") == "tracked+untracked",
         )
     )
-    return [path for path, _ in horos.diff_documents(committed, fresh)]
 
 
 def write(root, relpath, content):
@@ -67,6 +73,10 @@ def git(root, *args):
 class BoundaryCurrencyTests(unittest.TestCase):
     def test_the_committed_boundary_matches_a_fresh_scan(self):
         self.assertEqual(drifted_paths(ROOT), [], REFRESH)
+
+    def test_the_committed_boundary_metadata_matches_a_fresh_scan(self):
+        committed = horos.load_boundary(str(ROOT))
+        self.assertEqual(committed, fresh_boundary(ROOT, committed), REFRESH)
 
 
 @unittest.skipIf(GIT is None, "git unavailable")


### PR DESCRIPTION
# Add the guard-verdict unittest report path

## What changed

- Check in byte-identical copies of the accepted study and runbook.
- Add a standard-library unittest emitter that writes a fresh, bounded `unittest-json-v1` report for named selectors.
- Cover assertion failures, infrastructure errors, skips, clean and empty selections, interruptions, invalid selectors, replacement, confinement and bounded writes.
- Refresh the Horos boundary and make its currency test compare the complete canonical document.

## Why

Issue #327 needs a repository-owned structured report path before the next step can bind an Elenchus guard declaration to Fiat's Warden and `audit-round`. This step installs that test path without changing controller behaviour or verdict policy.

## Review

This stacked PR targets `fiat/327-elenchus-2-feed-the-guard-verdict-into-fiat`. The audit fixes were developed in [PR #455](https://github.com/wildcat-finance/skills/pull/455) and folded into this step. Findings and their dispositions are recorded under the three `Elenchus guard verdict, step 1` rounds in `audit/AUDIT.md`.

## Proof

```bash
python3 -m unittest plugins.hexaemeron.tests.test_emit_unittest_report -v
```

<!-- wildcat-origin: shoggoth -->
