### PR TITLE
Resume into the recorded worktree, and retire it at reset

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8255,3 +8255,46 @@ Machine checks clean.
 No new findings.
 
 Leads not pursued: the two carried from round 1, both unchanged.
+
+## Fiat run worktree, step 4, round 1 -- 2026-08-22
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| FRW-S4-R1-01 | medium | `docs/fiat-run-worktree-runbook.md` | The committed runbook puts worktree removal in `done integrate`. Built that way it removes the state and the ledger along with the tree, because both live in the tree, so the last act of a run is to delete its own evidence. Fiat's own contract then has the caller run `status` and `verify` after the run reports done, and neither has anywhere to read from. Seven existing integrate tests failed on exactly this. | fixed by moving retirement to `reset`, guarded by `test_reset_removes_a_clean_tree_and_archives_its_evidence` and `test_a_tree_holding_work_is_kept_and_never_forced` |
+
+The specification was wrong here and the code does not follow it. `reset` already
+means the run is finished and can be put away, it already archives, and it already
+refuses a run that is not done. `done integrate` records whether the tree was
+clean and says what `reset` will do with it, so the outcome is still named at the
+point the runbook wanted it named. The divergence is recorded here and in the
+pull request rather than resolved by editing the committed runbook, which is the
+frozen record of what the run believed when it started.
+
+A second thing fell out of the same reasoning. A run that lived in a worktree now
+archives into the checkout it was started from. Archiving inside the tree and then
+removing the tree would destroy the archive in the same breath.
+
+Reviewed against the eleven risk-register entries. `resume-orphan` is held: the
+breadcrumb and `git worktree list` agree, a recorded tree that is gone refuses
+naming that path instead of starting a second run, and a retired run drops out of
+the breadcrumb on the next read. `uncommitted-work-loss` is held by the rule and
+by a test: cleanliness is read before anything moves, a tree holding work is kept
+and named, and nothing anywhere passes `--force`. `legacy-state-resume` is held:
+state already sitting in a checkout still resumes, and the archived-run fixtures
+still verify. The other eight are unchanged from step 3.
+
+One incidental confirmation. An attempt to force a run to `done` by editing
+`state.json` directly was refused by the ledger chain check, which is the
+behaviour the state-shape rounds established and which this change does not
+weaken.
+
+Phylax, Ephoros and Hypomnema each exit 0. Suites: 784/784, 113 OK, both Promise
+Machine checks clean.
+
+1 finding, fixed.
+
+Leads not pursued: three. The two carried from step 3 are unchanged. New: if the
+archive move succeeds and the removal then fails, the tree is left without its
+state while the archive holds it; the tree is harmless at that point and the
+breadcrumb drops it, so the alternative would be to undo a completed archive to
+restore a directory nobody needs.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8234,3 +8234,24 @@ as untracked; overwriting somebody else's ignore file is the worse of the two.
 And the check-to-create race carried from step 2 is unchanged: `git worktree
 add` refuses an occupied path, so it closes into a refusal rather than a wrong
 tree.
+
+## Fiat run worktree, step 3, round 2 -- 2026-08-22
+
+Re-reviewed the fixed tree. FRW-S3-R1-01 is closed. Two runs started from one
+checkout each take their own tree and their own branch, the checkout stays on
+its own branch with its `HEAD` and `git status --short` unchanged, and the
+breadcrumb carries both. A repeat of the same run refuses and names that run's
+own tree. A breadcrumb entry whose state has gone is dropped on the next read,
+so a finished or reset run stops being offered while its neighbours stay.
+
+The same eleven risk-register entries were read again. Nothing in the fix widens
+a boundary: it changes how many lines the breadcrumb holds and which path a
+refusal names. `uncommitted-work-loss` and `resume-orphan` still belong to
+step 4.
+
+Phylax, Ephoros and Hypomnema each exit 0. Suites: 773/773, 113 OK, both Promise
+Machine checks clean.
+
+No new findings.
+
+Leads not pursued: the two carried from round 1, both unchanged.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8298,3 +8298,22 @@ archive move succeeds and the removal then fails, the tree is left without its
 state while the archive holds it; the tree is harmless at that point and the
 breadcrumb drops it, so the alternative would be to undo a completed archive to
 restore a directory nobody needs.
+
+## Fiat run worktree, step 4, round 2 -- 2026-08-22
+
+Re-reviewed the fixed tree. FRW-S4-R1-01 is closed. `done integrate` leaves the
+tree in place and reports its cleanliness, `status` and `verify` still read the
+run after it reports done, and `reset` archives into the origin checkout before
+removing anything. A tree holding work survives `reset` with its file intact and
+the run archived beside it.
+
+The same eleven risk-register entries were read again and none moved. Nothing in
+the fix widens a boundary: it changes which command retires the tree and where
+the archive lands.
+
+Phylax, Ephoros and Hypomnema each exit 0. Suites: 784/784, 113 OK, both Promise
+Machine checks clean.
+
+No new findings.
+
+Leads not pursued: the three from round 1, all unchanged.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8178,3 +8178,59 @@ No new findings.
 
 Leads not pursued: the check-to-create race recorded in round 1 is unchanged and
 belongs to step 3, where `git worktree add` turns it into a refusal.
+
+## Fiat run worktree, step 3, round 1 -- 2026-08-22
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| FRW-S3-R1-01 | medium | `plugins/hexaemeron/skills/fiat/scripts/hexctl.py` | The breadcrumb held one line, so `init` refused any second run from the same checkout, naming the first run's tree. [skills#439](https://github.com/wildcat-finance/skills/issues/439) asks for the opposite: two runs against one repository that do not contend for `HEAD` or the index. The guard turned an acceptance condition into a refusal. | fixed in the same commit as this entry, guarded by `test_two_runs_against_one_repository_each_get_their_own_tree`, `test_the_breadcrumb_records_every_live_run` and `test_repeating_a_topic_refuses_and_names_the_existing_tree` |
+
+Reviewed against the eleven risk-register entries. Nine are exercised here.
+`operator-head-mutation`, `dirty-origin-tree` and `partial-write` are each held
+by a test: the checkout's branch, `HEAD` and `git status --short` are captured
+before and after a successful `init`, a run starts from a deliberately dirty
+checkout, and every refusal path leaves no state, no ledger, no breadcrumb and
+no directory. `branch-already-checked-out` refuses by name before anything is
+written, and names the tree holding the branch. `stale-tree-reuse` and
+`path-escape` are step 2's validator, called before the first mutation.
+`subprocess-control` holds: two fixed-argv git invocations through the bounded
+reader, no caller value near a shell. `cross-filesystem-atomicity` holds by
+construction, since the tree is created under the repository root.
+`legacy-state-resume` holds: an existing state directory in a checkout still
+resumes and the archived-run fixtures still pass. `uncommitted-work-loss` and
+`resume-orphan` belong to step 4.
+
+The finding came from reading the issue's acceptance list against the built
+behaviour rather than from a lint. The breadcrumb is now one line per live run,
+sorted, with entries whose state has gone dropped on read, so a finished or
+reset run stops being offered. A repeat of the same run still refuses, and now
+names its own tree rather than somebody else's.
+
+Two things about the origin checkout, recorded rather than fixed. It keeps a
+`.hexaemeron/` holding three files: the self-ignoring `.gitignore` the
+controller has always written, the kernel lock taken before any mutating
+command runs, and the breadcrumb. Only the breadcrumb is the run's own writing,
+and the study's phrase about narrowing write access to one breadcrumb line
+describes that rather than the lock that precedes it. ADR-012 states what is
+actually kept. Separately, a refusal in a directory that is not a repository
+still leaves that `.hexaemeron/` behind, because the lock is taken before any
+command can decide the target is unusable; no state, ledger or breadcrumb is
+written, which is the standard the state-shape rounds set.
+
+The bounded reader was split into `bounded_run`, `bounded_tool` and
+`bounded_tool_status`. The security-relevant behaviour is unchanged and now sits
+in one place: no shell, fixed argv, a hard timeout, a hard output cap, and
+nothing from the child's stream in any diagnosis.
+
+Phylax, Ephoros and Hypomnema each exit 0. Suites after the fix: 773/773,
+113 OK, both Promise Machine checks clean.
+
+1 finding, fixed.
+
+Leads not pursued: two. `init` writes the worktree home's self-ignoring
+`.gitignore` only when none is there, so a repository that already keeps a
+different `tmp/fiat/.gitignore` would not get the ignore and would see the tree
+as untracked; overwriting somebody else's ignore file is the worse of the two.
+And the check-to-create race carried from step 2 is unchanged: `git worktree
+add` refuses an occupied path, so it closes into a refusal rather than a wrong
+tree.

