### PR TITLE
Commit the run-worktree specification

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8099,3 +8099,31 @@ required-text and forbidden-name assertions pass. The controller verifies its
 No new findings.
 
 Leads not pursued: none.
+
+## Fiat run worktree, step 1, round 1 -- 2026-08-22
+
+Reviewed the committed specification against all eleven risk-register entries.
+The step ships two documents and no executable path, so nine of the eleven are
+not exercised by anything here and are carried to the steps that build them.
+The two a document step can still get wrong were checked directly.
+
+`docs/fiat-run-worktree-study.md` and `docs/fiat-run-worktree-runbook.md` are
+byte-identical to the receipted artefacts, so the committed yardstick and the
+frozen run record agree. Neither document carries an absolute path under a home
+or root directory, which is the finding the earlier backed-out copy of this
+step recorded and fixed; the block that carried it is not present in this
+version. All five relative links resolve from `docs/`. The cited suite command
+at `AGENTS.md:138` is the line the study claims it is.
+
+The two inherited claims were re-measured rather than accepted. The four suite
+commands are green on this run's base with no exception: 741/741, 113 OK, and
+both Promise Machine checks clean. The earlier copy's two pinned-toolchain
+failures do not reproduce, because this machine carries the forge and node
+versions those fixtures assert; that is recorded in the study as a fact about a
+container rather than the repository.
+
+Phylax, Ephoros and Hypomnema each exit 0 on both documents.
+
+No findings.
+
+Leads not pursued: none.

