### PR TITLE
docs: correct the git-backed update route for the version gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,14 +284,17 @@ the controller unless the user names Hexaemeron or Fiat and asks to run it.
 
 Work lands here, in the public repository. What reaches an installed plugin
 depends on how that machine added the marketplace, and the two routes differ in
-who fetches the repository.
+who fetches the repository. Both share one way of going wrong: an installed
+plugin can sit a whole evolution behind while every link in the route it came by
+looks healthy. Neither route reports that, so both sections below end in how to
+read what a machine is actually serving.
 
 ### Git-backed, which needs no publishing step
 
 A marketplace added with `/plugin marketplace add wildcat-finance/skills`, or the
 Codex equivalent, is a clone the host pulls with the operator's own git
-credentials. Pushing to `main` is the whole of publishing. To pick up new
-commits:
+credentials. Pushing to `main` is the whole of publishing. Picking it up on a
+machine takes two commands that do different jobs:
 
 ```bash
 claude plugin marketplace update wildcat-labs
@@ -300,6 +303,50 @@ claude plugin update hexaemeron@wildcat-labs
 
 Inside a session that is `/plugin marketplace update` and
 `/plugin update <plugin>@wildcat-labs`. In a provisioning script, pass `--yes`.
+
+Only the first of those is dependable. `marketplace update` advances the
+checkout to the repository head, so afterwards the machine does hold the new
+commits. `plugin update` then compares the version declared in the plugin's
+`.claude-plugin/plugin.json` against the version the install already records,
+and the cache is laid out to match:
+`~/.claude/plugins/cache/<marketplace>/<plugin>/<version>` is keyed on that
+declared version and on nothing else. So a commit that changes a skill without
+bumping its plugin's version arrives in the checkout, maps to the cache slot
+already filled, and is reported as `already at the latest version`. The command
+exits zero and the machine keeps the old files.
+
+That gap was measured on 2026-08-22, over the 122 commits between an install at
+`793b112` and a head at `cd48583`. `plugin update` moved hexaemeron from 1.5.1
+to 1.5.4 and left the other thirteen plugins pinned at `793b112`, and all
+thirteen had real changes under `skills/*/SKILL.md`. Hermes was the worst of
+them: its plugin version stayed at 0.1.1 while the skill's own frontmatter went
+from 0.1.0 to 0.1.1, so the cached copy was short a 73-line `SKILL.md` diff
+carrying the pinned 120-rule gas corpus, the reference to that corpus JSON, and
+the rule refusing work outside the target's scope.
+
+Read it rather than trusting the exit code. Each install records the commit it
+was pinned to, so compare those against the head of the marketplace checkout:
+
+```bash
+git -C ~/.claude/plugins/marketplaces/wildcat-labs rev-parse HEAD
+jq -r '.plugins | to_entries[]
+  | select(.key | endswith("@wildcat-labs"))
+  | "\(.key) \(.value[0].version) \(.value[0].gitCommitSha[0:7])"' \
+  ~/.claude/plugins/installed_plugins.json
+```
+
+A plugin whose `gitCommitSha` is behind that head is serving stale files
+whatever its version says. Reinstalling it is what re-pins the commit, because
+the install is taken fresh from the checkout rather than diffed against it:
+
+```bash
+claude plugin uninstall <plugin>@wildcat-labs --keep-data
+claude plugin install <plugin>@wildcat-labs --yes
+```
+
+`--keep-data` preserves `~/.claude/plugins/data/{id}/`, and enabled status
+survived the round trip for all fourteen plugins. Do that for every plugin
+behind the head, not only the one being worked on.
 
 ### Organisation-distributed, through the private mirror
 
@@ -338,8 +385,8 @@ Two constraints follow from that route rather than from taste. Plugin sources in
 sync packages each plugin out of the mirror instead of fetching it from
 somewhere it may not be able to authenticate to. And a version bump is only
 released once it has crossed all three links: merged here, mirrored there,
-distributed by sync. An installed plugin can sit a whole evolution behind while
-every one of those looks healthy.
+distributed by sync. Each of those links can look healthy while sitting behind
+the one before it, which is how this route produces the gap named above.
 
 ### Which route a machine is on
 

--- a/plugins/hexaemeron/skills/fiat/references/plugin-currency.md
+++ b/plugins/hexaemeron/skills/fiat/references/plugin-currency.md
@@ -64,8 +64,9 @@ let an agent update anything:
 - **A git-backed marketplace.** The host holds a clone or a remote it can pull,
   and names a repository. The Claude Code CLI adds one with
   `/plugin marketplace add <owner/repo>`; Codex points at a repository and
-  derives the plugin from it. Here an update is a command, and the agent can run
-  it.
+  derives the plugin from it. Here an update is a command and the agent can run
+  it, but the command can report success and copy nothing; see the version gate
+  below.
 - **A managed marketplace.** The host holds an extracted, packaged copy under an
   opaque id, with a marketplace name and no git remote, no ref and no commit
   recorded anywhere. Nothing in the install says which commit it came from, which
@@ -87,6 +88,29 @@ Which repository matters only on the git-backed route, and then it is whichever
 one that marketplace was added from. A private marketplace is added from the
 mirror; a public one from `wildcat-finance/skills` directly. Read the host's
 configuration rather than inferring it from the two names above.
+
+### The version gate on the git-backed route
+
+`plugin update` is gated on the version the plugin declares in
+`.claude-plugin/plugin.json`, not on the commit the checkout now holds, and the
+cache is keyed the same way. A skill that changed without its plugin's version
+being bumped is therefore reported as `already at the latest version` and is
+never copied, at exit code zero. Read the recorded pin rather than the exit
+code, and reinstall whatever is behind the head:
+
+```text
+git -C ~/.claude/plugins/marketplaces/<marketplace> rev-parse HEAD
+jq -r '.plugins | to_entries[] | "\(.key) \(.value[0].gitCommitSha[0:7])"' \
+  ~/.claude/plugins/installed_plugins.json
+claude plugin uninstall <plugin>@<marketplace> --keep-data
+claude plugin install <plugin>@<marketplace> --yes
+```
+
+Reinstalling re-pins the commit because the files are taken fresh from the
+checkout; `--keep-data` leaves `~/.claude/plugins/data/{id}/` alone. This is the
+one case where a run can be told its plugins are current and still be driving
+the previous controller, so check the pin before recording two versions as
+agreed. Every plugin behind the head needs it, not only the one the run touches.
 
 ### On a warning
 
@@ -112,8 +136,10 @@ Do not carry on and mention it.
    files over an installed plugin: the next legitimate update overwrites it, and
    nothing records that the run was driven by a tree nobody published.
 3. Refresh through the host boundary above, then re-resolve the paths.
-4. Confirm the versions now agree. `hexctl init` warns only at init, so check
-   the two ledgers directly:
+4. Confirm the versions now agree, and on a git-backed install confirm the pin
+   moved too, because a matching version string is exactly what the gate above
+   leaves behind. `hexctl init` warns only at init, so check the two ledgers
+   directly:
 
    ```text
    grep '^- Current version' "$FIAT_SKILL_DIR/EVOLUTION.md"


### PR DESCRIPTION
`claude plugin update` compares the version declared in a plugin's
.claude-plugin/plugin.json, not the commit the marketplace checkout now
holds, and the cache path is keyed the same way. A commit that changes a
skill without bumping its plugin's version is reported as "already at the
latest version" and never copied, at exit code zero.

Measured on 2026-08-22 over the 122 commits between an install at 793b112
and a head at cd48583: `plugin update` moved hexaemeron 1.5.1 -> 1.5.4 and
left the other thirteen plugins pinned at 793b112, all thirteen with real
changes under skills/*/SKILL.md. Hermes was the worst, its cached copy
short a 73-line SKILL.md diff carrying the pinned 120-rule gas corpus.

The README now states the gate, how to detect it by comparing gitCommitSha
in installed_plugins.json against the marketplace checkout head, and the
uninstall --keep-data / install --yes remedy that re-pins the commit. The
warning about sitting a whole evolution behind while every link looks
healthy moves up to the Publish preamble, because it was only under the
organisation-distributed route and applies to both.

Fiat's plugin-currency.md reference carries the same correction, since the
README points there for this distinction: the git-backed bullet no longer
promises that an update command is enough, a new section states the gate,
and the post-update confirmation step now checks the pin rather than a
version string alone.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
