### PR TITLE
Derive and validate the run worktree path

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8127,3 +8127,34 @@ Phylax, Ephoros and Hypomnema each exit 0 on both documents.
 No findings.
 
 Leads not pursued: none.
+
+## Fiat run worktree, step 2, round 1 -- 2026-08-22
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| FRW-S2-R1-01 | medium | `plugins/hexaemeron/skills/fiat/scripts/hexctl.py` | `check_worktree_path` read occupancy off the resolved path. A dangling symlink at the derived path resolves to something that does not exist, so the check saw a free path, accepted it, and returned the link's target rather than the path it was asked about. Step 3 would then create the run's tree at a location the deriver never chose, with the state and breadcrumb naming a different path, and the link left in place. Contained inside the repository root, so it redirects rather than escapes. | fixed in the same commit as this entry, guarded by `test_a_dangling_symlink_at_the_derived_path_refuses` and `test_a_symlink_to_a_real_directory_inside_the_repository_refuses` |
+
+Reviewed against the eleven risk-register entries. Two are exercised by this
+step. `path-escape` is the whole subject of the change and drew the finding
+above; the escape controls themselves hold. `subprocess-control` holds: the one
+git invocation is `rev-parse --show-toplevel` through the existing bounded
+fixed-argv reader, with no caller value reaching a shell. The other nine belong
+to steps that write something, and this step writes nothing.
+
+The finding was found by probing rather than by a lint. Both the escape checks
+and the live-symlink case behaved correctly; the dangling case was the one
+combination where occupancy and resolution disagree. Occupancy is now read off
+the supplied path with `lexists`, and a link at the derived path is refused
+whether it dangles or not, because the run's tree is a real directory there or
+it is nothing.
+
+Phylax, Ephoros and Hypomnema each exit 0 on both changed files.
+
+1 finding, fixed. Suites after the fix: 759/759, 113 OK, both Promise Machine
+checks clean.
+
+Leads not pursued: one. There is a gap between validating a path and creating
+something at it, so a path free at the check can be occupied by the time step 3
+runs. `git worktree add` refuses a path that exists, so the race closes into a
+refusal rather than a wrong tree, and closing it earlier would mean holding a
+lock over a directory that does not exist yet.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8158,3 +8158,23 @@ something at it, so a path free at the check can be occupied by the time step 3
 runs. `git worktree add` refuses a path that exists, so the race closes into a
 refusal rather than a wrong tree, and closing it earlier would mean holding a
 lock over a directory that does not exist yet.
+
+## Fiat run worktree, step 2, round 2 -- 2026-08-22
+
+Re-reviewed the fixed tree. FRW-S2-R1-01 is closed: a dangling link, a live link
+to a real directory inside the repository, and a link leaving the repository are
+each refused, the first two naming the link and the third naming the crossing,
+and a free derived path is still accepted and returned unchanged. Both guards
+fail against the pre-fix validator and pass against this one.
+
+The same eleven risk-register entries were read again. `path-escape` and
+`subprocess-control` hold; the remaining nine are still not exercised by a step
+that writes nothing.
+
+Phylax, Ephoros and Hypomnema each exit 0. Suites: 759/759, 113 OK, both Promise
+Machine checks clean.
+
+No new findings.
+
+Leads not pursued: the check-to-create race recorded in round 1 is unchanged and
+belongs to step 3, where `git worktree add` turns it into a refusal.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8099,3 +8099,31 @@ required-text and forbidden-name assertions pass. The controller verifies its
 No new findings.
 
 Leads not pursued: none.
+
+## Fiat run worktree, step 1, round 1 -- 2026-08-22
+
+Reviewed the committed specification against all eleven risk-register entries.
+The step ships two documents and no executable path, so nine of the eleven are
+not exercised by anything here and are carried to the steps that build them.
+The two a document step can still get wrong were checked directly.
+
+`docs/fiat-run-worktree-study.md` and `docs/fiat-run-worktree-runbook.md` are
+byte-identical to the receipted artefacts, so the committed yardstick and the
+frozen run record agree. Neither document carries an absolute path under a home
+or root directory, which is the finding the earlier backed-out copy of this
+step recorded and fixed; the block that carried it is not present in this
+version. All five relative links resolve from `docs/`. The cited suite command
+at `AGENTS.md:138` is the line the study claims it is.
+
+The two inherited claims were re-measured rather than accepted. The four suite
+commands are green on this run's base with no exception: 741/741, 113 OK, and
+both Promise Machine checks clean. The earlier copy's two pinned-toolchain
+failures do not reproduce, because this machine carries the forge and node
+versions those fixtures assert; that is recorded in the study as a fact about a
+container rather than the repository.
+
+Phylax, Ephoros and Hypomnema each exit 0 on both documents.
+
+No findings.
+
+Leads not pursued: none.

