### PR TITLE
Ignore the scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ plugins/*/harness/cache/
 # search-record.json is not output. It is shipped evidence, it is tracked, and
 # tests/test_search_record.py holds it against the catalogue's law count and
 # digest. Ignoring it would let a fresh clone regenerate it and see no diff.
+
+# The scratch directory. The field-guide runbooks send builders and page renders
+# here deliberately, so nothing under it is a deliverable and a stray `git add`
+# should not be able to commit a virtualenv. Anchored to the repository root, so
+# a plugin that wants its own tmp/ still decides for itself.
+/tmp/


### PR DESCRIPTION
Adds `/tmp/` to `.gitignore`.

The field-guide runbooks send builders and page renders to `tmp/` on purpose, so nothing under it is a deliverable: a deck is rebuilt from its Markdown and assets, not from whatever last ran there. Ignoring it keeps a stray `git add -A` from committing a virtualenv.

Anchored to the repository root, so a plugin that wants its own `tmp/` still decides for itself.

## Checks

- `git check-ignore -v tmp/build_page6.py tmp/venv/pyvenv.cfg` resolves to this rule.
- No tracked file becomes ignored: `git ls-files | grep '^tmp/'` is empty.
- `python3 -m unittest discover -s tests`: 113 tests, all pass.

## What this does not fix

`.horos/candidates.json` still gains git-ignored paths on every scan. With `/tmp/` ignored, `.horos/boundary.json` correctly stops seeing it, but the candidates pass still adds `tmp/venv/.../build/` and `.claude/worktrees/.../build/`, all graded `candidate` on `directory name build alone, uncorroborated`.

So the boundary pass honours gitignore and the candidates pass does not. The scanner's own reasoning near line 503 of `plugins/horos/skills/horos/scripts/horos.py` argues for the ignore rule because a scan would otherwise answer differently on two machines, which is what the candidates pass now does. That is a Horos change rather than a `.gitignore` one, so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