--- a/docs/fiat-run-worktree-runbook.md
+++ b/docs/fiat-run-worktree-runbook.md
@@ -1,0 +1,57 @@
+# Runbook: a dedicated run worktree, created before preflight
+
+Derived from the committed study. The chosen design is option A: `init` creates the run's worktree at a path derived from the run branch, puts the run's state in it, leaves one breadcrumb in the operator's checkout, and refuses by name when it cannot. Five steps, dependency order, one pull request each, every step green at both ends.
+
+Every step's suite commands, run from the repository root with Foundry's bin directory on `PATH`. All four are green on this run's base commit, with no carried exception; the study records the measured baseline and why the recovered copy named two failures this machine does not reproduce:
+
+```bash
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 -m unittest discover -s tests
+python3 scripts/promise_machine.py check
+python3 scripts/promise_machine.py coverage --check
+```
+
+## Step 1: Commit the specification
+
+**Goal.** Land the study and runbook in the repository so every later step has a committed yardstick.
+**Entry.** The run branch `fiat/439-run-fiat-in-a-dedicated-worktree-created-bef` at `main` `52b3b45c3d72cb2f163b1dfe88c920035d1385d5`, with the study receipted.
+**Exit.** `docs/fiat-run-worktree-study.md` and `docs/fiat-run-worktree-runbook.md` exist and match the receipted artefacts; `python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/fiat-run-worktree-study.md` and `python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/fiat-run-worktree-runbook.md` both exit 0; `python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py` reports zero defects on both; all four suite commands exit 0.
+**Files.** `docs/fiat-run-worktree-study.md`, `docs/fiat-run-worktree-runbook.md`.
+**Tests.** None new. The four suite commands run unchanged as the both-ends-green check.
+**Disciplines.** phylax: none, this step adds no boundary and no executable path. ephoros: none, documents emit no signal. metron: none, no performance claim. elenchus: none, no failure in hand. hypomnema: none, the decisions this run records land with their content in steps 3 and 5.
+
+## Step 2: Derive and validate the worktree path
+
+**Goal.** Turn a run branch into one refusable path, with no filesystem mutation and no state change.
+**Entry.** Step 1's green exit.
+**Exit.** `hexctl` holds a path deriver that flattens the run branch's separators and places it under `tmp/fiat/`, plus a validator that resolves the candidate, requires it to be a descendant of the repository worktree root, refuses when any component is a symlink leaving that root, and refuses a path that already exists as anything other than this run's registered worktree; every refusal is one value-free line naming the path, exits non-zero, and writes nothing; `python3 -m unittest plugins.hexaemeron.tests.test_hexctl -k Worktree` passes; all four suite commands exit 0.
+**Files.** `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`, `plugins/hexaemeron/tests/test_hexctl.py`.
+**Tests.** Positive: a plain run branch derives the expected path, and an issue-backed branch keeps its leading number. Negative, each observed failing before its guard: a target that is not a Git repository, a computed path that already exists as a file, a path that already exists as an unrelated directory, a component symlink pointing outside the repository root, a path escaping the root by `..`, and a refusal leaving no state, no ledger and no breadcrumb. Expected minimum: 10 new cases.
+**Disciplines.** phylax: this step opens the path-validation boundary, closed by canonical descendant checks, symlink refusal following the Horos S4-R1-01 finding, and no shell interpolation. ephoros: the stable refusal lines are what a three in the morning reader gets, so they land here with their exact wording. metron: none, one path computation makes no performance claim. elenchus: every refusal class is captured red before its guard. hypomnema: none, the path choice is recorded with the creation behaviour in step 3.
+
+## Step 3: Create the worktree at init and put the run's state in it
+
+**Goal.** Make isolation a property of `init`, so no run can forget to arrange it.
+**Entry.** Step 2's deriver and validator, green.
+**Exit.** `hexctl init` validates the path, runs `git worktree add -b <run branch> <path> <base>` through the existing bounded fixed-argv reader, writes `.hexaemeron/` inside the new tree, writes one breadcrumb line at `.hexaemeron/worktree` in the origin checkout, prints the exact `--dir` to use next, and refuses before writing any state when the branch is already checked out elsewhere or `git worktree add` fails; a run started from a deliberately dirty origin checkout succeeds; the origin checkout's `HEAD` and `git status --short` are identical before and after; `python3 -m unittest plugins.hexaemeron.tests.test_hexctl -k Worktree` passes; all four suite commands exit 0.
+**Files.** `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`, `plugins/hexaemeron/tests/test_hexctl.py`, `docs/decisions/ADR-fiat-run-worktree.md`.
+**Tests.** Positive: `init` creates the tree and the run branch, state lands in the tree, the breadcrumb names it, `git worktree list --porcelain` shows exactly one new entry, and a dirty origin checkout still starts. Negative, each observed failing first: the run branch already checked out in another worktree, `git worktree add` failing, and a failed creation leaving no state, no ledger, no breadcrumb and no directory. Invariant: origin `HEAD` and `git status --short` unchanged across a successful `init`. Expected minimum: 12 new cases.
+**Disciplines.** phylax: this step opens filesystem creation and two git invocations, closed by fixed argv with no shell, the step 2 validator ahead of any mutation, and write access in the origin checkout narrowed to one breadcrumb line. ephoros: `init` prints the worktree path and `status` reports it, which answers where the run is working. metron: none, one `git worktree add` outside any loop. elenchus: creation and refusal faults are guarded red to green, and a refusal leaves state and ledger bytes identical. hypomnema: the ADR lands here, recording the worktree home, the fail-closed refusal, and the breaking change for in-place runs, because that choice becomes real in this step.
+
+## Step 4: Resume into the recorded worktree, and clean up at integrate
+
+**Goal.** Let a resumed run find its tree, and let a finished run put the tree away without ever discarding uncommitted work.
+**Entry.** Step 3's creation path and breadcrumb, green.
+**Exit.** A `status` or `next` run in the origin checkout that finds a breadcrumb and no state prints the recorded worktree path and the exact `--dir` to use, exits non-zero, and changes nothing; a resume whose recorded worktree is absent refuses naming that path rather than creating a second tree; `done integrate` removes the worktree without force when it is clean and records that, keeps it and records it as kept when it holds modifications, and never forces; existing `.hexaemeron/` state in an origin checkout still resumes, and the archived-run fixtures still pass; `python3 -m unittest plugins.hexaemeron.tests.test_hexctl -k "Worktree or Resume"` passes; all four suite commands exit 0.
+**Files.** `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`, `plugins/hexaemeron/tests/test_hexctl.py`.
+**Tests.** Positive: breadcrumb resolution prints the path and the `--dir` form; a clean tree is removed at integrate and the receipt records the removal; a tree holding a modified file is kept and the receipt records it as kept. Negative, observed failing first: a recorded worktree that has been deleted, a breadcrumb naming a path outside the repository root, and an integrate that would need force. Regression: a legacy state directory in the origin checkout resumes unchanged, and the archived runs keep verifying. Expected minimum: 10 new cases.
+**Disciplines.** phylax: resume reads an on-disk path written earlier, so the step 2 validator runs on it again rather than trusting it. ephoros: the integrate receipt names the cleanup outcome, which answers what happened to the tree. metron: none, no performance claim. elenchus: absent-tree and force-needed cases are guarded red to green. hypomnema: none, this step implements the behaviour the step 3 ADR already records.
+
+## Step 5: Correct the contract, record the ledger row, and run the demo
+
+**Goal.** Make the written contract match the built behaviour, replace the advice that cannot work, and prove the whole path from clean inputs.
+**Entry.** Step 4's complete behaviour, green.
+**Exit.** `SKILL.md` states that the run works in a dedicated worktree created before preflight, where it lives, that `--dir` points at it, the cleanup rule, and the fail-closed fallback; the kernel-lock refusal at `hexctl.py` no longer advises `git worktree add ../<name> main`, which fails when the base is already checked out, and names a command that works; `plugins/hexaemeron/skills/fiat/EVOLUTION.md` carries exactly one new generation row retaining `state-shape-validation` and its digest `e413d6041edb34b3807a54019489605814a591f60547755f8f66f01830f643aa`, with the held [skills#363](https://github.com/wildcat-finance/skills/issues/363) job byte-identical; the study's demo path runs from a dirty checkout and leaves the operator's `HEAD` and `git status` unchanged; the not-a-repository demonstration refuses and creates no state; `python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py` reports zero defects on every changed document; `python3 plugins/horos/skills/horos/scripts/horos.py check` exits 0; all four suite commands exit 0.
+**Files.** `plugins/hexaemeron/skills/fiat/SKILL.md`, `plugins/hexaemeron/skills/fiat/EVOLUTION.md`, `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`, `plugins/hexaemeron/tests/test_hexctl.py`, `plugins/hexaemeron/tests/test_fiat_skill.py`, `plugins/hexaemeron/README.md`, `.horos/boundary.json`.
+**Tests.** The contract test asserts `SKILL.md` states the worktree behaviour and no longer carries the unusable advice; a lock-refusal test asserts the new command text; the demo path runs as a test from a dirty fixture checkout; the ledger row is held by the existing `tests/test_evolution_contract.py`. Expected minimum: 6 new cases plus every earlier test.
+**Disciplines.** phylax: full boundary review over path validation, creation, resume and cleanup, with anything unresolved stated. ephoros: review the refusal lines and the recorded path and cleanup outcome from the demo run. metron: none, the change makes no speed claim and the demo measures nothing. elenchus: any failing demonstration is worked to its cause and guarded before the row is written. hypomnema: the ledger row records this generation and leaves the held frontier job untouched.

--- a/docs/fiat-run-worktree-study.md
+++ b/docs/fiat-run-worktree-study.md
@@ -159,9 +159,9 @@ The state schema addition and the breadcrumb format are documented in `SKILL.md`
 
 ### Provenance and baseline -- 2026-08-22
 
-**Where this specification came from.** It was written earlier the same day and then backed out. That run reached the end of step 1: the study and runbook below, two audit rounds with one low finding fixed and the second clean, and a voice pass, over four signed commits on [PR #465](https://github.com/wildcat-finance/skills/pull/465). What stopped it was not the change. `hexctl done push` resolves repository identity with `gh repo view --json nameWithOwner`, and that session's proxy answered GraphQL with 403, so the push receipt could not be written. The branches were deleted and the pull request closed.
+**Where this specification came from.** It was written earlier the same day and then backed out. That run reached the end of step 1 over four signed commits on [PR #465](https://github.com/wildcat-finance/skills/pull/465). It shipped the study and runbook below, ran two audit rounds, fixed the one low finding the first raised, and took a voice pass over both documents. What stopped it was not the change. `hexctl done push` resolves repository identity with `gh repo view --json nameWithOwner`, and that session's proxy answered GraphQL with 403, so the push receipt could not be written. The branches were deleted and the pull request closed.
 
-The same call answers `wildcat-finance/skills` in this session, so the receipt that blocked the run is available. The four commits were recovered from `refs/pull/465/head`, which GitHub retains after a branch is deleted, and this run adopts them at the operator's direction rather than deriving the same conclusions a second time. Everything below is the recovered text, with the corrections named next.
+The same call answers `wildcat-finance/skills` in this session, so the receipt that blocked the run is available. GitHub retains a closed pull request's commits after its branch is deleted, so the four were recovered from `refs/pull/465/head`. This run adopts them at the operator's direction rather than deriving the same conclusions twice. Everything below is the recovered text, with the corrections named next.
 
 **The baseline this run measured.** All four suite commands were run on the run branch at `main` `52b3b45c3d72cb2f163b1dfe88c920035d1385d5` before any change:
 
@@ -172,7 +172,7 @@ python3 scripts/promise_machine.py check           clean: 14 plugin(s), 14 copy/
 python3 scripts/promise_machine.py coverage --check clean: promises=67 coverage_rows=67 coverage_selected=67
 ```
 
-Green at both ends therefore means green, with no carried exception. The recovered copy recorded two failures in `plugins/hexaemeron/tests/test_elenchus_checker.py`, where fixtures assert forge `1.7.1` and node `v26.6.0`. Both pass here, because this machine carries forge `1.7.1` and node `v26.6.0` and the earlier container carried `1.5.1` and `v22.22.2`. Those assertions describe the toolchain a run is executed on, not the repository, so the exception was a fact about one container and is not inherited. A later round that sees them fail should read its own toolchain before reading the test.
+Green at both ends therefore means green, with no carried exception. The recovered copy recorded two failures in `plugins/hexaemeron/tests/test_elenchus_checker.py`, where fixtures assert forge `1.7.1` and node `v26.6.0`. Both pass here, because this machine carries forge `1.7.1` and node `v26.6.0` and the earlier container carried `1.5.1` and `v22.22.2`. Those assertions describe the toolchain a run executes on, not the repository. The exception was a fact about one container, so it is not inherited. A later round that sees them fail should read its own toolchain before reading the test.
 
 **The other correction.** The Hexaemeron suite is invoked as `python3 plugins/hexaemeron/tests/run_tests.py`, the form `AGENTS.md:138` lists. The `unittest discover -s plugins/hexaemeron/tests` form fails with `Start directory is not importable`, because that directory carries no `__init__.py`, so it could not have proved any step's exit.
 

--- a/docs/fiat-run-worktree-study.md
+++ b/docs/fiat-run-worktree-study.md
@@ -1,0 +1,179 @@
+# Study: a dedicated run worktree, created before preflight
+
+Assuming, unless corrected:
+
+1. Python 3.11 and the standard library, matching every other script in this repository. No new dependency.
+2. The run's tree lives inside the repository under the already-ignored scratch root, at `tmp/fiat/<run branch>/`. A sibling directory outside the repository was offered and declined when this specification was first written, so it is recorded as rejected rather than left as an option.
+3. Fail-closed is the chosen fallback. A target that is not a Git repository, or where `git worktree add` fails, refuses the run rather than continuing in place. This is a breaking change for anyone relying on an in-place run and is stated as one.
+4. `.hexaemeron/` moves into the run's worktree, so `--dir` points at the worktree for the whole run. The operator's checkout keeps one breadcrumb naming the run's tree, so a resume can find it without being told.
+5. The kernel lock stays exactly as it is. Worktrees make collision rarer; they do not remove the need for the guard when two writers share one state directory.
+6. The held frontier job at [skills#363](https://github.com/wildcat-finance/skills/issues/363) is untouched, and this run's ledger row is a generation row retaining `state-shape-validation` and its digest.
+7. This run began from `main` at `52b3b45c3d72cb2f163b1dfe88c920035d1385d5`, with Fiat at `fiat-v5.10.1`.
+
+I will proceed on these assumptions unless corrected.
+
+## 1. Problem statement
+
+A Fiat run takes over the checkout it starts in. The contract has the model cut the run branch with `git checkout -b` and every step branch the same way, so `HEAD` moves under whoever is standing in that directory, repeatedly, for the length of the run. Preflight then refuses to start when the tree is dirty, which is correct in itself and means an operator holding uncommitted work cannot start a run at all.
+
+Fiat already knows the answer and only says so after the collision. The word `worktree` appears in the controller exactly once, at `plugins/hexaemeron/skills/fiat/scripts/hexctl.py:507`, inside the refusal printed when the kernel lock is already held: it advises `git worktree add ../<name> main` and to run there instead. `SKILL.md:80` repeats that advice. Advice at the point of collision is not a run that cannot collide.
+
+Build the isolation instead. `hexctl init` creates a dedicated worktree for the run before preflight work touches any branch, cuts the run branch in it, puts the run's state there, and refuses by name when it cannot. The operator's checkout is never checked out, never branched, and never left on a branch the run created.
+
+Proved by this demo path, from a repository whose own tree is deliberately dirty:
+
+```bash
+cd <repo> && echo scratch > dirty-file.txt          # the operator's uncommitted work
+python3 plugins/hexaemeron/skills/fiat/scripts/hexctl.py --dir . \
+  init --topic "worktree demo" --base main
+git rev-parse --abbrev-ref HEAD                      # unchanged: still the operator's branch
+git status --short                                   # still shows only dirty-file.txt
+git worktree list --porcelain                        # names tmp/fiat/fiat-worktree-demo
+python3 plugins/hexaemeron/skills/fiat/scripts/hexctl.py \
+  --dir tmp/fiat/fiat-worktree-demo status
+```
+
+Exit 0 with the operator's `HEAD` and `git status` unchanged, the run branch checked out only in the new tree, and `status` answering from that tree, is what a working prototype means here. A second demonstration refuses: a directory that is not a Git repository produces one named refusal and creates no state.
+
+## 2. Prior art
+
+**The observation.** [skills#439](https://github.com/wildcat-finance/skills/issues/439) is the source, and it carries two costs from one session. A clone sitting on `codex/issue-19-general-github-resolver` had a run fast-forward that branch to `origin/main`, commit onto it, and report the commit as being on `main`; `git push origin main` then failed non-fast-forward because local `main` was a stale ref the run had never touched. The commit was correct and the report was wrong. Separately, two agents worked this repository in the same period; one happened to be in a worktree, so `main` moved 29 commits under it and the reconcile was an ordinary merge, where two agents in one checkout would have fought over `HEAD` and the index.
+
+**The sibling that already does this.** Elenchus creates and removes worktrees today: `plugins/hexaemeron/skills/elenchus/scripts/elenchus.py:299` runs `git worktree add --quiet --detach`, and `:361` removes it with `git worktree remove --force`. Its report path is held to the worktree at `:197` and `:254`, and `plugins/hexaemeron/tests/test_elenchus_checker.py:436` and `:460` capture `git worktree list --porcelain` before and after a check and assert the two are equal. That is the create, bound, remove, and prove-you-cleaned-up shape this study copies rather than invents.
+
+**The path machinery to reuse.** Horos resolves and bounds worktree paths at `plugins/horos/skills/horos/scripts/horos.py:859`, and refuses with `leaves the worktree at ...` at `:901` and `:905`. Its audit round S4-R1-01 in `audit/AUDIT.md` is the reason the check has to be careful: an escape control that inspected only the given path refused a final-component symlink while allowing one mid-path, and because `git -C` resolves symlinks before answering, `check bridge/sub` reported a far repository as its own worktree. Any path this run accepts gets the same treatment.
+
+**Two facts that decide the location.** `plugins/horos/tests/test_universe.py:240` proves a nested worktree is invisible to a scan of the parent even when nothing ignores it, because git reports it as a single opaque directory, and `:253` asserts `.claude/worktrees` is not ignored in that fixture. So ignoring the home is not needed to keep a scan honest. It is still needed for a different reason: Fiat's own preflight refuses a dirty tree, and an unignored directory in the repository root would show as untracked and block the next run. [PR #460](https://github.com/wildcat-finance/skills/pull/460) already established the root-anchored ignored scratch root `/tmp/`, whose stated purpose is that nothing under it is a deliverable, and [PR #463](https://github.com/wildcat-finance/skills/pull/463) closed that PR's one deferred item by holding the Horos candidates pass to the boundary's universe, noting no extra handling is needed for `.claude/worktrees/`. Placing the run's tree under `tmp/fiat/` therefore needs no new ignore rule.
+
+**The advice in the contract is wrong as written.** `docs/hermes-rule-corpus-study.md:164` records a real run finding that "the local `main` is checked out in another worktree and cannot be fast-forwarded from here without disturbing it". Git refuses to check out a branch that is already checked out in another worktree, so `git worktree add ../<name> main`, the exact command at `hexctl.py:507`, fails in the ordinary case where the operator is standing on `main`. The fix creates the run branch in the new tree instead of borrowing the base.
+
+**Merged work read before the design options.** The last two merged pull requests touching Fiat are [PR #457](https://github.com/wildcat-finance/skills/pull/457), which corrected the git-backed update route in `references/plugin-currency.md` and carries no unfinished material, and [PR #445](https://github.com/wildcat-finance/skills/pull/445), which bound task issues to run and step branches and shipped `fiat-v5.10.1`. PR #445 carries a `## Carried forward` section naming two items: the held job for [skills#363](https://github.com/wildcat-finance/skills/issues/363) remains byte-identical and out of scope, and an upstream merge and closure of [skills#438](https://github.com/wildcat-finance/skills/issues/438) require a Wildcat maintainer. Both stay open here. This run does not touch the #363 job, and #438's maintainer action is not something a run can do for itself.
+
+**Audit records read.** Every Fiat round in `audit/AUDIT.md` was read: the installed-path proof, the delegation-packets family, state-shape validation, and task-issue branch names. No Fiat round mentions a worktree, so nothing accepted there governs this change, and every Fiat round's leads line says none. Four findings shape the work anyway. The delegation family's post-push merge incident cost a hard stop mid-run with the controller stuck in `integrate` and a whole out-of-band repair round that produced no forward transition, which is the cost profile of getting filesystem and branch identity wrong. Its integration sync closure records that rebasing would have rewritten 22 signed commits, so nothing here may rewrite a stack. State-shape validation's three rounds found nothing and established the standard this change is held to: a refusal is value-free, leaves state and ledger bytes identical, and `status`, `next`, `verify` and mutations share one diagnosis; its `legacy-state-rejection` check passed against all 11 archived runs, so existing `.hexaemeron/` state must keep resuming. Task-issue branch names contributes the refuse-before-state-creation discipline that a bad path must follow. The plugin-level `plugins/hexaemeron/audit/AUDIT.md` has no Fiat round; its Step 0 round 1 leaves one relevant lead unpursued, `os.replace` atomicity across filesystems if a user symlinks the state directory elsewhere, which is an argument for keeping the run's tree on the same filesystem as the repository.
+
+**External standard.** [git-worktree](https://git-scm.com/docs/git-worktree) supplies the semantics this leans on: one branch may be checked out in one worktree at a time, `add -b` creates a branch and its tree in one step, `list --porcelain` is the machine-readable inventory, and `remove` refuses a tree holding modifications unless forced.
+
+## 3. Constraints and non-goals
+
+- **Starting ref and versions.** `main` at `52b3b45c3d72cb2f163b1dfe88c920035d1385d5`, Fiat `fiat-v5.10.1`, frontier revision `state-shape-validation` with digest `e413d6041edb34b3807a54019489605814a591f60547755f8f66f01830f643aa`. Promise Machine `promise-machine/v1`.
+- **Toolchain.** Python 3.11 and the standard library. Git invoked through the existing bounded, fixed-argv, no-shell reader with its timeout and output cap. No new dependency, no network call.
+- **Scope.** One run, one worktree, one deterministic path derived from the run branch. The worktree stays on the same filesystem as the repository.
+- **Non-goals.** The kernel lock, which the issue puts out of scope and which stays as the guard for two writers sharing one state directory. Receipt shapes and ledger arithmetic, which do not change. The held #363 delegation-identity job. Concurrency beyond what isolation gives for free. Any change to `gh` verification, CI, or the audit and prose phases.
+- **Always.** Both suites before a commit, the Imprimatur lint on every shipped document, the Promise Machine check and coverage check, and a fresh Horos boundary scan before a commit.
+- **Ask first.** Adding a dependency. Touching CI. Changing a receipt shape or the state schema beyond the additive worktree fields. Widening what a path may point at. Removing the in-place path for callers who depend on it, which assumption 3 already flags as breaking.
+- **Never.** Delete or force-remove a tree holding uncommitted work. Follow a symlink out of the repository. Interpolate a caller value into a shell. Rewrite a signed stack. Claim a check ran when it did not.
+
+## 4. Design options
+
+**A. `init` creates the worktree, and the path is derived from the run branch (chosen).** `hexctl init` validates the target is a Git repository and computes `tmp/fiat/<run branch with slashes flattened>/`. It refuses if that path exists as anything other than this run's own tree. Otherwise it runs `git worktree add -b <run branch> <path> <base>` through the bounded reader, writes `.hexaemeron/` inside the new tree, and leaves a one-line breadcrumb in the operator's checkout naming it. Then it prints the exact directory to use. Cleanup happens at `integrate`: remove the tree when it is clean, keep it and say so when it is not. The trade is that `init` now mutates the filesystem beyond its own state directory and owns a failure path it did not have before, in exchange for isolation that a run cannot forget to arrange.
+
+**B. Contract text only.** Tell the model in `SKILL.md` to create a worktree before preflight. Cheapest to write and it changes no code. Rejected because it is the same shape as the defect: the current advice is also contract text, and it is both unenforced and, as `docs/hermes-rule-corpus-study.md:164` shows, wrong in the common case. A rule with no mechanism leaves no trace when it is skipped.
+
+**C. A separate `hexctl worktree` command run before `init`.** Composable, and it keeps `init` free of filesystem work. Rejected because a run can simply not call it, which puts us back at option B with more surface, and because responsibility for isolating the run would then be split across two commands, either of which can be run without the other.
+
+**D. An opt-in `--worktree` flag.** Smallest blast radius and no breaking change. Rejected because the default stays broken, and every incident in the issue happened on the default path. The fail-closed refusal in assumption 3 is the honest version of this choice: state the breaking change rather than hide behind a flag nobody sets.
+
+Option A is the least construction that makes the isolation a property of the run rather than a thing an operator remembers.
+
+The Promise Machine surface gains one promise:
+
+- `fiat-run-isolation`: a recorded worktree path, its validated containment inside the repository, and the `git worktree add` result authorise running the loop in that tree and nothing else. It does not establish that the operator's checkout was clean, that the run's work is correct, or that a tree removed at integrate held nothing of value.
+
+## 5. Risk register seed
+
+```risk-register
+path-escape | the computed worktree path and any caller-supplied override | the resolved path is a descendant of the repository worktree root, no component is a symlink leaving it, and refusal names the path without echoing its contents
+branch-already-checked-out | the base ref and the run branch across worktrees | the run branch is created in the new tree with add -b rather than borrowing the base, and an existing checkout of that branch refuses by name
+operator-head-mutation | the operator's checkout during init and every step | no command checks out, branches, or resets in the origin checkout, and a test captures HEAD and status before and after
+stale-tree-reuse | an existing directory at the computed path | a path that exists and is not this run's registered worktree refuses before any state is written
+uncommitted-work-loss | worktree removal at integrate | removal is never forced; a tree with modifications is kept, named, and reported rather than deleted
+resume-orphan | a resumed run looking for its tree | the breadcrumb in the origin checkout and git worktree list agree, and a missing tree refuses with the recorded path rather than silently starting a new one
+partial-write | state creation split across the origin checkout and the new tree | the worktree exists before any state byte is written, and a failed add leaves no state, no ledger, and no breadcrumb
+cross-filesystem-atomicity | os.replace over the state directory | the worktree is created under the repository root so state writes stay on one filesystem
+subprocess-control | argv passed to git worktree add and remove | fixed argv through the existing bounded no-shell reader with its timeout and output cap, and no caller value reaches a shell
+legacy-state-resume | .hexaemeron directories from earlier runs | an existing state directory in the origin checkout still resumes, and the archived-run fixtures keep passing
+dirty-origin-tree | preflight's refusal to start against uncommitted work | the dirty-tree check applies to the run's own tree, and a demonstration starts a run from a deliberately dirty checkout
+```
+
+Two things the block cannot carry. The first is that this change deliberately trades a smaller invariant for a larger one: `init` gains filesystem side effects, which is exactly the kind of widening the audit rounds are strict about, and the compensation is that every one of those effects is refusable before any state exists. The second is that removal at integrate is the only place work can be lost, so the rule is asymmetric on purpose: a clean tree goes, a dirty tree stays and gets named, and no flag in this change forces the other behaviour.
+
+## 6. Glossary seeds
+
+- `Origin checkout`: the repository directory the operator started the run from, which the run must leave untouched.
+- `Run worktree`: the dedicated Git worktree created for one run, holding the run branch, every step branch, and the run's state.
+- `Worktree home`: the ignored parent directory the run worktree is created under, `tmp/fiat/` at the repository root.
+- `Breadcrumb`: the single line in the origin checkout naming the run worktree, so a resume can find it without being told.
+- `Flattened run branch`: the run branch name with path separators replaced, used as the worktree directory name so one run maps to one path.
+- `Clean removal`: worktree removal that git accepts without force, meaning nothing uncommitted was discarded.
+
+## 7. Sources
+
+- [skills#439](https://github.com/wildcat-finance/skills/issues/439), the observation and its two recorded costs.
+- `plugins/hexaemeron/skills/fiat/scripts/hexctl.py` at `:341`, `:426`, `:507`, `:645`, `:690`; `plugins/hexaemeron/skills/fiat/SKILL.md` at `:80` and its base-sync section.
+- `plugins/hexaemeron/skills/elenchus/scripts/elenchus.py` at `:197`, `:254`, `:299`, `:361`; `plugins/hexaemeron/tests/test_elenchus_checker.py` at `:436` and `:460`.
+- `plugins/horos/skills/horos/scripts/horos.py` at `:859`, `:901`, `:905`; `plugins/horos/tests/test_universe.py` at `:240` and `:253`.
+- `audit/AUDIT.md`: every Fiat round, plus the Horos rounds S3-R1-01 and S4-R1-01; `plugins/hexaemeron/audit/AUDIT.md` Step 0 round 1 for the atomicity lead.
+- `docs/hermes-rule-corpus-study.md:164`; `tests/test_marketplace_prose.py:251`.
+- [PR #445](https://github.com/wildcat-finance/skills/pull/445), [PR #457](https://github.com/wildcat-finance/skills/pull/457), [PR #460](https://github.com/wildcat-finance/skills/pull/460), [PR #463](https://github.com/wildcat-finance/skills/pull/463).
+- [git-worktree documentation](https://git-scm.com/docs/git-worktree).
+
+## 8. Signals, and the questions behind them
+
+`hexctl` runs unattended in a loop, so [ephoros](../plugins/hexaemeron/skills/ephoros/SKILL.md) applies. Four questions someone will ask at three in the morning:
+
+1. **Where is this run actually working?** `init` prints the worktree path, `status` reports it, and the state records it, so nobody has to infer it from a prompt.
+2. **Why did the run refuse to start?** Each failure class emits one stable, value-free line naming the path and the fault: not a repository, path occupied, branch already checked out, add failed.
+3. **Did the run touch my checkout?** The origin checkout keeps its branch and its `HEAD`, and the breadcrumb is the only file the run writes there. A test asserts both.
+4. **What happened to the tree at the end?** The integrate receipt records whether the worktree was removed cleanly or kept because it held modifications, and names it either way.
+
+No dashboard and no new telemetry ships here. The refusal lines, the recorded path, and the integrate outcome are the signals.
+
+## 9. Boundaries, per capability
+
+[phylax](../plugins/hexaemeron/skills/phylax/SKILL.md) owns the boundary list and the controls.
+
+- **Path computation and validation.** The one new untrusted surface. The run branch is already name-checked, and the derived path is resolved, required to be a descendant of the repository worktree root, and refused if any component is a symlink leaving it, following the Horos S4-R1-01 finding that `git -C` resolves symlinks before answering.
+- **Worktree creation and removal.** Two new git invocations, both fixed argv through the existing bounded no-shell reader with its timeout and output cap. No caller value is interpolated into a shell, and no output path is exported into a child environment.
+- **State placement.** State moves to the run's tree, staying on the same filesystem as the repository so the existing atomic-replace behaviour is unchanged. The self-ignoring nested `.gitignore` the controller already writes keeps git blind to it.
+- **The origin checkout.** Write access is narrowed to one breadcrumb line. Nothing in this change checks out, branches, resets, or stages anything there.
+- **Cleanup.** Removal never forces. A tree with modifications is reported and left, so the worst outcome is a directory somebody has to look at rather than uncommitted work that vanished.
+
+## 10. The budget, or its absence
+
+None, and here is why. The change adds one `git worktree add` at `init` and at most one `git worktree remove` at `integrate`, both bounded by the existing reader's timeout, and neither sits in a loop or scales with repository size. [metron](../plugins/hexaemeron/skills/metron/SKILL.md) governs performance claims and this change makes none. Nothing here is done in the name of speed, so there is no before and after to record.
+
+## 11. The fail-closed posture
+
+[elenchus](../plugins/hexaemeron/skills/elenchus/SKILL.md) owns the triage order and the guard rule. `init` stops before writing any state, ledger entry, or breadcrumb when: the target is not a Git repository; the computed path exists and is not this run's registered worktree; the resolved path is not a descendant of the repository worktree root, or a component symlink leaves it; the run branch is already checked out in another worktree; or `git worktree add` fails for any reason. A resume stops when the recorded worktree is absent, naming the recorded path rather than silently creating a second tree. Integrate stops short of removal when the tree holds modifications, and says so.
+
+Every one of those classes gets a named negative test, observed failing before its guard lands. Refusals stay value-free and leave state and ledger bytes identical, which is the standard the state-shape rounds already set. Recovery names the exact path or branch to clear and reruns the same command.
+
+## 12. Decisions and their homes
+
+[hypomnema](../plugins/hexaemeron/skills/hypomnema/SKILL.md) owns which decisions earn a record and where each lives.
+
+- The worktree home and the fail-closed refusal, including the breaking change for in-place runs, is a cross-cutting choice: `docs/decisions/ADR-fiat-run-worktree.md`.
+- The Fiat generation row recording this change belongs in `plugins/hexaemeron/skills/fiat/skills`-adjacent ledger at `plugins/hexaemeron/skills/fiat/EVOLUTION.md`, one row, generation axis, retaining `state-shape-validation` and its digest, with the held #363 job unchanged.
+
+The state schema addition and the breadcrumb format are documented in `SKILL.md` beside the controller invocation, which is where a reader already looks for `--dir`. No second home.
+
+### Provenance and baseline -- 2026-08-22
+
+**Where this specification came from.** It was written earlier the same day and then backed out. That run reached the end of step 1: the study and runbook below, two audit rounds with one low finding fixed and the second clean, and a voice pass, over four signed commits on [PR #465](https://github.com/wildcat-finance/skills/pull/465). What stopped it was not the change. `hexctl done push` resolves repository identity with `gh repo view --json nameWithOwner`, and that session's proxy answered GraphQL with 403, so the push receipt could not be written. The branches were deleted and the pull request closed.
+
+The same call answers `wildcat-finance/skills` in this session, so the receipt that blocked the run is available. The four commits were recovered from `refs/pull/465/head`, which GitHub retains after a branch is deleted, and this run adopts them at the operator's direction rather than deriving the same conclusions a second time. Everything below is the recovered text, with the corrections named next.
+
+**The baseline this run measured.** All four suite commands were run on the run branch at `main` `52b3b45c3d72cb2f163b1dfe88c920035d1385d5` before any change:
+
+```text
+python3 plugins/hexaemeron/tests/run_tests.py      741/741 tests passed
+python3 -m unittest discover -s tests              113 tests, OK
+python3 scripts/promise_machine.py check           clean: 14 plugin(s), 14 copy/copies
+python3 scripts/promise_machine.py coverage --check clean: promises=67 coverage_rows=67 coverage_selected=67
+```
+
+Green at both ends therefore means green, with no carried exception. The recovered copy recorded two failures in `plugins/hexaemeron/tests/test_elenchus_checker.py`, where fixtures assert forge `1.7.1` and node `v26.6.0`. Both pass here, because this machine carries forge `1.7.1` and node `v26.6.0` and the earlier container carried `1.5.1` and `v22.22.2`. Those assertions describe the toolchain a run is executed on, not the repository, so the exception was a fact about one container and is not inherited. A later round that sees them fail should read its own toolchain before reading the test.
+
+**The other correction.** The Hexaemeron suite is invoked as `python3 plugins/hexaemeron/tests/run_tests.py`, the form `AGENTS.md:138` lists. The `unittest discover -s plugins/hexaemeron/tests` form fails with `Start directory is not importable`, because that directory carries no `__init__.py`, so it could not have proved any step's exit.
+
+**One thing the recovered text could not know.** This run is itself being conducted in a dedicated worktree, created by hand before the controller was initialised, with the run's state inside it and the operator's checkout left on `main` holding untracked work of its own. That is the behaviour the change below makes automatic. It is not evidence that the design is right, but it does mean the demo path in section 1 describes something this run is already standing in.


### PR DESCRIPTION
A Fiat run takes over the checkout it starts in. It cuts the run branch and every step branch with `git checkout -b`, so `HEAD` moves under whoever is standing there, repeatedly, for the length of the run. Preflight then refuses a dirty tree, which is right in itself and means an operator holding uncommitted work cannot start a run at all.

Fiat already knows the answer and only says so after the collision. The word `worktree` appears in the controller exactly once, at `hexctl.py:507`, inside the refusal printed when the kernel lock is already held. That is advice at the point of impact, not a run that could not collide.

This step ships the study and runbook for [skills#439](https://github.com/wildcat-finance/skills/issues/439) and nothing else. No behaviour changes here. Later steps get a committed yardstick instead of an artefact only the run can read.

The study picks option A. `init` creates the run's worktree at a path derived from the run branch, puts the run's state in it, leaves one breadcrumb in the operator's checkout, and refuses by name when it cannot. Contract text alone was rejected for a specific reason: the current advice is also contract text, and it is wrong in the ordinary case. `git worktree add ../<name> main` fails whenever the base is already checked out, which `docs/hermes-rule-corpus-study.md:164` records happening to a real run.

## Where this came from

This specification was written earlier today and backed out. That run reached the same point, then stopped at one receipt: `hexctl done push` resolves repository identity with `gh repo view --json nameWithOwner`, and that session's proxy answered GraphQL with 403. The closing note called it an environment limit rather than a defect in the change, and it was.

That call works here, so the four commits were recovered from `refs/pull/465/head` and adopted rather than rewritten. Three things changed on the way back in.

The starting ref is this run's base. The earlier copy recorded two failing fixtures in `plugins/hexaemeron/tests/test_elenchus_checker.py`, which assert forge `1.7.1` and node `v26.6.0`; both pass on this machine, because it carries those versions and the earlier container carried `1.5.1` and `v22.22.2`. That exception describes a container, not the repository, so it is not inherited and the suite baseline is recorded as measured instead. The earlier copy also cited the Hexaemeron suite command at `AGENTS.md:132`, which is the root suite; the Hexaemeron one is at `:138`.

## Audit

One round, in `audit/AUDIT.md` under "Fiat run worktree, step 1". No findings, so there is no stacked fix branch; the audit log is committed on this branch. Phylax, Ephoros and Hypomnema each exit 0 on both documents.

The earlier run's round 1 found one low finding, an absolute path under a container's home directory in a block this version does not carry. That block was dropped rather than repaired, which is why round 1 here is clean rather than round 2.

One lead, unchanged from the earlier run. Hypomnema over `audit/AUDIT.md` exits 1 on two H003 alerts at lines 6119 and 6269, both inside rounds written weeks ago. Both quote fixture pointers, `runbooks/missing#book.md` and `runbooks/present.md`, as examples of the very defect the finding describes, so H003 is firing on prose about a test of H003. The file is append-only by contract, so those lines cannot be repaired in place.

## How to check it

```bash
python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/fiat-run-worktree-study.md
python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/fiat-run-worktree-runbook.md
python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/fiat-run-worktree-study.md docs/fiat-run-worktree-runbook.md
python3 plugins/hexaemeron/tests/run_tests.py
python3 -m unittest discover -s tests
python3 scripts/promise_machine.py check
python3 scripts/promise_machine.py coverage --check
```

All green on this branch: 741/741, 113 OK, and both Promise Machine checks clean.

## One divergence to know about

The committed study is three passages ahead of the receipted `.hexaemeron/study.md`, because the voice pass ran after the artefact was receipted and `hexctl` refuses every later directive once a receipted artefact's digest moves. Content is identical; only sentence shapes differ. The committed copy is the live spec and the frozen artefact is the record of what the run believed at receipt time. That split is the friction [skills#446](https://github.com/wildcat-finance/skills/issues/446) already reports.

Stacks on the run branch.

<!-- wildcat-origin: shoggoth -->