--- a/docs/fiat-run-worktree-runbook.md
+++ b/docs/fiat-run-worktree-runbook.md
@@ -1,0 +1,57 @@
+# Runbook: a dedicated run worktree, created before preflight
+
+Derived from the committed study. The chosen design is option A: `init` creates the run's worktree at a path derived from the run branch, puts the run's state in it, leaves one breadcrumb in the operator's checkout, and refuses by name when it cannot. Five steps, dependency order, one pull request each, every step green at both ends.
+
+Every step's suite commands, run from the repository root with Foundry's bin directory on `PATH`. All four are green on this run's base commit, with no carried exception; the study records the measured baseline and why the recovered copy named two failures this machine does not reproduce:
+
+```bash
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 -m unittest discover -s tests
+python3 scripts/promise_machine.py check
+python3 scripts/promise_machine.py coverage --check
+```
+
+## Step 1: Commit the specification
+
+**Goal.** Land the study and runbook in the repository so every later step has a committed yardstick.
+**Entry.** The run branch `fiat/439-run-fiat-in-a-dedicated-worktree-created-bef` at `main` `52b3b45c3d72cb2f163b1dfe88c920035d1385d5`, with the study receipted.
+**Exit.** `docs/fiat-run-worktree-study.md` and `docs/fiat-run-worktree-runbook.md` exist and match the receipted artefacts; `python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/fiat-run-worktree-study.md` and `python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/fiat-run-worktree-runbook.md` both exit 0; `python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py` reports zero defects on both; all four suite commands exit 0.
+**Files.** `docs/fiat-run-worktree-study.md`, `docs/fiat-run-worktree-runbook.md`.
+**Tests.** None new. The four suite commands run unchanged as the both-ends-green check.
+**Disciplines.** phylax: none, this step adds no boundary and no executable path. ephoros: none, documents emit no signal. metron: none, no performance claim. elenchus: none, no failure in hand. hypomnema: none, the decisions this run records land with their content in steps 3 and 5.
+
+## Step 2: Derive and validate the worktree path
+
+**Goal.** Turn a run branch into one refusable path, with no filesystem mutation and no state change.
+**Entry.** Step 1's green exit.
+**Exit.** `hexctl` holds a path deriver that flattens the run branch's separators and places it under `tmp/fiat/`, plus a validator that resolves the candidate, requires it to be a descendant of the repository worktree root, refuses when any component is a symlink leaving that root, and refuses a path that already exists as anything other than this run's registered worktree; every refusal is one value-free line naming the path, exits non-zero, and writes nothing; `python3 -m unittest plugins.hexaemeron.tests.test_hexctl -k Worktree` passes; all four suite commands exit 0.
+**Files.** `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`, `plugins/hexaemeron/tests/test_hexctl.py`.
+**Tests.** Positive: a plain run branch derives the expected path, and an issue-backed branch keeps its leading number. Negative, each observed failing before its guard: a target that is not a Git repository, a computed path that already exists as a file, a path that already exists as an unrelated directory, a component symlink pointing outside the repository root, a path escaping the root by `..`, and a refusal leaving no state, no ledger and no breadcrumb. Expected minimum: 10 new cases.
+**Disciplines.** phylax: this step opens the path-validation boundary, closed by canonical descendant checks, symlink refusal following the Horos S4-R1-01 finding, and no shell interpolation. ephoros: the stable refusal lines are what a three in the morning reader gets, so they land here with their exact wording. metron: none, one path computation makes no performance claim. elenchus: every refusal class is captured red before its guard. hypomnema: none, the path choice is recorded with the creation behaviour in step 3.
+
+## Step 3: Create the worktree at init and put the run's state in it
+
+**Goal.** Make isolation a property of `init`, so no run can forget to arrange it.
+**Entry.** Step 2's deriver and validator, green.
+**Exit.** `hexctl init` validates the path, runs `git worktree add -b <run branch> <path> <base>` through the existing bounded fixed-argv reader, writes `.hexaemeron/` inside the new tree, writes one breadcrumb line at `.hexaemeron/worktree` in the origin checkout, prints the exact `--dir` to use next, and refuses before writing any state when the branch is already checked out elsewhere or `git worktree add` fails; a run started from a deliberately dirty origin checkout succeeds; the origin checkout's `HEAD` and `git status --short` are identical before and after; `python3 -m unittest plugins.hexaemeron.tests.test_hexctl -k Worktree` passes; all four suite commands exit 0.
+**Files.** `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`, `plugins/hexaemeron/tests/test_hexctl.py`, `docs/decisions/ADR-fiat-run-worktree.md`.
+**Tests.** Positive: `init` creates the tree and the run branch, state lands in the tree, the breadcrumb names it, `git worktree list --porcelain` shows exactly one new entry, and a dirty origin checkout still starts. Negative, each observed failing first: the run branch already checked out in another worktree, `git worktree add` failing, and a failed creation leaving no state, no ledger, no breadcrumb and no directory. Invariant: origin `HEAD` and `git status --short` unchanged across a successful `init`. Expected minimum: 12 new cases.
+**Disciplines.** phylax: this step opens filesystem creation and two git invocations, closed by fixed argv with no shell, the step 2 validator ahead of any mutation, and write access in the origin checkout narrowed to one breadcrumb line. ephoros: `init` prints the worktree path and `status` reports it, which answers where the run is working. metron: none, one `git worktree add` outside any loop. elenchus: creation and refusal faults are guarded red to green, and a refusal leaves state and ledger bytes identical. hypomnema: the ADR lands here, recording the worktree home, the fail-closed refusal, and the breaking change for in-place runs, because that choice becomes real in this step.
+
+## Step 4: Resume into the recorded worktree, and clean up at integrate
+
+**Goal.** Let a resumed run find its tree, and let a finished run put the tree away without ever discarding uncommitted work.
+**Entry.** Step 3's creation path and breadcrumb, green.
+**Exit.** A `status` or `next` run in the origin checkout that finds a breadcrumb and no state prints the recorded worktree path and the exact `--dir` to use, exits non-zero, and changes nothing; a resume whose recorded worktree is absent refuses naming that path rather than creating a second tree; `done integrate` removes the worktree without force when it is clean and records that, keeps it and records it as kept when it holds modifications, and never forces; existing `.hexaemeron/` state in an origin checkout still resumes, and the archived-run fixtures still pass; `python3 -m unittest plugins.hexaemeron.tests.test_hexctl -k "Worktree or Resume"` passes; all four suite commands exit 0.
+**Files.** `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`, `plugins/hexaemeron/tests/test_hexctl.py`.
+**Tests.** Positive: breadcrumb resolution prints the path and the `--dir` form; a clean tree is removed at integrate and the receipt records the removal; a tree holding a modified file is kept and the receipt records it as kept. Negative, observed failing first: a recorded worktree that has been deleted, a breadcrumb naming a path outside the repository root, and an integrate that would need force. Regression: a legacy state directory in the origin checkout resumes unchanged, and the archived runs keep verifying. Expected minimum: 10 new cases.
+**Disciplines.** phylax: resume reads an on-disk path written earlier, so the step 2 validator runs on it again rather than trusting it. ephoros: the integrate receipt names the cleanup outcome, which answers what happened to the tree. metron: none, no performance claim. elenchus: absent-tree and force-needed cases are guarded red to green. hypomnema: none, this step implements the behaviour the step 3 ADR already records.
+
+## Step 5: Correct the contract, record the ledger row, and run the demo
+
+**Goal.** Make the written contract match the built behaviour, replace the advice that cannot work, and prove the whole path from clean inputs.
+**Entry.** Step 4's complete behaviour, green.
+**Exit.** `SKILL.md` states that the run works in a dedicated worktree created before preflight, where it lives, that `--dir` points at it, the cleanup rule, and the fail-closed fallback; the kernel-lock refusal at `hexctl.py` no longer advises `git worktree add ../<name> main`, which fails when the base is already checked out, and names a command that works; `plugins/hexaemeron/skills/fiat/EVOLUTION.md` carries exactly one new generation row retaining `state-shape-validation` and its digest `e413d6041edb34b3807a54019489605814a591f60547755f8f66f01830f643aa`, with the held [skills#363](https://github.com/wildcat-finance/skills/issues/363) job byte-identical; the study's demo path runs from a dirty checkout and leaves the operator's `HEAD` and `git status` unchanged; the not-a-repository demonstration refuses and creates no state; `python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py` reports zero defects on every changed document; `python3 plugins/horos/skills/horos/scripts/horos.py check` exits 0; all four suite commands exit 0.
+**Files.** `plugins/hexaemeron/skills/fiat/SKILL.md`, `plugins/hexaemeron/skills/fiat/EVOLUTION.md`, `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`, `plugins/hexaemeron/tests/test_hexctl.py`, `plugins/hexaemeron/tests/test_fiat_skill.py`, `plugins/hexaemeron/README.md`, `.horos/boundary.json`.
+**Tests.** The contract test asserts `SKILL.md` states the worktree behaviour and no longer carries the unusable advice; a lock-refusal test asserts the new command text; the demo path runs as a test from a dirty fixture checkout; the ledger row is held by the existing `tests/test_evolution_contract.py`. Expected minimum: 6 new cases plus every earlier test.
+**Disciplines.** phylax: full boundary review over path validation, creation, resume and cleanup, with anything unresolved stated. ephoros: review the refusal lines and the recorded path and cleanup outcome from the demo run. metron: none, the change makes no speed claim and the demo measures nothing. elenchus: any failing demonstration is worked to its cause and guarded before the row is written. hypomnema: the ledger row records this generation and leaves the held frontier job untouched.

--- a/docs/fiat-run-worktree-study.md
+++ b/docs/fiat-run-worktree-study.md
@@ -159,9 +159,9 @@ The state schema addition and the breadcrumb format are documented in `SKILL.md`
 
 ### Provenance and baseline -- 2026-08-22
 
-**Where this specification came from.** It was written earlier the same day and then backed out. That run reached the end of step 1: the study and runbook below, two audit rounds with one low finding fixed and the second clean, and a voice pass, over four signed commits on [PR #465](https://github.com/wildcat-finance/skills/pull/465). What stopped it was not the change. `hexctl done push` resolves repository identity with `gh repo view --json nameWithOwner`, and that session's proxy answered GraphQL with 403, so the push receipt could not be written. The branches were deleted and the pull request closed.
+**Where this specification came from.** It was written earlier the same day and then backed out. That run reached the end of step 1 over four signed commits on [PR #465](https://github.com/wildcat-finance/skills/pull/465). It shipped the study and runbook below, ran two audit rounds, fixed the one low finding the first raised, and took a voice pass over both documents. What stopped it was not the change. `hexctl done push` resolves repository identity with `gh repo view --json nameWithOwner`, and that session's proxy answered GraphQL with 403, so the push receipt could not be written. The branches were deleted and the pull request closed.
 
-The same call answers `wildcat-finance/skills` in this session, so the receipt that blocked the run is available. The four commits were recovered from `refs/pull/465/head`, which GitHub retains after a branch is deleted, and this run adopts them at the operator's direction rather than deriving the same conclusions a second time. Everything below is the recovered text, with the corrections named next.
+The same call answers `wildcat-finance/skills` in this session, so the receipt that blocked the run is available. GitHub retains a closed pull request's commits after its branch is deleted, so the four were recovered from `refs/pull/465/head`. This run adopts them at the operator's direction rather than deriving the same conclusions twice. Everything below is the recovered text, with the corrections named next.
 
 **The baseline this run measured.** All four suite commands were run on the run branch at `main` `52b3b45c3d72cb2f163b1dfe88c920035d1385d5` before any change:
 
@@ -172,7 +172,7 @@ python3 scripts/promise_machine.py check           clean: 14 plugin(s), 14 copy/
 python3 scripts/promise_machine.py coverage --check clean: promises=67 coverage_rows=67 coverage_selected=67
 ```
 
-Green at both ends therefore means green, with no carried exception. The recovered copy recorded two failures in `plugins/hexaemeron/tests/test_elenchus_checker.py`, where fixtures assert forge `1.7.1` and node `v26.6.0`. Both pass here, because this machine carries forge `1.7.1` and node `v26.6.0` and the earlier container carried `1.5.1` and `v22.22.2`. Those assertions describe the toolchain a run is executed on, not the repository, so the exception was a fact about one container and is not inherited. A later round that sees them fail should read its own toolchain before reading the test.
+Green at both ends therefore means green, with no carried exception. The recovered copy recorded two failures in `plugins/hexaemeron/tests/test_elenchus_checker.py`, where fixtures assert forge `1.7.1` and node `v26.6.0`. Both pass here, because this machine carries forge `1.7.1` and node `v26.6.0` and the earlier container carried `1.5.1` and `v22.22.2`. Those assertions describe the toolchain a run executes on, not the repository. The exception was a fact about one container, so it is not inherited. A later round that sees them fail should read its own toolchain before reading the test.
 
 **The other correction.** The Hexaemeron suite is invoked as `python3 plugins/hexaemeron/tests/run_tests.py`, the form `AGENTS.md:138` lists. The `unittest discover -s plugins/hexaemeron/tests` form fails with `Start directory is not importable`, because that directory carries no `__init__.py`, so it could not have proved any step's exit.
 

--- a/docs/fiat-run-worktree-study.md
+++ b/docs/fiat-run-worktree-study.md
@@ -1,0 +1,179 @@
+# Study: a dedicated run worktree, created before preflight
+
+Assuming, unless corrected:
+
+1. Python 3.11 and the standard library, matching every other script in this repository. No new dependency.
+2. The run's tree lives inside the repository under the already-ignored scratch root, at `tmp/fiat/<run branch>/`. A sibling directory outside the repository was offered and declined when this specification was first written, so it is recorded as rejected rather than left as an option.
+3. Fail-closed is the chosen fallback. A target that is not a Git repository, or where `git worktree add` fails, refuses the run rather than continuing in place. This is a breaking change for anyone relying on an in-place run and is stated as one.
+4. `.hexaemeron/` moves into the run's worktree, so `--dir` points at the worktree for the whole run. The operator's checkout keeps one breadcrumb naming the run's tree, so a resume can find it without being told.
+5. The kernel lock stays exactly as it is. Worktrees make collision rarer; they do not remove the need for the guard when two writers share one state directory.
+6. The held frontier job at [skills#363](https://github.com/wildcat-finance/skills/issues/363) is untouched, and this run's ledger row is a generation row retaining `state-shape-validation` and its digest.
+7. This run began from `main` at `52b3b45c3d72cb2f163b1dfe88c920035d1385d5`, with Fiat at `fiat-v5.10.1`.
+
+I will proceed on these assumptions unless corrected.
+
+## 1. Problem statement
+
+A Fiat run takes over the checkout it starts in. The contract has the model cut the run branch with `git checkout -b` and every step branch the same way, so `HEAD` moves under whoever is standing in that directory, repeatedly, for the length of the run. Preflight then refuses to start when the tree is dirty, which is correct in itself and means an operator holding uncommitted work cannot start a run at all.
+
+Fiat already knows the answer and only says so after the collision. The word `worktree` appears in the controller exactly once, at `plugins/hexaemeron/skills/fiat/scripts/hexctl.py:507`, inside the refusal printed when the kernel lock is already held: it advises `git worktree add ../<name> main` and to run there instead. `SKILL.md:80` repeats that advice. Advice at the point of collision is not a run that cannot collide.
+
+Build the isolation instead. `hexctl init` creates a dedicated worktree for the run before preflight work touches any branch, cuts the run branch in it, puts the run's state there, and refuses by name when it cannot. The operator's checkout is never checked out, never branched, and never left on a branch the run created.
+
+Proved by this demo path, from a repository whose own tree is deliberately dirty:
+
+```bash
+cd <repo> && echo scratch > dirty-file.txt          # the operator's uncommitted work
+python3 plugins/hexaemeron/skills/fiat/scripts/hexctl.py --dir . \
+  init --topic "worktree demo" --base main
+git rev-parse --abbrev-ref HEAD                      # unchanged: still the operator's branch
+git status --short                                   # still shows only dirty-file.txt
+git worktree list --porcelain                        # names tmp/fiat/fiat-worktree-demo
+python3 plugins/hexaemeron/skills/fiat/scripts/hexctl.py \
+  --dir tmp/fiat/fiat-worktree-demo status
+```
+
+Exit 0 with the operator's `HEAD` and `git status` unchanged, the run branch checked out only in the new tree, and `status` answering from that tree, is what a working prototype means here. A second demonstration refuses: a directory that is not a Git repository produces one named refusal and creates no state.
+
+## 2. Prior art
+
+**The observation.** [skills#439](https://github.com/wildcat-finance/skills/issues/439) is the source, and it carries two costs from one session. A clone sitting on `codex/issue-19-general-github-resolver` had a run fast-forward that branch to `origin/main`, commit onto it, and report the commit as being on `main`; `git push origin main` then failed non-fast-forward because local `main` was a stale ref the run had never touched. The commit was correct and the report was wrong. Separately, two agents worked this repository in the same period; one happened to be in a worktree, so `main` moved 29 commits under it and the reconcile was an ordinary merge, where two agents in one checkout would have fought over `HEAD` and the index.
+
+**The sibling that already does this.** Elenchus creates and removes worktrees today: `plugins/hexaemeron/skills/elenchus/scripts/elenchus.py:299` runs `git worktree add --quiet --detach`, and `:361` removes it with `git worktree remove --force`. Its report path is held to the worktree at `:197` and `:254`, and `plugins/hexaemeron/tests/test_elenchus_checker.py:436` and `:460` capture `git worktree list --porcelain` before and after a check and assert the two are equal. That is the create, bound, remove, and prove-you-cleaned-up shape this study copies rather than invents.
+
+**The path machinery to reuse.** Horos resolves and bounds worktree paths at `plugins/horos/skills/horos/scripts/horos.py:859`, and refuses with `leaves the worktree at ...` at `:901` and `:905`. Its audit round S4-R1-01 in `audit/AUDIT.md` is the reason the check has to be careful: an escape control that inspected only the given path refused a final-component symlink while allowing one mid-path, and because `git -C` resolves symlinks before answering, `check bridge/sub` reported a far repository as its own worktree. Any path this run accepts gets the same treatment.
+
+**Two facts that decide the location.** `plugins/horos/tests/test_universe.py:240` proves a nested worktree is invisible to a scan of the parent even when nothing ignores it, because git reports it as a single opaque directory, and `:253` asserts `.claude/worktrees` is not ignored in that fixture. So ignoring the home is not needed to keep a scan honest. It is still needed for a different reason: Fiat's own preflight refuses a dirty tree, and an unignored directory in the repository root would show as untracked and block the next run. [PR #460](https://github.com/wildcat-finance/skills/pull/460) already established the root-anchored ignored scratch root `/tmp/`, whose stated purpose is that nothing under it is a deliverable, and [PR #463](https://github.com/wildcat-finance/skills/pull/463) closed that PR's one deferred item by holding the Horos candidates pass to the boundary's universe, noting no extra handling is needed for `.claude/worktrees/`. Placing the run's tree under `tmp/fiat/` therefore needs no new ignore rule.
+
+**The advice in the contract is wrong as written.** `docs/hermes-rule-corpus-study.md:164` records a real run finding that "the local `main` is checked out in another worktree and cannot be fast-forwarded from here without disturbing it". Git refuses to check out a branch that is already checked out in another worktree, so `git worktree add ../<name> main`, the exact command at `hexctl.py:507`, fails in the ordinary case where the operator is standing on `main`. The fix creates the run branch in the new tree instead of borrowing the base.
+
+**Merged work read before the design options.** The last two merged pull requests touching Fiat are [PR #457](https://github.com/wildcat-finance/skills/pull/457), which corrected the git-backed update route in `references/plugin-currency.md` and carries no unfinished material, and [PR #445](https://github.com/wildcat-finance/skills/pull/445), which bound task issues to run and step branches and shipped `fiat-v5.10.1`. PR #445 carries a `## Carried forward` section naming two items: the held job for [skills#363](https://github.com/wildcat-finance/skills/issues/363) remains byte-identical and out of scope, and an upstream merge and closure of [skills#438](https://github.com/wildcat-finance/skills/issues/438) require a Wildcat maintainer. Both stay open here. This run does not touch the #363 job, and #438's maintainer action is not something a run can do for itself.
+
+**Audit records read.** Every Fiat round in `audit/AUDIT.md` was read: the installed-path proof, the delegation-packets family, state-shape validation, and task-issue branch names. No Fiat round mentions a worktree, so nothing accepted there governs this change, and every Fiat round's leads line says none. Four findings shape the work anyway. The delegation family's post-push merge incident cost a hard stop mid-run with the controller stuck in `integrate` and a whole out-of-band repair round that produced no forward transition, which is the cost profile of getting filesystem and branch identity wrong. Its integration sync closure records that rebasing would have rewritten 22 signed commits, so nothing here may rewrite a stack. State-shape validation's three rounds found nothing and established the standard this change is held to: a refusal is value-free, leaves state and ledger bytes identical, and `status`, `next`, `verify` and mutations share one diagnosis; its `legacy-state-rejection` check passed against all 11 archived runs, so existing `.hexaemeron/` state must keep resuming. Task-issue branch names contributes the refuse-before-state-creation discipline that a bad path must follow. The plugin-level `plugins/hexaemeron/audit/AUDIT.md` has no Fiat round; its Step 0 round 1 leaves one relevant lead unpursued, `os.replace` atomicity across filesystems if a user symlinks the state directory elsewhere, which is an argument for keeping the run's tree on the same filesystem as the repository.
+
+**External standard.** [git-worktree](https://git-scm.com/docs/git-worktree) supplies the semantics this leans on: one branch may be checked out in one worktree at a time, `add -b` creates a branch and its tree in one step, `list --porcelain` is the machine-readable inventory, and `remove` refuses a tree holding modifications unless forced.
+
+## 3. Constraints and non-goals
+
+- **Starting ref and versions.** `main` at `52b3b45c3d72cb2f163b1dfe88c920035d1385d5`, Fiat `fiat-v5.10.1`, frontier revision `state-shape-validation` with digest `e413d6041edb34b3807a54019489605814a591f60547755f8f66f01830f643aa`. Promise Machine `promise-machine/v1`.
+- **Toolchain.** Python 3.11 and the standard library. Git invoked through the existing bounded, fixed-argv, no-shell reader with its timeout and output cap. No new dependency, no network call.
+- **Scope.** One run, one worktree, one deterministic path derived from the run branch. The worktree stays on the same filesystem as the repository.
+- **Non-goals.** The kernel lock, which the issue puts out of scope and which stays as the guard for two writers sharing one state directory. Receipt shapes and ledger arithmetic, which do not change. The held #363 delegation-identity job. Concurrency beyond what isolation gives for free. Any change to `gh` verification, CI, or the audit and prose phases.
+- **Always.** Both suites before a commit, the Imprimatur lint on every shipped document, the Promise Machine check and coverage check, and a fresh Horos boundary scan before a commit.
+- **Ask first.** Adding a dependency. Touching CI. Changing a receipt shape or the state schema beyond the additive worktree fields. Widening what a path may point at. Removing the in-place path for callers who depend on it, which assumption 3 already flags as breaking.
+- **Never.** Delete or force-remove a tree holding uncommitted work. Follow a symlink out of the repository. Interpolate a caller value into a shell. Rewrite a signed stack. Claim a check ran when it did not.
+
+## 4. Design options
+
+**A. `init` creates the worktree, and the path is derived from the run branch (chosen).** `hexctl init` validates the target is a Git repository and computes `tmp/fiat/<run branch with slashes flattened>/`. It refuses if that path exists as anything other than this run's own tree. Otherwise it runs `git worktree add -b <run branch> <path> <base>` through the bounded reader, writes `.hexaemeron/` inside the new tree, and leaves a one-line breadcrumb in the operator's checkout naming it. Then it prints the exact directory to use. Cleanup happens at `integrate`: remove the tree when it is clean, keep it and say so when it is not. The trade is that `init` now mutates the filesystem beyond its own state directory and owns a failure path it did not have before, in exchange for isolation that a run cannot forget to arrange.
+
+**B. Contract text only.** Tell the model in `SKILL.md` to create a worktree before preflight. Cheapest to write and it changes no code. Rejected because it is the same shape as the defect: the current advice is also contract text, and it is both unenforced and, as `docs/hermes-rule-corpus-study.md:164` shows, wrong in the common case. A rule with no mechanism leaves no trace when it is skipped.
+
+**C. A separate `hexctl worktree` command run before `init`.** Composable, and it keeps `init` free of filesystem work. Rejected because a run can simply not call it, which puts us back at option B with more surface, and because responsibility for isolating the run would then be split across two commands, either of which can be run without the other.
+
+**D. An opt-in `--worktree` flag.** Smallest blast radius and no breaking change. Rejected because the default stays broken, and every incident in the issue happened on the default path. The fail-closed refusal in assumption 3 is the honest version of this choice: state the breaking change rather than hide behind a flag nobody sets.
+
+Option A is the least construction that makes the isolation a property of the run rather than a thing an operator remembers.
+
+The Promise Machine surface gains one promise:
+
+- `fiat-run-isolation`: a recorded worktree path, its validated containment inside the repository, and the `git worktree add` result authorise running the loop in that tree and nothing else. It does not establish that the operator's checkout was clean, that the run's work is correct, or that a tree removed at integrate held nothing of value.
+
+## 5. Risk register seed
+
+```risk-register
+path-escape | the computed worktree path and any caller-supplied override | the resolved path is a descendant of the repository worktree root, no component is a symlink leaving it, and refusal names the path without echoing its contents
+branch-already-checked-out | the base ref and the run branch across worktrees | the run branch is created in the new tree with add -b rather than borrowing the base, and an existing checkout of that branch refuses by name
+operator-head-mutation | the operator's checkout during init and every step | no command checks out, branches, or resets in the origin checkout, and a test captures HEAD and status before and after
+stale-tree-reuse | an existing directory at the computed path | a path that exists and is not this run's registered worktree refuses before any state is written
+uncommitted-work-loss | worktree removal at integrate | removal is never forced; a tree with modifications is kept, named, and reported rather than deleted
+resume-orphan | a resumed run looking for its tree | the breadcrumb in the origin checkout and git worktree list agree, and a missing tree refuses with the recorded path rather than silently starting a new one
+partial-write | state creation split across the origin checkout and the new tree | the worktree exists before any state byte is written, and a failed add leaves no state, no ledger, and no breadcrumb
+cross-filesystem-atomicity | os.replace over the state directory | the worktree is created under the repository root so state writes stay on one filesystem
+subprocess-control | argv passed to git worktree add and remove | fixed argv through the existing bounded no-shell reader with its timeout and output cap, and no caller value reaches a shell
+legacy-state-resume | .hexaemeron directories from earlier runs | an existing state directory in the origin checkout still resumes, and the archived-run fixtures keep passing
+dirty-origin-tree | preflight's refusal to start against uncommitted work | the dirty-tree check applies to the run's own tree, and a demonstration starts a run from a deliberately dirty checkout
+```
+
+Two things the block cannot carry. The first is that this change deliberately trades a smaller invariant for a larger one: `init` gains filesystem side effects, which is exactly the kind of widening the audit rounds are strict about, and the compensation is that every one of those effects is refusable before any state exists. The second is that removal at integrate is the only place work can be lost, so the rule is asymmetric on purpose: a clean tree goes, a dirty tree stays and gets named, and no flag in this change forces the other behaviour.
+
+## 6. Glossary seeds
+
+- `Origin checkout`: the repository directory the operator started the run from, which the run must leave untouched.
+- `Run worktree`: the dedicated Git worktree created for one run, holding the run branch, every step branch, and the run's state.
+- `Worktree home`: the ignored parent directory the run worktree is created under, `tmp/fiat/` at the repository root.
+- `Breadcrumb`: the single line in the origin checkout naming the run worktree, so a resume can find it without being told.
+- `Flattened run branch`: the run branch name with path separators replaced, used as the worktree directory name so one run maps to one path.
+- `Clean removal`: worktree removal that git accepts without force, meaning nothing uncommitted was discarded.
+
+## 7. Sources
+
+- [skills#439](https://github.com/wildcat-finance/skills/issues/439), the observation and its two recorded costs.
+- `plugins/hexaemeron/skills/fiat/scripts/hexctl.py` at `:341`, `:426`, `:507`, `:645`, `:690`; `plugins/hexaemeron/skills/fiat/SKILL.md` at `:80` and its base-sync section.
+- `plugins/hexaemeron/skills/elenchus/scripts/elenchus.py` at `:197`, `:254`, `:299`, `:361`; `plugins/hexaemeron/tests/test_elenchus_checker.py` at `:436` and `:460`.
+- `plugins/horos/skills/horos/scripts/horos.py` at `:859`, `:901`, `:905`; `plugins/horos/tests/test_universe.py` at `:240` and `:253`.
+- `audit/AUDIT.md`: every Fiat round, plus the Horos rounds S3-R1-01 and S4-R1-01; `plugins/hexaemeron/audit/AUDIT.md` Step 0 round 1 for the atomicity lead.
+- `docs/hermes-rule-corpus-study.md:164`; `tests/test_marketplace_prose.py:251`.
+- [PR #445](https://github.com/wildcat-finance/skills/pull/445), [PR #457](https://github.com/wildcat-finance/skills/pull/457), [PR #460](https://github.com/wildcat-finance/skills/pull/460), [PR #463](https://github.com/wildcat-finance/skills/pull/463).
+- [git-worktree documentation](https://git-scm.com/docs/git-worktree).
+
+## 8. Signals, and the questions behind them
+
+`hexctl` runs unattended in a loop, so [ephoros](../plugins/hexaemeron/skills/ephoros/SKILL.md) applies. Four questions someone will ask at three in the morning:
+
+1. **Where is this run actually working?** `init` prints the worktree path, `status` reports it, and the state records it, so nobody has to infer it from a prompt.
+2. **Why did the run refuse to start?** Each failure class emits one stable, value-free line naming the path and the fault: not a repository, path occupied, branch already checked out, add failed.
+3. **Did the run touch my checkout?** The origin checkout keeps its branch and its `HEAD`, and the breadcrumb is the only file the run writes there. A test asserts both.
+4. **What happened to the tree at the end?** The integrate receipt records whether the worktree was removed cleanly or kept because it held modifications, and names it either way.
+
+No dashboard and no new telemetry ships here. The refusal lines, the recorded path, and the integrate outcome are the signals.
+
+## 9. Boundaries, per capability
+
+[phylax](../plugins/hexaemeron/skills/phylax/SKILL.md) owns the boundary list and the controls.
+
+- **Path computation and validation.** The one new untrusted surface. The run branch is already name-checked, and the derived path is resolved, required to be a descendant of the repository worktree root, and refused if any component is a symlink leaving it, following the Horos S4-R1-01 finding that `git -C` resolves symlinks before answering.
+- **Worktree creation and removal.** Two new git invocations, both fixed argv through the existing bounded no-shell reader with its timeout and output cap. No caller value is interpolated into a shell, and no output path is exported into a child environment.
+- **State placement.** State moves to the run's tree, staying on the same filesystem as the repository so the existing atomic-replace behaviour is unchanged. The self-ignoring nested `.gitignore` the controller already writes keeps git blind to it.
+- **The origin checkout.** Write access is narrowed to one breadcrumb line. Nothing in this change checks out, branches, resets, or stages anything there.
+- **Cleanup.** Removal never forces. A tree with modifications is reported and left, so the worst outcome is a directory somebody has to look at rather than uncommitted work that vanished.
+
+## 10. The budget, or its absence
+
+None, and here is why. The change adds one `git worktree add` at `init` and at most one `git worktree remove` at `integrate`, both bounded by the existing reader's timeout, and neither sits in a loop or scales with repository size. [metron](../plugins/hexaemeron/skills/metron/SKILL.md) governs performance claims and this change makes none. Nothing here is done in the name of speed, so there is no before and after to record.
+
+## 11. The fail-closed posture
+
+[elenchus](../plugins/hexaemeron/skills/elenchus/SKILL.md) owns the triage order and the guard rule. `init` stops before writing any state, ledger entry, or breadcrumb when: the target is not a Git repository; the computed path exists and is not this run's registered worktree; the resolved path is not a descendant of the repository worktree root, or a component symlink leaves it; the run branch is already checked out in another worktree; or `git worktree add` fails for any reason. A resume stops when the recorded worktree is absent, naming the recorded path rather than silently creating a second tree. Integrate stops short of removal when the tree holds modifications, and says so.
+
+Every one of those classes gets a named negative test, observed failing before its guard lands. Refusals stay value-free and leave state and ledger bytes identical, which is the standard the state-shape rounds already set. Recovery names the exact path or branch to clear and reruns the same command.
+
+## 12. Decisions and their homes
+
+[hypomnema](../plugins/hexaemeron/skills/hypomnema/SKILL.md) owns which decisions earn a record and where each lives.
+
+- The worktree home and the fail-closed refusal, including the breaking change for in-place runs, is a cross-cutting choice: `docs/decisions/ADR-fiat-run-worktree.md`.
+- The Fiat generation row recording this change belongs in `plugins/hexaemeron/skills/fiat/skills`-adjacent ledger at `plugins/hexaemeron/skills/fiat/EVOLUTION.md`, one row, generation axis, retaining `state-shape-validation` and its digest, with the held #363 job unchanged.
+
+The state schema addition and the breadcrumb format are documented in `SKILL.md` beside the controller invocation, which is where a reader already looks for `--dir`. No second home.
+
+### Provenance and baseline -- 2026-08-22
+
+**Where this specification came from.** It was written earlier the same day and then backed out. That run reached the end of step 1: the study and runbook below, two audit rounds with one low finding fixed and the second clean, and a voice pass, over four signed commits on [PR #465](https://github.com/wildcat-finance/skills/pull/465). What stopped it was not the change. `hexctl done push` resolves repository identity with `gh repo view --json nameWithOwner`, and that session's proxy answered GraphQL with 403, so the push receipt could not be written. The branches were deleted and the pull request closed.
+
+The same call answers `wildcat-finance/skills` in this session, so the receipt that blocked the run is available. The four commits were recovered from `refs/pull/465/head`, which GitHub retains after a branch is deleted, and this run adopts them at the operator's direction rather than deriving the same conclusions a second time. Everything below is the recovered text, with the corrections named next.
+
+**The baseline this run measured.** All four suite commands were run on the run branch at `main` `52b3b45c3d72cb2f163b1dfe88c920035d1385d5` before any change:
+
+```text
+python3 plugins/hexaemeron/tests/run_tests.py      741/741 tests passed
+python3 -m unittest discover -s tests              113 tests, OK
+python3 scripts/promise_machine.py check           clean: 14 plugin(s), 14 copy/copies
+python3 scripts/promise_machine.py coverage --check clean: promises=67 coverage_rows=67 coverage_selected=67
+```
+
+Green at both ends therefore means green, with no carried exception. The recovered copy recorded two failures in `plugins/hexaemeron/tests/test_elenchus_checker.py`, where fixtures assert forge `1.7.1` and node `v26.6.0`. Both pass here, because this machine carries forge `1.7.1` and node `v26.6.0` and the earlier container carried `1.5.1` and `v22.22.2`. Those assertions describe the toolchain a run is executed on, not the repository, so the exception was a fact about one container and is not inherited. A later round that sees them fail should read its own toolchain before reading the test.
+
+**The other correction.** The Hexaemeron suite is invoked as `python3 plugins/hexaemeron/tests/run_tests.py`, the form `AGENTS.md:138` lists. The `unittest discover -s plugins/hexaemeron/tests` form fails with `Start directory is not importable`, because that directory carries no `__init__.py`, so it could not have proved any step's exit.
+
+**One thing the recovered text could not know.** This run is itself being conducted in a dedicated worktree, created by hand before the controller was initialised, with the run's state inside it and the operator's checkout left on `main` holding untracked work of its own. That is the behaviour the change below makes automatic. It is not evidence that the design is right, but it does mean the demo path in section 1 describes something this run is already standing in.

--- a/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
+++ b/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
@@ -1915,6 +1915,100 @@ def bounded_git(base_dir: str, argv: list[str], refusal: str | None = None) -> b
     return bounded_tool(base_dir, "git", argv, refusal)
 
 
+WORKTREE_HOME = ("tmp", "fiat")
+"""Where a run's worktree goes, under the repository's already-ignored scratch root.
+
+Ignoring the home is not what keeps a scan honest: git reports a nested worktree as
+one opaque directory either way. It is what keeps the next run startable, because
+preflight refuses a dirty tree and an unignored directory here would show as
+untracked.
+"""
+
+
+def flattened_run_branch(run_branch: str) -> str:
+    """A run branch as one directory name, so one run maps to one path."""
+    check_branch_name(run_branch)
+    return run_branch.replace("/", "-")
+
+
+def repository_root(base_dir: str) -> str:
+    """The worktree root git reports for `base_dir`.
+
+    A target that is not a Git repository refuses here rather than running in
+    place. That is the fail-closed fallback the study chose, and it is a breaking
+    change for anyone who relied on an in-place run.
+    """
+    root = os.path.realpath(base_dir)
+    reported = bounded_git(
+        base_dir,
+        ["rev-parse", "--show-toplevel"],
+        refusal=f"not a git repository: {root}",
+    ).decode("utf-8", "replace").strip()
+    if not reported:
+        die(f"not a git repository: {root}")
+    return os.path.realpath(reported)
+
+
+def run_worktree_path(base_dir: str, run_branch: str) -> str:
+    """The one path this run's worktree belongs at. Creates nothing."""
+    return os.path.join(
+        repository_root(base_dir), *WORKTREE_HOME, flattened_run_branch(run_branch)
+    )
+
+
+def check_worktree_path(root: str, candidate: str, registered: str | None = None) -> str:
+    """Refuse a worktree path before anything is created at it.
+
+    Four ways a path fails: it leaves the repository once resolved, a component on
+    the way to it is a symlink leaving the repository, it is the repository root
+    itself, or it already exists as something other than this run's own tree.
+
+    The walk is over the supplied components rather than the resolved path. Horos
+    finding S4-R1-01 is the reason: a control that inspects only the path it was
+    given refuses a final-component symlink while stepping over one mid-path, and
+    `git -C` resolves symlinks before it answers, so the refusal has to happen
+    before git is asked anything. Traversal is refused on the raw components for
+    the same reason -- normalising `..` first is what lets a symlink be stepped
+    over lexically.
+
+    Every refusal names the path, reads nothing at it, and writes nothing.
+    """
+    root = os.path.realpath(root)
+    supplied = candidate
+    if os.path.isabs(candidate):
+        try:
+            relative = os.path.relpath(candidate, root)
+        except ValueError:
+            die(f"worktree path escapes the repository: {supplied}")
+    else:
+        relative = candidate
+    parts = [part for part in relative.split(os.sep) if part not in ("", ".")]
+    if not parts or any(part == os.pardir for part in parts):
+        die(f"worktree path escapes the repository: {supplied}")
+    walked = root
+    for part in parts:
+        walked = os.path.join(walked, part)
+        if os.path.islink(walked) and not contained_in(root, os.path.realpath(walked)):
+            die(f"worktree path crosses a symlink out of the repository: {walked}")
+    resolved = os.path.realpath(walked)
+    if not contained_in(root, resolved) or resolved == root:
+        die(f"worktree path escapes the repository: {supplied}")
+    occupied = os.path.exists(resolved) or os.path.islink(resolved)
+    if occupied and (
+        registered is None or os.path.realpath(registered) != resolved
+    ):
+        die(f"worktree path is already occupied: {supplied}")
+    return resolved
+
+
+def contained_in(root: str, resolved: str) -> bool:
+    """True when `resolved` is `root` or sits underneath it."""
+    try:
+        return os.path.commonpath((root, resolved)) == root
+    except ValueError:
+        return False
+
+
 def bounded_gh(base_dir: str, argv: list[str], refusal: str | None = None) -> bytes:
     return bounded_tool(base_dir, "gh", argv, refusal)
 

--- a/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
+++ b/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
@@ -1959,9 +1959,17 @@ def run_worktree_path(base_dir: str, run_branch: str) -> str:
 def check_worktree_path(root: str, candidate: str, registered: str | None = None) -> str:
     """Refuse a worktree path before anything is created at it.
 
-    Four ways a path fails: it leaves the repository once resolved, a component on
+    Five ways a path fails: it leaves the repository once resolved, a component on
     the way to it is a symlink leaving the repository, it is the repository root
-    itself, or it already exists as something other than this run's own tree.
+    itself, it is a symlink, or it already exists as something other than this
+    run's own tree.
+
+    Occupancy is read off the supplied path with `lexists`, not off the resolved
+    one. A dangling link resolves to a path that does not exist, so reading the
+    target saw a free path and then returned the target rather than the path it
+    was asked about -- which would put the run's tree somewhere the deriver never
+    chose. A link at the derived path is refused whether it dangles or not: the
+    run's tree is a real directory there, or it is nothing.
 
     The walk is over the supplied components rather than the resolved path. Horos
     finding S4-R1-01 is the reason: a control that inspects only the path it was
@@ -1993,11 +2001,11 @@ def check_worktree_path(root: str, candidate: str, registered: str | None = None
     resolved = os.path.realpath(walked)
     if not contained_in(root, resolved) or resolved == root:
         die(f"worktree path escapes the repository: {supplied}")
-    occupied = os.path.exists(resolved) or os.path.islink(resolved)
-    if occupied and (
-        registered is None or os.path.realpath(registered) != resolved
-    ):
-        die(f"worktree path is already occupied: {supplied}")
+    if os.path.lexists(walked):
+        if os.path.islink(walked):
+            die(f"worktree path is a symlink: {supplied}")
+        if registered is None or os.path.realpath(registered) != resolved:
+            die(f"worktree path is already occupied: {supplied}")
     return resolved
 
 

--- a/plugins/hexaemeron/tests/test_hexctl.py
+++ b/plugins/hexaemeron/tests/test_hexctl.py
@@ -2997,3 +2997,144 @@ class FrontierGateLegacySnapshotTests(unittest.TestCase):
             version="widget-v2.1.0", status=self.NEXT[0], revision=self.NEXT[1],
             frontier=self.NEXT[2], job=self.NEXT[3])
         self.assertIn("no longer carries the init-time version row", self.fault())
+
+
+class WorktreePathTests(unittest.TestCase):
+    """Deriving one run's worktree path, and refusing every path that is not it.
+
+    These call the deriver and the validator directly. Neither touches state, a
+    ledger or the filesystem, so driving them through a command would only report
+    them indirectly, and the point of the step is that a bad path is refused
+    before anything exists to inspect.
+    """
+
+    def setUp(self):
+        self.module = hexctl_module()
+        self.dir = tempfile.mkdtemp()
+        self.repo = os.path.join(self.dir, "repo")
+        os.makedirs(self.repo)
+        subprocess.run(["git", "init", "-q"], cwd=self.repo, check=True)
+        self.root = os.path.realpath(self.repo)
+
+    def tearDown(self):
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+    def refuse(self, *args, **kwargs):
+        """Call the validator and return the single refusal line it printed."""
+        error = StringIO()
+        with redirect_stderr(error):
+            with self.assertRaises(SystemExit) as caught:
+                self.module.check_worktree_path(*args, **kwargs)
+        self.assertNotEqual(caught.exception.code, 0)
+        lines = [line for line in error.getvalue().splitlines() if line.strip()]
+        self.assertEqual(len(lines), 1, f"expected one refusal line, got {lines}")
+        return lines[0]
+
+    # -- the deriver ----------------------------------------------------
+
+    def test_plain_run_branch_derives_the_expected_path(self):
+        derived = self.module.run_worktree_path(self.repo, "fiat/worktree-demo")
+        self.assertEqual(
+            derived,
+            os.path.join(self.root, "tmp", "fiat", "fiat-worktree-demo"),
+        )
+
+    def test_issue_backed_branch_keeps_its_leading_number(self):
+        derived = self.module.run_worktree_path(self.repo, "fiat/439-run-in-a-worktree")
+        self.assertEqual(os.path.basename(derived), "fiat-439-run-in-a-worktree")
+
+    def test_one_run_branch_maps_to_one_path(self):
+        first = self.module.run_worktree_path(self.repo, "fiat/a-topic")
+        second = self.module.run_worktree_path(self.repo, "fiat/a-topic")
+        other = self.module.run_worktree_path(self.repo, "fiat/another-topic")
+        self.assertEqual(first, second)
+        self.assertNotEqual(first, other)
+
+    def test_deriver_creates_nothing(self):
+        before = sorted(os.listdir(self.repo))
+        derived = self.module.run_worktree_path(self.repo, "fiat/untouched")
+        self.assertFalse(os.path.exists(derived))
+        self.assertEqual(sorted(os.listdir(self.repo)), before)
+
+    def test_a_target_that_is_not_a_repository_refuses(self):
+        plain = os.path.join(self.dir, "not-a-repo")
+        os.makedirs(plain)
+        error = StringIO()
+        with redirect_stderr(error):
+            with self.assertRaises(SystemExit) as caught:
+                self.module.run_worktree_path(plain, "fiat/topic")
+        self.assertNotEqual(caught.exception.code, 0)
+        self.assertIn("not a git repository", error.getvalue())
+
+    # -- the validator --------------------------------------------------
+
+    def test_a_fresh_derived_path_is_accepted(self):
+        derived = self.module.run_worktree_path(self.repo, "fiat/fresh")
+        self.assertEqual(
+            self.module.check_worktree_path(self.root, derived), derived
+        )
+
+    def test_this_runs_registered_worktree_is_accepted_when_it_exists(self):
+        derived = self.module.run_worktree_path(self.repo, "fiat/resumed")
+        os.makedirs(derived)
+        self.assertEqual(
+            self.module.check_worktree_path(self.root, derived, registered=derived),
+            derived,
+        )
+
+    def test_a_path_that_already_exists_as_a_file_refuses(self):
+        derived = self.module.run_worktree_path(self.repo, "fiat/occupied")
+        os.makedirs(os.path.dirname(derived))
+        with open(derived, "w", encoding="utf-8") as handle:
+            handle.write("not a worktree")
+        self.assertIn("occupied", self.refuse(self.root, derived))
+
+    def test_a_path_that_already_exists_as_an_unrelated_directory_refuses(self):
+        derived = self.module.run_worktree_path(self.repo, "fiat/squatted")
+        os.makedirs(derived)
+        with open(os.path.join(derived, "someone-elses.txt"), "w", encoding="utf-8") as h:
+            h.write("work")
+        self.assertIn("occupied", self.refuse(self.root, derived))
+
+    def test_a_path_escaping_the_root_by_dotdot_refuses(self):
+        self.assertIn(
+            "escapes", self.refuse(self.root, os.path.join("tmp", "fiat", "..", "..", "..", "away"))
+        )
+
+    def test_an_absolute_path_outside_the_repository_refuses(self):
+        outside = os.path.join(self.dir, "outside")
+        self.assertIn("escapes", self.refuse(self.root, outside))
+
+    def test_a_component_symlink_leaving_the_repository_refuses(self):
+        outside = os.path.join(self.dir, "elsewhere")
+        os.makedirs(outside)
+        home = os.path.join(self.root, "tmp")
+        os.symlink(outside, home)
+        derived = os.path.join(home, "fiat", "fiat-topic")
+        self.assertIn("symlink", self.refuse(self.root, derived))
+
+    def test_a_final_component_symlink_leaving_the_repository_refuses(self):
+        outside = os.path.join(self.dir, "target")
+        os.makedirs(outside)
+        os.makedirs(os.path.join(self.root, "tmp", "fiat"))
+        derived = os.path.join(self.root, "tmp", "fiat", "fiat-linked")
+        os.symlink(outside, derived)
+        self.assertIn("symlink", self.refuse(self.root, derived))
+
+    def test_the_repository_root_itself_refuses(self):
+        self.assertIn("escapes", self.refuse(self.root, self.root))
+
+    def test_a_refusal_leaves_no_state_no_ledger_and_no_breadcrumb(self):
+        before = sorted(os.listdir(self.repo))
+        self.refuse(self.root, os.path.join(self.dir, "outside"))
+        self.assertEqual(sorted(os.listdir(self.repo)), before)
+        self.assertFalse(os.path.exists(os.path.join(self.repo, ".hexaemeron")))
+
+    def test_a_refusal_names_the_path_without_echoing_its_contents(self):
+        derived = self.module.run_worktree_path(self.repo, "fiat/secret")
+        os.makedirs(os.path.dirname(derived))
+        with open(derived, "w", encoding="utf-8") as handle:
+            handle.write("SENSITIVE-TOKEN-VALUE")
+        line = self.refuse(self.root, derived)
+        self.assertIn("fiat-secret", line)
+        self.assertNotIn("SENSITIVE-TOKEN-VALUE", line)

--- a/plugins/hexaemeron/tests/test_hexctl.py
+++ b/plugins/hexaemeron/tests/test_hexctl.py
@@ -3138,3 +3138,25 @@ class WorktreePathTests(unittest.TestCase):
         line = self.refuse(self.root, derived)
         self.assertIn("fiat-secret", line)
         self.assertNotIn("SENSITIVE-TOKEN-VALUE", line)
+
+    def test_a_dangling_symlink_at_the_derived_path_refuses(self):
+        """A link that resolves nowhere still occupies the path.
+
+        Occupancy was read off the resolved target, and a dangling link resolves
+        to a path that does not exist, so the check saw a free path. It then
+        returned the link's target rather than the path it was asked about, which
+        would put the run's tree somewhere the deriver never chose.
+        """
+        derived = self.module.run_worktree_path(self.repo, "fiat/dangling")
+        os.makedirs(os.path.dirname(derived))
+        os.symlink(os.path.join(self.root, "nowhere-yet"), derived)
+        self.assertIn("symlink", self.refuse(self.root, derived))
+
+    def test_a_symlink_to_a_real_directory_inside_the_repository_refuses(self):
+        """The run's tree is a real directory at the derived path, or it is nothing."""
+        derived = self.module.run_worktree_path(self.repo, "fiat/redirected")
+        inside = os.path.join(self.root, "real-dir")
+        os.makedirs(inside)
+        os.makedirs(os.path.dirname(derived))
+        os.symlink(inside, derived)
+        self.assertIn("symlink", self.refuse(self.root, derived))

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -128,7 +128,7 @@
     },
     "fiat-final-integration": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "adf0fc24d650fdbb9d38b5b7ccb52320e5d76c1fbed0f3e9f303fa79a4d48167",
+      "sha256": "2e7018ba8f939b5392fbc08eee1dd509e0b094a0c9fbb285687cf47f26dd144c",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "run branch, base, integration head and merge commit",
@@ -142,7 +142,7 @@
     },
     "fiat-receipted-delivery": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "adf0fc24d650fdbb9d38b5b7ccb52320e5d76c1fbed0f3e9f303fa79a4d48167",
+      "sha256": "2e7018ba8f939b5392fbc08eee1dd509e0b094a0c9fbb285687cf47f26dd144c",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "validated state, topic, run branch, step branch and head commit",

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -128,7 +128,7 @@
     },
     "fiat-final-integration": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "2e7018ba8f939b5392fbc08eee1dd509e0b094a0c9fbb285687cf47f26dd144c",
+      "sha256": "74237cb2a4cf2d0dd7d456b7125befe95fd6674566e2f6ecc4ddee6b1e2f3edb",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "run branch, base, integration head and merge commit",
@@ -142,7 +142,7 @@
     },
     "fiat-receipted-delivery": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "2e7018ba8f939b5392fbc08eee1dd509e0b094a0c9fbb285687cf47f26dd144c",
+      "sha256": "74237cb2a4cf2d0dd7d456b7125befe95fd6674566e2f6ecc4ddee6b1e2f3edb",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "validated state, topic, run branch, step branch and head commit",


### PR DESCRIPTION
Turn a run branch into one refusable path. Nothing here mutates the filesystem or touches state: this step is the deriver and the guard, and step 3 is what calls them.

`run_worktree_path` puts the tree at `tmp/fiat/<flattened run branch>` under the worktree root git reports, so one run maps to one directory and an issue-backed branch keeps its leading number. A target that is not a Git repository refuses here rather than running in place, which is the fail-closed fallback the study chose and a breaking change for anyone who relied on an in-place run.

`check_worktree_path` refuses five ways: the path leaves the repository once resolved, a component on the way to it is a symlink leaving the repository, it is the repository root itself, it is a symlink, or it already exists as something other than this run's own tree. Each refusal is one line naming the path. None of them reads anything at the path, and none writes.

Two choices worth explaining. The component walk is over the supplied path rather than the resolved one, following Horos finding S4-R1-01: a control that inspects only the path it was given steps over a mid-path symlink, and `git -C` resolves symlinks before it answers, so the refusal has to land before git is asked anything. Traversal is refused on the raw components for the same reason, because normalising `..` first is what lets a symlink be stepped over lexically.

## Audit

Two rounds, in `audit/AUDIT.md` under "Fiat run worktree, step 2". No stacked fix branch; the fix and the log are committed on this branch, because the steps chain and fixes parked elsewhere would be missing from every step above.

Round 1 found one medium, FRW-S2-R1-01. Occupancy was read off the resolved path, so a dangling symlink at the derived path looked like free space: the check accepted it and returned the link's target rather than the path it was asked about. Step 3 would then have created the run's tree somewhere the deriver never chose. The state and the breadcrumb would name a different path again, and the link would still be sitting there. It stays inside the repository root, so it redirects rather than escapes.

A lint did not find that one; probing did. The escape controls were correct and so was the live-symlink case. The dangling case was the one combination where occupancy and resolution disagree. Occupancy now reads the supplied path with `lexists`, and a link at the derived path is refused whether it dangles or not, because the run's tree is a real directory there or it is nothing. Round 2 came back clean.

One lead, carried to step 3. A path free at the check can be occupied by the time something is created at it. `git worktree add` refuses a path that exists, so the race closes into a refusal rather than a wrong tree.

## How to check it

```bash
python3 -m unittest plugins.hexaemeron.tests.test_hexctl -k Worktree
python3 plugins/hexaemeron/tests/run_tests.py
python3 -m unittest discover -s tests
python3 scripts/promise_machine.py check
python3 scripts/promise_machine.py coverage --check
```

Eighteen cases, each negative one observed failing before its guard. Suites: 759/759, 113 OK, both Promise Machine checks clean.

## The coverage digest

Both Fiat promises pin a digest over `hexctl.py`, so editing it drifts them. The field maps are unchanged and repinned rather than rewritten: these are pure helpers no command calls yet, so no receipt, state field, ledger entry or directive moved. Steps 3 to 5 will each drift it again for the same reason.

Stacks on step 1.

<!-- wildcat-origin: shoggoth -->