--- a/docs/decisions/ADR-012-run-fiat-in-a-dedicated-worktree.md
+++ b/docs/decisions/ADR-012-run-fiat-in-a-dedicated-worktree.md
@@ -1,0 +1,104 @@
+# ADR-012: Run Fiat in a dedicated worktree, created at init
+
+## Status
+
+Accepted, 2026-08-22. Recorded for [skills#439](https://github.com/wildcat-finance/skills/issues/439).
+
+## Context
+
+A Fiat run took over the checkout it was started in. The contract had the model
+cut the run branch with `git checkout -b`, and every step branch the same way,
+so `HEAD` moved under whoever was standing in that directory, repeatedly, for
+the length of the run.
+
+Two costs are recorded in the issue. A clone sitting on an unrelated branch had
+a run fast-forward that branch to `origin/main`, commit onto it, and report the
+commit as being on `main`; the push then failed non-fast-forward, because local
+`main` was a stale ref the run had never touched. The commit was right and the
+report was wrong. Separately, two agents worked one repository in the same
+period, and only an accident of one being in a worktree kept them from fighting
+over `HEAD` and the index.
+
+Preflight refused to start against a dirty tree, which is correct in itself and
+meant an operator holding uncommitted work could not start a run at all.
+
+Fiat already knew the answer and only said so after the collision. The word
+`worktree` appeared in the controller exactly once, inside the refusal printed
+when the kernel lock was already held, advising `git worktree add ../<name>
+main`. That advice is also wrong in the ordinary case: git will not check out a
+branch that is already checked out elsewhere, so borrowing the base fails
+whenever the operator is standing on it.
+
+## Decision
+
+`hexctl init` creates the run's worktree before any preflight work touches a
+branch, and the run lives there for its whole length.
+
+- **Where it lives.** `tmp/fiat/<run branch with separators flattened>`, under
+  the worktree root git reports. One run maps to one directory, and an
+  issue-backed branch keeps its leading number.
+- **The home ignores itself.** `init` writes a `.gitignore` holding `*` into
+  `tmp/fiat/`, the same trick the state directory has always used. Without it
+  the home shows as untracked in the origin checkout, which breaks the promise
+  that a run leaves that checkout's `git status` alone and blocks the next run,
+  because preflight refuses a dirty tree. Doing it here rather than leaning on
+  the target repository's own ignore rules means the promise holds whichever
+  repository the run was started in.
+- **The run branch is created in the new tree.** `git worktree add -b <run
+  branch> <path> <base>` cuts it there rather than borrowing the base, which is
+  what makes the ordinary case work.
+- **State moves with it.** `.hexaemeron/` is written inside the worktree, so
+  `--dir` points at the worktree for the rest of the run. `init` prints the
+  exact command to use next.
+- **The origin checkout keeps a breadcrumb.** One line at
+  `.hexaemeron/worktree` naming the run's tree, so a resume can find it without
+  being told.
+- **Fail closed.** A target that is not a Git repository, a derived path that is
+  occupied or escapes the repository, a run branch already checked out
+  somewhere, or a failing `git worktree add`, each refuse by name before any
+  state, ledger or breadcrumb is written. This is a breaking change for anyone
+  who relied on an in-place run, and it is stated as one rather than hidden
+  behind a flag nobody sets.
+
+## What the origin checkout actually keeps
+
+Three files, all inside `.hexaemeron/` and all invisible to git: the
+self-ignoring `.gitignore` the controller has always written, the kernel lock
+taken before any mutating command runs, and the breadcrumb. The breadcrumb is
+the only one the run itself adds. The study's phrasing, that write access is
+narrowed to one breadcrumb line, describes the run's own writing and not the
+lock that precedes it.
+
+## Alternatives
+
+- **Contract text only.** Tell the model in `SKILL.md` to create a worktree
+  first. Cheapest, and rejected because it is the same shape as the defect: the
+  advice already there is contract text, and it is both unenforced and wrong in
+  the common case. A rule with no mechanism leaves no trace when it is skipped.
+- **A separate `hexctl worktree` command before `init`.** Composable, and it
+  keeps `init` free of filesystem work. Rejected because a run can simply not
+  call it, which is the previous option with more surface, and because
+  responsibility for isolating a run would sit in two commands either of which
+  can run without the other.
+- **An opt-in `--worktree` flag.** Smallest blast radius and no breaking
+  change. Rejected because the default stays broken, and every incident in the
+  issue happened on the default path.
+- **A sibling directory outside the repository.** Offered and declined. Keeping
+  the tree inside the repository also keeps state writes on one filesystem,
+  which the existing atomic replace depends on.
+
+## Consequences
+
+`init` now mutates the filesystem beyond its own state directory and owns a
+failure path it did not have before. Every one of those effects is refusable
+before any state exists, which is the compensation.
+
+The kernel lock stays exactly as it is. Separate worktrees mean separate state
+directories, which makes collision rarer without removing the need for the
+guard when two writers share one directory.
+
+Runs started before this change keep working: an existing `.hexaemeron/` in a
+checkout still resumes, and the archived-run fixtures still verify.
+
+Every test fixture that runs `init` is now a real repository, because a run that
+creates a worktree needs one to create it in.

--- a/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
+++ b/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
@@ -400,6 +400,25 @@ def validate_state_shape(state) -> dict:
 def load_state(base_dir: str) -> dict:
     path = state_path(base_dir)
     if not os.path.exists(path):
+        # A checkout that started a run has no state of its own: the run's state
+        # is in its worktree. Say which one and how to reach it, rather than
+        # reporting the absence and letting somebody start a second run over the
+        # top of the first.
+        live = read_breadcrumbs(base_dir)
+        if live:
+            named = "\n".join(f"  hexctl --dir {entry} next" for entry in live)
+            die(
+                f"no state here; this checkout's {'run works' if len(live) == 1 else 'runs work'} "
+                f"in {'its own worktree' if len(live) == 1 else 'their own worktrees'}:\n{named}"
+            )
+        recorded = raw_breadcrumbs(base_dir)
+        if recorded:
+            named = ", ".join(recorded)
+            die(
+                f"this checkout recorded a run worktree that is no longer "
+                f"there: {named}. Restore it or clear the breadcrumb at "
+                f"{breadcrumb_path(base_dir)}; a second run is not started for you"
+            )
         die(f"no state at {path}; run `hexctl init --topic ...` first")
     try:
         with open(path, "r", encoding="utf-8") as fh:
@@ -644,6 +663,7 @@ def parse_value(raw: str):
 # ------------------------------------------------------------------ commands
 
 def cmd_init(args) -> None:
+    origin_root = os.path.realpath(args.dir)
     root = state_root(args.dir)
     if os.path.exists(state_path(args.dir)):
         die(f"state already exists at {root}; resume with `hexctl next`")
@@ -756,12 +776,13 @@ def cmd_init(args) -> None:
         "frontier": frontier,
     }
     state["worktree"] = worktree
+    state["origin"] = origin_root
     init_data = {"topic": args.topic, "base": args.base, "run_branch": run_branch}
     if args.task_issue is not None:
         init_data["task_issue"] = args.task_issue
     try:
         commit(worktree, state, "init", init_data)
-        write_breadcrumb(args.dir, worktree)
+        write_breadcrumbs(args.dir, worktree)
     except OSError:
         remove_run_worktree(args.dir, worktree)
         die(f"could not record the run at {root}")
@@ -1754,8 +1775,20 @@ def done_integrate(args, state: dict) -> None:
     }
     if sync:
         state["receipts"]["integrate"]["sync"] = sync
+    worktree = state.get("worktree")
+    if worktree and os.path.isdir(worktree):
+        state["receipts"]["integrate"]["worktree_clean"] = worktree_is_clean(worktree)
     state["phase"] = "done"
     commit(args.dir, state, "done:integrate", state["receipts"]["integrate"])
+    if worktree and os.path.isdir(worktree):
+        clean = state["receipts"]["integrate"]["worktree_clean"]
+        print(
+            f"run worktree {worktree} "
+            + ("is clean; `hexctl reset` will archive the run and remove it"
+               if clean else
+               "holds modifications; `hexctl reset` will archive the run and "
+               "keep the tree. Nothing is ever forced")
+        )
     print(
         f"{run_branch_of(state)} merged into {state['base']} "
         f"({args.merge_commit}); run complete"
@@ -2111,6 +2144,15 @@ def breadcrumb_path(base_dir: str) -> str:
     return os.path.join(state_root(base_dir), WORKTREE_FILE)
 
 
+def raw_breadcrumbs(base_dir: str) -> list[str]:
+    """Every run this checkout recorded, live or not, as written."""
+    try:
+        with open(breadcrumb_path(base_dir), encoding="utf-8") as handle:
+            return sorted({line.strip() for line in handle if line.strip()})
+    except OSError:
+        return []
+
+
 def read_breadcrumbs(base_dir: str) -> list[str]:
     """Every run this checkout started that still has state, in path order.
 
@@ -2128,7 +2170,7 @@ def read_breadcrumbs(base_dir: str) -> list[str]:
     return sorted({entry for entry in recorded if os.path.exists(state_path(entry))})
 
 
-def write_breadcrumb(base_dir: str, worktree: str) -> None:
+def write_breadcrumbs(base_dir: str, worktree: str | None = None) -> None:
     """Leave one line in the origin checkout naming the run's tree.
 
     This is the only thing a run writes into the checkout it was started from. A
@@ -2142,7 +2184,7 @@ def write_breadcrumb(base_dir: str, worktree: str) -> None:
     if not os.path.exists(gitignore):
         with open(gitignore, "w", encoding="utf-8") as handle:
             handle.write("*\n")
-    entries = sorted(set(read_breadcrumbs(base_dir)) | {worktree})
+    entries = sorted(set(read_breadcrumbs(base_dir)) | ({worktree} if worktree else set()))
     with open(breadcrumb_path(base_dir), "w", encoding="utf-8") as handle:
         handle.write("".join(f"{entry}\n" for entry in entries))
 
@@ -2160,6 +2202,23 @@ def remove_run_worktree(base_dir: str, worktree: str, force: bool = False) -> bo
     argv.append(worktree)
     bounded_tool_status(base_dir, "git", argv)
     return not os.path.exists(worktree)
+
+
+def archive_name(state: dict) -> str:
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    topic = re.sub(r"[^a-z0-9]+", "-", state["topic"].lower()).strip("-")[:48]
+    return f"{stamp}-{topic or 'completed-run'}"
+
+
+def worktree_is_clean(worktree: str) -> bool:
+    """True when git has nothing to lose in this tree.
+
+    Read before anything is moved. Removal is never forced, so a tree holding
+    work is kept and named instead, and the worst outcome here is a directory
+    somebody has to look at.
+    """
+    porcelain = bounded_git(worktree, ["status", "--porcelain"])
+    return not porcelain.strip()
 
 
 def contained_in(root: str, resolved: str) -> bool:
@@ -2747,7 +2806,19 @@ def cmd_verify(args) -> None:
 
 
 def cmd_reset(args) -> None:
-    """Archive a completed run inside its ignored state directory."""
+    """Archive a completed run, and retire the worktree it ran in.
+
+    Retirement belongs here rather than in `done integrate`, because the
+    controller's own contract has the caller run `status` and `verify` after the
+    run reports done. A tree removed at integrate would take the state and the
+    ledger those two commands read with it, so the last thing a run did would be
+    to delete its own evidence. `reset` is already the command that means the run
+    is finished and can be put away.
+
+    A run that lived in a worktree archives into the checkout it was started
+    from, because archiving inside the tree and then removing the tree would
+    destroy the archive in the same breath.
+    """
     count = verify_run(args.dir)
     state = load_state(args.dir)
     if state["phase"] != "done":
@@ -2757,7 +2828,11 @@ def cmd_reset(args) -> None:
         )
 
     root = state_root(args.dir)
