### PR TITLE
flag credential-named values in subprocess argv

### DIFF
--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 1440
+    "files_walked": 1445
   },
   "entries": [
     {

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8513,3 +8513,62 @@ not word-split an unquoted variable, so a lint invoked as `lint $FILES` receives
 one argument naming a file that does not exist and reports it unreadable. It was
 caught here because the exit status was read; a round that only read the word
 `clean` would not have seen it.
+
+## Phylax credential argv, step 1, round 1 -- 2026-08-22
+
+### Suite disposition
+
+The Solidity suite was waived exactly as recorded by the controller:
+`waived: issue 325 changes the Python Phylax lint, fixtures, and governed prose;
+it has no Solidity target`. No `.sol` file appears in the step diff. X-Ray,
+Solidity Auditor and Fizz therefore did not run, and this round does not count
+their absence as a clean Solidity review.
+
+### Finding table
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| review-code | none | `plugins/hexaemeron/skills/phylax/scripts/phylax.py` | No confirmed code finding. | clean |
+| review-tests | none | `plugins/hexaemeron/tests/test_phylax_checker.py` | No confirmed test or diagnostic-secrecy finding. | clean |
+| review-records | none | governed prose, ledgers and generated records | No confirmed specification, ledger, coverage or tracked-artifact finding. | clean |
+
+Finding count: 0.
+
+### Evidence
+
+The review read all eight changed files and the full diff from
+`4408597bcd0130b0cee8bd7aab0b55d64ff957c7` through
+`23c7b3d57e66d5da7c91ab027b6952d372d3413d`. Each of the ten risk-register
+rows was checked. Runner resolution remains the existing import-bound
+`_starts_process` decision; only the first positional argument or explicit
+`args=` value is walked; `env=` remains clean; nested names, tuples and list
+concatenation are covered; local and unrelated runners stay clean; reasoned
+and bare suppressions retain opposite results; P001 and P002 keep their prior
+classifications; and neither text nor JSON diagnostics contain the fixture
+credential value.
+
+The tracked study and runbook match their receipted artefacts byte for byte.
+The canonical frontier line recomputes to
+`3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604`;
+only generation moves, from `phylax-v1.1.0` to `phylax-v1.2.0`. The Promise
+Machine coverage digest matches the changed `SKILL.md`, and the Horos boundary
+matches the tracked tree.
+
+The focused Phylax suite passes 61/61 on Python 3.9.6 and 3.12.13. The first
+full Hexaemeron run stopped because ambient Node v22.22.3 did not match the
+fixture's declared v26.6.0. The official v26.6.0 Darwin arm64 archive matched
+its published SHA-256,
+`75480cd43b6fcb35d8e772dd18983fbd9f691b2f03b1c94393206098e9944b5e`,
+and a PATH-scoped rerun passed 833/833 without changing the repository or
+system toolchain. The root suite passes 118/118, the evolution contract passes
+8/8, and the full Promise Machine check is clean. Phylax, Ephoros and
+Hypomnema each exit 0.
+
+### Leads not pursued
+
+Leads not pursued: `API_TOKEN` in the study's motivating specimen remains
+outside the existing `CREDENTIAL` grammar, and attribute/subscript values,
+separately assigned argv, star-expanded call forms, `**kwargs`, runner-name
+rebinding and flag interpretation remain outside the receipted source-local
+boundary. Widening any of them would change the approved finding grammar or
+runner-resolution contract rather than repair this implementation.

--- a/docs/phylax-credential-argv/runbook.md
+++ b/docs/phylax-credential-argv/runbook.md
@@ -1,0 +1,111 @@
+# Runbook: flag credential-named values in subprocess argv
+
+- capability: flag credential-named values in resolved subprocess argv.
+- boundary: inspect the source-local `args` expression only.
+- delivery shape: one atomic implementation and verification step.
+
+## Construction
+
+The chosen construction walks the `args` expression of calls resolved by
+`_starts_process` and applies P004 to matching `ast.Name` nodes. Splitting the
+fixture, visitor change, governed prose and generation row would leave an
+intermediate branch either red or misdescribed, so one step both scaffolds the
+specification and runs the final demonstration.
+
+## Implementation boundary
+
+The step may change only the named checker, tests, governed Phylax prose,
+generation evidence, tracked study and runbook, and regenerated Horos boundary.
+Fiat's later audit and pull-request artefacts remain separate phase outputs.
+
+## Step 1: Enforce credential-free subprocess argv
+
+**Goal.** Report P004 when a credential-named value appears in the inline argv
+expression of a resolved subprocess runner, without widening the finding beyond
+argv or changing an existing finding contract.
+
+**Entry.** The controller's run branch
+`fiat/325-phylax-credential-argv-r2` at
+`4408597bcd0130b0cee8bd7aab0b55d64ff957c7`, with `.hexaemeron/study.md`
+receipted at SHA-256
+`7bb214f42361f33a8b4ab71f5f9ad22b9a2c88431311b5abff482b50935154d0` and
+the focused Phylax suite green at 46 tests under Python 3.9.6 and 3.12.13.
+
+**Exit.** The committed study and runbook match the receipted artefacts. A
+focused guard first reproduces the missing P004 finding, then passes after the
+visitor inspects only the first positional `args` expression or, when it is
+absent, the explicit `args=` expression of a resolved runner. Module imports,
+module aliases, direct imports and direct-import aliases report; inline list
+concatenation reports without gaining P002. Ordinary argv values, a local
+`run`, an unrelated `.call` and an `env=`-only credential stay clean. A
+reason-bearing suppression clears the new finding, a bare pragma does not, and
+text and JSON results never contain the fixture credential value. P000-P003,
+the existing P004 writer check, CLI arguments, output schemas and exit codes
+remain unchanged.
+
+`plugins/hexaemeron/skills/phylax/SKILL.md` names command arguments in P004's
+mechanical scope, and the Promise Machine coverage digest is recomputed for the
+changed canonical bytes. `plugins/hexaemeron/skills/phylax/EVOLUTION.md` moves
+once to `phylax-v1.2.0` on the generation axis while retaining frontier status
+`mature`, revision `off-chain-boundary-controls`, current-frontier text, next
+job `None -- mature` and digest
+`3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604`.
+The tracked-file boundary is regenerated and current. The step is complete
+when every command below exits zero and both `cmp` commands produce no output:
+
+```bash
+cmp .hexaemeron/study.md docs/phylax-credential-argv/study.md
+cmp .hexaemeron/runbook.md docs/phylax-credential-argv/runbook.md
+uv run --python 3.12.13 python -m unittest plugins.hexaemeron.tests.test_phylax_checker
+uv run --python 3.12.13 python plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+uv run --python 3.12.13 python plugins/hexaemeron/tests/run_tests.py
+uv run --python 3.12.13 python -m unittest discover -s tests
+uv run --python 3.12.13 python -m unittest tests.test_evolution_contract
+uv run --python 3.12.13 python scripts/promise_machine.py check
+uv run --python 3.12.13 python plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/phylax-credential-argv/study.md
+uv run --python 3.12.13 python plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/phylax-credential-argv/runbook.md
+uv run --python 3.12.13 python plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/phylax-credential-argv/*.md plugins/hexaemeron/skills/phylax/SKILL.md plugins/hexaemeron/skills/phylax/EVOLUTION.md
+(
+  for file in docs/phylax-credential-argv/study.md docs/phylax-credential-argv/runbook.md plugins/hexaemeron/skills/phylax/SKILL.md plugins/hexaemeron/skills/phylax/EVOLUTION.md; do
+    uv run --python 3.12.13 python plugins/brevitas/skills/brevitas/scripts/brevitas.py "$file" || exit
+  done
+)
+uv run --python 3.12.13 python plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+uv run --python 3.12.13 python plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs
+uv run --python 3.12.13 python plugins/horos/skills/horos/scripts/horos.py scan . --write
+uv run --python 3.12.13 python plugins/horos/skills/horos/scripts/horos.py check .
+git diff --check
+```
+
+**Files.** Create or change only these planned paths, plus pull-request
+artefacts required by Fiat's later phases:
+
+- `plugins/hexaemeron/skills/phylax/scripts/phylax.py`
+- `plugins/hexaemeron/tests/test_phylax_checker.py`
+- `plugins/hexaemeron/skills/phylax/SKILL.md`
+- `plugins/hexaemeron/skills/phylax/EVOLUTION.md`
+- `tests/promise_machine_coverage.json`
+- `docs/phylax-credential-argv/study.md`
+- `docs/phylax-credential-argv/runbook.md`
+- `.horos/boundary.json`
+- `audit/AUDIT.md` when the audit phase records its rounds
+
+**Tests.** Add the hostile argv specimen before the visitor change and record
+its missing P004 result. Cover module, module-alias, direct-import and
+direct-import-alias runners; positional and keyword `args`; list
+concatenation; the four safe neighbours above; reason-bearing and bare
+suppressions; unchanged P001/P002 classification; and secret-free text and JSON
+rendering. Preserve all 46 existing focused tests and add at least 13 bounded
+cases. Run the focused suite after the red-to-green change, then every exit
+command above.
+
+**Disciplines.** phylax: untrusted Python source reaches a new argv-only P004
+check, closed by existing runner resolution, source-local AST walking, safe
+neighbours and secret-free diagnostics. ephoros: none, the checker adds no
+unattended service and preserves its existing path, line, code and exit
+signals. metron: none, no performance claim or speed-motivated edit is
+authorised. elenchus: the missed hostile specimen is captured red before the
+cause-level visitor change and every regression must turn green before broader
+gates run. hypomnema: the tracked study and runbook hold the build contract,
+the audit file holds round evidence, and the Phylax generation row records the
+source-local decision without reopening the mature frontier.

--- a/docs/phylax-credential-argv/study.md
+++ b/docs/phylax-credential-argv/study.md
@@ -1,0 +1,423 @@
+# Study: flag credential-named values in subprocess argv
+
+## assumptions
+
+Assuming, unless corrected:
+
+1. The run starts from `main` at
+   `4408597bcd0130b0cee8bd7aab0b55d64ff957c7`; `HEAD` and local `main`
+   both resolved to that commit before this study.
+2. A `RUNNERS` call's argument list means the value passed as subprocess
+   `args`: its first positional argument, or explicit `args=` when there is no
+   positional argument. `env=` and the other process options are not argv.
+3. P004 keeps its existing name-based evidence. The new check follows
+   `ast.Name` nodes within the source-local argv expression, including list
+   and tuple literals, nested expressions and list concatenation. It does not
+   follow a command assigned to another name or infer a credential from a flag
+   such as `--token`.
+4. A credential transported only through `env=` stays outside this finding.
+   Phylax currently recommends environment transport; broadening P004 to
+   environments would contradict that documented policy and mislabel the
+   exposure as argv.
+5. The checker remains standard-library-only and compatible with Python 3.9
+   and 3.12.13. The final demonstration uses uv's Python 3.12.13, matching the
+   approved run's toolchain.
+6. Issue #325 is generation work against a mature skill. Phylax advances from
+   `phylax-v1.1.0` to `phylax-v1.2.0`; its frontier status, revision, current
+   frontier, next job and frontier digest remain byte-identical.
+7. The failed predecessor run is evidence, not an implementation source. This
+   study retains its approved source-local design but is a new initial spec,
+   with no amendment block. Its Brevitas gate invokes the one-draft CLI once
+   per file.
+8. This is one independently verifiable lint capability, so module
+   decomposition would add ceremony without separating any shippable result.
+
+The issue, current source, versioning contract and reproduced failure settle
+these readings. No unresolved ambiguity changes the design or build order.
+
+## 1. problem statement
+
+Phylax's P004 currently reports credential literals and credential-named
+values handed to `print` or a logger. The skill also forbids credentials in
+command lines, but `Visitor.visit_Call` checks resolved subprocess calls only
+for P001 and P002. This input therefore passes today:
+
+```python
+import subprocess
+
+API_TOKEN = load()
+subprocess.run(["curl", "--token", API_TOKEN])
+```
+
+The users are contributors running Phylax and reviewers treating its named
+mechanical boundary as a gate. A working prototype reports P004 when an
+`ast.Name` matching `CREDENTIAL` appears inside the argv expression of a call
+accepted by `_starts_process`, keeps close non-subprocess and non-argv cases
+clean, and changes no existing finding contract.
+
+The final demo path is:
+
+```bash
+uv run --python 3.12.13 python -m unittest plugins.hexaemeron.tests.test_phylax_checker
+uv run --python 3.12.13 python plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+uv run --python 3.12.13 python plugins/hexaemeron/tests/run_tests.py
+uv run --python 3.12.13 python -m unittest discover -s tests
+uv run --python 3.12.13 python -m unittest tests.test_evolution_contract
+uv run --python 3.12.13 python scripts/promise_machine.py check
+uv run --python 3.12.13 python plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/phylax-credential-argv/study.md
+uv run --python 3.12.13 python plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/phylax-credential-argv/runbook.md
+uv run --python 3.12.13 python plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/phylax-credential-argv/*.md plugins/hexaemeron/skills/phylax/SKILL.md plugins/hexaemeron/skills/phylax/EVOLUTION.md
+(
+  for file in docs/phylax-credential-argv/study.md docs/phylax-credential-argv/runbook.md plugins/hexaemeron/skills/phylax/SKILL.md plugins/hexaemeron/skills/phylax/EVOLUTION.md; do
+    uv run --python 3.12.13 python plugins/brevitas/skills/brevitas/scripts/brevitas.py "$file" || exit
+  done
+)
+uv run --python 3.12.13 python plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+uv run --python 3.12.13 python plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs
+uv run --python 3.12.13 python plugins/horos/skills/horos/scripts/horos.py check .
+git diff --check
+```
+
+The subshell around the Brevitas loop preserves a failing file's non-zero
+status without exiting the operator's parent shell. Each `brevitas.py`
+process receives exactly one `draft` positional, matching its CLI.
+
+The prototype is demonstrated only when:
+
+- module, module-alias, direct-import and direct-import-alias subprocess calls
+  report P004 for a credential-named argv value;
+- positional `args`, explicit keyword `args=` and inline list concatenation
+  report, while concatenation does not acquire P002;
+- an ordinary argv value, a local `run`, an unrelated `.call`, and a
+  credential present only in `env=` remain clean;
+- reason-bearing suppression clears the new finding and a bare pragma does
+  not;
+- P001 and P002 classifications retain their existing behavior;
+- text and JSON output never repeat the fixture credential value; and
+- every command above exits zero.
+
+Before the build, the sample above returned `[]`. The focused suite passed
+46/46 tests on Python 3.9.6 and 46/46 on Python 3.12.13, so the missing P004
+finding is reproduced without an existing red test.
+
+## 2. prior art
+
+### in this repository
+
+- `plugins/hexaemeron/skills/phylax/scripts/phylax.py` already supplies
+  `RUNNERS`, `CREDENTIAL`, import-alias tracking, `_starts_process`, P001/P002,
+  the P004 finding path and reason-bearing suppression. The smallest seam is
+  the resolved-runner branch in `Visitor.visit_Call`.
+- `plugins/hexaemeron/tests/test_phylax_checker.py` pairs each reported case
+  with safe neighbours. Its subprocess fixtures already protect list
+  concatenation, a local helper named `run` and an unrelated `.call` method.
+- `plugins/ariadne/scripts/ariadne_lib/scrub.py` and
+  `plugins/ariadne/tests/test_capture_scrubbing.py` redact argv values after
+  secret flags from captured command records. That is post-execution record
+  hygiene, not permission for source to put credentials in argv.
+- `plugins/hexaemeron/skills/phylax/SKILL.md` already states the no-credential
+  argv policy. Its mechanical-subset paragraph currently documents only
+  source and output, so the implementation and governed prose must move
+  together.
+- `plugins/hexaemeron/skills/phylax/EVOLUTION.md` and
+  `plugins/hexaemeron/skills/VERSIONING.md` require a generation row to retain
+  the mature frontier revision and digest. Recomputing the canonical frontier
+  line produced
+  `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604`,
+  matching the ledger.
+- `plugins/brevitas/skills/brevitas/scripts/brevitas.py --help` exposes one
+  optional `draft` positional. The blocked predecessor's multi-file call
+  exited 2; this study's per-file subshell loop is the corrected gate.
+
+The last two merged pull requests that changed the Python checker and its
+fixtures were read before choosing a design:
+
+- PR #193, `Add TypeScript boundary checks to Phylax`, kept the Python visitor
+  and added a bounded TypeScript surface. Its audit found one unbounded file
+  read, fixed it with a 1 MiB cap, then closed with no lead.
+- PR #103, `Add six practice skills to Hexaemeron`, introduced P001-P004. Its
+  first Phylax pass established why runner names must resolve through imports
+  and why list-plus-list is not a string command. Its known CI gap remains in
+  `.github/workflows/`; issue #325 does not authorize a CI change.
+
+The two latest merged pull requests touching the wider Phylax skill surface
+were also checked. PR #441 added the ADR-010 boundary pointer and carried no
+unfinished Phylax work. PR #426 removed duplicated sibling-routing prose and
+left marketplace-context text alone. Neither changes the argv design.
+
+The Phylax entries in `audit/AUDIT.md` were read before the options below.
+Round 1 found the TypeScript input-size gap; round 2 closed it with no further
+finding or lead. `plugins/hexaemeron/audit/AUDIT.md` contains no Phylax round.
+Nothing carried there widens or narrows issue #325.
+
+### in the organisation
+
+Issue #325 identifies this as the second stated never-rule the lint does not
+mechanically enforce and names the existing subprocess visitor as the cheap
+seam. Public organisation searches found ordinary subprocess use but no
+separate source analyser or argv-credential detector to reuse. That search is
+not proof about private or unindexed repositories.
+
+### outside the organisation
+
+- MITRE CWE-214 identifies sensitive process invocation data, including
+  command-line arguments, as information other processes may observe:
+  <https://cwe.mitre.org/data/definitions/214.html>.
+- Python 3.12's `subprocess` documentation defines `args` separately from the
+  `env` mapping and recommends a sequence for program arguments:
+  <https://docs.python.org/3.12/library/subprocess.html#popen-constructor>.
+
+These sources support the exposure boundary. They do not choose Phylax's
+source-local, identifier-based heuristic.
+
+## 3. constraints and non-goals
+
+### constraints
+
+- Start at `4408597bcd0130b0cee8bd7aab0b55d64ff957c7` and stay within issue
+  #325.
+- Preserve P000-P007, CLI arguments, output schemas, exit codes, import
+  resolution, suppression syntax and every existing safe neighbour.
+- Reuse `_starts_process`; a bare `run`, `call` or `Popen` spelling is not
+  enough evidence that the call starts a process.
+- Walk only the selected argv expression. Do not classify `env=`, `cwd=`,
+  `input=` or other process configuration as command-line exposure.
+- Emit the identifier, path, line, code and fixed explanation, never the value
+  associated with the identifier.
+- Add no dependency, shell execution, network call, target-source execution or
+  filesystem write to the checker.
+- Keep Python 3.9 and 3.12.13 support.
+- Update Phylax's mechanical prose and recompute the Promise Machine coverage
+  digest for any changed canonical bytes.
+- Record `phylax-v1.2.0` on the `generation` axis while retaining frontier
+  status `mature`, revision `off-chain-boundary-controls`, current-frontier
+  text, next job `None -- mature` and digest
+  `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604`.
+- Invoke Brevitas once per file. No command may pass it multiple draft paths,
+  and the loop must propagate any file's non-zero result.
+
+Expected implementation and record paths are:
+
+- `plugins/hexaemeron/skills/phylax/scripts/phylax.py`
+- `plugins/hexaemeron/tests/test_phylax_checker.py`
+- `plugins/hexaemeron/skills/phylax/SKILL.md`
+- `plugins/hexaemeron/skills/phylax/EVOLUTION.md`
+- `tests/promise_machine_coverage.json`
+- `docs/phylax-credential-argv/study.md`
+- `docs/phylax-credential-argv/runbook.md`
+- `.horos/boundary.json`
+- `audit/AUDIT.md` when the audit loop records its rounds
+
+### non-goals
+
+- Inter-statement or interprocedural dataflow, including following an argv
+  list assigned before the subprocess call.
+- Secret-shaped literal detection, flag-name interpretation, or evaluation of
+  a call that produces an argv element.
+- Widening P004's writer analysis to attributes, containers, formatted strings
+  or logger templates.
+- Treating environment transport as argv exposure or changing the existing
+  credential-storage policy.
+- A new finding code, any P001/P002 redesign, another language surface, or CI
+  work for the known Hexaemeron-suite gap.
+- Reopening the mature frontier, changing its digest, advancing evolution or
+  epoch, or creating a held job.
+- Applying the predecessor stash to this run. Mason may implement the accepted
+  design from this study and the current tree only.
+
+### operating boundaries
+
+**Always.** Add the hostile P004 fixture before the visitor change; run the
+focused suite, both repository suites, Phylax over `plugins tests`, Promise
+Machine checks and each required prose check before committing. Run Brevitas
+once for each named file.
+
+**Ask first.** Add a dependency; widen analysis beyond the source-local argv
+expression; change P004's identifier grammar, public message shape or
+suppression behavior; touch CI; or alter any mature-frontier field.
+
+**Never.** Put a real credential in a fixture, diagnostic, command, commit or
+receipt; weaken runner resolution; delete a safe neighbour; apply unreceipted
+predecessor code; edit vendored source; or claim an unrun command passed.
+
+## 4. design options
+
+### option A: walk the resolved call's argv expression (chosen)
+
+Select the first positional argument, or explicit `args=` when no positional
+argument exists. For a call accepted by `_starts_process`, walk only that AST
+subtree and report P004 for each `ast.Name` matching `CREDENTIAL`. Keep the
+existing P001/P002 logic, suppression filter and renderers.
+
+This handles inline lists, tuples, nested syntax and list concatenation with a
+small local change. It deliberately misses argv assembled in another
+statement. That source-local miss is legible and testable.
+
+### option B: follow argv assignments within a scope
+
+Track assignments whose value contains a credential-named node, then follow
+the assigned name into a later runner call. This catches `argv = [...]`, but
+it opens rebinding, ordering, branch, alias and scope questions. A partial
+dataflow engine costs more to understand and can imply coverage it has not
+earned.
+
+### option C: walk the whole subprocess call
+
+Inspect every positional and keyword value after resolving the runner. This is
+shorter than choosing `args`, but it reports credentials in `env=`, `cwd=` and
+unrelated options as command-line exposure. The message would make a claim
+the inspected syntax does not support.
+
+Option A is the lowest-comprehension-cost construction that meets the issue.
+It trades away separately assembled argv and preserves an exact boundary
+between process arguments and process configuration.
+
+## 5. risk register seed
+
+```risk-register
+runner-identity | imported call binding at the subprocess boundary | only calls accepted by existing module and direct-import resolution receive the new check
+argv-selection | the subprocess args parameter | only first positional args or explicit args keyword is walked and env remains outside the finding
+name-recursion | untrusted Python syntax inside the argv expression | ast names are visited without executing source or following statement-level dataflow
+safe-neighbour | local run and unrelated call methods beside resolved runners | negative fixtures remain clean while module and direct-import aliases report
+secret-diagnostic | credential-bearing source crossing text and JSON rendering | findings name the identifier but never reproduce the associated value
+suppression-location | the new P004 finding crossing the existing line filter | a reason on the line or line above suppresses while a bare pragma does not
+classification-drift | new P004 logic beside existing P001 and P002 checks | shell and string-command specimens retain their prior codes
+prose-gate-arity | changed prose crossing the Brevitas CLI | one process receives one file and any failed file makes the subshell fail
+partial-run | an interrupted lint or test before its final status | no clean result or receipt is accepted from incomplete or non-zero commands
+ledger-integrity | generation bookkeeping at the mature Phylax frontier | only generation advances while the revision current text next job and digest remain unchanged
+```
+
+There is no funds arithmetic, blockchain call, upgrade path or signing-key
+custody in this checker. Secret custody is limited to reading source that may
+name a credential and ensuring its value does not enter findings. The checker
+adds no subprocess or write; existing bounded reads and P000 failure behavior
+remain unchanged.
+
+## 6. glossary seeds
+
+- `argv expression`: the AST node passed as a subprocess runner's `args`,
+  either first positional or explicit `args=`.
+- `credential-named value`: an `ast.Name` whose identifier matches the
+  existing `CREDENTIAL` expression; it is name evidence, not proof of a live
+  secret.
+- `resolved runner`: a call `_starts_process` ties to `subprocess` through a
+  module import, module alias, direct import or direct-import alias.
+- `safe neighbour`: nearby syntax that must remain clean and fixes the
+  false-positive boundary.
+- `source-local`: decided within the current call expression without following
+  earlier assignments, imported values or runtime state.
+- `generation row`: a behavior change that increments the second skill counter
+  while retaining the frontier revision and digest.
+- `per-file prose gate`: one Brevitas process with one draft positional,
+  repeated for each changed prose file with failure propagated.
+
+## 7. sources and checks
+
+Primary sources:
+
+- Issue #325: <https://github.com/wildcat-finance/skills/issues/325>.
+- Starting ref: `4408597bcd0130b0cee8bd7aab0b55d64ff957c7`.
+- Issue census ref named by #325:
+  `3c061c2e15df085cf300220250b421bbd03f664c`.
+- `plugins/hexaemeron/skills/phylax/scripts/phylax.py`, especially
+  `RUNNERS`, `CREDENTIAL`, `_starts_process` and `Visitor.visit_Call`.
+- `plugins/hexaemeron/tests/test_phylax_checker.py`, especially
+  `ShellInvocation`, `StringCommands`, `Credentials` and `Suppression`.
+- `plugins/hexaemeron/skills/phylax/SKILL.md`, `EVOLUTION.md`, and
+  `plugins/hexaemeron/skills/VERSIONING.md`.
+- `plugins/brevitas/skills/brevitas/scripts/brevitas.py --help`.
+- `plugins/ariadne/scripts/ariadne_lib/scrub.py` and
+  `plugins/ariadne/tests/test_capture_scrubbing.py`.
+- `audit/AUDIT.md`, `Phylax TypeScript boundaries`, rounds 1 and 2.
+- Pull requests #103, #193, #426 and #441 in `wildcat-finance/skills`.
+- MITRE CWE-214 and Python 3.12 `subprocess` documentation linked above.
+
+Checks run during this study:
+
+- `git rev-parse HEAD` and `git rev-parse main` both returned the starting
+  commit above; the worktree was clean before this file was written.
+- A current public read found issue #325 open, unassigned, with no comments or
+  linked development branch.
+- The inline `API_TOKEN` specimen returned `[]` before implementation.
+- `python3 -m unittest plugins.hexaemeron.tests.test_phylax_checker` passed
+  46/46 on Python 3.9.6.
+- The same focused command passed 46/46 through uv Python 3.12.13.
+- `python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests`
+  exited zero and printed `clean`.
+- The frontier digest was recomputed from the exact canonical line and matched
+  the `phylax-v1.1.0` history row.
+- The preserved predecessor patch was inspected to confirm the accepted option
+  and fixture boundary, then left unapplied. Its failed multi-file Brevitas
+  command was checked against the current one-positional CLI.
+- Public organisation search found no reusable analyser; this is negative
+  search evidence, not proof of absence.
+
+These observations establish the current gap and a buildable boundary. They
+do not establish that Option A is implemented correctly or that its future
+tests and audit rounds pass.
+
+## 8. signals and the questions behind them
+
+`plugins/hexaemeron/skills/ephoros/SKILL.md` does not add an implementation
+gate because this change introduces no unattended service, route, persistent
+job or alert. The existing CLI already answers the two operator questions:
+
+1. Which source location failed? Text exposes `path:line`, P004 and its fixed
+   message; JSON exposes the same fields separately.
+2. Did the selected scan complete cleanly? Exit zero and final `clean` answer
+   yes. A finding, parse failure, bad invocation or interruption cannot supply
+   that clean completion evidence.
+
+No new event, metric, trace, correlation id or alert is warranted. The runbook
+should test the present signal shape rather than invent telemetry for a local
+lint.
+
+## 9. boundaries per capability
+
+`plugins/hexaemeron/skills/phylax/SKILL.md` applies to the new capability:
+untrusted Python source crosses the AST visitor and influences a P004 result.
+What is worth taking is the credential value and confidence in a clean lint.
+Controls are parse-only inspection, existing import-based runner resolution,
+argv-only selection, source-local AST walking, safe-neighbour tests,
+secret-free output and fail-closed commands. The risk ids `runner-identity`,
+`argv-selection`, `name-recursion`, `safe-neighbour`, `secret-diagnostic` and
+`partial-run` enumerate the review.
+
+Changed prose also crosses the Brevitas CLI. `prose-gate-arity` closes that
+boundary with one file per process and failure propagation from the subshell.
+No new host, dependency, launched subprocess in Phylax, output path, agent tool,
+network input or checker filesystem write is introduced.
+
+## 10. budget or its absence
+
+`plugins/hexaemeron/skills/metron/SKILL.md` has no performance gate here. Issue
+#325 makes no speed, memory or latency claim, and Option A walks one subtree of
+an AST already built for the file. No speed-motivated change is authorized, so
+there is no baseline or budget to manufacture. The focused suite is a
+correctness gate, not a benchmark.
+
+## 11. fail-closed posture
+
+`plugins/hexaemeron/skills/elenchus/SKILL.md` governs the reproduced miss and
+any new failure. The hostile fixture must be observed red against the current
+visitor and green after the cause-level change. A safe-neighbour finding,
+secret value in output, changed P001/P002 classification, ledger mismatch,
+Brevitas file failure or any non-zero required command stops the step. The
+focused guard and both suites must be green before work resumes. Existing P000
+parse and read failures keep their fail-closed behavior.
+
+## 12. decisions and their homes
+
+`plugins/hexaemeron/skills/hypomnema/SKILL.md` places this skill-local behavior
+decision in `plugins/hexaemeron/skills/phylax/EVOLUTION.md`. Its generation row
+should record the source-local argv walk, the deliberately rejected dataflow
+scope and pointers to the shipped study and tests while leaving the mature
+frontier unchanged.
+
+Exact copies of the receipted study and runbook belong at
+`docs/phylax-credential-argv/study.md` and
+`docs/phylax-credential-argv/runbook.md`; audit rounds append their evidence to
+`audit/AUDIT.md`. No repository-wide ADR is justified because the change adds
+no shared schema, dependency, storage layout or cross-skill trust boundary.
+If implementation needs a wider analysis boundary, change this study before
+the code; a generation row cannot smuggle in a frontier change.

--- a/plugins/hexaemeron/skills/phylax/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/phylax/EVOLUTION.md
@@ -1,8 +1,13 @@
 # Phylax evolution ledger
 
+## Current state
+
 Policy: [../VERSIONING.md](../VERSIONING.md)
 
-- Current version: `phylax-v1.1.0`
+- Current version: `phylax-v1.2.0`
+
+## Frontier
+
 - Frontier status: `mature`
 - Frontier revision: `off-chain-boundary-controls`
 - Current frontier: Phylax mechanically checks its established Python boundaries and source-local TypeScript controls for raw HTML ordering, persisted session credentials and runtime-selected absolute fetch hosts.
@@ -14,3 +19,4 @@ Policy: [../VERSIONING.md](../VERSIONING.md)
 | --- | --- | --- | --- | --- | --- |
 | `phylax-v0.1.0` | baseline | `off-chain-boundary-controls` | `ce1e5ed764d74b77b7a8608305353de47ebd0b1ef6fb0091bd7590140e188fb6` | [ariadne untrusted-input tests](../../../ariadne/tests/test_untrusted_input.py) | Phylax starts here, holding the off-chain surface that the Solidity audit skills do not cover. |
 | `phylax-v1.1.0` | evolution | `off-chain-boundary-controls` | `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604` | [TypeScript boundary fixtures](../../tests/test_phylax_checker.py), [shared lexer fixtures](../../tests/test_typescript_lexer.py), [study](../../../../docs/phylax-typescript-boundaries/study.md) | The lint absorbs Horos's lexer contract inside Hexaemeron and adds `P005` through `P007`; the held job is complete and no evidenced next frontier remains. |
+| `phylax-v1.2.0` | generation | `off-chain-boundary-controls` | `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604` | [credential argv fixtures](../../tests/test_phylax_checker.py), [study](../../../../docs/phylax-credential-argv/study.md) | P004 now walks only the inline argv expression of a resolved subprocess runner for credential-named values; assignment dataflow remains deliberately out of scope. |

--- a/plugins/hexaemeron/skills/phylax/SKILL.md
+++ b/plugins/hexaemeron/skills/phylax/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   it to diagnose a failure that has already happened, which belongs to
   elenchus.
 metadata:
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Phylax
@@ -275,8 +275,8 @@ python3 "$PLUGIN_ROOT/skills/phylax/scripts/phylax.py" src tests
 
 For Python and requirements files it reports a shell invocation, a subprocess
 command passed as a string rather than an argument list, a requirement with no
-exact pin, and a credential in source or handed to something that writes
-output.
+exact pin, and a credential in source, in command arguments or handed to
+something that writes output.
 
 For tracked `.ts` and `.tsx` source it reports three source-local cases. A
 `rehype-raw` binding in a rendered plugin array needs a later

--- a/plugins/hexaemeron/skills/phylax/scripts/phylax.py
+++ b/plugins/hexaemeron/skills/phylax/scripts/phylax.py
@@ -7,7 +7,7 @@ reading intent. Everything else in SKILL.md stays a judgement.
   P001  a shell invocation, which invites a command built from data
   P002  a subprocess command passed as a string rather than an argument list
   P003  a requirement with no exact pin
-  P004  a credential in source, or handed to something that writes output
+  P004  a credential in source, command arguments, or output
   P005  raw HTML reaches a renderer without a later trusted sanitiser
   P006  a session credential reaches persisted browser storage
   P007  a runtime-selected absolute fetch host has no prior allowlist check
@@ -159,6 +159,17 @@ class Visitor(ast.NodeVisitor):
             if node.args and _is_string(node.args[0]):
                 built = " built by formatting" if _is_formatted(node.args[0]) else ""
                 self._add(node, "P002", f"command passed as a string{built}; pass a list")
+            argv = node.args[0] if node.args else next(
+                (kw.value for kw in node.keywords if kw.arg == "args"), None
+            )
+            if argv is not None:
+                for value in ast.walk(argv):
+                    if isinstance(value, ast.Name) and CREDENTIAL.search(value.id):
+                        self._add(
+                            node,
+                            "P004",
+                            f"credential-named value `{value.id}` passed in command arguments",
+                        )
 
         if _attr_name(node.func) in WRITERS:
             for arg in node.args + [kw.value for kw in node.keywords]:

--- a/plugins/hexaemeron/tests/test_phylax_checker.py
+++ b/plugins/hexaemeron/tests/test_phylax_checker.py
@@ -70,6 +70,91 @@ class StringCommands(unittest.TestCase):
             "Client().call('eth_chainId', [])\n"))
 
 
