### PR TITLE
Add and demonstrate Fiat's receipted study amendment

### DIFF
--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 1427
+    "files_walked": 1429
   },
   "entries": [
     {

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8207,3 +8207,54 @@ Leads not pursued: a general transaction rewrite for controller mutations
 other than `amend study`, the deliberately separate runbook-repair transition,
 and the truth of amendment prose or operator verdicts. None is authorised or
 claimed by this step.
+
+## Fiat receipted study amendments, step 2, round 2 -- 2026-08-22
+
+The fixed tree at `35d79f4eaa7515bb2dd4078d2bcf45bbc3f6bb5e` was
+re-audited against all three round-1 mechanisms and the complete twelve-item
+risk register. The recorded waiver still applies: no Solidity entered the
+tree, so `x-ray`, `solidity-auditor`, `fizz` and a Solidity campaign did not
+run.
+
+### Findings
+
+- Findings: 0. The round-1 fixes hold.
+
+### Risk-register dispositions
+
+| risk id | status | round-2 evidence |
+| --- | --- | --- |
+| `prefix-forgery` | clean | The fixed prefix-drift guard still refuses before any durable mutation. |
+| `amendment-selection` | clean | Fence state now retains delimiter character and opening length; the long-fence specimen, ordinary fenced decoy, duplicate block and trailing section all refuse as intended. |
+| `field-ambiguity` | clean | Calendar date, exact four-field cardinality, order and non-empty values remain guarded. |
+| `step-verdict-coverage` | clean | Missing, duplicate, ambiguous, unknown and completed-step verdict cases remain refused; each non-done step receives one normalized verdict. |
+| `broken-step-transition` | clean | The broken demonstration records its amendment, emits `blocked`, emits no delegated agent brief, and every step receipt remains refused. Fiat's loop and stop contract names that receipt-free terminal outcome. |
+| `checker-binding` | clean | The fixed sibling checker path, captured private temporary file, argv-only invocation, timeout, output cap and bounded refusal remain unchanged. |
+| `path-scope` | clean | Real-path containment, regular-file checks and the source byte ceiling remain ahead of the write-ahead transition. |
+| `partial-write` | clean | Round 2 exercised marker-before-replacement rollback and post-commit marker cleanup in addition to the two committed interruption guards. All four windows recover with matching artefact, state and ledger. |
+| `receipt-history` | clean | Recovery after a written ledger event completes state without appending a second `amend:study`; holding and broken histories retain all three digests and normalized verdicts. |
+| `post-amend-drift` | clean | Both `next` and `verify` recompute the amended artefact digest and refuse later drift. |
+| `legacy-state` | clean | Source-bound receipts without an amendment member retain their ordinary packet behavior, while receipts lacking a digest cannot invoke the new transition. |
+| `evidence-overclaim` | clean | `fiat-study-amendment` remains consequence 2 and authorises only recoverable replacement, receipt re-pinning and the holding-or-blocked result. It still refuses correction truth, verdict correctness and runbook repair. |
+
+The write-ahead order is marker, canonical artefact, ledger, state,
+cross-file verification, then marker removal. A probe interrupted before the
+canonical replacement and recovered by visibly rolling back to the prior
+digest. A second probe interrupted after the state and ledger commit and
+recovered by verifying the recorded transition and clearing the marker. The
+two committed guards continue to cover interruption after artefact replacement
+and after ledger append but before state replacement; the latter still leaves
+exactly one amendment event.
+
+### Checks and bounded leads
+
+The temporary holding and broken demonstrations both pass. The focused
+controller, Fiat prose and Protasis suite passes 313/313; the root suite passes
+113/113; the complete Hexaemeron suite passes 765/765. Promise Machine checks
+are clean at 68 promises and 68 selected coverage rows. Phylax, Ephoros and
+Hypomnema each exit 0 on the source-bound plugin paths.
+
+Leads not pursued: the same bounded exclusions remain: a general transaction
+rewrite outside `amend study`, the separately specified runbook-repair
+transition, and the truth of amendment prose or operator verdicts. None is a
+new defect in the fixed Step 2 tree.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8144,3 +8144,66 @@ delivery. The two published documents are exact copies of the receipted
 sources, so this audit does not revise the accepted specification.
 
 Leads not pursued: none.
+
+## Fiat receipted study amendments, step 2, round 1 -- 2026-08-22
+
+The Pashov `x-ray`, `solidity-auditor`, and `fizz` suite did not run under the
+recorded waiver because this step changes Fiat's Python controller, tests and
+instructions and ships no Solidity. The audit reviewed the exact Step 2 commit
+`6edcf7f72ca12ec797aead542dd8d7dc17ff7696` against its parent
+`de7090b7c107241dac13d4655c8dc2f68bf12574`, then reviewed every fix on the
+stacked audit branch.
+
+Findings: 3.
+
+| id | severity | file | mechanism | status |
+| --- | --- | --- | --- | --- |
+| FSA-S2-R1-01 | high | `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`; `plugins/hexaemeron/tests/test_hexctl.py` | `_replace_study_bytes` ran before the ledger/state `commit`. An interruption in that gap left the new study with the old receipt and ledger, while `hexctl verify` still exited 0. An interruption after the ledger append could also make recovery append the same `amend:study` event twice. | fixed in this round with a fsynced write-ahead marker, refusal of every other controller command while it exists, exact-byte revalidation, finish-or-rollback recovery, final cross-file verification before marker removal, and non-duplicating completion of an already-written ledger event; both guards were observed red before the fix |
+| FSA-S2-R1-02 | medium | `plugins/hexaemeron/skills/fiat/SKILL.md`; `plugins/hexaemeron/tests/test_fiat_skill.py`; `tests/promise_machine_coverage.json`; `tests/test_promise_machine_contract.py` | The new consequence-2 durable mutation had no Promise whose `Authorises` field permitted canonical study replacement and receipt re-pinning. The new `blocked` directive was also absent from Fiat's loop terminal set, action table and stop contract. | fixed in this round with `fiat-study-amendment`, operation-specific positive/missing/stale/overclaim/recovery bindings, and an explicit receipt-free `blocked` stop; the contract guards were observed red before the fix |
+| FSA-S2-R1-03 | medium | `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`; `plugins/hexaemeron/tests/test_hexctl.py` | The Markdown selector tracked only the fence character, so three backticks closed a four-backtick fence. A heading still inside the longer Markdown fence could therefore be selected as the live amendment. | fixed in this round by tracking the opening delimiter length and accepting only a same-character closing delimiter at least as long; the adversarial guard was observed accepting the fenced heading before the fix |
+
+### Risk-register dispositions
+
+| risk id | status | disposition |
+| --- | --- | --- |
+| `prefix-forgery` | closed | The candidate prefix is hashed against the current receipt before mutation; the original prefix-drift guard leaves artefact, state and ledger unchanged. |
+| `amendment-selection` | fixed | FSA-S2-R1-03 makes fenced decoys respect delimiter character and length; duplicate final blocks and trailing sections refuse. |
+| `field-ambiguity` | closed | Date validity, exact cardinality, non-empty values and accepted order are covered by named guards. |
+| `step-verdict-coverage` | closed | Every non-done step gets one exact entry-and-exit verdict; missing, duplicate, ambiguous, unknown and completed-step cases refuse. |
+| `broken-step-transition` | fixed | FSA-S2-R1-02 records a broken current-step amendment, makes `next` emit the source-bound `blocked` outcome, refuses step receipts, and names inspection, halt or a separately specified repair as recovery. |
+| `checker-binding` | closed | The controller writes the captured bytes to a private temporary file, invokes the sibling Protasis checker with `sys.executable` and a fixed argv list, bounds time and output, suppresses raw diagnostics, and refuses a non-zero exit. |
+| `path-scope` | closed | Candidate and canonical paths use the existing real-path containment and byte cap; outside paths, non-files and oversized inputs refuse before the write-ahead transition. |
+| `partial-write` | fixed | FSA-S2-R1-01 adds a durable pending record before replacement; recovery distinguishes prior, candidate and already-committed states and verifies artefact, state and ledger before clearing it. |
+| `receipt-history` | closed | State and ledger carry prior, new and amendment digests plus normalized touched-step and verdict metadata; interruption recovery records the event exactly once. |
+| `post-amend-drift` | closed | Both `next` and `verify` recompute the receipted study digest, and the general verify path now checks every source-bound study rather than only one already carrying amendment history. |
+| `legacy-state` | closed | A study receipt with no amendment member retains ordinary packet behavior; an unbound legacy receipt may still be read but cannot use the new mutation. |
+| `evidence-overclaim` | fixed | FSA-S2-R1-02 establishes checked byte continuity, structure, checker exit and recorded operator verdicts, not correction truth, verdict correctness or runbook repair. |
+
+### Evidence and checks
+
+The two implementation guards were applied to detached parent
+`de7090b7c107241dac13d4655c8dc2f68bf12574`: the parser rejected the absent
+`amend` command and the append demonstration remained unable to replace the
+ordinary digest refusal. The three audit mechanisms were then observed red
+against unfixed Step 2 commit `6edcf7f72ca12ec797aead542dd8d7dc17ff7696`:
+the long-fence specimen was accepted, no pending transaction survived the
+replace/commit interruption, and Fiat had neither the `blocked` loop outcome
+nor an amendment `Authorises` block. The ledger-before-state interruption
+guard additionally reproduced two amendment events before the recovery fix.
+
+The fixed temporary-repository demonstration records a holding amendment,
+finds all three digests in state and ledger, and reconstructs the amended Mason
+packet. Its second run records a broken current step and receives the durable
+blocked directive. No fixture is described as a production run.
+
+The focused controller, Fiat prose and Protasis suite passes 313/313; the root
+suite passes 113/113; the complete Hexaemeron suite passes 765/765. Promise
+Machine contract and coverage checks are clean at 68 promises and 68 selected
+rows. Phylax, Ephoros and Hypomnema each exit 0 on their required scopes.
+Imprimatur finds no defect in the changed Fiat skill; Brevitas exits 0 on that
+skill and on this appended audit entry.
+
+Leads not pursued: a general transaction rewrite for controller mutations
+other than `amend study`, the deliberately separate runbook-repair transition,
+and the truth of amendment prose or operator verdicts. None is authorised or
+claimed by this step.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8099,3 +8099,48 @@ required-text and forbidden-name assertions pass. The controller verifies its
 No new findings.
 
 Leads not pursued: none.
+
+## Fiat receipted study amendments, step 1, round 1 -- 2026-08-22
+
+The Pashov `x-ray`, `solidity-auditor`, and `fizz` suite did not run under the
+recorded waiver because this step publishes two Markdown specifications and a
+deterministic Horos boundary update, and ships no Solidity.
+
+Reviewed commit `f3555a06229edb169628bbddf6050c2b765718b9` against run branch
+`fiat/446-receipted-study-amendments`. The exact diff adds the byte-identical
+tracked study and runbook and changes only `files_walked` from 1427 to 1429 in
+`.horos/boundary.json`. The two `cmp` checks, both Protasis modes, Imprimatur,
+Brevitas, `git diff --check`, all 113 root tests, and all 741 Hexaemeron tests
+exit 0. Phylax, Ephoros, and Hypomnema each exit 0 on their required scopes.
+
+Findings: 0.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| -- | -- | -- | No findings. | clean |
+
+### Risk-register dispositions
+
+| risk id | disposition |
+| --- | --- |
+| `prefix-forgery` | Specified for step 2 and not activated by this documentation-only step. The study requires an exact prefix hash against the current receipt before mutation, and the runbook requires named regression guards. |
+| `amendment-selection` | Specified for step 2 and not activated here. The study fixes selection to one final dated block and requires fenced-decoy, duplicate-final-block, and trailing-prose cases to refuse. |
+| `field-ambiguity` | Specified for step 2 and not activated here. The study requires each of the four fields exactly once with non-empty bounded content, and the runbook assigns invalid-field guards. |
+| `step-verdict-coverage` | Specified for step 2 and not activated here. Every unbuilt step must appear exactly once with entry-and-exit verdicts; missing, duplicate, ambiguous, and completed-step cases are assigned tests. |
+| `broken-step-transition` | Specified for step 2 and not activated here. A valid broken-current-step amendment must be recorded before durable state blocks all dependent packets, with explicit recovery left available. |
+| `checker-binding` | Specified for step 2 and not activated here. The study binds an argv-only invocation to the bundled checker, exact candidate bytes, its exit, timeout, and bounded diagnostics. |
+| `path-scope` | Specified for step 2 and not activated here. Candidate and canonical paths must remain inside the target; symlink escape, unreadable, and oversized sources refuse before mutation. |
+| `partial-write` | Specified for step 2 and not activated here. Validation must finish before the existing state lock and recoverable atomic-write sequence mutate the artefact, state, or ledger. |
+| `receipt-history` | Specified for step 2 and not activated here. The receipt and ledger must retain old, new, and amendment digests plus bounded verdict metadata without erasing prior transitions. |
+| `post-amend-drift` | Specified for step 2 and not activated here. `next` and `verify` must recompute the amended digest and retain the ordinary refusal for any later unreceipted edit. |
+| `legacy-state` | Specified for step 2 and not activated here. Runs without an amendments member retain their ordinary read and `next` behaviour until the new command is used. |
+| `evidence-overclaim` | Closed for the published specification and retained as an implementation boundary. The study limits the future receipt to checked structure, order, digests, and recorded operator verdicts, not the truth of the correction or correctness of the remaining plan. |
+
+The record-placement review found the chosen command and its rejected
+alternatives in the tracked study, the semantic origin linked to PR 307, and
+the durable behaviour explicitly assigned to Fiat's canonical skill and tests
+in step 2. No evolution row or standalone ADR is claimed by this ordinary
+delivery. The two published documents are exact copies of the receipted
+sources, so this audit does not revise the accepted specification.
+
+Leads not pursued: none.

--- a/docs/fiat-receipted-study-amendments-runbook.md
+++ b/docs/fiat-receipted-study-amendments-runbook.md
@@ -1,0 +1,126 @@
+# Runbook: receipted study amendments
+
+This runbook implements the accepted study at exact start
+`52b3b45c3d72cb2f163b1dfe88c920035d1385d5`. It is ordinary Fiat delivery for
+issue 446. It does not alter Fiat's evolution ledger, held issue 363 frontier,
+or package versions.
+
+## Delivery boundary
+
+- Step 1 publishes the accepted records.
+- Step 2 implements, guards, documents, and demonstrates the transition.
+
+## Step 1: Publish the accepted amendment specification
+
+**Goal.** Commit byte-identical tracked copies of the accepted study and
+runbook so the implementation and audit have a reviewable specification.
+
+**Entry.** Run branch `fiat/446-receipted-study-amendments` at
+`52b3b45c3d72cb2f163b1dfe88c920035d1385d5`, with `.hexaemeron/study.md` and
+`.hexaemeron/runbook.md` receipted and mechanically clean.
+
+- Evidence is limited to the named files and commands below.
+
+**Exit.** The two tracked documents match their receipted sources byte for
+byte, the Horos boundary describes the new tracked tree, Protasis accepts both
+artefacts, Imprimatur and Brevitas accept the shipped prose, the root suite and
+Hexaemeron suite pass, and `git diff --check` exits 0.
+
+```bash
+cmp .hexaemeron/study.md docs/fiat-receipted-study-amendments-study.md
+cmp .hexaemeron/runbook.md docs/fiat-receipted-study-amendments-runbook.md
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/fiat-receipted-study-amendments-study.md
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/fiat-receipted-study-amendments-runbook.md
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/fiat-receipted-study-amendments-study.md docs/fiat-receipted-study-amendments-runbook.md
+python3 plugins/brevitas/skills/brevitas/scripts/brevitas.py docs/fiat-receipted-study-amendments-study.md
+python3 plugins/brevitas/skills/brevitas/scripts/brevitas.py docs/fiat-receipted-study-amendments-runbook.md
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/tests/run_tests.py
+git diff --check
+```
+
+**Files.** Create
+`docs/fiat-receipted-study-amendments-study.md` and
+`docs/fiat-receipted-study-amendments-runbook.md`; refresh
+`.horos/boundary.json` only if the deterministic scan changes it.
+
+**Tests.** Run the exact comparison, both Protasis modes, Imprimatur, Brevitas,
+the root suite, the complete Hexaemeron suite, the Horos currency check carried
+by the root suite, and the diff check. No test count is assumed before the run.
+
+**Disciplines.** phylax: the step adds only bounded Markdown records and the
+generated reading boundary, with no executable input. ephoros: none, the step
+runs nothing unattended. metron: none, no performance claim. elenchus: exact
+byte comparisons guard the accepted artefacts. hypomnema: the tracked study and
+runbook are the durable homes for the design and build order.
+
+## Step 2: Add and demonstrate the receipted amendment transition
+
+**Goal.** Add the narrow `amend study` transition, its fail-closed guards and
+user contract, then demonstrate a holding amendment and a broken-current-step
+block against a temporary run.
+
+**Entry.** Step 1's stacked branch, with the accepted records committed and all
+entry checks green.
+
+- Evidence is limited to the named controller, contract, tests, and checks.
+
+**Exit.** The unfixed parent first reproduces the absent-command/digest refusal;
+the fixed controller accepts only one append-only Protasis amendment, records
+the prior, new, and amendment digests plus complete unbuilt-step verdicts,
+re-pins the study, continues only on a holding current step, and durably blocks
+a broken current step. Arbitrary mutation, prefix drift, invalid fields,
+ambiguous or missing step verdicts, wrong phase, unsafe path, oversize, checker
+failure, concurrent mutation, legacy state, and post-amend drift have named
+guards. The CLI and Fiat instructions expose the recovery boundary. The
+focused controller and prose tests, both complete suites, Promise Machine
+checks, all three non-Solidity discipline lints, Imprimatur, Brevitas, the
+temporary demonstration, and `git diff --check` exit 0.
+
+```bash
+python3 -m unittest plugins.hexaemeron.tests.test_hexctl plugins.hexaemeron.tests.test_fiat_skill plugins.hexaemeron.tests.test_protasis_checker
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 scripts/promise_machine.py check
+python3 scripts/promise_machine.py coverage --check
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs
+git diff --check
+```
+
+The demonstration uses a temporary Git repository and the checked-in
+controller. It receipts a complete study and two-step runbook, appends a dated
+four-field amendment whose two verdicts hold, runs the new command, observes
+both study digests in state and ledger, and obtains the amended Mason packet.
+A second temporary run records a valid amendment whose current-step verdict is
+broken and observes the controller's durable blocked directive. No fixture
+state is presented as a production run.
+
+**Files.** Modify
+`plugins/hexaemeron/skills/fiat/scripts/hexctl.py`,
+`plugins/hexaemeron/tests/test_hexctl.py`,
+`plugins/hexaemeron/skills/fiat/SKILL.md`, and
+`plugins/hexaemeron/tests/test_fiat_skill.py`. Update
+`tests/promise_machine_coverage.json` only for exact changed runtime or skill
+digests. Modify no evolution ledger, manifest, marketplace, package version,
+vendored skill, or CI file.
+
+**Tests.** Add red-parent guards for the missing amendment command and the
+existing digest refusal before implementation. Extend controller tests for the
+positive transition, digest history, packet reconstruction, broken-current-step
+block, all study risk-register failure classes, unchanged legacy behavior, and
+the demonstration path. Extend skill prose tests for the command, boundary,
+receipt, and recovery wording. Run the focused and complete commands above;
+record actual counts only after they finish.
+
+**Disciplines.** phylax: candidate paths, Markdown bytes, subprocess arguments,
+bounded diagnostics, temporary files, atomic writes, and killed-run recovery
+are implementation boundaries. ephoros: stdout, stderr, state, ledger, and
+`next` must answer which digests and step verdicts control continuation.
+metron: none, no speed change is claimed and existing byte/time ceilings are
+safety bounds. elenchus: the known digest refusal is reproduced red first and
+every accepted or rejected transition receives a regression guard.
+hypomnema: stable behavior belongs in Fiat's canonical skill, the code in the
+controller, the guards in tests, and round dispositions in the audit log; no
+evolution row or ADR is warranted.

--- a/docs/fiat-receipted-study-amendments-study.md
+++ b/docs/fiat-receipted-study-amendments-study.md
@@ -1,0 +1,183 @@
+# Study: receipted study amendments
+
+Assuming, unless corrected:
+
+1. Issue 446 is ordinary Fiat delivery. It does not advance Fiat's held issue 363 frontier, change Fiat's evolution ledger, or require a package version bump.
+2. The exact start is `52b3b45c3d72cb2f163b1dfe88c920035d1385d5` on `main`; the isolated run branch is `fiat/446-receipted-study-amendments`.
+3. The accepted subject is the study already receipted by `done study`, after the runbook exists and while a step is open. Draft edits before the study receipt remain ordinary edits.
+4. The amended candidate contains the receipted study bytes unchanged followed by one final dated Protasis amendment block. No deletion, rewrite, insertion, or reordering of earlier bytes is an amendment.
+5. The amendment block uses Protasis's four fields: `What changed`, `Why`, `Steps touched`, and `Still holding`. Every current or pending step is unbuilt and receives an explicit entry-and-exit verdict in `Still holding`.
+6. A valid amendment may continue only when the current step's entry and exit still hold. A broken current-step verdict is recorded but blocks the dependent transition, leaving inspection and an explicit halt or later re-specification available.
+7. Python 3 and the standard library remain the implementation boundary. The controller may invoke the bundled Protasis checker by an argv-only subprocess; it adds no dependency or network access.
+8. The existing 1 MiB bounded-source limit, scoped-path checks, state lock, atomic state write, hash-chained ledger, and state version 1 remain in force.
+9. The ledger records digests and bounded verdict metadata, never the full study, signature material, credentials, or uncontrolled subprocess output.
+10. The two reported reproductions are maintainer-recorded issue evidence. Their application trees and timing were not independently inspected in this run.
+
+## 1. Problem statement
+
+Fiat pins the study digest at `done study` and recomputes it before every later delegated packet. Protasis requires a mid-run correction to append a dated amendment to that same study. The first required edit therefore looks identical to tampering, and `hexctl next` refuses it. The controller offers no sanctioned transition that preserves the original belief, validates the correction, and re-pins the amended bytes.
+
+Issue 446 records two separate runs where step 1's baseline disproved the pre-build specification. The first corrected a stray-literal count and an HTML-entity false positive. The second found that lint could not start and three tests were already failing, invalidating stated runbook exits. Re-initialisation recovered execution but erased the original belief from the active ledger.
+
+The working prototype adds a receipted study-amendment command. Given a candidate that appends one valid Protasis amendment, it proves the old receipted bytes are the unchanged prefix, validates the complete study and amendment fields, binds every unbuilt step to a verdict, records both digests, and re-pins the study. A holding amendment lets `next` continue. A broken current-step verdict remains recorded but blocks the dependent transition.
+
+Acceptance is checked by:
+
+```bash
+python3 -m unittest plugins.hexaemeron.tests.test_hexctl plugins.hexaemeron.tests.test_fiat_skill plugins.hexaemeron.tests.test_protasis_checker
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 scripts/promise_machine.py check
+```
+
+The named demonstration creates a temporary run, receipts a study and runbook, appends a four-field amendment, receipts it, observes both digests in the ledger, and obtains the next source-bound packet from the amended study. Negative demonstrations cover prefix mutation, missing fields, missing step verdicts, a broken current step, invalid Protasis structure, oversized input, and post-amendment drift.
+
+## 2. Prior art
+
+`plugins/hexaemeron/skills/fiat/scripts/hexctl.py` already supplies most of the required safety boundary. `done_study` reads bounded bytes and stores their SHA-256. `receipted_source` refuses later drift before `delegation_packet` selects a study risk register or runbook step. Mutating commands share the state lock and `commit` appends a hash-chained ledger transition. What is absent is a transition that can replace the expected digest without weakening the drift refusal.
+
+The last two merged pull requests touching the target controller and tests were read before choosing a design:
+
+- [PR 445](https://github.com/wildcat-finance/skills/pull/445), "Bind task issues to Fiat run and step branches", added issue-bound initialization and more fail-closed state and branch evidence. Its carried-forward section leaves issue 363 open and reports no amendment work.
+- [PR 444](https://github.com/wildcat-finance/skills/pull/444), "Widen the ledger row gate to the compact shape", aligned controller ledger parsing with the suite and anchored append-only frontier history. It reinforces the rule that a controller mutation needs an explicit, replayable ledger transition.
+
+[PR 307](https://github.com/wildcat-finance/skills/pull/307), "The mid-run spec amendment contract", is the semantic origin. It chose an appended block over an in-place edit or separate amendments file so the document itself preserves the earlier belief. It requires four fields and a verdict for every unbuilt step. It carried the first live use forward; issue 446 is that live use exposing Fiat's missing transition.
+
+The applicable Fiat audit records were read in `audit/AUDIT.md`, including the delegation-packet, state-shape, and task-issue rounds. They show the established pattern: validate bounded external values before state traversal or mutation, bind the exact subject and digest, preserve append-only evidence, and keep receipts narrower than the underlying judgement. The task-issue rounds closed their only parser finding and carried no open lead into this design. The Protasis amendment audit recorded two clean rounds and left live controller use open rather than claiming it existed.
+
+Issue 446 and its maintainer comment are the current failure record. No previous Fiat integration body carries a study-amendment implementation forward. Issue 363 remains the separately held delegated-task identity job and is a non-goal here.
+
+## 3. Constraints and non-goals
+
+The implementation begins at the recorded start SHA and changes only the Fiat controller, focused tests, Fiat instructions or reference prose needed to expose the command, Promise Machine runtime bindings required by a changed canonical skill, and the tracked study/runbook copies required by this delivery. It does not change state version 1 or reinterpret an existing receipt without an explicit amendment history.
+
+The command operates only after both study and runbook receipts exist and while the run is in `steps`. The study receipt remains the canonical path. A candidate outside the target root, unreadable input, symlink escape, wrong phase, absent receipt, digest mismatch unrelated to a final appended block, or oversized source fails before state or ledger mutation.
+
+The original receipted bytes must be the exact prefix of the candidate. The final amendment is the only suffix. Its dated heading and four fields are parsed deterministically, the complete candidate passes the bundled `protasis.py --study` checker, and every step whose status is not `done` is named once with an entry-and-exit verdict. Ambiguous, duplicate, or missing verdicts fail.
+
+An accepted holding amendment updates `receipts.study.sha256` and appends amendment history containing the prior digest, new digest, amendment digest, date, touched step numbers, and normalized step verdicts. The ledger transition carries the same bounded facts. The full prose stays in the study artefact, where the original bytes remain readable as its prefix.
+
+If the current step is marked broken, the controller first records the valid append-only amendment and then blocks later work in durable controller state. It must not emit another Mason, Warden, or Scribe packet from a step whose entry or exit no longer holds. Recovery remains inspection, an explicit safe halt, or a separately specified runbook-repair transition; inventing that second transition is outside issue 446.
+
+Non-goals are arbitrary study rewrites, amending a runbook, editing completed-step history, reopening the study phase, automatically repairing an invalid step, accepting free-form verdicts that cannot be bound to step numbers, changing the Protasis amendment contract, closing issue 363, changing package or skill versions, adding a dependency, touching CI, or weakening ordinary digest-drift refusal.
+
+**Always.** Keep the old bytes as the exact prefix; validate the full study and one final amendment; bind every unbuilt step verdict; use bounded scoped reads and argv-only checker execution; make state and ledger updates under the existing lock; run focused and complete suites before each Fiat commit; run Imprimatur on shipped prose; sign every Fiat-created commit and verify its signature and provenance trailers.
+
+**Ask first.** Change state version or public receipt shape incompatibly; add a dependency; accept edits before the old digest boundary; add a runbook-repair transition; touch CI; edit the held frontier; bypass a failed checker; merge without required gates.
+
+**Never.** Treat arbitrary drift as an amendment; erase the earlier study bytes; infer a holding verdict from silence; emit work for a broken current step; put full study prose, raw checker output, credentials, or signature material in the ledger; claim a checker, test, signature, audit, push, or merge that did not occur.
+
+## 4. Design options
+
+### Option A: restore, edit, and re-run `done study`
+
+This reuses an existing verb but requires reopening the study phase or bypassing its phase gate. It overwrites the one study receipt and leaves no explicit old-to-new transition. The ledger would show a second completion rather than an amendment, obscuring the reason and the step verdicts.
+
+### Option B: accept any new study digest through `record`
+
+A generic receipt replacement is small but cannot distinguish a valid append from arbitrary mutation. It would make the existing tamper refusal user-overridable and would not validate Protasis or bind step effects.
+
+### Option C: a dedicated append-only `amend study` transition (chosen)
+
+Add a narrow command that reads the amended candidate, finds the final amendment boundary, hashes the unchanged prefix against the current receipt, validates the candidate and four-field block, checks every unbuilt step verdict, and commits the new digest plus bounded amendment history. The study itself retains the original bytes and correction. A holding amendment continues; a broken current step records the new evidence but blocks the dependent packet.
+
+This is the cheapest construction that preserves both contracts. Its trade is deliberate narrowness: it does not repair a runbook or allow earlier prose cleanup. A correction that changes a step still needs a separately specified recovery after the amendment is safely recorded.
+
+### Option D: store amendments in a separate file
+
+This keeps the receipted study immutable but contradicts Protasis's decision that the document itself show the earlier belief and its correction. Every consumer would also need to discover and order a second artefact before reading the specification.
+
+## 5. Risk register seed
+
+```risk-register
+prefix-forgery | the boundary between receipted bytes and the amendment suffix | the exact candidate prefix hashes to the current study receipt and any earlier-byte mutation refuses before state change
+amendment-selection | the final dated amendment block selected from Markdown | fenced decoys earlier headings duplicate final blocks and trailing prose cannot confuse the selected suffix
+field-ambiguity | the four required amendment fields | each field occurs exactly once in the final block with non-empty bounded content
+step-verdict-coverage | Still holding text mapped to current and pending steps | every unbuilt step number appears exactly once with an entry-and-exit verdict and completed steps cannot be rewritten
+broken-step-transition | a valid amendment that invalidates the current step | the amendment is recorded but controller state blocks all dependent packets until explicit recovery
+checker-binding | the amended bytes supplied to Protasis | argv-only invocation uses the bundled checker exact candidate and exit status with bounded diagnostic handling
+path-scope | candidate and canonical study paths | real paths remain inside the target and bounded reads reject symlink escape directories and oversized sources
+partial-write | study artefact state file and ledger during amendment | validation finishes first and controller mutation uses the existing lock and recoverable atomic-write order
+receipt-history | mutable current digest beside prior study evidence | amendment history and ledger carry old new and amendment digests without erasing earlier transitions
+post-amend-drift | study bytes after a successful amendment | next and verify recompute the new digest and refuse any further unreceipted edit
+legacy-state | runs whose study receipt has no amendments member | ordinary reads and next behavior remain unchanged until the new command is used
+evidence-overclaim | checker success and normalized verdicts | receipts claim structure order and recorded operator verdicts not truth of the correction or correctness of the remaining plan
+```
+
+## 6. Glossary seeds
+
+| Term | Meaning | Boundary |
+| --- | --- | --- |
+| Receipted study | The study path and SHA-256 accepted by `done study`. | Its current digest is immutable except through the amendment transition. |
+| Amendment candidate | The complete original study plus one proposed final amendment block. | It is not trusted until prefix, shape, checker, and step verdict gates pass. |
+| Amendment boundary | The byte offset where the final dated amendment heading begins. | Everything before it must hash to the current receipt. |
+| Unbuilt step | The current open step and every pending step whose status is not `done`. | Each needs one entry-and-exit verdict. |
+| Holding verdict | A step-specific statement that both entry and exit remain valid. | Silence and ambiguous prose are not holding. |
+| Broken current step | A current-step verdict saying its entry or exit no longer holds. | The amendment remains evidence, but no dependent packet is authorised. |
+| Amendment history | Bounded digest and verdict metadata stored with the current study receipt and on the ledger. | It does not copy the study prose or prove the correction true. |
+
+## 7. Sources
+
+- [Issue 446](https://github.com/wildcat-finance/skills/issues/446) and its maintainer comment, two recorded reproductions, conflict analysis, and proposed acceptance shape.
+- Exact start: Git commit `52b3b45c3d72cb2f163b1dfe88c920035d1385d5`.
+- `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`, especially bounded source reads, `done_study`, `receipted_source`, delegation packets, state commit, halt, verify, and CLI parsing.
+- `plugins/hexaemeron/tests/test_hexctl.py`, especially study receipt binding, mutation refusal, packet reconstruction, source decoys, state-shape, locking, and bounded-input cases.
+- `plugins/hexaemeron/skills/protasis/SKILL.md`, especially “The spec stays alive”, and `plugins/hexaemeron/skills/protasis/scripts/protasis.py`.
+- `plugins/hexaemeron/skills/fiat/SKILL.md`, `PROMISE_MACHINE.md`, and `plugins/hexaemeron/AGENTS.md`.
+- [PR 445](https://github.com/wildcat-finance/skills/pull/445), [PR 444](https://github.com/wildcat-finance/skills/pull/444), and amendment-origin [PR 307](https://github.com/wildcat-finance/skills/pull/307).
+- `audit/AUDIT.md`, Fiat delegation-packet, state-shape, task-issue, and Protasis amendment-contract rounds.
+
+## 8. Signals, and the questions behind them
+
+This remains an interactive controller, not an unattended service. No metric, trace, alert, or background log is added. The command's bounded stdout and stderr, `status --json`, `next`, and the ledger answer the operator questions.
+
+1. “Which study belief changed?” The amendment receipt and ledger expose old, new, and amendment digests plus the amendment date.
+2. “Was this an append or arbitrary drift?” A prefix mismatch produces a bounded refusal before controller mutation.
+3. “Which steps were reconsidered?” The normalized verdict map names every current and pending step.
+4. “May the current step continue?” `next` either emits its source-bound packet against the new study digest or reports the durable broken-step block.
+
+The amendment step emits these signals. Existing `verify` and `next` recheck the amended subject. [Ephoros](../plugins/hexaemeron/skills/ephoros/SKILL.md) remains the signal authority; this study cites rather than restates its contract.
+
+## 9. Boundaries, per capability
+
+The candidate path and bytes are untrusted filesystem input. Their value is one proposed append-only study. Scoped real-path checks, the existing byte ceiling, exact prefix hashing, deterministic final-block selection, and bounded UTF-8 decoding close that boundary.
+
+The amendment prose is untrusted structured input. Its value is a reasoned correction and step verdicts. Exact field cardinality, explicit step-number coverage, ambiguity refusal, and the bundled Protasis check close that boundary. The controller records that the operator supplied the verdict; it does not assert the prose is true.
+
+The Protasis checker is an internal subprocess boundary. Its value is the mechanical study-shape verdict. The controller invokes the fixed sibling path with `sys.executable`, an argv list, no shell, a timeout, bounded captured output, and the exact candidate bytes presented through a controlled temporary file when necessary.
+
+The study artefact, state, and ledger form the durable-write boundary. Validation completes before mutation. The existing state lock prevents a second controller writer. Atomic replacement and the hash-chained state commit keep the new artefact digest and receipt transition recoverable; a killed run must leave either the old receipted state or the new recorded state, never an unlabelled mixed claim.
+
+[Phylax](../plugins/hexaemeron/skills/phylax/SKILL.md) remains the boundary and control authority; this study does not duplicate its rules.
+
+## 10. The budget, or its absence
+
+No speed improvement is claimed, so there is no Metron before-and-after budget. The command performs bounded linear reads and one bundled checker invocation over a study already capped at 1 MiB. Existing controller timeouts and byte ceilings are functional safety limits, not performance claims.
+
+The focused regression command is the repeatable check:
+
+```bash
+python3 -m unittest plugins.hexaemeron.tests.test_hexctl
+```
+
+If implementation introduces an optimization, cache, parallel path, or a new latency claim, amend this study before the change. [Metron](../plugins/hexaemeron/skills/metron/SKILL.md) remains the measurement authority.
+
+## 11. The fail-closed posture
+
+The known red parent is the reproduction already present in `test_receipts_bind_bytes_and_mutation_refuses_packets`: after a receipted study changes, `next` returns the study-digest refusal. New Elenchus guards preserve that refusal for arbitrary edits while demonstrating the one sanctioned append path.
+
+Before implementation, focused tests must show the unfixed controller has no `amend` verb and that a Protasis-shaped append still leaves `next` refusing. The fixed tree then accepts only the valid append, records both digests, and emits the amended packet. Removing prefix comparison, any required field, a step-verdict coverage check, checker binding, or the current-step block must make a named regression red again.
+
+Malformed candidate paths, prefix edits, duplicate or missing fields, fenced-heading decoys, invalid dates, missing or duplicate step verdicts, completed-step rewrites, checker failure, oversize, wrong phase, concurrent mutation, and post-amend drift stop at the nearest boundary. No error path rewrites the ledger to manufacture a pass. A valid amendment that marks the current step broken is recorded, then the controller blocks dependent work and names explicit recovery.
+
+[Elenchus](../plugins/hexaemeron/skills/elenchus/SKILL.md) remains the triage and guard authority. The audit record must distinguish the original failure, each red guard, the fix, and the clean rerun.
+
+## 12. Decisions and their homes
+
+The append-only command, prefix proof, four-field validation, unbuilt-step verdict gate, bounded receipt history, and broken-current-step block are governed Fiat behavior. Their stable contract belongs in `plugins/hexaemeron/skills/fiat/SKILL.md` and the narrow CLI implementation in `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`.
+
+Red-to-green behavior belongs in `plugins/hexaemeron/tests/test_hexctl.py`; structural prose assertions belong in `plugins/hexaemeron/tests/test_fiat_skill.py`; existing Protasis checker behavior remains in its own tests unless implementation exposes a concrete missing checker rule. Promise Machine digest bindings move only as required by changed canonical bytes.
+
+The accepted study and runbook receive tracked copies in the existing Fiat documentation area during step 1. Audit dispositions append to `audit/AUDIT.md`. The implementation decision does not earn a standalone ADR because one governed skill's instructions and tests are its established home. It does not earn an evolution row or version change because issue 446 is not the held frontier job.
+
+If implementation needs a runbook-amendment transition, a new state version, a dependency, or a change to Protasis's contract, amend this study before code. [Hypomnema](../plugins/hexaemeron/skills/hypomnema/SKILL.md) remains the record-placement authority.

--- a/plugins/hexaemeron/skills/fiat/SKILL.md
+++ b/plugins/hexaemeron/skills/fiat/SKILL.md
@@ -320,6 +320,33 @@ Run the `imprimatur` lint on each artefact before receipting it, and pass the
 skills that ran to the receipt. Repo copies are committed later, in step 1 of
 the runbook, after the prose pass.
 
+**Amending a receipted study.** After the study and runbook receipts exist,
+and only while build steps are active, append one final dated Protasis
+amendment to the receipted study and run:
+
+```text
+hexctl amend study --artifact <candidate>
+```
+
+The candidate keeps the currently receipted study bytes as its exact prefix.
+Its suffix is one `### Amendment -- YYYY-MM-DD` block with `What changed`,
+`Why`, `Steps touched`, and `Still holding` fields, in that order. The last
+field contains one exact verdict for every current or pending step:
+`Step N: entry holds|broken; exit holds|broken.` The command checks the whole
+candidate with the bundled Protasis checker, copies captured candidate bytes
+to the canonical study path atomically, records the prior, new, and amendment
+digests with bounded step verdicts in state and the ledger, and re-pins the
+study receipt. It does not establish that the amendment is true or that a
+holding verdict is correct.
+
+Arbitrary drift, an edited prefix, a malformed block, incomplete or ambiguous
+step verdicts, a checker failure, an unsafe or oversized path, and an attempt
+outside the steps phase leave the current receipt unchanged. A broken entry or
+exit verdict for the current step is recorded, then `next` returns a durable
+blocked directive and step receipts refuse to advance. Inspect the amendment,
+halt the run, or use a separately specified runbook-repair transition; do not
+resume dependent work by editing state or repeating `done study`.
+
 **Implementation.** Pick the construction that takes the least effort to
 comprehend, then stop. The step runs under the phase skills: `phylax` names
 the boundaries the step introduces and the control each needs, `ephoros` names

--- a/plugins/hexaemeron/skills/fiat/SKILL.md
+++ b/plugins/hexaemeron/skills/fiat/SKILL.md
@@ -273,7 +273,7 @@ the whole delivery.
 
 ## The loop
 
-Repeat until `next` returns `done`, `halted`, or `audit-verdict`:
+Repeat until `next` returns `done`, `halted`, `blocked`, or `audit-verdict`:
 
 ```text
 hexctl next
@@ -295,6 +295,7 @@ Act on the single directive it prints, then receipt it. The directory:
 | `sync-run` | When the base advanced and the integration PR conflicts, receipt one signed two-parent merge of the exact remote base tip into the completed run stack | [push-discipline.md](references/push-discipline.md) | `done sync-run --commit <sha> --base-commit <sha>` |
 | `integrate` | Open and merge one PR from the run branch into the base, name what the run leaves unfinished in `.hexaemeron/run-pr.md`, then clean up and close any recorded task issue | [push-discipline.md](references/push-discipline.md) | `done integrate --pr-url <url> --merge-commit <sha> [--closed-issue-url <url>]` |
 | `audit-verdict` | Max rounds hit with findings open | ask the user | `done audit --no-further-leads --reason ...` or `halt --reason ...` |
+| `blocked` | A receipted study amendment broke the current step; inspect it, halt, or use a separately specified repair transition | below | -- |
 | `halted` | Report the reason; wait for the user | -- | `resume --note ...` when cleared |
 | `done` | Final report | below | -- |
 
@@ -334,10 +335,13 @@ Its suffix is one `### Amendment -- YYYY-MM-DD` block with `What changed`,
 field contains one exact verdict for every current or pending step:
 `Step N: entry holds|broken; exit holds|broken.` The command checks the whole
 candidate with the bundled Protasis checker, copies captured candidate bytes
-to the canonical study path atomically, records the prior, new, and amendment
-digests with bounded step verdicts in state and the ledger, and re-pins the
-study receipt. It does not establish that the amendment is true or that a
-holding verdict is correct.
+to the canonical study path through a recoverable write-ahead transaction,
+records the prior, new, and amendment digests with bounded step verdicts in
+state and the ledger, and re-pins the study receipt. A pending transaction
+blocks every other controller command; rerun `amend study` against the
+canonical study to finish or roll back the labelled transition. The command
+does not establish that the amendment is true or that a holding verdict is
+correct.
 
 Arbitrary drift, an edited prefix, a malformed block, incomplete or ambiguous
 step verdicts, a checker failure, an unsafe or oversized path, and an attempt
@@ -419,7 +423,7 @@ artefacts and state digest deterministically reconstruct the packet.
 
 ## Stop conditions
 
-Stop and ask the user when: `next` says `audit-verdict`; a push is rejected;
+Stop and ask the user when: `next` says `audit-verdict` or `blocked`; a push is rejected;
 the security suite cannot be resolved for a Solidity repo; or `verify` fails.
 Use `hexctl halt --reason ...` so the stop itself is on the ledger.
 
@@ -461,6 +465,18 @@ its merge SHA, audit rounds per step with the closing state of each, and where
 the study and runbook live.
 
 ## Promise Machine contract
+
+### fiat-study-amendment
+
+- Promise: A successful `hexctl amend study` establishes that the captured candidate preserved the currently receipted study bytes as its exact prefix, carried one structurally accepted final amendment, passed the bundled Protasis check, and recorded bounded digest and unbuilt-step verdict evidence.
+- Evidence: Scoped bounded reads of the receipted study and candidate, exact prefix SHA-256, deterministic amendment and field parsing, complete unbuilt-step verdict coverage, the bundled checker exit, the write-ahead transaction, canonical artefact digest, state receipt and `amend:study` ledger event.
+- Evidence classes: checked, recorded
+- Boundary: The receipt establishes candidate structure, byte continuity, checker acceptance and recorded operator verdicts; it does not establish that the correction is true, that a holding verdict is correct, or that a broken runbook has been repaired.
+- Authorises: Recoverably replacing the canonical study with the exact checked candidate, re-pinning its receipt, and either continuing to the existing next directive when the current step holds or emitting a durable blocked directive when it does not.
+- Consequence: 2
+- Refuses: An edited prefix, ambiguous or malformed amendment, incomplete verdict coverage, unsafe or oversized path, failed checker, unlabelled interrupted mutation, or dependent work after a broken current-step verdict.
+- Recovery: Inspect the pending record and study, rerun `hexctl amend study --artifact <canonical-study>` to finish or roll back an interrupted transaction, halt safely, or use a separately specified runbook-repair transition after a recorded broken verdict.
+- Exceptions: none
 
 ### fiat-receipted-delivery
 

--- a/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
+++ b/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
@@ -31,6 +31,7 @@ import re
 import selectors
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.parse
 
@@ -412,6 +413,7 @@ MUTATING = frozenset(
         "cmd_init",
         "cmd_record",
         "cmd_config",
+        "cmd_amend_study",
         "cmd_done",
         "cmd_audit_round",
         "cmd_halt",
@@ -607,11 +609,53 @@ def require_global_phase(state: dict, phase: str) -> None:
         die(f"out of order: expected phase '{state['phase']}', got '{phase}'")
 
 
+def amendment_block(state: dict) -> dict | None:
+    """Return the latest recorded broken verdict for the current step."""
+    if state.get("phase") != "steps" or state.get("current_step") is None:
+        return None
+    amendments = as_dict(as_dict(state.get("receipts")).get("study")).get(
+        "amendments"
+    )
+    if not isinstance(amendments, list):
+        return None
+    step_number = state["current_step"]
+    for amendment in reversed(amendments):
+        verdicts = as_dict(amendment).get("step_verdicts")
+        if not isinstance(verdicts, list):
+            continue
+        for verdict in verdicts:
+            item = as_dict(verdict)
+            if item.get("step") != step_number:
+                continue
+            if item.get("entry") == "holds" and item.get("exit") == "holds":
+                return None
+            return {
+                "step": step_number,
+                "entry": item.get("entry"),
+                "exit": item.get("exit"),
+                "amendment_sha256": amendment.get("amendment_sha256"),
+                "study_sha256": amendment.get("new_sha256"),
+            }
+    return None
+
+
+def require_no_amendment_block(state: dict) -> None:
+    blocked = amendment_block(state)
+    if blocked is None:
+        return
+    die(
+        "study amendment blocks step {step}: entry {entry}, exit {exit}; "
+        "inspect the amendment, halt the run, or use a separately specified "
+        "runbook-repair transition".format(**blocked)
+    )
+
+
 def require_step_phase(state: dict, phase: str) -> dict:
     if state.get("halted"):
         die(f"run is halted ({state['halted']['reason']}); `hexctl resume` first")
     if state["phase"] != "steps":
         die(f"out of order: run is in phase '{state['phase']}', not working steps")
+    require_no_amendment_block(state)
     step = current_step(state)
     if step["phase"] != phase:
         die(
@@ -1118,6 +1162,7 @@ def done_implement(args, state: dict) -> None:
     # Treat that legacy phase as implementation-ready and retire it in the
     # implementation receipt rather than forcing a GitHub side effect.
     step = current_step(state)
+    require_no_amendment_block(state)
     if state.get("halted"):
         die(f"run is halted ({state['halted']['reason']}); `hexctl resume` first")
     if state["phase"] != "steps" or step["phase"] not in ("issue", "implement"):
@@ -1763,6 +1808,21 @@ STEP_HEADING_RE = re.compile(
 )
 MARKDOWN_FENCE_RE = re.compile(r"^\s*(?P<mark>`{3,}|~{3,})")
 RISK_REGISTER_INFO = "risk-register"
+AMENDMENT_HEADING_RE = re.compile(
+    r"^###\s+Amendment\s+--\s+(?P<date>\d{4}-\d{2}-\d{2})\s*$"
+)
+AMENDMENT_FIELDS = ("What changed", "Why", "Steps touched", "Still holding")
+AMENDMENT_FIELD_RE = re.compile(
+    r"^\*\*(?P<name>What changed|Why|Steps touched|Still holding)\.\*\*"
+    r"(?:\s*(?P<value>.*))?$"
+)
+ANY_AMENDMENT_FIELD_RE = re.compile(r"^\*\*[^*\n]+\.\*\*(?:\s*.*)?$")
+STEP_VERDICT_RE = re.compile(
+    r"Step\s+(?P<step>[1-9]\d*)\s*:\s*"
+    r"entry\s+(?P<entry>holds|broken)\s*;\s*"
+    r"exit\s+(?P<exit>holds|broken)\s*\.",
+    re.IGNORECASE,
+)
 
 
 def markdown_lines(text: str):
@@ -1783,6 +1843,264 @@ def markdown_lines(text: str):
         else:
             yield offset, offset + len(physical), line, open_mark is not None, was_open
         offset += len(physical)
+
+
+def _study_amendment_boundary(text: str, expected: str) -> tuple[int, int, str]:
+    """Find the one real final amendment whose byte prefix has the receipt hash."""
+    headings = []
+    for start, _, line, in_fence, _ in markdown_lines(text):
+        if in_fence:
+            continue
+        match = AMENDMENT_HEADING_RE.fullmatch(line)
+        if match:
+            headings.append((start, match.group("date")))
+
+    matches = []
+    for heading_start, date_text in headings:
+        boundary = heading_start
+        candidates = [boundary]
+        while boundary > 0 and text[boundary - 1] in "\r\n":
+            boundary -= 1
+            candidates.append(boundary)
+        for candidate in candidates:
+            digest = hashlib.sha256(text[:candidate].encode("utf-8")).hexdigest()
+            if digest == expected:
+                matches.append((candidate, heading_start, date_text))
+
+    if not matches:
+        die(
+            "amendment candidate does not preserve the currently receipted "
+            "study bytes as its exact prefix"
+        )
+    if len(matches) != 1:
+        die("amendment candidate has an ambiguous receipted prefix boundary")
+    boundary, heading_start, date_text = matches[0]
+    later = [start for start, _ in headings if start > heading_start]
+    if later:
+        die("amendment candidate appends more than one final amendment block")
+    try:
+        datetime.date.fromisoformat(date_text)
+    except ValueError:
+        die(f"amendment heading has an invalid calendar date: {date_text}")
+    return boundary, heading_start, date_text
+
+
+def _study_amendment_fields(text: str, heading_start: int) -> dict[str, str]:
+    """Read the four ordered fields in the final amendment and nothing else."""
+    fields = []
+    headings_after = []
+    for start, end, line, in_fence, _ in markdown_lines(text):
+        if start <= heading_start or in_fence:
+            continue
+        if re.fullmatch(r"#{1,3}\s+.*", line):
+            headings_after.append(line)
+        match = AMENDMENT_FIELD_RE.fullmatch(line)
+        if match:
+            fields.append((start, end, match.group("name"), match.group("value") or ""))
+            continue
+        if ANY_AMENDMENT_FIELD_RE.fullmatch(line):
+            die(f"amendment carries an unexpected field: {line}")
+    if headings_after:
+        die("amendment block must be the final section of the study")
+
+    names = [item[2] for item in fields]
+    if names != list(AMENDMENT_FIELDS):
+        for name in AMENDMENT_FIELDS:
+            count = names.count(name)
+            if count != 1:
+                die(f"amendment field '{name}' must occur exactly once (got {count})")
+        die("amendment fields must appear in the accepted four-field order")
+
+    values = {}
+    for index, (_, end, name, first_line) in enumerate(fields):
+        stop = fields[index + 1][0] if index + 1 < len(fields) else len(text)
+        value = " ".join((first_line + "\n" + text[end:stop]).split())
+        if not value:
+            die(f"amendment field '{name}' must not be empty")
+        values[name] = value
+    return values
+
+
+def _study_step_verdicts(fields: dict[str, str], state: dict) -> tuple[list[int], list[dict]]:
+    """Bind touched steps and exact entry/exit verdicts to every unbuilt step."""
+    touched_text = fields["Steps touched"]
+    if re.search(r"\bsteps?\b", touched_text, re.IGNORECASE) is None:
+        die("amendment field 'Steps touched' must name at least one step number")
+    touched = sorted({int(value) for value in re.findall(r"\b\d+\b", touched_text)})
+    if not touched:
+        die("amendment field 'Steps touched' must name at least one step number")
+
+    all_steps = {step["n"]: step for step in state["steps"]}
+    unknown_touched = [number for number in touched if number not in all_steps]
+    if unknown_touched:
+        die(f"amendment names unknown touched step(s): {unknown_touched}")
+    completed_touched = [
+        number for number in touched if all_steps[number].get("status") == "done"
+    ]
+    if completed_touched:
+        die(f"amendment cannot rewrite completed step(s): {completed_touched}")
+
+    verdict_text = fields["Still holding"]
+    verdicts = []
+    cursor = 0
+    for match in STEP_VERDICT_RE.finditer(verdict_text):
+        if verdict_text[cursor:match.start()].strip():
+            die(
+                "amendment field 'Still holding' must contain only unambiguous "
+                "'Step N: entry holds|broken; exit holds|broken.' verdicts"
+            )
+        verdicts.append(
+            {
+                "step": int(match.group("step")),
+                "entry": match.group("entry").lower(),
+                "exit": match.group("exit").lower(),
+            }
+        )
+        cursor = match.end()
+    if verdict_text[cursor:].strip():
+        die(
+            "amendment field 'Still holding' must contain only unambiguous "
+            "'Step N: entry holds|broken; exit holds|broken.' verdicts"
+        )
+
+    numbers = [verdict["step"] for verdict in verdicts]
+    duplicates = sorted({number for number in numbers if numbers.count(number) > 1})
+    if duplicates:
+        die(f"amendment has duplicate step verdict(s): {duplicates}")
+
+    unbuilt = sorted(
+        step["n"] for step in state["steps"] if step.get("status") != "done"
+    )
+    completed = sorted(set(numbers) - set(unbuilt))
+    if completed:
+        die(f"amendment cannot rewrite completed or unknown step(s): {completed}")
+    missing = sorted(set(unbuilt) - set(numbers))
+    if missing:
+        die(f"amendment is missing verdict(s) for unbuilt step(s): {missing}")
+    return touched, sorted(verdicts, key=lambda item: item["step"])
+
+
+def _check_amended_study(base_dir: str, candidate: bytes) -> None:
+    """Run Protasis over the exact captured bytes through a controlled file."""
+    root = state_root(base_dir)
+    os.makedirs(root, exist_ok=True)
+    descriptor, path = tempfile.mkstemp(prefix="amended-study-", suffix=".md", dir=root)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(candidate)
+            handle.flush()
+            os.fsync(handle.fileno())
+        checker = os.path.join(plugin_root(), "skills", "protasis", "scripts", "protasis.py")
+        bounded_tool(
+            base_dir,
+            sys.executable,
+            [checker, "--study", path],
+            "Protasis rejected the amendment candidate",
+        )
+    finally:
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+
+
+def _replace_study_bytes(path: str, data: bytes) -> None:
+    """Replace the canonical study atomically after every validation has passed."""
+    directory = os.path.dirname(path)
+    descriptor, temporary = tempfile.mkstemp(prefix=".hexctl-study-", dir=directory)
+    try:
+        os.fchmod(descriptor, os.stat(path).st_mode & 0o777)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except OSError as exc:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        die(f"study artefact could not be replaced atomically: {exc}", 1)
+
+
+def cmd_amend_study(args) -> None:
+    """Receipt one append-only Protasis amendment while build steps are active."""
+    state = load_state(args.dir)
+    if state.get("halted"):
+        die(f"run is halted ({state['halted']['reason']}); `hexctl resume` first")
+    if state.get("phase") != "steps":
+        die("study amendments are accepted only while build steps are active")
+    require_no_amendment_block(state)
+
+    receipt = as_dict(as_dict(state.get("receipts")).get("study"))
+    expected = receipt.get("sha256")
+    if not isinstance(expected, str) or not re.fullmatch(r"[0-9a-f]{64}", expected):
+        die("study amendment requires a source-bound study receipt with sha256")
+    artifact = receipt.get("artifact")
+    if not isinstance(artifact, str) or not artifact:
+        die("study receipt has no artefact path")
+
+    candidate_arg = _require_file(args.artifact, "artifact")
+    candidate_path, candidate = read_bounded_source(
+        args.dir, candidate_arg, "study amendment candidate"
+    )
+    canonical_path, canonical_bytes = read_bounded_source(
+        args.dir, artifact, "study artefact"
+    )
+    if candidate_path != canonical_path:
+        actual = hashlib.sha256(canonical_bytes).hexdigest()
+        if actual != expected and canonical_bytes != candidate:
+            die(
+                f"study artefact digest changed: expected {expected}, got {actual}; "
+                "restore the receipted bytes or halt the run"
+            )
+
+    text = decoded_source(candidate, "study amendment candidate")
+    boundary, heading_start, date_text = _study_amendment_boundary(text, expected)
+    fields = _study_amendment_fields(text, heading_start)
+    touched, verdicts = _study_step_verdicts(fields, state)
+    _check_amended_study(args.dir, candidate)
+
+    prefix_bytes = text[:boundary].encode("utf-8")
+    amendment_bytes = candidate[len(prefix_bytes):]
+    prior_sha256 = hashlib.sha256(prefix_bytes).hexdigest()
+    new_sha256 = hashlib.sha256(candidate).hexdigest()
+    amendment_sha256 = hashlib.sha256(amendment_bytes).hexdigest()
+    amendment = {
+        "date": date_text,
+        "prior_sha256": prior_sha256,
+        "new_sha256": new_sha256,
+        "amendment_sha256": amendment_sha256,
+        "steps_touched": touched,
+        "step_verdicts": verdicts,
+    }
+    existing_history = receipt.get("amendments")
+    if existing_history is not None and not isinstance(existing_history, list):
+        die("study receipt amendments history must be an array", 1)
+
+    # Replace from the captured bytes even when the candidate is already the
+    # canonical path. An editor can change that path after the bounded read;
+    # the receipt must name the bytes this command validated, not a later read.
+    _replace_study_bytes(canonical_path, candidate)
+    receipt["sha256"] = new_sha256
+    history = receipt.setdefault("amendments", [])
+    history.append(amendment)
+    commit(args.dir, state, "amend:study", amendment)
+
+    current = state["current_step"]
+    verdict = next(item for item in verdicts if item["step"] == current)
+    disposition = (
+        "holds" if verdict["entry"] == "holds" and verdict["exit"] == "holds"
+        else "broken; dependent work is blocked"
+    )
+    print(
+        f"study amended: prior {prior_sha256}; new {new_sha256}; "
+        f"amendment {amendment_sha256}; step {current} {disposition}"
+    )
 
 
 def source_runbook_step(source: dict, step: dict) -> dict:
@@ -2316,6 +2634,21 @@ def cmd_next(args) -> None:
 def _next_directive(state: dict) -> dict:
     if state.get("halted"):
         return {"do": "halted", "reason": state["halted"]["reason"]}
+    blocked = amendment_block(state)
+    if blocked is not None:
+        return {
+            "do": "blocked",
+            "reason": (
+                f"study amendment marks step {blocked['step']} entry "
+                f"{blocked['entry']} and exit {blocked['exit']}"
+            ),
+            "amendment_sha256": blocked["amendment_sha256"],
+            "study_sha256": blocked["study_sha256"],
+            "recovery": (
+                "inspect the amendment, halt the run, or use a separately "
+                "specified runbook-repair transition"
+            ),
+        }
     phase = state["phase"]
     if phase == "study":
         return {
@@ -2389,6 +2722,12 @@ def cmd_status(args) -> None:
         print(f"run:   {state['run_branch']} -> {state['base']}")
     if state.get("halted"):
         print(f"HALTED: {state['halted']['reason']}")
+    blocked = amendment_block(state)
+    if blocked is not None:
+        print(
+            f"BLOCKED: study amendment marks step {blocked['step']} "
+            f"entry {blocked['entry']} and exit {blocked['exit']}"
+        )
     phase = state["phase"]
     if phase in ("study", "runbook"):
         print(f"phase: {phase} (day {DAY[phase]})")
@@ -2471,6 +2810,11 @@ def verify_run(base_dir: str) -> int:
             "state file does not match the last ledger entry; "
             "state.json was edited outside hexctl", 1
         )
+    amendments = as_dict(as_dict(state.get("receipts")).get("study")).get(
+        "amendments"
+    )
+    if amendments:
+        receipted_source(base_dir, state, "study")
     if state["phase"] == "integrate":
         merged = as_dict(state.get("integrate")).get("merged") or []
         expected = [s["n"] for s in state["steps"][: len(merged)]]
@@ -2565,6 +2909,12 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("key")
     sp.add_argument("value")
     sp.set_defaults(fn=cmd_record)
+
+    sp = sub.add_parser("amend", help="receipt a bounded mid-run amendment")
+    amend = sp.add_subparsers(dest="amend_subject", required=True)
+    study = amend.add_parser("study", help="receipt one append-only study amendment")
+    study.add_argument("--artifact", required=True)
+    study.set_defaults(fn=cmd_amend_study)
 
     sp = sub.add_parser("config", help="get or set a config value")
     sp.add_argument("action", choices=["get", "set"])

--- a/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
+++ b/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
@@ -38,6 +38,7 @@ import urllib.parse
 STATE_DIR_NAME = ".hexaemeron"
 STATE_FILE = "state.json"
 LEDGER_FILE = "ledger.jsonl"
+STUDY_AMENDMENT_PENDING_FILE = "study-amendment-pending.json"
 
 # The run-level pull request body the prose phase writes and the integrate
 # phase opens the integration pull request from. It is the last thing a run
@@ -396,7 +397,89 @@ def validate_state_shape(state) -> dict:
     return root
 
 
-def load_state(base_dir: str) -> dict:
+def study_amendment_pending_path(base_dir: str) -> str:
+    return os.path.join(state_root(base_dir), STUDY_AMENDMENT_PENDING_FILE)
+
+
+def load_study_amendment_pending(base_dir: str) -> dict | None:
+    """Read the bounded write-ahead record for an interrupted amendment."""
+    path = study_amendment_pending_path(base_dir)
+    if not os.path.exists(path):
+        return None
+    if os.path.islink(path) or not os.path.isfile(path):
+        die("study amendment pending record is not a regular file", 1)
+    try:
+        with open(path, "rb") as handle:
+            raw = handle.read(65537)
+    except OSError as exc:
+        die(f"study amendment pending record cannot be read: {exc}", 1)
+    if len(raw) > 65536:
+        die("study amendment pending record exceeds 65536-byte cap", 1)
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError):
+        die("study amendment pending record is malformed", 1)
+    if not isinstance(value, dict) or value.get("version") != 1:
+        die("study amendment pending record has an unsupported shape", 1)
+    if not isinstance(value.get("artifact"), str) or not value["artifact"]:
+        die("study amendment pending record has no artefact path", 1)
+    before = value.get("state_before_sha256")
+    if not isinstance(before, str) or not re.fullmatch(r"[0-9a-f]{64}", before):
+        die("study amendment pending record has an invalid state digest", 1)
+    amendment = value.get("amendment")
+    if not isinstance(amendment, dict):
+        die("study amendment pending record has no amendment object", 1)
+    return value
+
+
+def write_study_amendment_pending(base_dir: str, value: dict) -> None:
+    """Publish a durable marker before replacing any receipted study bytes."""
+    root = state_root(base_dir)
+    path = study_amendment_pending_path(base_dir)
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=".study-amendment-pending-", dir=root
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        directory = os.open(root, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except OSError as exc:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        die(f"study amendment pending record could not be written: {exc}", 1)
+
+
+def clear_study_amendment_pending(base_dir: str) -> None:
+    """Remove the write-ahead marker only after the receipt commit is durable."""
+    path = study_amendment_pending_path(base_dir)
+    try:
+        os.unlink(path)
+        directory = os.open(state_root(base_dir), os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        die(f"study amendment pending record could not be cleared: {exc}", 1)
+
+
+def load_state(base_dir: str, *, allow_pending_amendment: bool = False) -> dict:
     path = state_path(base_dir)
     if not os.path.exists(path):
         die(f"no state at {path}; run `hexctl init --topic ...` first")
@@ -405,7 +488,13 @@ def load_state(base_dir: str) -> dict:
             state = json.load(fh)
     except (ValueError, OSError) as exc:
         die(f"state file unreadable at {path}: {exc}", 1)
-    return validate_state_shape(state)
+    state = validate_state_shape(state)
+    if not allow_pending_amendment and load_study_amendment_pending(base_dir):
+        die(
+            "study amendment transaction is pending; rerun `hexctl amend study "
+            "--artifact <canonical-study>` to recover before continuing"
+        )
+    return state
 
 
 MUTATING = frozenset(
@@ -1829,16 +1918,24 @@ def markdown_lines(text: str):
     """Yield source offsets and fence state without treating quoted headings as real."""
     offset = 0
     open_mark = None
+    open_length = None
     for physical in text.splitlines(keepends=True):
         line = physical.rstrip("\r\n")
         fence = MARKDOWN_FENCE_RE.match(line)
         was_open = open_mark
         if fence:
-            mark = fence.group("mark")[0]
+            sequence = fence.group("mark")
+            mark = sequence[0]
             if open_mark is None:
                 open_mark = mark
-            elif mark == open_mark:
+                open_length = len(sequence)
+            elif (
+                mark == open_mark
+                and len(sequence) >= open_length
+                and not line[fence.end():].strip()
+            ):
                 open_mark = None
+                open_length = None
             yield offset, offset + len(physical), line, True, was_open
         else:
             yield offset, offset + len(physical), line, open_mark is not None, was_open
@@ -2015,6 +2112,11 @@ def _replace_study_bytes(path: str, data: bytes) -> None:
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(temporary, path)
+        parent = os.open(directory, os.O_RDONLY)
+        try:
+            os.fsync(parent)
+        finally:
+            os.close(parent)
     except OSError as exc:
         try:
             os.close(descriptor)
@@ -2027,9 +2129,134 @@ def _replace_study_bytes(path: str, data: bytes) -> None:
         die(f"study artefact could not be replaced atomically: {exc}", 1)
 
 
+def _study_amendment_record(
+    state: dict, expected: str, candidate: bytes
+) -> dict:
+    """Validate captured candidate bytes and return only bounded receipt data."""
+    text = decoded_source(candidate, "study amendment candidate")
+    boundary, heading_start, date_text = _study_amendment_boundary(text, expected)
+    fields = _study_amendment_fields(text, heading_start)
+    touched, verdicts = _study_step_verdicts(fields, state)
+    prefix_bytes = text[:boundary].encode("utf-8")
+    amendment_bytes = candidate[len(prefix_bytes):]
+    return {
+        "date": date_text,
+        "prior_sha256": hashlib.sha256(prefix_bytes).hexdigest(),
+        "new_sha256": hashlib.sha256(candidate).hexdigest(),
+        "amendment_sha256": hashlib.sha256(amendment_bytes).hexdigest(),
+        "steps_touched": touched,
+        "step_verdicts": verdicts,
+    }
+
+
+def _apply_study_amendment_receipt(receipt: dict, amendment: dict) -> None:
+    history = receipt.setdefault("amendments", [])
+    history.append(amendment)
+    receipt["sha256"] = amendment["new_sha256"]
+
+
+def _commit_or_complete_study_amendment(
+    base_dir: str, state: dict, amendment: dict
+) -> None:
+    """Do not duplicate an event written before an interrupted state replace."""
+    last = None
+    path = ledger_path(base_dir)
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            lines = [line for line in handle.read().splitlines() if line.strip()]
+        if lines:
+            last = json.loads(lines[-1])
+    except (OSError, ValueError):
+        last = None
+    expected_state = state_fingerprint(state)
+    if (
+        isinstance(last, dict)
+        and last.get("event") == "amend:study"
+        and last.get("data") == amendment
+        and last.get("state") == expected_state
+    ):
+        save_state(base_dir, state)
+        return
+    commit(base_dir, state, "amend:study", amendment)
+
+
+def _recover_study_amendment(
+    base_dir: str, state: dict, pending: dict
+) -> bool:
+    """Finish or roll back the labelled gap left by an interrupted command.
+
+    Returns True after the pending amendment is committed or visibly rolled
+    back. A later command may retry a rolled-back candidate as a fresh
+    transaction.
+    """
+    receipt = as_dict(as_dict(state.get("receipts")).get("study"))
+    artifact = receipt.get("artifact")
+    if artifact != pending["artifact"]:
+        die("pending study amendment does not match the current artefact path", 1)
+    amendment = pending["amendment"]
+    prior = amendment.get("prior_sha256")
+    new = amendment.get("new_sha256")
+    if not all(
+        isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value)
+        for value in (prior, new)
+    ):
+        die("pending study amendment has invalid receipt digests", 1)
+
+    canonical_path, canonical = read_bounded_source(
+        base_dir, artifact, "study artefact"
+    )
+    actual = hashlib.sha256(canonical).hexdigest()
+    current = receipt.get("sha256")
+
+    if current == new:
+        history = receipt.get("amendments")
+        if (
+            actual != new
+            or not isinstance(history, list)
+            or not history
+            or history[-1] != amendment
+        ):
+            die("pending study amendment disagrees with the committed receipt", 1)
+        verify_run(base_dir, allow_pending_amendment=True)
+        clear_study_amendment_pending(base_dir)
+        print(f"study amendment recovered: committed {new}")
+        return True
+
+    if current != prior or state_fingerprint(state) != pending["state_before_sha256"]:
+        die("pending study amendment no longer matches controller state", 1)
+    if actual == prior:
+        verify_run(base_dir, allow_pending_amendment=True)
+        clear_study_amendment_pending(base_dir)
+        print(f"study amendment recovered: rolled back to {prior}")
+        return True
+    if actual != new:
+        die(
+            "pending study amendment found neither the prior nor candidate bytes; "
+            "restore one recorded digest before recovery",
+            1,
+        )
+
+    recovered = _study_amendment_record(state, prior, canonical)
+    _check_amended_study(base_dir, canonical)
+    if recovered != amendment:
+        die("pending study amendment metadata does not match the candidate bytes", 1)
+    existing_history = receipt.get("amendments")
+    if existing_history is not None and not isinstance(existing_history, list):
+        die("study receipt amendments history must be an array", 1)
+    _apply_study_amendment_receipt(receipt, amendment)
+    _commit_or_complete_study_amendment(base_dir, state, amendment)
+    verify_run(base_dir, allow_pending_amendment=True)
+    clear_study_amendment_pending(base_dir)
+    print(f"study amendment recovered: recorded {new}")
+    return True
+
+
 def cmd_amend_study(args) -> None:
     """Receipt one append-only Protasis amendment while build steps are active."""
-    state = load_state(args.dir)
+    state = load_state(args.dir, allow_pending_amendment=True)
+    pending = load_study_amendment_pending(args.dir)
+    if pending is not None and _recover_study_amendment(args.dir, state, pending):
+        return
     if state.get("halted"):
         die(f"run is halted ({state['halted']['reason']}); `hexctl resume` first")
     if state.get("phase") != "steps":
@@ -2059,47 +2286,38 @@ def cmd_amend_study(args) -> None:
                 "restore the receipted bytes or halt the run"
             )
 
-    text = decoded_source(candidate, "study amendment candidate")
-    boundary, heading_start, date_text = _study_amendment_boundary(text, expected)
-    fields = _study_amendment_fields(text, heading_start)
-    touched, verdicts = _study_step_verdicts(fields, state)
+    amendment = _study_amendment_record(state, expected, candidate)
     _check_amended_study(args.dir, candidate)
-
-    prefix_bytes = text[:boundary].encode("utf-8")
-    amendment_bytes = candidate[len(prefix_bytes):]
-    prior_sha256 = hashlib.sha256(prefix_bytes).hexdigest()
-    new_sha256 = hashlib.sha256(candidate).hexdigest()
-    amendment_sha256 = hashlib.sha256(amendment_bytes).hexdigest()
-    amendment = {
-        "date": date_text,
-        "prior_sha256": prior_sha256,
-        "new_sha256": new_sha256,
-        "amendment_sha256": amendment_sha256,
-        "steps_touched": touched,
-        "step_verdicts": verdicts,
-    }
     existing_history = receipt.get("amendments")
     if existing_history is not None and not isinstance(existing_history, list):
         die("study receipt amendments history must be an array", 1)
 
+    pending = {
+        "version": 1,
+        "artifact": artifact,
+        "state_before_sha256": state_fingerprint(state),
+        "amendment": amendment,
+    }
+    write_study_amendment_pending(args.dir, pending)
     # Replace from the captured bytes even when the candidate is already the
     # canonical path. An editor can change that path after the bounded read;
     # the receipt must name the bytes this command validated, not a later read.
     _replace_study_bytes(canonical_path, candidate)
-    receipt["sha256"] = new_sha256
-    history = receipt.setdefault("amendments", [])
-    history.append(amendment)
+    _apply_study_amendment_receipt(receipt, amendment)
     commit(args.dir, state, "amend:study", amendment)
+    verify_run(args.dir, allow_pending_amendment=True)
+    clear_study_amendment_pending(args.dir)
 
     current = state["current_step"]
-    verdict = next(item for item in verdicts if item["step"] == current)
+    verdict = next(item for item in amendment["step_verdicts"] if item["step"] == current)
     disposition = (
         "holds" if verdict["entry"] == "holds" and verdict["exit"] == "holds"
         else "broken; dependent work is blocked"
     )
     print(
-        f"study amended: prior {prior_sha256}; new {new_sha256}; "
-        f"amendment {amendment_sha256}; step {current} {disposition}"
+        f"study amended: prior {amendment['prior_sha256']}; "
+        f"new {amendment['new_sha256']}; amendment "
+        f"{amendment['amendment_sha256']}; step {current} {disposition}"
     )
 
 
@@ -2772,8 +2990,10 @@ def cmd_resume(args) -> None:
     print("resumed")
 
 
-def verify_run(base_dir: str) -> int:
-    state = load_state(base_dir)
+def verify_run(base_dir: str, *, allow_pending_amendment: bool = False) -> int:
+    state = load_state(
+        base_dir, allow_pending_amendment=allow_pending_amendment
+    )
     path = ledger_path(base_dir)
     if not os.path.exists(path):
         die("ledger missing", 1)
@@ -2810,10 +3030,8 @@ def verify_run(base_dir: str) -> int:
             "state file does not match the last ledger entry; "
             "state.json was edited outside hexctl", 1
         )
-    amendments = as_dict(as_dict(state.get("receipts")).get("study")).get(
-        "amendments"
-    )
-    if amendments:
+    study_receipt = as_dict(as_dict(state.get("receipts")).get("study"))
+    if study_receipt.get("sha256") is not None:
         receipted_source(base_dir, state, "study")
     if state["phase"] == "integrate":
         merged = as_dict(state.get("integrate")).get("merged") or []

--- a/plugins/hexaemeron/tests/test_fiat_skill.py
+++ b/plugins/hexaemeron/tests/test_fiat_skill.py
@@ -157,6 +157,24 @@ class FiatSkillContractTests(unittest.TestCase):
         self.assertIn("Never merge into the base more than once in a run", self.fiat)
         self.assertIn("nothing merges while the steps run", fiat.lower())
 
+    def test_receipted_study_amendment_command_and_phase_boundary_are_explicit(self):
+        flat = " ".join(self.fiat.split())
+        self.assertIn("hexctl amend study --artifact <candidate>", self.fiat)
+        self.assertIn("only while build steps are active", flat)
+        self.assertIn("currently receipted study bytes as its exact prefix", flat)
+
+    def test_amendment_receipt_names_digests_verdicts_and_evidence_boundary(self):
+        flat = " ".join(self.fiat.split())
+        self.assertIn("prior, new, and amendment digests", flat)
+        self.assertIn("bounded step verdicts in state and the ledger", flat)
+        self.assertIn("does not establish that the amendment is true", flat)
+
+    def test_broken_current_step_has_a_durable_block_and_recovery(self):
+        flat = " ".join(self.fiat.split())
+        self.assertIn("`next` returns a durable blocked directive", flat)
+        self.assertIn("step receipts refuse to advance", flat)
+        self.assertIn("separately specified runbook-repair transition", flat)
+
 
 class StackBringDownTests(unittest.TestCase):
     """The order the stack comes down in, and why deleting early is fatal.

--- a/plugins/hexaemeron/tests/test_fiat_skill.py
+++ b/plugins/hexaemeron/tests/test_fiat_skill.py
@@ -175,6 +175,19 @@ class FiatSkillContractTests(unittest.TestCase):
         self.assertIn("step receipts refuse to advance", flat)
         self.assertIn("separately specified runbook-repair transition", flat)
 
+    def test_blocked_is_a_terminal_loop_outcome_with_no_implied_receipt(self):
+        loop = self.fiat.split("## The loop", 1)[1].split("## Phase notes", 1)[0]
+        self.assertIn("`blocked`", loop)
+        self.assertRegex(loop, r"\| `blocked` \|.*\| -- \|")
+
+    def test_amendment_mutation_has_its_own_promise_authorisation(self):
+        promise = self.fiat.split("### fiat-study-amendment", 1)[1]
+        promise = promise.split("### ", 1)[0]
+        self.assertIn("- Consequence: 2", promise)
+        self.assertIn("- Authorises:", promise)
+        self.assertIn("re-pinning", promise)
+        self.assertIn("durable blocked directive", promise)
+
 
 class StackBringDownTests(unittest.TestCase):
     """The order the stack comes down in, and why deleting early is fatal.

--- a/plugins/hexaemeron/tests/test_hexctl.py
+++ b/plugins/hexaemeron/tests/test_hexctl.py
@@ -18,6 +18,7 @@ from unittest import mock
 HERE = os.path.dirname(os.path.abspath(__file__))
 HEXCTL = os.path.join(HERE, "..", "skills", "fiat", "scripts", "hexctl.py")
 PROTASIS = os.path.join(HERE, "..", "skills", "protasis", "scripts", "protasis.py")
+COMPLETE_STUDY = os.path.join(HERE, "fixtures", "protasis", "complete-study.md")
 
 SUITE = '["hexaemeron:x-ray", "hexaemeron:solidity-auditor"]'
 """A security_suite receipt shaped like the one preflight records.
@@ -443,6 +444,45 @@ with module.held_lock(sys.argv[2], sys.argv[3]):
         for step in state["steps"]:
             self.git("branch", self.step_branch(step["n"], state))
 
+    def to_amendable_steps(self, titles=("Core", "Finish")):
+        self.init()
+        with open(COMPLETE_STUDY, encoding="utf-8") as handle:
+            original = handle.read()
+        study = self.write("study.md", original)
+        self.run_ctl("done", "study", "--artifact", study)
+        runbook = self.write(
+            "runbook.md",
+            "# Runbook\n\n" + "\n".join(
+                f"## Step {number}: {title}\n\n**Goal.** {title}.\n"
+                for number, title in enumerate(titles, 1)
+            ),
+        )
+        steps = self.write("steps.json", json.dumps(list(titles)))
+        self.run_ctl(
+            "done", "runbook", "--artifact", runbook, "--steps-file", steps
+        )
+        return original
+
+    @staticmethod
+    def amendment(
+        verdicts=(
+            "Step 1: entry holds; exit holds. "
+            "Step 2: entry holds; exit holds."
+        ),
+        *,
+        date="2026-08-22",
+        what="The fixture assumption was corrected.",
+        why="The receipted baseline disproved it.",
+        touched="Steps 1 and 2.",
+    ):
+        return (
+            f"\n### Amendment -- {date}\n\n"
+            f"**What changed.** {what}\n"
+            f"**Why.** {why}\n"
+            f"**Steps touched.** {touched}\n"
+            f"**Still holding.** {verdicts}\n"
+        )
+
     def git(self, *args, expect=0):
         proc = subprocess.run(
             ["git", *args], cwd=self.dir, capture_output=True, text=True
@@ -647,6 +687,48 @@ class TestDelegationPackets(HexctlCase):
         proc = self.run_ctl("next", expect=2)
         self.assertIn("runbook artefact digest changed", proc.stderr)
 
+    def test_amend_study_command_is_registered(self):
+        self.to_steps(("Core",))
+        parser = hexctl_module().build_parser()
+        args = parser.parse_args(
+            ["--dir", self.dir, "amend", "study", "--artifact", "study.md"]
+        )
+        self.assertEqual(args.fn.__name__, "cmd_amend_study")
+
+    def test_amend_study_replaces_the_digest_refusal_before_next(self):
+        self.init()
+        with open(COMPLETE_STUDY, encoding="utf-8") as handle:
+            original = handle.read()
+        study = self.write("study.md", original)
+        self.run_ctl("done", "study", "--artifact", study)
+        runbook = self.write(
+            "runbook.md",
+            "# Runbook\n\n"
+            "## Step 1: Core\n\n**Goal.** Core.\n\n"
+            "## Step 2: Finish\n\n**Goal.** Finish.\n",
+        )
+        steps = self.write("steps.json", '["Core", "Finish"]')
+        self.run_ctl(
+            "done", "runbook", "--artifact", runbook, "--steps-file", steps
+        )
+        amendment = (
+            "\n### Amendment -- 2026-08-22\n\n"
+            "**What changed.** The fixture assumption was corrected.\n"
+            "**Why.** The receipted baseline disproved it.\n"
+            "**Steps touched.** Steps 1 and 2.\n"
+            "**Still holding.** Step 1: entry holds; exit holds. "
+            "Step 2: entry holds; exit holds.\n"
+        )
+        candidate = self.write("candidate.md", original + amendment)
+        self.write("study.md", original + amendment)
+
+        refused = self.run_ctl("next", expect=2)
+        self.assertIn("study artefact digest changed", refused.stderr)
+
+        self.run_ctl("amend", "study", "--artifact", candidate)
+        packet = self.next_json()
+        self.assertEqual((packet["do"], packet["agent"]), ("implement", "mason"))
+
     def test_risk_block_drift_and_ambiguous_step_refuse(self):
         self.to_audit()
         self.run_ctl("record", "security_suite", SUITE)
@@ -819,6 +901,350 @@ class TestDelegationPackets(HexctlCase):
             with self.assertRaises(SystemExit):
                 module.bounded_git(self.dir, ["diff"])
         self.assertIn("2097152-byte output cap", error.getvalue())
+
+
+class TestStudyAmendments(HexctlCase):
+    def test_temporary_git_repositories_demonstrate_holding_and_broken_runs(self):
+        original = self.to_amendable_steps()
+        self.git("init", "-b", "main")
+        self.git("config", "user.email", "tests@example.com")
+        self.git("config", "user.name", "Hexctl Tests")
+        self.git("add", "study.md", "runbook.md", "steps.json")
+        self.git("commit", "-m", "temporary holding run")
+        candidate_text = original + self.amendment()
+        candidate = self.write("candidate.md", candidate_text)
+        self.run_ctl("amend", "study", "--artifact", candidate)
+        state = self.state()
+        ledger_path = os.path.join(self.dir, ".hexaemeron", "ledger.jsonl")
+        with open(ledger_path, encoding="utf-8") as handle:
+            ledger = [json.loads(line) for line in handle if line.strip()]
+        self.assertEqual(state["receipts"]["study"]["sha256"],
+                         hashlib.sha256(candidate_text.encode()).hexdigest())
+        self.assertEqual(ledger[-1]["event"], "amend:study")
+        self.assertEqual((self.next_json()["do"], self.next_json()["agent"]),
+                         ("implement", "mason"))
+
+        broken = HexctlCase(methodName="runTest")
+        broken.setUp()
+        try:
+            original = broken.to_amendable_steps()
+            broken.git("init", "-b", "main")
+            broken.git("config", "user.email", "tests@example.com")
+            broken.git("config", "user.name", "Hexctl Tests")
+            broken.git("add", "study.md", "runbook.md", "steps.json")
+            broken.git("commit", "-m", "temporary broken run")
+            candidate = broken.write(
+                "candidate.md",
+                original + broken.amendment(
+                    "Step 1: entry holds; exit broken. "
+                    "Step 2: entry holds; exit holds."
+                ),
+            )
+            broken.run_ctl("amend", "study", "--artifact", candidate)
+            directive = broken.next_json()
+            self.assertEqual((directive["do"], directive["agent"], directive["brief"]),
+                             ("blocked", None, {}))
+            self.assertIn("exit broken", directive["reason"])
+        finally:
+            broken.tearDown()
+
+    def test_valid_append_records_digest_history_and_reconstructs_the_packet(self):
+        original = self.to_amendable_steps()
+        prior = hashlib.sha256(original.encode()).hexdigest()
+        candidate_text = original + self.amendment()
+        candidate = self.write("candidate.md", candidate_text)
+
+        result = self.run_ctl("amend", "study", "--artifact", candidate)
+        state = self.state()
+        receipt = state["receipts"]["study"]
+        amendment = receipt["amendments"][0]
+        new = hashlib.sha256(candidate_text.encode()).hexdigest()
+        suffix = candidate_text[len(original):].encode()
+
+        self.assertEqual(receipt["sha256"], new)
+        self.assertEqual(amendment["prior_sha256"], prior)
+        self.assertEqual(amendment["new_sha256"], new)
+        self.assertEqual(amendment["amendment_sha256"], hashlib.sha256(suffix).hexdigest())
+        self.assertEqual(amendment["steps_touched"], [1, 2])
+        self.assertEqual(
+            amendment["step_verdicts"],
+            [
+                {"step": 1, "entry": "holds", "exit": "holds"},
+                {"step": 2, "entry": "holds", "exit": "holds"},
+            ],
+        )
+        self.assertIn(prior, result.stdout)
+        self.assertIn(new, result.stdout)
+        with open(os.path.join(self.dir, "study.md"), encoding="utf-8") as handle:
+            self.assertEqual(handle.read(), candidate_text)
+        with open(os.path.join(self.dir, ".hexaemeron", "ledger.jsonl"), encoding="utf-8") as handle:
+            ledger = [json.loads(line) for line in handle if line.strip()]
+        self.assertEqual(ledger[-1]["event"], "amend:study")
+        self.assertEqual(ledger[-1]["data"], amendment)
+        first = self.next_json()
+        second = self.next_json()
+        self.assertEqual(first, second)
+        self.assertEqual((first["do"], first["agent"]), ("implement", "mason"))
+
+    def test_broken_current_step_is_recorded_and_durably_blocks_work(self):
+        original = self.to_amendable_steps()
+        candidate = self.write(
+            "candidate.md",
+            original + self.amendment(
+                "Step 1: entry broken; exit holds. "
+                "Step 2: entry holds; exit holds."
+            ),
+        )
+        result = self.run_ctl("amend", "study", "--artifact", candidate)
+        self.assertIn("dependent work is blocked", result.stdout)
+        blocked = self.next_json()
+        self.assertEqual((blocked["do"], blocked["agent"], blocked["brief"]),
+                         ("blocked", None, {}))
+        self.assertRegex(blocked["amendment_sha256"], r"^[0-9a-f]{64}$")
+        self.assertIn("runbook-repair transition", blocked["recovery"])
+        proc = self.run_ctl(
+            "done", "implement", "--branch", self.step_branch(1),
+            "--commit", "abc", expect=2,
+        )
+        self.assertIn("study amendment blocks step 1", proc.stderr)
+        self.assertIn("BLOCKED:", self.run_ctl("status").stdout)
+        self.run_ctl("verify")
+
+    def test_prefix_drift_refuses_without_mutating_any_durable_record(self):
+        original = self.to_amendable_steps()
+        state_before = self.state()
+        ledger_path = os.path.join(self.dir, ".hexaemeron", "ledger.jsonl")
+        with open(ledger_path, "rb") as handle:
+            ledger_before = handle.read()
+        candidate = self.write("candidate.md", "changed\n" + original + self.amendment())
+        proc = self.run_ctl("amend", "study", "--artifact", candidate, expect=2)
+        self.assertIn("exact prefix", proc.stderr)
+        self.assertEqual(self.state(), state_before)
+        with open(ledger_path, "rb") as handle:
+            self.assertEqual(handle.read(), ledger_before)
+        with open(os.path.join(self.dir, "study.md"), encoding="utf-8") as handle:
+            self.assertEqual(handle.read(), original)
+
+    def test_date_and_four_field_shape_are_exact(self):
+        cases = {
+            "invalid date": (self.amendment(date="2026-02-30"), "invalid calendar date"),
+            "missing field": (
+                self.amendment().replace(
+                    "**Why.** The receipted baseline disproved it.\n", ""
+                ),
+                "field 'Why' must occur exactly once",
+            ),
+            "duplicate field": (
+                self.amendment().replace(
+                    "**Why.** The receipted baseline disproved it.\n",
+                    "**Why.** First.\n**Why.** Second.\n",
+                ),
+                "field 'Why' must occur exactly once",
+            ),
+            "empty field": (
+                self.amendment(what=""), "field 'What changed' must not be empty"
+            ),
+            "wrong order": (
+                self.amendment().replace(
+                    "**What changed.** The fixture assumption was corrected.\n"
+                    "**Why.** The receipted baseline disproved it.\n",
+                    "**Why.** The receipted baseline disproved it.\n"
+                    "**What changed.** The fixture assumption was corrected.\n",
+                ),
+                "accepted four-field order",
+            ),
+        }
+        for label, (suffix, message) in cases.items():
+            with self.subTest(label=label):
+                other = HexctlCase(methodName="runTest")
+                other.setUp()
+                try:
+                    original = other.to_amendable_steps()
+                    candidate = other.write("candidate.md", original + suffix)
+                    proc = other.run_ctl(
+                        "amend", "study", "--artifact", candidate, expect=2
+                    )
+                    self.assertIn(message, proc.stderr)
+                finally:
+                    other.tearDown()
+
+    def test_every_unbuilt_step_gets_one_unambiguous_entry_and_exit_verdict(self):
+        cases = {
+            "missing": ("Step 1: entry holds; exit holds.", "missing verdict(s)"),
+            "duplicate": (
+                "Step 1: entry holds; exit holds. "
+                "Step 1: entry holds; exit holds. "
+                "Step 2: entry holds; exit holds.",
+                "duplicate step verdict",
+            ),
+            "ambiguous": (
+                "Step 1 probably holds. Step 2 should hold.", "only unambiguous"
+            ),
+            "unknown": (
+                "Step 1: entry holds; exit holds. "
+                "Step 2: entry holds; exit holds. "
+                "Step 3: entry holds; exit holds.",
+                "completed or unknown step",
+            ),
+        }
+        for label, (verdicts, message) in cases.items():
+            with self.subTest(label=label):
+                other = HexctlCase(methodName="runTest")
+                other.setUp()
+                try:
+                    original = other.to_amendable_steps()
+                    candidate = other.write(
+                        "candidate.md", original + other.amendment(verdicts)
+                    )
+                    proc = other.run_ctl(
+                        "amend", "study", "--artifact", candidate, expect=2
+                    )
+                    self.assertIn(message, proc.stderr)
+                finally:
+                    other.tearDown()
+
+    def test_completed_step_cannot_be_touched_or_given_a_new_verdict(self):
+        original = self.to_amendable_steps()
+        path = os.path.join(self.dir, ".hexaemeron", "state.json")
+        with open(path, encoding="utf-8") as handle:
+            state = json.load(handle)
+        state["steps"][0]["status"] = "done"
+        state["steps"][0]["phase"] = "push"
+        state["steps"][1]["status"] = "open"
+        state["steps"][1]["phase"] = "implement"
+        state["current_step"] = 2
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(state, handle)
+        candidate = self.write("candidate.md", original + self.amendment())
+        proc = self.run_ctl("amend", "study", "--artifact", candidate, expect=2)
+        self.assertIn("cannot rewrite completed step(s): [1]", proc.stderr)
+
+    def test_wrong_phase_and_legacy_unbound_receipt_refuse(self):
+        self.init()
+        with open(COMPLETE_STUDY, encoding="utf-8") as handle:
+            original = handle.read()
+        study = self.write("study.md", original)
+        self.run_ctl("done", "study", "--artifact", study)
+        candidate = self.write("candidate.md", original + self.amendment())
+        proc = self.run_ctl("amend", "study", "--artifact", candidate, expect=2)
+        self.assertIn("only while build steps are active", proc.stderr)
+
+        other = HexctlCase(methodName="runTest")
+        other.setUp()
+        try:
+            original = other.to_amendable_steps()
+            state_path = os.path.join(other.dir, ".hexaemeron", "state.json")
+            with open(state_path, encoding="utf-8") as handle:
+                state = json.load(handle)
+            state["receipts"]["study"].pop("sha256")
+            with open(state_path, "w", encoding="utf-8") as handle:
+                json.dump(state, handle)
+            candidate = other.write("candidate.md", original + other.amendment())
+            proc = other.run_ctl(
+                "amend", "study", "--artifact", candidate, expect=2
+            )
+            self.assertIn("source-bound study receipt", proc.stderr)
+        finally:
+            other.tearDown()
+
+    def test_candidate_path_and_size_bounds_refuse(self):
+        original = self.to_amendable_steps()
+        outside = tempfile.NamedTemporaryFile("w", delete=False)
+        try:
+            outside.write(original + self.amendment())
+            outside.close()
+            proc = self.run_ctl(
+                "amend", "study", "--artifact", outside.name, expect=2
+            )
+            self.assertIn("escapes target directory", proc.stderr)
+        finally:
+            os.unlink(outside.name)
+
+        large = self.write(
+            "large.md", original + self.amendment() + "x" * (2 * 1024 * 1024)
+        )
+        proc = self.run_ctl("amend", "study", "--artifact", large, expect=2)
+        self.assertIn("exceeds 2097152-byte cap", proc.stderr)
+
+    def test_complete_candidate_must_pass_the_bundled_protasis_checker(self):
+        self.to_steps(("Core", "Finish"))
+        with open(os.path.join(self.dir, "study.md"), encoding="utf-8") as handle:
+            original = handle.read()
+        candidate = self.write("candidate.md", original + self.amendment())
+        proc = self.run_ctl("amend", "study", "--artifact", candidate, expect=2)
+        self.assertIn("Protasis rejected the amendment candidate", proc.stderr)
+        self.assertNotIn("S001", proc.stderr)
+
+    def test_live_controller_writer_blocks_amendment_mutation(self):
+        original = self.to_amendable_steps()
+        candidate = self.write("candidate.md", original + self.amendment())
+        holder, _, release = self.start_lock_holder(command="cmd_record")
+        try:
+            proc = self.run_ctl("amend", "study", "--artifact", candidate, expect=1)
+            self.assertIn("another hexctl is holding this run", proc.stderr)
+        finally:
+            self.release_lock_holder(holder, release)
+
+    def test_fenced_decoy_is_ignored_but_duplicate_block_and_trailing_section_refuse(self):
+        with open(COMPLETE_STUDY, encoding="utf-8") as handle:
+            fixture = handle.read()
+        decoy = fixture.replace(
+            "## 1. Problem statement",
+            "```markdown\n### Amendment -- 2026-01-01\n```\n\n"
+            "## 1. Problem statement",
+        )
+        self.init()
+        study = self.write("study.md", decoy)
+        self.run_ctl("done", "study", "--artifact", study)
+        runbook = self.write(
+            "runbook.md", "## Step 1: Core\n\n**Goal.** Core.\n"
+            "## Step 2: Finish\n\n**Goal.** Finish.\n"
+        )
+        steps = self.write("steps.json", '["Core", "Finish"]')
+        self.run_ctl("done", "runbook", "--artifact", runbook, "--steps-file", steps)
+        candidate = self.write("candidate.md", decoy + self.amendment())
+        self.run_ctl("amend", "study", "--artifact", candidate)
+
+        for label, suffix, message in (
+            ("duplicate", self.amendment() + self.amendment(), "more than one"),
+            ("trailing", self.amendment() + "\n## Notes\n\nLater.\n", "final section"),
+        ):
+            with self.subTest(label=label):
+                other = HexctlCase(methodName="runTest")
+                other.setUp()
+                try:
+                    original = other.to_amendable_steps()
+                    candidate = other.write("candidate.md", original + suffix)
+                    proc = other.run_ctl(
+                        "amend", "study", "--artifact", candidate, expect=2
+                    )
+                    self.assertIn(message, proc.stderr)
+                finally:
+                    other.tearDown()
+
+    def test_same_path_candidate_and_multiple_holding_amendments_are_supported(self):
+        original = self.to_amendable_steps()
+        first_text = original + self.amendment()
+        self.write("study.md", first_text)
+        self.run_ctl("amend", "study", "--artifact", "study.md")
+        second_text = first_text + self.amendment(
+            date="2026-08-23", what="A second baseline fact changed."
+        )
+        second = self.write("second.md", second_text)
+        self.run_ctl("amend", "study", "--artifact", second)
+        history = self.state()["receipts"]["study"]["amendments"]
+        self.assertEqual(len(history), 2)
+        self.assertEqual(history[1]["prior_sha256"], history[0]["new_sha256"])
+
+    def test_post_amendment_drift_refuses_next_and_verify(self):
+        original = self.to_amendable_steps()
+        candidate = self.write("candidate.md", original + self.amendment())
+        self.run_ctl("amend", "study", "--artifact", candidate)
+        self.write("study.md", original + self.amendment() + "drift\n")
+        for command in (("next",), ("verify",)):
+            with self.subTest(command=command[0]):
+                proc = self.run_ctl(*command, expect=2)
+                self.assertIn("study artefact digest changed", proc.stderr)
 
 
 class TestCommitVerification(HexctlCase):

--- a/plugins/hexaemeron/tests/test_hexctl.py
+++ b/plugins/hexaemeron/tests/test_hexctl.py
@@ -1,5 +1,6 @@
 """End-to-end tests for hexctl, run through the CLI the way the skill uses it."""
 
+import argparse
 import glob
 import json
 import hashlib
@@ -1221,6 +1222,96 @@ class TestStudyAmendments(HexctlCase):
                     self.assertIn(message, proc.stderr)
                 finally:
                     other.tearDown()
+
+    def test_short_fence_cannot_expose_an_amendment_heading_inside_a_long_fence(self):
+        self.init()
+        with open(COMPLETE_STUDY, encoding="utf-8") as handle:
+            original = handle.read() + "\n````markdown\n```\n"
+        study = self.write("study.md", original)
+        self.run_ctl("done", "study", "--artifact", study)
+        runbook = self.write(
+            "runbook.md",
+            "# Runbook\n\n"
+            "## Step 1: Core\n\n**Goal.** Core.\n\n"
+            "## Step 2: Finish\n\n**Goal.** Finish.\n",
+        )
+        steps = self.write("steps.json", '["Core", "Finish"]')
+        self.run_ctl(
+            "done", "runbook", "--artifact", runbook, "--steps-file", steps
+        )
+        candidate = self.write("candidate.md", original + self.amendment())
+
+        proc = self.run_ctl("amend", "study", "--artifact", candidate, expect=2)
+        self.assertIn("exact prefix", proc.stderr)
+
+    def test_interrupted_replacement_is_durable_pending_work_and_recovers(self):
+        original = self.to_amendable_steps()
+        candidate_text = original + self.amendment()
+        candidate = self.write("candidate.md", candidate_text)
+        candidate_path = os.path.join(self.dir, candidate)
+        module = hexctl_module()
+
+        with mock.patch.object(
+            module,
+            "commit",
+            side_effect=KeyboardInterrupt(
+                "simulated interruption after artefact replacement"
+            ),
+        ):
+            with self.assertRaises(KeyboardInterrupt):
+                module.cmd_amend_study(
+                    argparse.Namespace(dir=self.dir, artifact=candidate_path)
+                )
+
+        with open(os.path.join(self.dir, "study.md"), encoding="utf-8") as handle:
+            self.assertEqual(handle.read(), candidate_text)
+        pending = os.path.join(
+            self.dir, ".hexaemeron", "study-amendment-pending.json"
+        )
+        self.assertTrue(os.path.isfile(pending))
+        refused = self.run_ctl("verify", expect=2)
+        self.assertIn("study amendment transaction is pending", refused.stderr)
+
+        recovered = self.run_ctl(
+            "amend", "study", "--artifact", os.path.join(self.dir, "study.md")
+        )
+        self.assertIn("recovered", recovered.stdout)
+        self.assertFalse(os.path.exists(pending))
+        self.run_ctl("verify")
+        self.assertEqual(
+            self.state()["receipts"]["study"]["sha256"],
+            hashlib.sha256(candidate_text.encode()).hexdigest(),
+        )
+
+    def test_recovery_completes_a_written_ledger_event_without_duplicating_it(self):
+        original = self.to_amendable_steps()
+        candidate_text = original + self.amendment()
+        candidate = self.write("candidate.md", candidate_text)
+        module = hexctl_module()
+
+        with mock.patch.object(
+            module,
+            "save_state",
+            side_effect=OSError("simulated interruption before state replacement"),
+        ):
+            with self.assertRaises(OSError):
+                module.cmd_amend_study(
+                    argparse.Namespace(
+                        dir=self.dir, artifact=os.path.join(self.dir, candidate)
+                    )
+                )
+
+        recovered = self.run_ctl(
+            "amend", "study", "--artifact", os.path.join(self.dir, "study.md")
+        )
+        self.assertIn("recovered", recovered.stdout)
+        with open(
+            os.path.join(self.dir, ".hexaemeron", "ledger.jsonl"),
+            encoding="utf-8",
+        ) as handle:
+            events = [json.loads(line)["event"] for line in handle if line.strip()]
+        self.assertEqual(events.count("amend:study"), 1)
+        self.run_ctl("verify")
 
     def test_same_path_candidate_and_multiple_holding_amendments_are_supported(self):
         original = self.to_amendable_steps()

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -128,7 +128,7 @@
     },
     "fiat-final-integration": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "32575098d23a7f28ca3a148b61ba47d0dd6e6eed838aabc826e0442af7df190e",
+      "sha256": "ec99b17a5acb3dd3daa0bf98136906c19db17d4cb5cbb47bf7324b55d5fd0958",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "run branch, base, integration head and merge commit",
@@ -140,9 +140,23 @@
         "exception": "canonical Exceptions field"
       }
     },
+    "fiat-study-amendment": {
+      "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
+      "sha256": "ec99b17a5acb3dd3daa0bf98136906c19db17d4cb5cbb47bf7324b55d5fd0958",
+      "bindings": {
+        "promise_id": "coverage key joined to the canonical promise heading and amend:study event",
+        "subject": "current study receipt, captured candidate bytes and canonical study path",
+        "scope": "one append-only final amendment and every unbuilt-step verdict",
+        "evidence_references": "prefix digest, amendment fields, Protasis exit, write-ahead record, state receipt and ledger event",
+        "evidence_classes": "checked structure and recorded operator verdicts joined to the canonical Evidence classes field",
+        "unknowns": "truth of the correction, correctness of holding verdicts and any unperformed runbook repair",
+        "transition": "canonical study replacement, receipt re-pin and holding-or-blocked result joined to the canonical Authorises field",
+        "exception": "canonical Exceptions field"
+      }
+    },
     "fiat-receipted-delivery": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "32575098d23a7f28ca3a148b61ba47d0dd6e6eed838aabc826e0442af7df190e",
+      "sha256": "ec99b17a5acb3dd3daa0bf98136906c19db17d4cb5cbb47bf7324b55d5fd0958",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "validated state, topic, run branch, step branch and head commit",
@@ -615,6 +629,31 @@
       "selector": "test_ephoros_review_recovery",
       "claim": "The named review case records a recovery that supplies new operational evidence before review repeats.",
       "evidence_class": "recorded"
+    },
+    "fiat-amendment-p": {
+      "path": "plugins/hexaemeron/tests/test_hexctl.py",
+      "selector": "test_valid_append_records_digest_history_and_reconstructs_the_packet",
+      "claim": "A valid append exercises the exact checked mutation and holding continuation authorised by the amendment promise."
+    },
+    "fiat-amendment-m": {
+      "path": "plugins/hexaemeron/tests/test_hexctl.py",
+      "selector": "test_prefix_drift_refuses_without_mutating_any_durable_record",
+      "claim": "Missing exact-prefix evidence refuses the durable amendment transition before mutation."
+    },
+    "fiat-amendment-s": {
+      "path": "plugins/hexaemeron/tests/test_hexctl.py",
+      "selector": "test_post_amendment_drift_refuses_next_and_verify",
+      "claim": "A later artefact no longer matching the amended receipt cannot inherit its authorisation."
+    },
+    "fiat-amendment-o": {
+      "path": "plugins/hexaemeron/tests/test_fiat_skill.py",
+      "selector": "test_amendment_receipt_names_digests_verdicts_and_evidence_boundary",
+      "claim": "The command records checked structure and operator verdicts without claiming that the amendment is true."
+    },
+    "fiat-amendment-r": {
+      "path": "plugins/hexaemeron/tests/test_hexctl.py",
+      "selector": "test_interrupted_replacement_is_durable_pending_work_and_recovers",
+      "claim": "An interrupted durable mutation remains labelled, blocks dependent work and can be recovered by the named rerun."
     },
     "fiat-p": {
       "path": "plugins/hexaemeron/tests/test_hexctl.py",
@@ -1718,6 +1757,22 @@
         "S": "fiat-s",
         "O": "fiat-o",
         "R": "fiat-r",
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      }
+    },
+    {
+      "promise_id": "fiat-study-amendment",
+      "skill_path": "plugins/hexaemeron/skills/fiat/SKILL.md",
+      "group": "executable",
+      "cases": {
+        "P": "fiat-amendment-p",
+        "M": "fiat-amendment-m",
+        "S": "fiat-amendment-s",
+        "O": "fiat-amendment-o",
+        "R": "fiat-amendment-r",
         "X": {
           "not_applicable": true,
           "reason": "The canonical declaration supports no exception for this promise."

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -128,7 +128,7 @@
     },
     "fiat-final-integration": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "adf0fc24d650fdbb9d38b5b7ccb52320e5d76c1fbed0f3e9f303fa79a4d48167",
+      "sha256": "32575098d23a7f28ca3a148b61ba47d0dd6e6eed838aabc826e0442af7df190e",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "run branch, base, integration head and merge commit",
@@ -142,7 +142,7 @@
     },
     "fiat-receipted-delivery": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "adf0fc24d650fdbb9d38b5b7ccb52320e5d76c1fbed0f3e9f303fa79a4d48167",
+      "sha256": "32575098d23a7f28ca3a148b61ba47d0dd6e6eed838aabc826e0442af7df190e",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "validated state, topic, run branch, step branch and head commit",

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -518,13 +518,17 @@ class PromiseStructureTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["promises"], 62)
+        self.assertEqual(report["counts"]["promises"], 63)
 
     def test_hexaemeron_contract_population_is_complete(self):
         expected = {
             "elenchus": {"elenchus-fixed-and-guarded"},
             "ephoros": {"ephoros-mechanical-gate", "ephoros-observability-review"},
-            "fiat": {"fiat-receipted-delivery", "fiat-final-integration"},
+            "fiat": {
+                "fiat-study-amendment",
+                "fiat-receipted-delivery",
+                "fiat-final-integration",
+            },
             "hypomnema": {"hypomnema-pointer-gate", "hypomnema-record-placement"},
             "imprimatur": {"imprimatur-prose-gate"},
             "kronos": {
@@ -580,7 +584,7 @@ class PromiseOverlayTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["promises"], 67)
+        self.assertEqual(report["counts"]["promises"], 68)
         self.assertEqual(report["counts"]["overlays"], 1)
 
     def test_one_byte_vendored_mutation_is_refused(self):
@@ -956,8 +960,8 @@ class PromiseCoverageTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["coverage_rows"], 67)
-        self.assertEqual(report["counts"]["coverage_selected"], 51)
+        self.assertEqual(report["counts"]["coverage_rows"], 68)
+        self.assertEqual(report["counts"]["coverage_selected"], 52)
 
     def test_berean_and_janus_boundaries_are_explicit(self):
         coverage = json.loads(
@@ -1015,7 +1019,7 @@ class PromiseCoverageTests(unittest.TestCase):
             "transition",
             "exception",
         }
-        self.assertEqual(len(coverage["runtime"]), 29)
+        self.assertEqual(len(coverage["runtime"]), 30)
         for promise_id, binding in coverage["runtime"].items():
             with self.subTest(promise_id=promise_id):
                 self.assertEqual(set(binding), {"source", "sha256", "bindings"})
@@ -1155,7 +1159,7 @@ class PromiseCoverageTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["coverage_rows"], 67)
+        self.assertEqual(report["counts"]["coverage_rows"], 68)
         self.assertEqual(report["counts"]["coverage_selected"], 16)
 
     def test_prompt_and_vendored_evaluations_never_claim_proof(self):


### PR DESCRIPTION
## What changed

This is step 2 for issue #446. It adds `hexctl amend study --artifact <candidate>` as a narrow, receipted transition for one final Protasis amendment. The controller proves the old study is the candidate's exact prefix, validates the four required fields and every unbuilt-step verdict, runs the bundled Protasis checker, and records the prior, new and amendment digests.

The durable write now uses a fsynced pending marker and recoverable order across the canonical study, ledger and state. A holding amendment continues with a packet bound to the amended study. A broken current-step verdict records the amendment and returns a receipt-free `blocked` directive.

This PR is stacked on `fiat/446-receipted-study-amendments-step-1-publish-the-accepted-amendment-s`.

## Why

Fiat previously treated every post-receipt study edit as digest drift, although Protasis requires a dated amendment when new evidence disproves the accepted specification. This change admits only the append-only correction defined in step 1. Arbitrary rewrites still refuse, and the receipt does not establish that the amendment prose or operator verdicts are true.

## Audit

The complete review is in [`audit/AUDIT.md`](https://github.com/wildcat-finance/skills/blob/fiat/446-receipted-study-amendments-step-2-add-and-demonstrate-the-receipte/audit/AUDIT.md#fiat-receipted-study-amendments-step-2-round-1----2026-08-22).

| id | severity | finding | fix |
| --- | --- | --- | --- |
| `FSA-S2-R1-01` | high | An interruption between study replacement and state commit left mismatched durable files; recovery could also duplicate the ledger event. | Added a fsynced write-ahead marker, exact-byte finish-or-rollback recovery, cross-file verification and non-duplicating ledger completion. |
| `FSA-S2-R1-02` | medium | The consequence-2 mutation had no Promise authorising study replacement and receipt re-pinning, and Fiat did not define `blocked` as a terminal loop result. | Added `fiat-study-amendment`, operation-specific contract guards and an explicit receipt-free `blocked` stop. |
| `FSA-S2-R1-03` | medium | Three backticks could close a four-backtick fence, allowing a fenced heading to be selected as the live amendment. | The selector now retains delimiter character and opening length and accepts only a matching close of at least that length. |

Round 2 found zero findings. No audit finding remains open.

## Proof

- Focused controller, Fiat prose and Protasis: 313/313.
- Root suite: 113/113.
- Complete Hexaemeron suite: 765/765.
- Promise Machine: 68/68 promises and selected coverage rows.
- Phylax, Ephoros and Hypomnema lints: 0/0/0.

The recorded security-suite waiver still applies because the step changes Python, tests and instructions and ships no Solidity.

## Demonstration

- The holding case records all three digests in state and ledger, then reconstructs the amended Mason packet.
- The broken-current-step case records the amendment, returns the durable `blocked` directive with no delegated brief, and refuses every step receipt.
- Interruption probes recover both before canonical replacement and after state and ledger commit, leaving matching durable files and exactly one amendment event.

<!-- wildcat-origin: shoggoth -->