-    archive_root = os.path.join(root, "archive")
+    origin = state.get("origin")
+    worktree = state.get("worktree")
+    retiring = bool(origin and worktree and os.path.isdir(worktree)
+                    and os.path.realpath(worktree) == os.path.realpath(args.dir))
+    archive_root = os.path.join(state_root(origin) if retiring else root, "archive")
     os.makedirs(archive_root, exist_ok=True)
     stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     topic = re.sub(r"[^a-z0-9]+", "-", state["topic"].lower()).strip("-")[:48]
@@ -2779,6 +2854,16 @@ def cmd_reset(args) -> None:
         f"archived completed run ({count} ledger entries) at {destination}; "
         "active state cleared"
     )
+    if retiring:
+        if worktree_is_clean(worktree) and remove_run_worktree(origin, worktree):
+            print(f"run worktree removed: {worktree}")
+        else:
+            print(
+                f"run worktree kept at {worktree}: it holds work git would not "
+                f"discard. Nothing was forced.",
+                file=sys.stderr,
+            )
+        write_breadcrumbs(origin)
 
 
 # ---------------------------------------------------------------------- cli

--- a/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
+++ b/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
@@ -647,12 +647,6 @@ def cmd_init(args) -> None:
     root = state_root(args.dir)
     if os.path.exists(state_path(args.dir)):
         die(f"state already exists at {root}; resume with `hexctl next`")
-    recorded = read_breadcrumb(args.dir)
-    if recorded is not None and os.path.exists(state_path(recorded)):
-        die(
-            f"this checkout already started a run in {recorded}; "
-            f"resume with `hexctl --dir {recorded} next`"
-        )
     prefix = DEFAULT_CONFIG["git"]["run_branch_prefix"]
     issue_number = (
         task_issue_number(args.task_issue) if args.task_issue is not None else None
@@ -698,7 +692,13 @@ def cmd_init(args) -> None:
     # refusal still costs nothing: no worktree, no state, no ledger, no
     # breadcrumb.
     repo_root = repository_root(args.dir)
-    worktree = check_worktree_path(repo_root, run_worktree_path(args.dir, run_branch))
+    candidate = run_worktree_path(args.dir, run_branch)
+    if os.path.exists(state_path(candidate)):
+        die(
+            f"this run already has a worktree at {candidate}; "
+            f"resume with `hexctl --dir {candidate} next`"
+        )
+    worktree = check_worktree_path(repo_root, candidate)
     refuse_checked_out_branch(args.dir, run_branch)
 
     home = os.path.dirname(worktree)
@@ -2111,14 +2111,21 @@ def breadcrumb_path(base_dir: str) -> str:
     return os.path.join(state_root(base_dir), WORKTREE_FILE)
 
 
-def read_breadcrumb(base_dir: str):
-    """The worktree this checkout last started a run in, or None."""
+def read_breadcrumbs(base_dir: str) -> list[str]:
+    """Every run this checkout started that still has state, in path order.
+
+    One line per run rather than one line per checkout. The issue asks for two
+    runs against one repository that do not contend, so a second run has to be
+    recordable rather than refused, and a resume has to be able to say which
+    trees it found. Entries whose state has gone are dropped on the way out, so
+    a finished or reset run stops being offered.
+    """
     try:
         with open(breadcrumb_path(base_dir), encoding="utf-8") as handle:
-            recorded = handle.read().strip()
+            recorded = [line.strip() for line in handle if line.strip()]
     except OSError:
-        return None
-    return recorded or None
+        return []
+    return sorted({entry for entry in recorded if os.path.exists(state_path(entry))})
 
 
 def write_breadcrumb(base_dir: str, worktree: str) -> None:
@@ -2135,8 +2142,9 @@ def write_breadcrumb(base_dir: str, worktree: str) -> None:
     if not os.path.exists(gitignore):
         with open(gitignore, "w", encoding="utf-8") as handle:
             handle.write("*\n")
+    entries = sorted(set(read_breadcrumbs(base_dir)) | {worktree})
     with open(breadcrumb_path(base_dir), "w", encoding="utf-8") as handle:
-        handle.write(f"{worktree}\n")
+        handle.write("".join(f"{entry}\n" for entry in entries))
 
 
 def remove_run_worktree(base_dir: str, worktree: str, force: bool = False) -> bool:

--- a/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
+++ b/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
@@ -43,6 +43,8 @@ LEDGER_FILE = "ledger.jsonl"
 # writes into the repository, so it is where the work a run gave up on has to
 # be named: the next study over the same target reads it as prior art.
 RUN_PR_FILE = "run-pr.md"
+WORKTREE_FILE = "worktree"
+"""The one line the origin checkout keeps, naming the tree the run works in."""
 CARRIED_FORWARD_HEADING = "## Carried forward"
 
 # ``issue`` remains accepted only so runs created by older controllers can
@@ -645,6 +647,12 @@ def cmd_init(args) -> None:
     root = state_root(args.dir)
     if os.path.exists(state_path(args.dir)):
         die(f"state already exists at {root}; resume with `hexctl next`")
+    recorded = read_breadcrumb(args.dir)
+    if recorded is not None and os.path.exists(state_path(recorded)):
+        die(
+            f"this checkout already started a run in {recorded}; "
+            f"resume with `hexctl --dir {recorded} next`"
+        )
     prefix = DEFAULT_CONFIG["git"]["run_branch_prefix"]
     issue_number = (
         task_issue_number(args.task_issue) if args.task_issue is not None else None
@@ -685,11 +693,48 @@ def cmd_init(args) -> None:
             "version_at_init": ledger_field(text, "Current version"),
         }
 
-    os.makedirs(root, exist_ok=True)
-    # Self-ignoring: git never sees the state directory even in repos whose
-    # .gitignore was not touched. Nested .gitignore with `*` covers it.
-    with open(os.path.join(root, ".gitignore"), "w", encoding="utf-8") as fh:
-        fh.write("*\n")
+    # Everything refusable happens before the first mutation. The path is derived
+    # and validated, and the branch is checked for an existing tree, while a
+    # refusal still costs nothing: no worktree, no state, no ledger, no
+    # breadcrumb.
+    repo_root = repository_root(args.dir)
+    worktree = check_worktree_path(repo_root, run_worktree_path(args.dir, run_branch))
+    refuse_checked_out_branch(args.dir, run_branch)
+
+    home = os.path.dirname(worktree)
+    os.makedirs(home, exist_ok=True)
+    # Self-ignoring, the same trick the state directory uses. Without it the
+    # worktree home shows as untracked in the origin checkout, which both breaks
+    # the promise that a run leaves that checkout's `git status` alone and blocks
+    # the next run, because preflight refuses a dirty tree. Doing it here rather
+    # than leaning on the target repository's own rules means the promise holds
+    # whichever repository the run was started in.
+    home_gitignore = os.path.join(home, ".gitignore")
+    if not os.path.exists(home_gitignore):
+        with open(home_gitignore, "w", encoding="utf-8") as fh:
+            fh.write("*\n")
+    bounded_git(
+        args.dir,
+        ["worktree", "add", "-b", run_branch, worktree, args.base],
+        refusal=(
+            f"could not create the run worktree at {worktree} "
+            f"for '{run_branch}' off '{args.base}'"
+        ),
+    )
+
+    # From here the run's home is the worktree, so a failure has something to
+    # undo. Anything that goes wrong while writing state takes the tree with it,
+    # because a tree with no state is not a run anybody can resume.
+    root = state_root(worktree)
+    try:
+        os.makedirs(root, exist_ok=True)
+        # Self-ignoring: git never sees the state directory even in repos whose
+        # .gitignore was not touched. Nested .gitignore with `*` covers it.
+        with open(os.path.join(root, ".gitignore"), "w", encoding="utf-8") as fh:
+            fh.write("*\n")
+    except OSError:
+        remove_run_worktree(args.dir, worktree)
+        die(f"could not write the run's state into {root}")
 
     receipts = {}
     if args.task_issue is not None:
@@ -710,14 +755,22 @@ def cmd_init(args) -> None:
         "halted": None,
         "frontier": frontier,
     }
+    state["worktree"] = worktree
     init_data = {"topic": args.topic, "base": args.base, "run_branch": run_branch}
     if args.task_issue is not None:
         init_data["task_issue"] = args.task_issue
-    commit(args.dir, state, "init", init_data)
+    try:
+        commit(worktree, state, "init", init_data)
+        write_breadcrumb(args.dir, worktree)
+    except OSError:
+        remove_run_worktree(args.dir, worktree)
+        die(f"could not record the run at {root}")
     print(
         f"initialised {root} (topic: {args.topic}); "
         f"run branch {run_branch} off {args.base}"
     )
+    print(f"run worktree {worktree}")
+    print(f"work in it: hexctl --dir {worktree} next")
     if frontier is not None:
         print(
             f"frontier run: {frontier['ledger']} at {frontier['version_at_init']}, "
@@ -1853,13 +1906,15 @@ def source_risk_register(source: dict) -> dict:
     }
 
 