+class SubprocessCredentialArguments(unittest.TestCase):
+    def test_it_flags_module_runner_argv(self):
+        self.assertEqual(["P004"], codes(
+            "import subprocess\napi_key = load()\n"
+            "subprocess.run(['tool', api_key])\n"))
+
+    def test_it_flags_module_alias_runner_argv(self):
+        self.assertEqual(["P004"], codes(
+            "import subprocess as sp\nsecret = load()\n"
+            "sp.check_call(['tool', secret])\n"))
+
+    def test_it_flags_direct_import_runner_argv(self):
+        self.assertEqual(["P004"], codes(
+            "from subprocess import run\nauth_token = load()\n"
+            "run(('tool', auth_token))\n"))
+
+    def test_it_flags_direct_import_alias_runner_argv(self):
+        self.assertEqual(["P004"], codes(
+            "from subprocess import Popen as spawn\nprivate_key = load()\n"
+            "spawn(['tool', private_key])\n"))
+
+    def test_it_flags_keyword_args_argv(self):
+        self.assertEqual(["P004"], codes(
+            "import subprocess\ncredential = load()\n"
+            "subprocess.run(args=['tool', credential])\n"))
+
+    def test_it_flags_list_concatenation_without_p002(self):
+        self.assertEqual(["P004"], codes(
+            "import subprocess\naccess_token = load()\n"
+            "subprocess.run(['tool'] + ['--auth', access_token])\n"))
+
+    def test_it_allows_ordinary_argv_values(self):
+        self.assertEqual([], codes(
+            "import subprocess\nmarket = load()\n"
+            "subprocess.run(['tool', market])\n"))
+
+    def test_it_ignores_a_local_runner_name(self):
+        self.assertEqual([], codes(
+            "def run(argv):\n    return argv\n\nsecret = load()\n"
+            "run(['tool', secret])\n"))
+
+    def test_it_ignores_an_unrelated_call_method(self):
+        self.assertEqual([], codes(
+            "class Client:\n    def call(self, argv):\n        return argv\n\n"
+            "api_key = load()\nClient().call(['tool', api_key])\n"))
+
+    def test_it_allows_a_credential_only_in_env(self):
+        self.assertEqual([], codes(
+            "import subprocess\napi_key = load()\n"
+            "subprocess.run(['tool'], env={'API_KEY': api_key})\n"))
+
+    def test_a_stated_reason_suppresses_the_argv_finding(self):
+        self.assertEqual([], codes(
+            "import subprocess\nsecret = load()\n"
+            "subprocess.run(['fixture', secret])  # phylax: allow hostile fixture\n"))
+
+    def test_a_bare_pragma_does_not_suppress_the_argv_finding(self):
+        self.assertEqual(["P004"], codes(
+            "import subprocess\nsecret = load()\n"
+            "subprocess.run(['fixture', secret])  # phylax: allow\n"))
+
+    def test_shell_classification_stays_p001_beside_p004(self):
+        self.assertEqual(["P001", "P004"], codes(
+            "import subprocess\nsecret = load()\n"
+            "subprocess.run(['tool', secret], shell=True)\n"))
+
+    def test_string_command_classification_stays_p002(self):
+        self.assertEqual(["P002"], codes(
+            "import subprocess\nsubprocess.run('tool --version')\n"))
+
+    def test_argv_findings_do_not_repeat_secret_material_in_text_or_json(self):
+        sample_value = "test-only-credential-value"
+        result = findings(
+            "import subprocess\n"
+            f'api_key = load("{sample_value}")\n'
+            "subprocess.run(['tool', api_key])\n",
+            "sample.py",
+        )
+        self.assertEqual(["P004"], [finding.code for finding in result])
+        rendered = "\n".join(str(finding) for finding in result)
+        encoded = json.dumps([finding.as_dict() for finding in result])
+        self.assertNotIn(sample_value, rendered)
+        self.assertNotIn(sample_value, encoded)
+
+
 class Requirements(unittest.TestCase):
     def test_it_flags_an_unpinned_requirement(self):
         self.assertIn("P003", codes("rlp>=4.0.0\n", name="requirements.txt"))

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -394,7 +394,7 @@
     },
     "phylax-boundary-review": {
       "source": "plugins/hexaemeron/skills/phylax/SKILL.md",
-      "sha256": "4ec03afb88700211ef0679b368ec509fab9ee1c182f8ee0011f1333e1e6b92cf",
+      "sha256": "64d5af79bb36e5a401daad05982413873a48eb803251aebab55a4336156321b6",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "reviewed step, source tree and external-input boundary",


### PR DESCRIPTION
base: `fiat/325-phylax-credential-argv-r2` at
`4408597bcd0130b0cee8bd7aab0b55d64ff957c7`

stack: step 1 targets that run branch. tracks #325.

## what changed

P004 now walks the inline `args` expression of calls that `_starts_process`
resolves to `subprocess`. It reports credential-named `ast.Name` values in the
first positional argument or explicit `args=`, including imported aliases and
inline list concatenation. `env=`, separately assigned argv, local runner names
and unrelated methods stay outside the check.

the checker still emits the identifier rather than its value. fifteen bounded
fixtures hold the runner, suppression, P001/P002, safe-neighbour and text/JSON
secrecy boundaries.

Phylax moves from `phylax-v1.1.0` to `phylax-v1.2.0` on the generation axis.
the mature frontier and its digest stay unchanged. the tracked study and
runbook match their receipts, the Promise Machine coverage digest is repinned,
and the Horos boundary is regenerated.

## why

Phylax already forbids credentials in command arguments, but P004 enforced only
credentials in source or sent to writers. issue #325 exposed the missing
mechanical check.

## audit

`audit/AUDIT.md`, section `Phylax credential argv, step 1, round 1`, records a
clean review with 0 findings at head
`5d3daadea3c8342bd5ca1224067873cd1d774447`. the Solidity suite was waived
because the step has no Solidity target.

## proof

```bash
uv run --python 3.12.13 python -m unittest plugins.hexaemeron.tests.test_phylax_checker
uv run --python 3.12.13 python plugins/hexaemeron/tests/run_tests.py
uv run --python 3.12.13 python -m unittest discover -s tests
uv run --python 3.12.13 python -m unittest tests.test_evolution_contract
uv run --python 3.12.13 python scripts/promise_machine.py check
```

the guard was red with 9/15 new assertions failing before the visitor change.
after the fix, the focused suite passed 61/61 on Python 3.9.6 and 3.12.13. the
full Hexaemeron suite passed 833/833 with Node v26.6.0 on `PATH`; the root suite
passed 118/118, the evolution contract passed 8/8, and the Promise Machine,
prose, boundary and diff gates were clean.

<!-- wildcat-origin: shoggoth -->