-def bounded_tool(
-    base_dir: str,
-    program: str,
-    argv: list[str],
-    refusal: str | None = None,
-) -> bytes:
-    """Run one fixed-argv tool without exposing its output in failures."""
+def bounded_run(base_dir: str, program: str, argv: list[str]) -> tuple[int, bytes]:
+    """Run one fixed-argv tool and return its status and output.
+
+    The reader itself: no shell, a hard timeout, a hard output cap, and nothing
+    from the child's stream in any diagnosis. Callers that treat a non-zero
+    status as fatal go through `bounded_tool`; callers for which a refusal is a
+    real answer, such as git declining to remove a tree holding modifications,
+    read the status here.
+    """
     operation = f"{program} {argv[0]}" if argv else program
     try:
         process = subprocess.Popen(
@@ -1904,11 +1959,28 @@ def bounded_tool(
     finally:
         selector.close()
         process.stdout.close()
+    return returncode, bytes(output)
+
+
+def bounded_tool(
+    base_dir: str,
+    program: str,
+    argv: list[str],
+    refusal: str | None = None,
+) -> bytes:
+    """Run one fixed-argv tool without exposing its output in failures."""
+    returncode, output = bounded_run(base_dir, program, argv)
     if returncode != 0:
         if refusal is not None:
             die(refusal)
+        operation = f"{program} {argv[0]}" if argv else program
         die(f"{operation} failed with exit {returncode}")
-    return bytes(output)
+    return output
+
+
+def bounded_tool_status(base_dir: str, program: str, argv: list[str]) -> int:
+    """The exit status of one fixed-argv tool, for callers a refusal informs."""
+    return bounded_run(base_dir, program, argv)[0]
 
 
 def bounded_git(base_dir: str, argv: list[str], refusal: str | None = None) -> bytes:
@@ -2007,6 +2079,79 @@ def check_worktree_path(root: str, candidate: str, registered: str | None = None
         if registered is None or os.path.realpath(registered) != resolved:
             die(f"worktree path is already occupied: {supplied}")
     return resolved
+
+
+def checked_out_worktrees(base_dir: str) -> dict:
+    """Branch -> worktree path, for every tree git currently knows about."""
+    porcelain = bounded_git(base_dir, ["worktree", "list", "--porcelain"]).decode(
+        "utf-8", "replace"
+    )
+    trees: dict[str, str] = {}
+    path = None
+    for line in porcelain.splitlines():
+        if line.startswith("worktree "):
+            path = line[len("worktree "):].strip()
+        elif line.startswith("branch ") and path is not None:
+            trees[line[len("branch "):].strip().removeprefix("refs/heads/")] = path
+    return trees
+
+
+def refuse_checked_out_branch(base_dir: str, run_branch: str) -> None:
+    """Git holds one branch in one tree, so a second checkout cannot be created.
+
+    Refusing by name here is what turns `git worktree add`'s own failure into a
+    sentence that says which branch and which tree, before anything is written.
+    """
+    existing = checked_out_worktrees(base_dir).get(run_branch)
+    if existing is not None:
+        die(f"run branch '{run_branch}' is already checked out at {existing}")
+
+
+def breadcrumb_path(base_dir: str) -> str:
+    return os.path.join(state_root(base_dir), WORKTREE_FILE)
+
+
+def read_breadcrumb(base_dir: str):
+    """The worktree this checkout last started a run in, or None."""
+    try:
+        with open(breadcrumb_path(base_dir), encoding="utf-8") as handle:
+            recorded = handle.read().strip()
+    except OSError:
+        return None
+    return recorded or None
+
+
+def write_breadcrumb(base_dir: str, worktree: str) -> None:
+    """Leave one line in the origin checkout naming the run's tree.
+
+    This is the only thing a run writes into the checkout it was started from. A
+    resume reads it so nobody has to remember the path, and it is one line rather
+    than state because two state directories for one run is the confusion the
+    breadcrumb exists to avoid.
+    """
+    root = state_root(base_dir)
+    os.makedirs(root, exist_ok=True)
+    gitignore = os.path.join(root, ".gitignore")
+    if not os.path.exists(gitignore):
+        with open(gitignore, "w", encoding="utf-8") as handle:
+            handle.write("*\n")
+    with open(breadcrumb_path(base_dir), "w", encoding="utf-8") as handle:
+        handle.write(f"{worktree}\n")
+
+
+def remove_run_worktree(base_dir: str, worktree: str, force: bool = False) -> bool:
+    """Take the run's tree away, and say whether it went.
+
+    Never forced by default. Git refuses to remove a tree holding modifications,
+    and that refusal is the point: the worst outcome here is a directory somebody
+    has to look at, never uncommitted work that vanished.
+    """
+    argv = ["worktree", "remove"]
+    if force:
+        argv.append("--force")
+    argv.append(worktree)
+    bounded_tool_status(base_dir, "git", argv)
+    return not os.path.exists(worktree)
 
 
 def contained_in(root: str, resolved: str) -> bool:

--- a/plugins/hexaemeron/tests/test_hexctl.py
+++ b/plugins/hexaemeron/tests/test_hexctl.py
@@ -32,6 +32,49 @@ LINTS_CLEAN = ("--phylax-exit", "0", "--ephoros-exit", "0", "--hypomnema-exit", 
 """What a non-Solidity round records when all three lints came back clean."""
 
 
+def make_origin_checkout(path):
+    """A real repository on `main` at `path`.
+
+    `init` creates a worktree, so every fixture it runs against has to be a real
+    repository. The fake git covers signatures, refs and pull requests; it cannot
+    stand in for repository structure.
+    """
+    for argv in (
+        ["init", "-q", "-b", "main"],
+        ["config", "user.email", "fixture@example.invalid"],
+        ["config", "user.name", "Fixture"],
+        ["config", "commit.gpgsign", "false"],
+        ["commit", "-q", "--allow-empty", "-m", "base"],
+    ):
+        subprocess.run(["git", *argv], cwd=path, check=True, capture_output=True)
+
+
+def run_target(base_dir):
+    """Where a run started in `base_dir` keeps its state.
+
+    `init` prints the run worktree and tells the caller to pass it as `--dir`.
+    The tests follow the same breadcrumb rather than reaching past it, so they
+    exercise the arrangement an operator actually gets.
+    """
+    crumb = os.path.join(base_dir, ".hexaemeron", "worktree")
+    try:
+        with open(crumb, encoding="utf-8") as handle:
+            recorded = handle.read().strip()
+    except OSError:
+        return base_dir
+    if recorded and os.path.exists(os.path.join(recorded, ".hexaemeron", "state.json")):
+        return recorded
+    return base_dir
+
+
+class OriginCheckoutMixin:
+    """A `target` that follows the run into its worktree."""
+
+    @property
+    def target(self):
+        return run_target(self.dir)
+
+
 def hexctl_module():
     """The controller imported as a module.
 
@@ -57,7 +100,7 @@ def protasis_module():
     return module
 
 
-class HexctlCase(unittest.TestCase):
+class HexctlCase(OriginCheckoutMixin, unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
         self.dir = self.tmp.name
@@ -67,6 +110,8 @@ class HexctlCase(unittest.TestCase):
         self.fake_prs = {}
         self.fake_parents = {}
         self.install_fake_delivery_tools()
+        make_origin_checkout(self.dir)
+
 
     def tearDown(self):
         for process in self.processes:
@@ -79,7 +124,7 @@ class HexctlCase(unittest.TestCase):
         pending_refs = dict(self.fake_refs)
         pending_prs = json.loads(json.dumps(self.fake_prs))
         pending_parents = json.loads(json.dumps(self.fake_parents))
-        state_path = os.path.join(self.dir, ".hexaemeron", "state.json")
+        state_path = os.path.join(self.target, ".hexaemeron", "state.json")
         state = None
         if os.path.exists(state_path):
             try:
@@ -127,7 +172,7 @@ class HexctlCase(unittest.TestCase):
         env["FAKE_GH_PRS"] = json.dumps(pending_prs)
         proc = subprocess.run(
             [sys.executable, HEXCTL, *args],
-            cwd=self.dir,
+            cwd=self.target,
             capture_output=True,
             text=True,
             env=env,
@@ -174,7 +219,7 @@ import time
 
 args = sys.argv[1:]
 mode = os.environ.get("FAKE_GIT_MODE", "valid")
-if args and args[0] == "rev-parse":
+if args and args[0] == "rev-parse" and "--show-toplevel" not in args:
     if mode == "missing-commit":
         raise SystemExit(2)
     ref = args[-1].removesuffix("^{{commit}}")
@@ -292,8 +337,8 @@ print(json.dumps(payload))
         return json.loads(self.run_ctl("next").stdout)
 
     def write(self, name, content="stub\n"):
-        path = os.path.join(self.dir, name)
-        os.makedirs(os.path.dirname(path) or self.dir, exist_ok=True)
+        path = os.path.join(self.target, name)
+        os.makedirs(os.path.dirname(path) or self.target, exist_ok=True)
         with open(path, "w", encoding="utf-8") as fh:
             fh.write(content)
         return name
@@ -331,7 +376,7 @@ print(json.dumps(payload))
 
     def strip_run_branch(self):
         """Make the state look like a run started before stacked branches."""
-        path = os.path.join(self.dir, ".hexaemeron", "state.json")
+        path = os.path.join(self.target, ".hexaemeron", "state.json")
         with open(path, encoding="utf-8") as fh:
             state = json.load(fh)
         state.pop("run_branch", None)
@@ -373,12 +418,12 @@ with module.held_lock(sys.argv[2], sys.argv[3]):
                 "-c",
                 program,
                 HEXCTL,
-                self.dir,
+                self.target,
                 command,
                 ready,
                 release,
             ],
-            cwd=self.dir,
+            cwd=self.target,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
@@ -433,19 +478,18 @@ with module.held_lock(sys.argv[2], sys.argv[3]):
         steps = self.write("steps.json", json.dumps(list(titles)))
         self.run_ctl("done", "runbook", "--artifact", runbook,
                      "--steps-file", steps)
-        self.git("init", "-b", "main")
-        self.git("config", "user.email", "tests@example.com")
-        self.git("config", "user.name", "Hexctl Tests")
+        # The repository and the run branch both exist already: the fixture is a
+        # real checkout, and `init` cut the run branch when it created the run's
+        # worktree. Only the step branches are still this helper's to make.
         self.git("add", study, runbook, steps)
         self.git("commit", "-m", "fixture")
         state = self.state()
-        self.git("branch", state["run_branch"])
         for step in state["steps"]:
             self.git("branch", self.step_branch(step["n"], state))
 
     def git(self, *args, expect=0):
         proc = subprocess.run(
-            ["git", *args], cwd=self.dir, capture_output=True, text=True
+            ["git", *args], cwd=self.target, capture_output=True, text=True
         )
         if proc.returncode != expect:
             raise AssertionError(
@@ -478,7 +522,7 @@ with module.held_lock(sys.argv[2], sys.argv[3]):
 class TestLifecycle(HexctlCase):
     def test_init_creates_state_ledger_and_gitignore(self):
         self.init()
-        root = os.path.join(self.dir, ".hexaemeron")
+        root = os.path.join(self.target, ".hexaemeron")
         self.assertTrue(os.path.exists(os.path.join(root, "state.json")))
         self.assertTrue(os.path.exists(os.path.join(root, "ledger.jsonl")))
         with open(os.path.join(root, ".gitignore")) as fh:
@@ -545,11 +589,11 @@ class TestDelegationPackets(HexctlCase):
             ("topic", "target_dir", "base_ref", "output_path"),
         )
         self.assertEqual(out["brief"]["topic"], "packet work")
-        self.assertEqual(out["brief"]["target_dir"], os.path.realpath(self.dir))
+        self.assertEqual(out["brief"]["target_dir"], os.path.realpath(self.target))
         self.assertEqual(out["brief"]["base_ref"], "main")
         self.assertEqual(
             out["brief"]["output_path"],
-            os.path.realpath(os.path.join(self.dir, ".hexaemeron", "study.md")),
+            os.path.realpath(os.path.join(self.target, ".hexaemeron", "study.md")),
         )
         self.assertEqual(out["state_sha256"], hashlib.sha256(
             json.dumps(self.state(), sort_keys=True, separators=(",", ":")).encode()
@@ -571,13 +615,9 @@ class TestDelegationPackets(HexctlCase):
         steps = self.write("steps.json", '["Core"]')
         self.run_ctl("done", "runbook", "--artifact", runbook,
                      "--steps-file", steps)
-        self.git("init", "-b", "main")
-        self.git("config", "user.email", "tests@example.com")
-        self.git("config", "user.name", "Hexctl Tests")
         self.git("add", study, runbook, steps)
         self.git("commit", "-m", "base")
         state = self.state()
-        self.git("branch", state["run_branch"])
         self.git("branch", self.step_branch(1, state))
 
         mason = self.next_json()
@@ -757,7 +797,7 @@ class TestDelegationPackets(HexctlCase):
 
     def test_legacy_receipts_do_not_claim_source_binding(self):
         self.to_steps(("Core",))
-        path = os.path.join(self.dir, ".hexaemeron", "state.json")
+        path = os.path.join(self.target, ".hexaemeron", "state.json")
         with open(path, encoding="utf-8") as handle:
             state = json.load(handle)
         state["receipts"]["runbook"].pop("sha256")
@@ -768,7 +808,7 @@ class TestDelegationPackets(HexctlCase):
 
     def test_missing_receipted_source_refuses(self):
         self.to_steps(("Core",))
-        os.unlink(os.path.join(self.dir, "runbook.md"))
+        os.unlink(os.path.join(self.target, "runbook.md"))
         proc = self.run_ctl("next", expect=2)
         self.assertIn("runbook artefact is not a regular file", proc.stderr)
 
@@ -929,7 +969,7 @@ class TestPublicationBindings(HexctlCase):
         self.write_run_pr()
 
     def edit_push_receipt(self, edit):
-        path = os.path.join(self.dir, ".hexaemeron", "state.json")
+        path = os.path.join(self.target, ".hexaemeron", "state.json")
         with open(path, encoding="utf-8") as handle:
             state = json.load(handle)
         edit(state["steps"][0]["receipts"]["push"])
@@ -1258,13 +1298,9 @@ class TestDelegationPacketLifecycle(HexctlCase):
         self.run_ctl(
             "done", "runbook", "--artifact", runbook, "--steps-file", steps
         )
-        self.git("init", "-b", "main")
-        self.git("config", "user.email", "tests@example.com")
-        self.git("config", "user.name", "Hexctl Tests")
         self.git("add", study, runbook, steps)
         self.git("commit", "-m", "fixture")
         state = self.state()
-        self.git("branch", state["run_branch"])
         self.git("branch", self.step_branch(1, state))
         self.stable_next("implement", "mason")
         self.run_ctl(
@@ -1317,7 +1353,7 @@ class TestDelegationPacketLifecycle(HexctlCase):
             state["receipts"]["integrate"]["final_step_merge"], "e" * 40
         )
         with open(
-            os.path.join(self.dir, ".hexaemeron", "ledger.jsonl"),
+            os.path.join(self.target, ".hexaemeron", "ledger.jsonl"),
             encoding="utf-8",
         ) as handle:
             ledger = handle.read()
@@ -1356,7 +1392,7 @@ class TestRunLock(HexctlCase):
         self.init()
         holder, _, release = self.start_lock_holder()
         self.release_lock_holder(holder, release)
-        path = os.path.join(self.dir, ".hexaemeron", "lock")
+        path = os.path.join(self.target, ".hexaemeron", "lock")
         with open(path, "rb") as handle:
             self.assertEqual(handle.read(), b"")
 
@@ -1410,8 +1446,8 @@ class TestStepGates(HexctlCase):
 
     def test_legacy_issue_phase_advances_without_creating_an_issue(self):
         self.to_steps()
-        state_path = os.path.join(self.dir, ".hexaemeron", "state.json")
-        ledger_path = os.path.join(self.dir, ".hexaemeron", "ledger.jsonl")
+        state_path = os.path.join(self.target, ".hexaemeron", "state.json")
+        ledger_path = os.path.join(self.target, ".hexaemeron", "ledger.jsonl")
         with open(state_path, encoding="utf-8") as handle:
             state = json.load(handle)
         state["steps"][0]["phase"] = "issue"
@@ -1594,7 +1630,7 @@ class TestProseAndPush(HexctlCase):
         self.assertEqual(state["run_branch"], "fiat/438-carry-the-task-issue-number")
         self.assertEqual(state["receipts"]["task_issue"], issue)
         with open(
-            os.path.join(self.dir, ".hexaemeron", "ledger.jsonl"),
+            os.path.join(self.target, ".hexaemeron", "ledger.jsonl"),
             encoding="utf-8",
         ) as handle:
             entries = [json.loads(line) for line in handle if line.strip()]
@@ -1638,7 +1674,7 @@ class TestProseAndPush(HexctlCase):
                     "init", "--topic", "t", "--task-issue", issue, expect=2
                 )
                 self.assertIn("--task-issue", proc.stderr)
-                root = os.path.join(self.dir, ".hexaemeron")
+                root = os.path.join(self.target, ".hexaemeron")
                 self.assertFalse(os.path.exists(os.path.join(root, "state.json")))
                 self.assertFalse(os.path.exists(os.path.join(root, "ledger.jsonl")))
 
@@ -1650,7 +1686,7 @@ class TestProseAndPush(HexctlCase):
                     "--run-branch", branch, expect=2,
                 )
                 self.assertIn("fiat/438-", proc.stderr)
-                root = os.path.join(self.dir, ".hexaemeron")
+                root = os.path.join(self.target, ".hexaemeron")
                 self.assertFalse(os.path.exists(os.path.join(root, "state.json")))
                 self.assertFalse(os.path.exists(os.path.join(root, "ledger.jsonl")))
 
@@ -1679,8 +1715,8 @@ class TestProseAndPush(HexctlCase):
 
     def test_task_issue_cannot_first_be_recorded_after_init(self):
         self.init()
-        state_path = os.path.join(self.dir, ".hexaemeron", "state.json")
-        ledger_path = os.path.join(self.dir, ".hexaemeron", "ledger.jsonl")
+        state_path = os.path.join(self.target, ".hexaemeron", "state.json")
+        ledger_path = os.path.join(self.target, ".hexaemeron", "ledger.jsonl")
         with open(state_path, "rb") as handle:
             state_before = handle.read()
         with open(ledger_path, "rb") as handle:
@@ -1698,8 +1734,8 @@ class TestProseAndPush(HexctlCase):
     def test_task_issue_repeat_is_idempotent_and_cannot_change(self):
         issue = "https://github.com/wildcat-finance/skills/issues/438"
         self.init(task_issue=issue)
-        state_path = os.path.join(self.dir, ".hexaemeron", "state.json")
-        ledger_path = os.path.join(self.dir, ".hexaemeron", "ledger.jsonl")
+        state_path = os.path.join(self.target, ".hexaemeron", "state.json")
+        ledger_path = os.path.join(self.target, ".hexaemeron", "ledger.jsonl")
         with open(state_path, "rb") as handle:
             state_before = handle.read()
         with open(ledger_path, "rb") as handle:
@@ -1719,8 +1755,8 @@ class TestProseAndPush(HexctlCase):
     def test_legacy_task_issue_state_keeps_its_stored_branch(self):
         issue = "https://github.com/wildcat-finance/skills/issues/438"
         self.to_steps(("One",))
-        state_path = os.path.join(self.dir, ".hexaemeron", "state.json")
-        ledger_path = os.path.join(self.dir, ".hexaemeron", "ledger.jsonl")
+        state_path = os.path.join(self.target, ".hexaemeron", "state.json")
+        ledger_path = os.path.join(self.target, ".hexaemeron", "ledger.jsonl")
         with open(state_path, encoding="utf-8") as handle:
             state = json.load(handle)
         state["receipts"]["task_issue"] = issue
@@ -1919,7 +1955,7 @@ class TestControls(HexctlCase):
     def test_verify_ok_and_tamper_detected(self):
         self.to_steps()
         self.run_ctl("verify")
-        ledger = os.path.join(self.dir, ".hexaemeron", "ledger.jsonl")
+        ledger = os.path.join(self.target, ".hexaemeron", "ledger.jsonl")
         with open(ledger) as fh:
             lines = fh.read().splitlines()
         entry = json.loads(lines[0])
@@ -1962,8 +1998,11 @@ class TestControls(HexctlCase):
         self.integrate_run()
         self.assertEqual(self.next_json()["do"], "done")
 
+        # `reset` clears the state, after which the breadcrumb no longer resolves
+        # and `target` falls back to the checkout. The archive is in the run's
+        # own tree, so hold that path before the reset rather than after.
+        root = os.path.join(self.target, ".hexaemeron")
         self.run_ctl("reset")
-        root = os.path.join(self.dir, ".hexaemeron")
         self.assertFalse(os.path.exists(os.path.join(root, "state.json")))
         archives = os.listdir(os.path.join(root, "archive"))
         self.assertEqual(len(archives), 1)
@@ -1995,10 +2034,10 @@ class TestFuzzRegressions(HexctlCase):
     """Pins for the day-5 fuzz findings (F-01..F-09)."""
 
     def state_file(self):
-        return os.path.join(self.dir, ".hexaemeron", "state.json")
+        return os.path.join(self.target, ".hexaemeron", "state.json")
 
     def ledger_file(self):
-        return os.path.join(self.dir, ".hexaemeron", "ledger.jsonl")
+        return os.path.join(self.target, ".hexaemeron", "ledger.jsonl")
 
     def to_audit_with_suite(self):
         self.to_audit()
@@ -2111,8 +2150,8 @@ class StateContainerValidationTests(HexctlCase):
         self.run_ctl(
             "audit-round", "--findings", "1", "--log", "audit/AUDIT.md"
         )
-        self.state_path = os.path.join(self.dir, ".hexaemeron", "state.json")
-        self.ledger_path = os.path.join(self.dir, ".hexaemeron", "ledger.jsonl")
+        self.state_path = os.path.join(self.target, ".hexaemeron", "state.json")
+        self.ledger_path = os.path.join(self.target, ".hexaemeron", "ledger.jsonl")
         with open(self.state_path, "rb") as handle:
             self.valid_state_bytes = handle.read()
         with open(self.ledger_path, "rb") as handle:
@@ -2241,7 +2280,7 @@ class StateContainerValidationTests(HexctlCase):
         state["steps"][0]["audit"]["rounds"][0]["legacy_leaf"] = [None]
         self.write_state(state)
 
-        loaded = hexctl_module().load_state(self.dir)
+        loaded = hexctl_module().load_state(self.target)
 
         self.assertEqual(loaded, state)
         self.assertEqual(loaded["version"], 1)
@@ -2417,7 +2456,7 @@ class LintReceiptTests(HexctlCase):
         self.to_waived_audit()
         self.run_ctl("audit-round", "--findings", "0", "--log", "audit/AUDIT.md",
                      *LINTS_CLEAN)
-        path = os.path.join(self.dir, ".hexaemeron", "state.json")
+        path = os.path.join(self.target, ".hexaemeron", "state.json")
         with open(path, encoding="utf-8") as fh:
             state = json.load(fh)
         state["steps"][0]["audit"]["rounds"][0].pop("lints")
@@ -2566,7 +2605,7 @@ if __name__ == "__main__":
     unittest.main(verbosity=2)
 
 
-class StaleControllerTests(unittest.TestCase):
+class StaleControllerTests(OriginCheckoutMixin, unittest.TestCase):
     """A run driven by an installed plugin older than the repository it edits.
 
     A marketplace plugin is installed from a published copy, so a repository that
@@ -2650,6 +2689,7 @@ class StaleControllerTests(unittest.TestCase):
     def test_init_warns_on_stderr_without_failing_the_run(self):
         module_dir = tempfile.mkdtemp()
         try:
+            make_origin_checkout(module_dir)
             self._repo(module_dir, "fiat-v99.9.9")
             done = subprocess.run(
                 [sys.executable, HEXCTL, "--dir", module_dir, "init",
@@ -2705,7 +2745,7 @@ def row(version, axis, revision, digest, change="Did the thing."):
     return f"| `{version}` | {axis} | `{revision}` | `{digest}` | [e](f) | {change} |\n"
 
 
-class FrontierGateTests(unittest.TestCase):
+class FrontierGateTests(OriginCheckoutMixin, unittest.TestCase):
     """A frontier run proves its ledger update instead of asserting it.
 
     The maturity gate says to update the ledger exactly once per completed
@@ -2721,6 +2761,7 @@ class FrontierGateTests(unittest.TestCase):
 
     def setUp(self):
         self.dir = tempfile.mkdtemp()
+        make_origin_checkout(self.dir)
         self.ledger = os.path.join(
             self.dir, "plugins", "demo", "skills", "widget", "EVOLUTION.md")
         self.base_digest = frontier_digest(*self.HELD)
@@ -2826,7 +2867,7 @@ class FrontierGateTests(unittest.TestCase):
              "--base", "main"], capture_output=True, text=True)
         self.assertEqual(done.returncode, 0, done.stderr)
         self.assertNotIn("frontier run:", done.stdout)
-        with open(os.path.join(self.dir, ".hexaemeron", "state.json"),
+        with open(os.path.join(self.target, ".hexaemeron", "state.json"),
                   encoding="utf-8") as fh:
             self.assertIsNone(json.load(fh)["frontier"])
 
@@ -2838,7 +2879,7 @@ class FrontierGateTests(unittest.TestCase):
         self.assertEqual(done.returncode, 0, done.stderr)
         self.assertIn("frontier run:", done.stdout)
         self.assertIn("widget-v1.1.0", done.stdout)
-        with open(os.path.join(self.dir, ".hexaemeron", "state.json"),
+        with open(os.path.join(self.target, ".hexaemeron", "state.json"),
                   encoding="utf-8") as fh:
             held = json.load(fh)["frontier"]
         self.assertEqual(held["rows"], 1)
@@ -2931,7 +2972,7 @@ class FrontierGateCompactTests(FrontierGateTests):
         self.assertIn("they have to be the same row", self.fault())
 
 
-class FrontierGateLegacySnapshotTests(unittest.TestCase):
+class FrontierGateLegacySnapshotTests(OriginCheckoutMixin, unittest.TestCase):
     """A snapshot taken while the gate could not see compact rows counted a
     real history as empty. The gate anchors on the init-time version instead
     of trusting that count, so such a run can still close honestly."""
@@ -2941,6 +2982,7 @@ class FrontierGateLegacySnapshotTests(unittest.TestCase):
 
     def setUp(self):
         self.dir = tempfile.mkdtemp()
+        make_origin_checkout(self.dir)
         self.ledger = os.path.join(
             self.dir, "plugins", "demo", "skills", "widget", "EVOLUTION.md")
         digest = frontier_digest(*self.HELD)
@@ -3160,3 +3202,157 @@ class WorktreePathTests(unittest.TestCase):
         os.makedirs(os.path.dirname(derived))
         os.symlink(inside, derived)
         self.assertIn("symlink", self.refuse(self.root, derived))
+
+
+class WorktreeCreationTests(HexctlCase):
+    """`init` arranges the run's isolation, so no run can forget to.
+
+    The origin checkout is the thing under test as much as the worktree is: a run
+    that leaves it on a branch it created, or with a `git status` it did not have
+    before, has failed even if every receipt it wrote is correct.
+    """
+
+    def origin(self, *args):
+        proc = subprocess.run(["git", *args], cwd=self.dir, capture_output=True,
+                              text=True, check=True)
+        return proc.stdout.strip()
+
+    def worktree_entries(self):
+        listing = self.origin("worktree", "list", "--porcelain")
+        return [line[len("worktree "):] for line in listing.splitlines()
+                if line.startswith("worktree ")]
+
+    # -- what a successful init arranges ---------------------------------
+
+    def test_init_creates_the_tree_and_the_run_branch(self):
+        before = self.worktree_entries()
+        self.init()
+        after = self.worktree_entries()
+        self.assertEqual(len(after), len(before) + 1)
+        created = [entry for entry in after if entry not in before][0]
+        self.assertEqual(os.path.realpath(created), os.path.realpath(self.target))
+        self.assertEqual(
+            self.origin("rev-parse", "--abbrev-ref", "HEAD"), "main"
+        )
+        self.assertEqual(
+            subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                           cwd=self.target, capture_output=True, text=True).stdout.strip(),
+            "fiat/test-topic",
+        )
+
+    def test_the_runs_state_lands_in_the_tree_not_the_checkout(self):
+        self.init()
+        self.assertNotEqual(os.path.realpath(self.target), os.path.realpath(self.dir))
+        self.assertTrue(os.path.exists(
+            os.path.join(self.target, ".hexaemeron", "state.json")))
+        self.assertFalse(os.path.exists(
+            os.path.join(self.dir, ".hexaemeron", "state.json")))
+
+    def test_the_breadcrumb_names_the_tree(self):
+        self.init()
+        with open(os.path.join(self.dir, ".hexaemeron", "worktree"),
+                  encoding="utf-8") as handle:
+            recorded = handle.read().strip()
+        self.assertEqual(os.path.realpath(recorded), os.path.realpath(self.target))
+
+    def test_the_checkout_keeps_only_the_breadcrumb_and_the_lock(self):
+        """The breadcrumb is the only thing the run itself writes there.
+
+        The directory around it is the kernel lock's, taken before any command
+        runs, and the self-ignoring `.gitignore` the controller has always
+        written. No state, no ledger, and nothing git can see.
+        """
+        self.init()
+        kept = sorted(os.listdir(os.path.join(self.dir, ".hexaemeron")))
+        self.assertEqual(kept, [".gitignore", "lock", "worktree"])
+
+    def test_init_prints_the_dir_to_use_next(self):
+        proc = self.run_ctl("init", "--topic", "printed path")
+        self.assertIn(f"hexctl --dir {self.target} next", proc.stdout)
+
+    # -- what it leaves alone --------------------------------------------
+
+    def test_the_origin_checkout_is_unchanged_across_a_successful_init(self):
+        before_head = self.origin("rev-parse", "HEAD")
+        before_branch = self.origin("rev-parse", "--abbrev-ref", "HEAD")
+        before_status = self.origin("status", "--short")
+        self.init()
+        self.assertEqual(self.origin("rev-parse", "HEAD"), before_head)
+        self.assertEqual(self.origin("rev-parse", "--abbrev-ref", "HEAD"), before_branch)
+        self.assertEqual(self.origin("status", "--short"), before_status)
+
+    def test_the_worktree_home_does_not_show_as_untracked(self):
+        """The home ignores itself, so the promise does not depend on the
+        target repository already ignoring `tmp/`."""
+        before = self.origin("status", "--short")
+        self.init()
+        self.assertEqual(self.origin("status", "--short"), before)
+        self.assertNotIn("tmp/", self.origin("status", "--short"))
+
+    def test_a_run_starts_from_a_dirty_origin_checkout(self):
+        """The dirty tree is no longer the run's tree, so it no longer blocks."""
+        with open(os.path.join(self.dir, "operators-work.txt"), "w",
+                  encoding="utf-8") as handle:
+            handle.write("uncommitted\n")
+        before_status = self.origin("status", "--short")
+        self.assertIn("operators-work.txt", before_status)
+        self.init()
+        self.assertEqual(self.origin("status", "--short"), before_status)
+        self.assertTrue(os.path.exists(
+            os.path.join(self.target, ".hexaemeron", "state.json")))
+
+    # -- what it refuses --------------------------------------------------
+
+    def test_a_run_branch_already_checked_out_elsewhere_refuses(self):
+        other = os.path.join(self.dir, "other-tree")
+        subprocess.run(["git", "worktree", "add", "-q", "-b", "fiat/test-topic",
+                        other, "main"], cwd=self.dir, check=True, capture_output=True)
+        proc = self.run_ctl("init", "--topic", "test topic", expect=2)
+        self.assertIn("already checked out", proc.stderr)
+        self.assertIn(other, proc.stderr)
+        self.assert_nothing_recorded()
+
+    def test_a_failing_worktree_add_refuses(self):
+        """A branch that exists but is checked out nowhere still stops `add -b`."""
+        subprocess.run(["git", "branch", "fiat/test-topic"], cwd=self.dir,
+                       check=True, capture_output=True)
+        proc = self.run_ctl("init", "--topic", "test topic", expect=2)
+        self.assertIn("could not create the run worktree", proc.stderr)
+        self.assert_nothing_recorded()
+
+    def test_a_target_that_is_not_a_repository_refuses(self):
+        plain = tempfile.mkdtemp()
+        try:
+            proc = subprocess.run(
+                [sys.executable, HEXCTL, "--dir", plain, "init", "--topic", "t"],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("not a git repository", proc.stderr)
+            for name in ("state.json", "ledger.jsonl", "worktree"):
+                self.assertFalse(
+                    os.path.exists(os.path.join(plain, ".hexaemeron", name)), name
+                )
+        finally:
+            shutil.rmtree(plain, ignore_errors=True)
+
+    def test_a_second_init_from_the_same_checkout_names_the_recorded_tree(self):
+        self.init()
+        recorded = self.target
+        proc = subprocess.run(
+            [sys.executable, HEXCTL, "--dir", self.dir, "init",
+             "--topic", "another topic"],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn(recorded, proc.stderr)
+        self.assertIn("--dir", proc.stderr)
+
+    def assert_nothing_recorded(self):
+        """A refusal leaves no state, no ledger, no breadcrumb and no tree."""
+        state_dir = os.path.join(self.dir, ".hexaemeron")
+        self.assertFalse(os.path.exists(os.path.join(state_dir, "worktree")))
+        self.assertFalse(os.path.exists(os.path.join(state_dir, "state.json")))
+        self.assertFalse(os.path.exists(os.path.join(state_dir, "ledger.jsonl")))
+        derived = os.path.join(self.dir, "tmp", "fiat", "fiat-test-topic")
+        self.assertFalse(os.path.exists(derived))

--- a/plugins/hexaemeron/tests/test_hexctl.py
+++ b/plugins/hexaemeron/tests/test_hexctl.py
@@ -3336,18 +3336,6 @@ class WorktreeCreationTests(HexctlCase):
         finally:
             shutil.rmtree(plain, ignore_errors=True)
 
-    def test_a_second_init_from_the_same_checkout_names_the_recorded_tree(self):
-        self.init()
-        recorded = self.target
-        proc = subprocess.run(
-            [sys.executable, HEXCTL, "--dir", self.dir, "init",
-             "--topic", "another topic"],
-            capture_output=True, text=True,
-        )
-        self.assertEqual(proc.returncode, 2)
-        self.assertIn(recorded, proc.stderr)
-        self.assertIn("--dir", proc.stderr)
-
     def assert_nothing_recorded(self):
         """A refusal leaves no state, no ledger, no breadcrumb and no tree."""
         state_dir = os.path.join(self.dir, ".hexaemeron")
@@ -3356,3 +3344,50 @@ class WorktreeCreationTests(HexctlCase):
         self.assertFalse(os.path.exists(os.path.join(state_dir, "ledger.jsonl")))
         derived = os.path.join(self.dir, "tmp", "fiat", "fiat-test-topic")
         self.assertFalse(os.path.exists(derived))
+
+    def test_two_runs_against_one_repository_each_get_their_own_tree(self):
+        """The issue asks for two runs that do not contend, not for a second
+        run that is refused."""
+        self.init("run alpha")
+        alpha = self.target
+        second = subprocess.run(
+            [sys.executable, HEXCTL, "--dir", self.dir, "init", "--topic", "run beta"],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(second.returncode, 0, second.stderr)
+        beta = os.path.join(self.dir, "tmp", "fiat", "fiat-run-beta")
+        self.assertNotEqual(os.path.realpath(alpha), os.path.realpath(beta))
+        for tree, branch in ((alpha, "fiat/run-alpha"), (beta, "fiat/run-beta")):
+            self.assertTrue(os.path.exists(os.path.join(tree, ".hexaemeron", "state.json")))
+            self.assertEqual(
+                subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=tree,
+                               capture_output=True, text=True).stdout.strip(),
+                branch,
+            )
+        self.assertEqual(self.origin("rev-parse", "--abbrev-ref", "HEAD"), "main")
+
+    def test_the_breadcrumb_records_every_live_run(self):
+        self.init("run alpha")
+        subprocess.run(
+            [sys.executable, HEXCTL, "--dir", self.dir, "init", "--topic", "run beta"],
+            capture_output=True, text=True, check=True,
+        )
+        with open(os.path.join(self.dir, ".hexaemeron", "worktree"),
+                  encoding="utf-8") as handle:
+            recorded = [line.strip() for line in handle if line.strip()]
+        self.assertEqual(len(recorded), 2)
+        self.assertEqual(
+            sorted(os.path.basename(entry) for entry in recorded),
+            ["fiat-run-alpha", "fiat-run-beta"],
+        )
+
+    def test_repeating_a_topic_refuses_and_names_the_existing_tree(self):
+        self.init("run alpha")
+        existing = self.target
+        again = subprocess.run(
+            [sys.executable, HEXCTL, "--dir", self.dir, "init", "--topic", "run alpha"],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(again.returncode, 2)
+        self.assertIn(existing, again.stderr)
+        self.assertIn("--dir", again.stderr)

--- a/plugins/hexaemeron/tests/test_hexctl.py
+++ b/plugins/hexaemeron/tests/test_hexctl.py
@@ -1998,10 +1998,10 @@ class TestControls(HexctlCase):
         self.integrate_run()
         self.assertEqual(self.next_json()["do"], "done")
 
-        # `reset` clears the state, after which the breadcrumb no longer resolves
-        # and `target` falls back to the checkout. The archive is in the run's
-        # own tree, so hold that path before the reset rather than after.
-        root = os.path.join(self.target, ".hexaemeron")
+        # A run that lived in a worktree archives into the checkout it was
+        # started from, because archiving inside the tree and then removing the
+        # tree would destroy the archive in the same breath.
+        root = os.path.join(self.dir, ".hexaemeron")
         self.run_ctl("reset")
         self.assertFalse(os.path.exists(os.path.join(root, "state.json")))
         archives = os.listdir(os.path.join(root, "archive"))
@@ -3391,3 +3391,133 @@ class WorktreeCreationTests(HexctlCase):
         self.assertEqual(again.returncode, 2)
         self.assertIn(existing, again.stderr)
         self.assertIn("--dir", again.stderr)
+
+
+class ResumeAndRetirementTests(HexctlCase):
+    """Finding the run again, and putting its tree away once it has landed."""
+
+    def origin_ctl(self, *args):
+        return subprocess.run(
+            [sys.executable, HEXCTL, "--dir", self.dir, *args],
+            capture_output=True, text=True,
+        )
+
+    def state_dir_listing(self):
+        return sorted(os.listdir(os.path.join(self.dir, ".hexaemeron")))
+
+    # -- resume -----------------------------------------------------------
+
+    def test_status_from_the_checkout_names_the_runs_worktree(self):
+        self.init()
+        proc = self.origin_ctl("status")
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn(self.target, proc.stderr)
+        self.assertIn(f"hexctl --dir {self.target} next", proc.stderr)
+
+    def test_next_from_the_checkout_names_the_runs_worktree(self):
+        self.init()
+        proc = self.origin_ctl("next")
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn(f"hexctl --dir {self.target} next", proc.stderr)
+
+    def test_pointing_at_the_checkout_changes_nothing(self):
+        self.init()
+        before = self.state_dir_listing()
+        self.origin_ctl("status")
+        self.origin_ctl("next")
+        self.assertEqual(self.state_dir_listing(), before)
+        self.assertFalse(os.path.exists(
+            os.path.join(self.dir, ".hexaemeron", "state.json")))
+
+    def test_both_runs_are_named_when_the_checkout_started_two(self):
+        self.init("run alpha")
+        alpha = self.target
+        subprocess.run([sys.executable, HEXCTL, "--dir", self.dir, "init",
+                        "--topic", "run beta"], capture_output=True, check=True)
+        beta = os.path.join(self.dir, "tmp", "fiat", "fiat-run-beta")
+        proc = self.origin_ctl("status")
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn(alpha, proc.stderr)
+        self.assertIn(beta, proc.stderr)
+
+    def test_a_recorded_worktree_that_is_gone_refuses_by_name(self):
+        self.init()
+        recorded = self.target
+        shutil.rmtree(recorded)
+        proc = self.origin_ctl("status")
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn(recorded, proc.stderr)
+        self.assertIn("no longer there", proc.stderr)
+
+    def test_a_recorded_worktree_that_is_gone_does_not_start_a_second_run(self):
+        self.init()
+        shutil.rmtree(self.target)
+        self.origin_ctl("next")
+        self.assertFalse(os.path.exists(
+            os.path.join(self.dir, ".hexaemeron", "state.json")))
+        self.assertFalse(os.path.exists(os.path.join(self.dir, "tmp", "fiat",
+                                                     "fiat-test-topic")))
+
+    def test_state_already_in_a_checkout_still_resumes(self):
+        """A run that predates the worktree keeps working where it is."""
+        legacy = os.path.join(self.dir, ".hexaemeron")
+        os.makedirs(legacy, exist_ok=True)
+        self.init()
+        shutil.copytree(os.path.join(self.target, ".hexaemeron"),
+                        legacy, dirs_exist_ok=True)
+        os.remove(os.path.join(legacy, "worktree"))
+        proc = self.origin_ctl("status", "--json")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(json.loads(proc.stdout)["topic"], "test topic")
+
+    # -- retirement -------------------------------------------------------
+
+    def land_a_run(self):
+        """A one-step run, driven all the way to the integrate phase."""
+        self.to_steps(titles=("Scaffold",))
+        self.run_ctl("record", "security_suite", '"waived: fixture"')
+        self.finish_step(1)
+
+    def test_reset_removes_a_clean_tree_and_archives_its_evidence(self):
+        self.land_a_run()
+        self.integrate_run()
+        self.assertTrue(os.path.isdir(self.retired),
+                        "integrate leaves the tree so status and verify still run")
+        self.run_ctl("reset")
+        self.assertFalse(os.path.isdir(self.retired))
+        archives = os.listdir(os.path.join(self.dir, ".hexaemeron", "archive"))
+        self.assertEqual(len(archives), 1)
+        archived = os.path.join(self.dir, ".hexaemeron", "archive", archives[0])
+        for name in ("state.json", "ledger.jsonl"):
+            self.assertTrue(os.path.exists(os.path.join(archived, name)), name)
+
+    def test_the_integrate_receipt_records_the_tree_as_clean(self):
+        self.land_a_run()
+        self.integrate_run()
+        self.assertIs(self.state()["receipts"]["integrate"]["worktree_clean"], True)
+
+    def test_a_tree_holding_work_is_kept_and_never_forced(self):
+        self.land_a_run()
+        held = self.target
+        with open(os.path.join(held, "someone-was-working.txt"), "w",
+                  encoding="utf-8") as handle:
+            handle.write("do not lose me\n")
+        self.integrate_run()
+        self.run_ctl("reset")
+        self.assertTrue(os.path.isdir(held))
+        self.assertTrue(os.path.exists(
+            os.path.join(held, "someone-was-working.txt")))
+        archives = os.listdir(os.path.join(self.dir, ".hexaemeron", "archive"))
+        self.assertEqual(len(archives), 1)
+
+    def test_a_retired_run_drops_out_of_the_breadcrumb(self):
+        self.land_a_run()
+        self.integrate_run()
+        self.run_ctl("reset")
+        with open(os.path.join(self.dir, ".hexaemeron", "worktree"),
+                  encoding="utf-8") as handle:
+            self.assertEqual(handle.read().strip(), "")
+
+    @property
+    def retired(self):
+        return os.path.join(self.dir, "tmp", "fiat", "fiat-test-topic")

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -128,7 +128,7 @@
     },
     "fiat-final-integration": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "2da90c255f3920f9e1584a13cf79c895be2cb0c3a5d7ceae06fa9488e69bc8cb",
+      "sha256": "f0ca25dce603cbbf704bf1677488e138a3e14585fb312b75a1dae942c0479215",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "run branch, base, integration head and merge commit",
@@ -142,7 +142,7 @@
     },
     "fiat-receipted-delivery": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "2da90c255f3920f9e1584a13cf79c895be2cb0c3a5d7ceae06fa9488e69bc8cb",
+      "sha256": "f0ca25dce603cbbf704bf1677488e138a3e14585fb312b75a1dae942c0479215",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "validated state, topic, run branch, step branch and head commit",

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -128,7 +128,7 @@
     },
     "fiat-final-integration": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "74237cb2a4cf2d0dd7d456b7125befe95fd6674566e2f6ecc4ddee6b1e2f3edb",
+      "sha256": "5fdf2272242eb858ff6587b00066fd49b4a41443895b256d448733f0e2571be1",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "run branch, base, integration head and merge commit",
@@ -142,7 +142,7 @@
     },
     "fiat-receipted-delivery": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "74237cb2a4cf2d0dd7d456b7125befe95fd6674566e2f6ecc4ddee6b1e2f3edb",
+      "sha256": "5fdf2272242eb858ff6587b00066fd49b4a41443895b256d448733f0e2571be1",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "validated state, topic, run branch, step branch and head commit",

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -128,7 +128,7 @@
     },
     "fiat-final-integration": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "5fdf2272242eb858ff6587b00066fd49b4a41443895b256d448733f0e2571be1",
+      "sha256": "2da90c255f3920f9e1584a13cf79c895be2cb0c3a5d7ceae06fa9488e69bc8cb",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "run branch, base, integration head and merge commit",
@@ -142,7 +142,7 @@
     },
     "fiat-receipted-delivery": {
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "5fdf2272242eb858ff6587b00066fd49b4a41443895b256d448733f0e2571be1",
+      "sha256": "2da90c255f3920f9e1584a13cf79c895be2cb0c3a5d7ceae06fa9488e69bc8cb",
       "bindings": {
         "promise_id": "coverage key joined to controller phase and canonical promise heading",
         "subject": "validated state, topic, run branch, step branch and head commit",


### PR DESCRIPTION
A checkout that started a run has no state of its own, because the run's state is in its worktree. `status` and `next` there used to report that absence, which is true and useless. They now name the run's worktree and the exact `--dir` to reach it, exit non-zero, and change nothing. Two runs from one checkout get both named. A recorded tree that is no longer there refuses naming that path, rather than quietly starting a second run over the top of the first.

## Where retirement went, and why it is not where the runbook said

The committed runbook puts worktree removal in `done integrate`. Built that way it removes the run's state and ledger along with the tree, because both live in the tree. Fiat's own contract then has the caller run `hexctl status` and `hexctl verify` after the run reports done, and neither has anywhere to read from. Seven existing integrate tests failed on exactly that.

Retirement therefore sits in `reset`, which already means the run is finished and can be put away, already archives, and already refuses a run that is not done. `done integrate` records whether the tree was clean and says what `reset` will do with it, so the outcome is still named where the runbook wanted it named.

The specification is wrong here and the code does not follow it. That is recorded in `audit/AUDIT.md` as FRW-S4-R1-01 rather than fixed by editing the runbook, which is the frozen record of what the run believed when it started.

A second thing fell out of the same reasoning. A run that lived in a worktree archives into the checkout it was started from. Archiving inside the tree and then removing the tree would destroy the archive in the same breath.

## What is never done

Nothing here passes `--force`. Cleanliness is read before anything moves, and a tree holding work git would not discard is kept and named on stderr. The worst outcome is a directory somebody has to look at.

## Audit

Two rounds, under "Fiat run worktree, step 4". One medium in round 1, the specification divergence above, and round 2 clean.

An attempt to force a run to `done` by editing `state.json` directly was refused by the ledger chain check while probing. That is the behaviour the state-shape rounds established, and this change does not weaken it.

Three leads carried, all in the audit file. The newest: if the archive move succeeds and the removal then fails, the tree is left without its state while the archive holds it. The tree is harmless at that point and the breadcrumb drops it, so the alternative would be undoing a completed archive to restore a directory nobody needs.

## How to check it

```bash
python3 -m unittest plugins.hexaemeron.tests.test_hexctl -k Worktree
python3 -m unittest plugins.hexaemeron.tests.test_hexctl -k Resume
python3 plugins/hexaemeron/tests/run_tests.py
python3 -m unittest discover -s tests
python3 scripts/promise_machine.py check
python3 scripts/promise_machine.py coverage --check
```

The runbook states the first two as one `-k "Worktree or Resume"` invocation. `unittest -k` takes a pattern rather than a boolean expression, so that form silently selects nothing; the two are run separately here. Eleven new cases, forty-three across the run. Suites: 784/784, 113 OK, both Promise Machine checks clean.

Stacks on step 3.

<!-- wildcat-origin: shoggoth -->
