### PR TITLE
audit: close P008 import-binding gaps

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8647,3 +8647,80 @@ findings with the reason-bearing pragma as the escape. An exploratory
 whole-file Hypomnema scan reported H003 at `audit/AUDIT.md:6119` and
 `audit/AUDIT.md:6269`; both are quoted prior findings outside the step paths,
 so neither enters this round's required lint exits.
+
+## Phylax unsafe deserialization, step 1, round 2 -- 2026-08-22
+
+### Suite disposition
+
+The controller waiver remains exact: `waived: issue 324 changes the Python
+Phylax lint, fixtures, and governed prose; it has no Solidity target`. The
+complete base-to-stacked diff and the round 2 fix contain no `.sol` path.
+X-Ray and Solidity Auditor did not run. Their active instruction digests match
+the Promise Machine overlays; the waiver applies only to those two operations.
+
+The active-plugin Phylax, Ephoros and Hypomnema lints each exit 0 on the
+repository-mandated scopes. The manual pass re-read the full diff and checked
+all thirteen receipted risks against the fixed tree.
+
+### Finding table
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R2-01 | low | `plugins/hexaemeron/skills/phylax/scripts/phylax.py:305` | Conflicting imports retained several possible call identities, but sorted iteration let the first unsafe candidate supply a false family-specific diagnostic. | fixed and guarded in round 2 |
+| S1-R2-review | none | full base-to-stacked diff | No other code, test, record or payload-disclosure finding was confirmed. | clean |
+| S1-R2-records | none | study, runbook, evolution and Promise Machine binding | The committed records still match their receipted bytes and generation-only boundary. | clean |
+
+Finding count: 1.
+
+### Risk coverage
+
+| risk id | evidence checked | disposition |
+| --- | --- | --- |
+| `source-parse` | P008 uses `ast.parse`, `ast.walk` and the existing visitor; no target import, deserialization or execution was added. | clean |
+| `call-identity` | Late module and direct imports resolve from functions and class bodies; nested imports remain conservative source-local evidence. | clean |
+| `pickle-scope` | `load` and `loads` report; dump calls, JSON and unrelated readers remain clean. | clean |
+| `marshal-scope` | `load` reports and the named `loads` exclusion stays clean. | clean |
+| `yaml-loader` | Positional and keyword safe-loader forms pass; absent, unsafe, unknown and conflicting loader bindings report. | clean |
+| `dynamic-source` | Names, calls and f-strings report; inline string and bytes constants pass. | clean |
+| `alias-rebinding` | Conflicting import identities retain one conservative finding without inventing one family; assignment and lexical-scope dataflow remain excluded. | fixed by S1-R2-01 |
+| `suppression-line` | Reason-bearing and bare pragmas retain opposite results. | clean |
+| `diagnostic-output` | Text and JSON use a fixed unresolved-family message for ambiguous imports and omit the sentinel payload. | fixed by S1-R2-01 |
+| `classification-drift` | P000 through P007 guards and the full focused, plugin and root suites pass. | clean |
+| `analysis-work` | Binding classification adds one bounded pass over the import identities already collected; no recursion, dataflow or target execution enters. | clean |
+| `partial-run` | Every result below reached a terminal zero exit; no partial dot stream was counted. | clean |
+| `ledger-integrity` | `phylax-v1.3.0`, the mature frontier fields and its digest remain unchanged; Promise Machine verification is clean. | clean |
+
+### Evidence
+
+The review started on the exact stacked branch at signed commit
+`116819e77574e116e5f5ddcaed57ef4e22d2c4af` and inspected all eight paths in
+the full diff from `64096f4d89fc821ab9d91d075cd86be7e7bb92b5`.
+The tracked and receipted study copies both hash to
+`5eac7e9c171969933bf9d08a07a50aefd0e3f52ff353fada05691271373f397f`;
+the runbook copies both hash to
+`678e406845563e2bb51cae9dbbcc6d0b3d6f048ee3d3e8a68ceb84b71decdf07`.
+
+The reduced guard
+`UnsafeDeserialization.test_conflicting_imports_do_not_claim_one_call_family`
+failed on the unfixed tree for all four module, direct, neighbour and explicit
+bare-shadow specimens. It passes after the fix, which records ambiguity from
+all visible import identities and emits one fixed unresolved-family message.
+The same guard checks text and JSON for the sentinel payload.
+
+The focused Phylax suite passes 79/79 on Python 3.9.6 and 3.12.13. With the
+checksum-verified Node v26.6.0 fixture first on `PATH`, the full Hexaemeron
+suite passes 851/851. The root suite passes 118/118 and the evolution contract
+passes 8/8. The full Promise Machine check, both Protasis checks, the Horos
+boundary check, the changed-tree Phylax scan and `git diff --check` each exit
+0. The active-plugin Phylax, Ephoros and Hypomnema lint exits are `0`, `0` and
+`0`.
+
+### Leads not pursued
+
+Leads not pursued: `marshal.loads`; wildcard and dynamic imports; assignment,
+lexical-scope, taint and control-flow analysis; custom-loader proofs; the
+accepted pragma-in-string quirk; and Python file-size policy. In particular,
+reassigning an imported safe YAML alias or importing it in another lexical
+scope can retain source-local trust. The study names both limits, and the
+public contract says assignments are not followed, so changing either requires
+a study amendment rather than an audit-side widening.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8799,3 +8799,77 @@ can still retain source-local trust for an actual `yaml.load` call. Those
 limits are inside the receipted exact-import grammar; widening them requires a
 study amendment. Bare `eval` and `exec` are no longer allowed to disappear
 behind that exclusion.
+
+## Phylax unsafe deserialization, step 1, round 4 -- 2026-08-22
+
+### Suite disposition
+
+The controller waiver remains exact: `waived: issue 324 changes the Python
+Phylax lint, fixtures, and governed prose; it has no Solidity target`. No
+`.sol` path appears in the complete `main`-to-stacked diff. X-Ray and Solidity
+Auditor did not run; the waiver applies only to that pair.
+
+The active-plugin Phylax, Ephoros and Hypomnema lints each exit 0 on the
+repository-mandated scopes. The manual pass read the complete diff from
+`64096f4d89fc821ab9d91d075cd86be7e7bb92b5` through signed head
+`dec65fcf1dc52b055d5d188633eb3b3c226f8007` and checked all thirteen
+receipted risks against the accumulated fixes.
+
+### Finding table
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R4-review | none | full base-to-stacked diff | No new code, test or payload-disclosure finding was confirmed. | clean |
+| S1-R4-tests | none | P008 focused and round-4 probe suites | No classification, ordering or diagnostic-secrecy failure was confirmed. | clean |
+| S1-R4-records | none | study, runbook, evolution and Promise Machine binding | No record drift or unreceipted boundary change was confirmed. | clean |
+
+Finding count: 0.
+
+### Risk coverage
+
+| risk id | evidence checked | disposition |
+| --- | --- | --- |
+| `source-parse` | P008 still uses `ast.parse`, `ast.walk` and the existing visitor; the checker neither imports nor runs target source. | clean |
+| `call-identity` | Same-scope, late and cross-scope module/direct imports, neighbour conflicts and boundary-family conflicts retain one conservative result. | clean |
+| `pickle-scope` | Module/direct `load` and `loads` report once; dump calls and unrelated readers stay clean. | clean |
+| `marshal-scope` | `load` reports once and the receipted `loads` exclusion stays clean. | clean within scope |
+| `yaml-loader` | Positional and keyword `SafeLoader`/`CSafeLoader` forms pass; absent, unsafe, unknown and conflicting loader evidence reports. | clean |
+| `dynamic-source` | Bare and resolved `eval`/`exec` report names, calls and f-strings; inline string/bytes constants pass. | clean |
+| `alias-rebinding` | Conflicting identities retain one unresolved-family result, and bare built-ins survive YAML aliases from another scope. Assignment and general scope analysis remain excluded. | clean within scope |
+| `suppression-line` | Reason-bearing and bare pragma fixtures retain opposite results. | clean |
+| `diagnostic-output` | Conflict probes emit one fixed message, omit payload text and return identical JSON under hash seeds 1 and 947. | clean |
+| `classification-drift` | The 61 pre-existing cases inside the 80-test focused suite pass on Python 3.9.6 and 3.12.13; P000 through P007 remain guarded. | clean |
+| `analysis-work` | Import collection is one linear AST walk, followed by constant-size candidate checks per call; no dataflow or target execution enters. | clean |
+| `partial-run` | Both focused runs, all three required lints and every supporting check below reached terminal exit 0. | clean |
+| `ledger-integrity` | Receipted and tracked artifacts match, `phylax-v1.3.0` advances generation only, the mature frontier fields stay fixed, and Promise Machine verification passes. | clean |
+
+### Evidence
+
+The focused Phylax suite passes 80/80 on Python 3.9.6 and 3.12.13. A separate
+round-4 matrix passes 28 same/cross-scope call cases and four ambiguous-message
+guards. The root suite passes 118/118 and the evolution contract passes 8/8.
+The repository Phylax scan, Promise Machine check, both Protasis checks, Horos
+boundary check and `git diff --check` each exit 0. Active-plugin lint exits are
+Phylax 0, Ephoros 0 and Hypomnema 0.
+
+The receipted and tracked study copies both hash to
+`5eac7e9c171969933bf9d08a07a50aefd0e3f52ff353fada05691271373f397f`;
+the runbook copies both hash to
+`678e406845563e2bb51cae9dbbcc6d0b3d6f048ee3d3e8a68ceb84b71decdf07`.
+The checked `SKILL.md` hashes to
+`fc3fdf6bf76cd24bf602d39ae30d1b77b1f196a34e0207522fec7ff9115007ca`,
+matching its Promise Machine pin.
+
+No retained Node v26.6.0 binary was present, so round 4 did not repeat the
+supplementary full Hexaemeron suite. Round 3's 852/852 run remains the latest
+full-suite evidence for this exact code head; it is not counted as a round-4
+execution.
+
+### Leads not pursued
+
+Leads not pursued: `marshal.loads`; relative, wildcard, dynamic and dotted
+imports; assignment, general lexical-scope, taint and control-flow analysis;
+custom-loader proofs; the accepted pragma-in-string quirk; and Python file-size
+policy. Cross-scope YAML module and loader aliases can retain source-local
+trust for an actual `yaml.load` call. The receipted study excludes that scope,
+so changing it would require an amendment rather than an audit-side widening.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8572,3 +8572,78 @@ separately assigned argv, star-expanded call forms, `**kwargs`, runner-name
 rebinding and flag interpretation remain outside the receipted source-local
 boundary. Widening any of them would change the approved finding grammar or
 runner-resolution contract rather than repair this implementation.
+
+## Phylax unsafe deserialization, step 1, round 1 -- 2026-08-22
+
+### Suite disposition
+
+The controller recorded this waiver: `waived: issue 324 changes the Python
+Phylax lint, fixtures, and governed prose; it has no Solidity target`. No
+`.sol` file appears in the full step or stacked diff. X-Ray and Solidity
+Auditor did not run; the waiver applies only to that pair.
+
+The active-plugin Phylax, Ephoros and Hypomnema lints each exit 0 over every
+step-changed path. The manual review covered the full diff and every receipted risk.
+
+### Finding table
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R1-01 | medium | `plugins/hexaemeron/skills/phylax/scripts/phylax.py:138` | Depth-first import discovery missed dangerous calls inside functions defined before their module or direct import. | fixed and guarded |
+| S1-R1-02 | low | `plugins/hexaemeron/skills/phylax/scripts/phylax.py:187` | Conflicting imports could select one safe identity and hide an unsafe loader or deserializer under the same alias. | fixed and guarded |
+| S1-R1-review | none | full step diff | No further code, test, record or payload-disclosure finding was confirmed. | clean |
+
+Finding count: 2.
+
+### Risk coverage
+
+| risk id | evidence checked | disposition |
+| --- | --- | --- |
+| `source-parse` | `ast.parse`, one `ast.walk` and the existing visitor inspect source without importing, executing or deserializing it. | clean |
+| `call-identity` | Module, module-alias, direct and direct-alias fixtures include imports after function definitions; relative imports remain excluded. | fixed by S1-R1-01 |
+| `pickle-scope` | `load` and `loads` report; `dump`, `dumps` and unrelated loaders stay clean. | clean |
+| `marshal-scope` | `load` reports and `loads` has an explicit negative fixture. | clean |
+| `yaml-loader` | Positional and keyword `SafeLoader` and `CSafeLoader` aliases pass; absent, unknown, unsafe and conflicting bindings report. | fixed by S1-R1-02 |
+| `dynamic-source` | Names, calls and f-strings report; inline string and bytes constants pass; no-argument and keyword-only shapes follow the stated first-positional-argument grammar. | clean |
+| `alias-rebinding` | Assignment rebinding remains outside analysis; conflicting import evidence is conservative, and a bare/local `eval` collision still reports. | clean within scope |
+| `suppression-line` | A reason-bearing pragma suppresses P008 and a bare pragma does not. | clean |
+| `diagnostic-output` | Text and JSON carry fixed family messages and omit the sentinel payload. | clean |
+| `classification-drift` | P000 through P007 guards and the full focused and plugin suites pass. | clean |
+| `analysis-work` | The change adds one linear AST import pass and constant-time checks per relevant call, with no dataflow or target execution. | clean |
+| `partial-run` | Every required lint and relevant test was read to completion; no interrupted result is counted as clean. | clean |
+| `ledger-integrity` | `phylax-v1.3.0` advances generation only; the mature frontier fields and digest remain unchanged, and Promise Machine verification passes. | clean |
+
+### Evidence
+
+The review read all seven files changed from
+`64096f4d89fc821ab9d91d075cd86be7e7bb92b5` through
+`3766c516bf6960945774aeaa0b2b0c819bbbde95`, then reviewed the stacked fixes.
+The tracked study matches `.hexaemeron/study.md` at
+`5eac7e9c171969933bf9d08a07a50aefd0e3f52ff353fada05691271373f397f`.
+
+The fix collects import evidence before call classification, retains exact
+absolute module and direct-import resolution, and trusts a YAML module or
+loader alias only when all explicit imports under that local name belong to
+the safe family. Guards at
+`plugins/hexaemeron/tests/test_phylax_checker.py:104` cover late module and
+direct imports; the adjacent cases cover conflicting bindings, loader
+precedence, relative imports, bare/local eval collisions, no-argument and
+keyword-only shapes, and one finding per nested boundary call.
+
+The focused Phylax suite passes 78/78 on Python 3.9.6 and 3.12.13. With the
+fixture-pinned Node v26.6.0 first on `PATH`, the full Hexaemeron suite passes
+850/850. The root suite passes 118/118, the evolution contract passes 8/8,
+the full Promise Machine check is clean, the Horos boundary matches the tree,
+and `git diff --check` exits 0. The ambient Node v22.22.3 run stopped at the
+fixture's exact-version assertion before the pinned-version rerun passed.
+
+### Leads not pursued
+
+Leads not pursued: `marshal.loads`; wildcard and dynamic imports; assignment,
+scope, taint and control-flow analysis; custom-loader proofs; the accepted
+pragma-in-string quirk; and Python file-size policy. The receipted study names
+these as exclusions. Bare/local `eval` collisions remain conservative P008
+findings with the reason-bearing pragma as the escape. An exploratory
+whole-file Hypomnema scan reported H003 at `audit/AUDIT.md:6119` and
+`audit/AUDIT.md:6269`; both are quoted prior findings outside the step paths,
+so neither enters this round's required lint exits.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8724,3 +8724,78 @@ reassigning an imported safe YAML alias or importing it in another lexical
 scope can retain source-local trust. The study names both limits, and the
 public contract says assignments are not followed, so changing either requires
 a study amendment rather than an audit-side widening.
+
+## Phylax unsafe deserialization, step 1, round 3 -- 2026-08-22
+
+### Suite disposition
+
+The controller waiver remains exact: `waived: issue 324 changes the Python
+Phylax lint, fixtures, and governed prose; it has no Solidity target`. No
+`.sol` path appears from `main` through the accumulated fixed tree. X-Ray and
+Solidity Auditor did not run; the waiver applies only to that pair.
+
+The active-plugin Phylax, Ephoros and Hypomnema lints each exit 0 on the
+repository-mandated scopes. The manual pass read the complete base-to-stacked
+diff and checked all thirteen receipted risks against the round 2 fixes.
+
+### Finding table
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R3-01 | medium | `plugins/hexaemeron/skills/phylax/scripts/phylax.py:215` | A direct YAML boundary import under bare `eval` or `exec`, collected from another lexical scope, displaced the built-in candidate; paired safe-loader evidence could make an outer non-literal dynamic call produce no P008. | fixed and guarded in round 3 |
+| S1-R3-review | none | full base-to-stacked diff | No other code, test, record or payload-disclosure finding was confirmed. | clean |
+| S1-R3-records | none | study, runbook, evolution and Promise Machine binding | The tracked study remains byte-identical to the receipted artifact, and generation-only bookkeeping remains unchanged. | clean |
+
+Finding count: 1.
+
+### Risk coverage
+
+| risk id | evidence checked | disposition |
+| --- | --- | --- |
+| `source-parse` | P008 still uses `ast.parse`, `ast.walk` and the existing visitor without importing, executing or deserializing target source. | clean |
+| `call-identity` | Same-family, boundary-to-boundary and boundary-to-neighbour conflicts were exercised; bare built-ins now remain candidates beside direct imports. | fixed by S1-R3-01 |
+| `pickle-scope` | Module and direct aliases for `load` and `loads` report once; dumps and unrelated readers remain clean. | clean |
+| `marshal-scope` | `load` reports once while the receipted `loads` exclusion remains clean. | clean within scope |
+| `yaml-loader` | Module and loader aliases for `SafeLoader` and `CSafeLoader` pass; unsafe and conflicting evidence reports. Lexical-scope trust remains an explicit exclusion. | bounded by the receipted exclusion |
+| `dynamic-source` | Bare `eval` and `exec` with non-literal source report even when another scope imports YAML boundaries under those names. Literal source remains clean. | fixed by S1-R3-01 |
+| `alias-rebinding` | Conflicts now keep every possible call family, including the implicit built-in family. Assignment and general scope analysis remain excluded. | clean within scope |
+| `suppression-line` | The existing reason-bearing and bare pragma cases retain opposite results. | clean |
+| `diagnostic-output` | Conflict cases emit one fixed unresolved-family message per call, omit payload text in text and JSON, and retain stable order under two hash seeds. | clean |
+| `classification-drift` | P000 through P007 guards, both focused interpreter runs and the full plugin suite pass. | clean |
+| `analysis-work` | The fix adds one set member and a constant-size union per bare dynamic call; it adds no recursive walk, dataflow or target execution. | clean |
+| `partial-run` | Every recorded test and lint reached a terminal zero exit; the two expected red guard runs are identified separately. | clean |
+| `ledger-integrity` | `phylax-v1.3.0`, the mature frontier fields and its digest are unchanged; Promise Machine verification exits 0. | clean |
+
+### Evidence
+
+The review started from exact signed stacked head
+`f5a2ef2c23c22840dd8f06af62cc759d6a3fd1e3` and re-read all eight paths from
+`64096f4d89fc821ab9d91d075cd86be7e7bb92b5`. The tracked and receipted study
+copies still hash to
+`5eac7e9c171969933bf9d08a07a50aefd0e3f52ff353fada05691271373f397f`.
+
+The reduced guard
+`UnsafeDeserialization.test_bare_dynamic_calls_survive_cross_scope_yaml_aliases`
+failed twice on the unfixed tree, for both `eval` and `exec`. Each specimen
+places a YAML boundary and safe-loader import in another function while the
+outer function passes non-literal source and a globals mapping to the actual
+built-in. The fix retains the built-in family beside direct-import evidence,
+so both calls now emit one ambiguous P008 instead of escaping the rule.
+
+The focused Phylax suite passes 80/80 on Python 3.9.6 and 3.12.13. With the
+retained Node v26.6.0 fixture first on `PATH`, the full Hexaemeron suite passes
+852/852. The root suite passes 118/118 and the evolution contract passes 8/8.
+The full Promise Machine check, both Protasis checks, the Horos boundary check,
+the changed-tree Phylax scan and `git diff --check` each exit 0. The
+active-plugin Phylax, Ephoros and Hypomnema lint exits are `0`, `0` and `0`.
+
+### Leads not pursued
+
+Leads not pursued: `marshal.loads`; relative, wildcard, dynamic and dotted
+imports such as `import yaml.loader`; assignment, general lexical-scope, taint
+and control-flow analysis; custom-loader proofs; the accepted pragma-in-string
+quirk; and Python file-size policy. Cross-scope YAML module and loader aliases
+can still retain source-local trust for an actual `yaml.load` call. Those
+limits are inside the receipted exact-import grammar; widening them requires a
+study amendment. Bare `eval` and `exec` are no longer allowed to disappear
+behind that exclusion.

--- a/plugins/hexaemeron/skills/phylax/scripts/phylax.py
+++ b/plugins/hexaemeron/skills/phylax/scripts/phylax.py
@@ -46,6 +46,9 @@ P008_MESSAGES = {
     "yaml": "yaml.load has no resolved SafeLoader or CSafeLoader",
     "builtins": "dynamic execution receives non-literal source",
 }
+P008_AMBIGUOUS_MESSAGE = (
+    "source-local bindings leave the boundary call family unresolved"
+)
 
 CREDENTIAL = re.compile(
     r"(?:^|_)(?:priv(?:ate)?_?key|secret|passwd|password|mnemonic|seed_?phrase"
@@ -137,7 +140,13 @@ def _is_dynamic_literal(node: ast.AST) -> bool:
 
 def _boundary_bindings(
     tree: ast.AST,
-) -> tuple[dict[str, set[str]], dict[str, set[str]], set[str], set[str]]:
+) -> tuple[
+    dict[str, set[str]],
+    dict[str, set[str]],
+    set[str],
+    set[str],
+    set[str],
+]:
     """Collect source-local import evidence before descending function bodies.
 
     A depth-first visitor reaches a function's calls before module imports that
@@ -189,7 +198,31 @@ def _boundary_bindings(
             for level, module, name in imported
         )
     }
-    return modules, direct, safe_yaml_modules, safe_yaml_loaders
+    ambiguous_calls = set()
+    for local, imported in identities.items():
+        families = set()
+        for level, module, name in imported:
+            if level == -1 and module in BOUNDARY_CALLS:
+                families.add(module)
+            elif (
+                level == 0
+                and module in BOUNDARY_CALLS
+                and name in BOUNDARY_CALLS[module]
+            ):
+                families.add(module)
+            else:
+                families.add(None)
+        if local in BOUNDARY_CALLS["builtins"] and local not in direct:
+            families.add("builtins")
+        if len(families) > 1:
+            ambiguous_calls.add(local)
+    return (
+        modules,
+        direct,
+        safe_yaml_modules,
+        safe_yaml_loaders,
+        ambiguous_calls,
+    )
 
 
 class Visitor(ast.NodeVisitor):
@@ -209,6 +242,7 @@ class Visitor(ast.NodeVisitor):
             self.boundary_direct,
             self.safe_yaml_modules,
             self.safe_yaml_loaders,
+            self.ambiguous_boundary_calls,
         ) = _boundary_bindings(tree)
 
     def visit_Import(self, node: ast.Import) -> None:
@@ -258,6 +292,12 @@ class Visitor(ast.NodeVisitor):
         return isinstance(loader, ast.Name) and loader.id in self.safe_yaml_loaders
 
     def _check_p008(self, node: ast.Call) -> None:
+        binding = (
+            node.func.value.id
+            if isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            else node.func.id if isinstance(node.func, ast.Name) else None
+        )
         loader = next(
             (keyword.value for keyword in node.keywords if keyword.arg == "Loader"),
             node.args[1] if len(node.args) > 1 else None,
@@ -269,7 +309,12 @@ class Visitor(ast.NodeVisitor):
             elif module == "builtins":
                 if not node.args or _is_dynamic_literal(node.args[0]):
                     continue
-            self._add(node, "P008", P008_MESSAGES[module])
+            message = (
+                P008_AMBIGUOUS_MESSAGE
+                if binding in self.ambiguous_boundary_calls
+                else P008_MESSAGES[module]
+            )
+            self._add(node, "P008", message)
             return
 
     def visit_Call(self, node: ast.Call) -> None:

--- a/plugins/hexaemeron/skills/phylax/scripts/phylax.py
+++ b/plugins/hexaemeron/skills/phylax/scripts/phylax.py
@@ -135,6 +135,63 @@ def _is_dynamic_literal(node: ast.AST) -> bool:
     )
 
 
+def _boundary_bindings(
+    tree: ast.AST,
+) -> tuple[dict[str, set[str]], dict[str, set[str]], set[str], set[str]]:
+    """Collect source-local import evidence before descending function bodies.
+
+    A depth-first visitor reaches a function's calls before module imports that
+    follow its definition, even though those imports bind before normal calls.
+    Conflicting imports remain conservative evidence because scope and runtime
+    rebinding are outside this rule.
+    """
+    modules: dict[str, set[str]] = {}
+    direct: dict[str, set[str]] = {}
+    identities: dict[str, set[tuple[int, str | None, str]]] = {}
+    imports = (
+        node for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+    )
+    for node in imports:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                local = alias.asname or alias.name.split(".", 1)[0]
+                identities.setdefault(local, set()).add((-1, alias.name, ""))
+                if alias.name in BOUNDARY_CALLS:
+                    modules.setdefault(local, set()).add(alias.name)
+            continue
+
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            local = alias.asname or alias.name
+            identities.setdefault(local, set()).add(
+                (node.level, node.module, alias.name)
+            )
+            if node.level != 0 or node.module not in BOUNDARY_CALLS:
+                continue
+            if alias.name in BOUNDARY_CALLS[node.module]:
+                direct.setdefault(local, set()).add(node.module)
+
+    safe_yaml_modules = {
+        local
+        for local, imported in identities.items()
+        if all(
+            level == -1 and module == "yaml"
+            for level, module, _name in imported
+        )
+    }
+    safe_yaml_loaders = {
+        local
+        for local, imported in identities.items()
+        if all(
+            level == 0 and module == "yaml" and name in SAFE_YAML_LOADERS
+            for level, module, name in imported
+        )
+    }
+    return modules, direct, safe_yaml_modules, safe_yaml_loaders
+
+
 class Visitor(ast.NodeVisitor):
     """Flag only calls resolved by the source-local import grammar.
 
@@ -142,21 +199,22 @@ class Visitor(ast.NodeVisitor):
     `run` and `.call` methods must stay outside the rule that owns each name.
     """
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path, tree: ast.AST) -> None:
         self.path = path
         self.findings: list[Finding] = []
         self.modules: set[str] = set()
         self.direct: set[str] = set()
-        self.boundary_modules: dict[str, str] = {}
-        self.boundary_direct: dict[str, str] = {}
-        self.safe_yaml_loaders: set[str] = set()
+        (
+            self.boundary_modules,
+            self.boundary_direct,
+            self.safe_yaml_modules,
+            self.safe_yaml_loaders,
+        ) = _boundary_bindings(tree)
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
             if alias.name == "subprocess":
                 self.modules.add(alias.asname or "subprocess")
-            if alias.name in BOUNDARY_CALLS:
-                self.boundary_modules[alias.asname or alias.name] = alias.name
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
@@ -164,13 +222,6 @@ class Visitor(ast.NodeVisitor):
             for alias in node.names:
                 if alias.name in RUNNERS:
                     self.direct.add(alias.asname or alias.name)
-        if node.level == 0 and node.module in BOUNDARY_CALLS:
-            for alias in node.names:
-                local = alias.asname or alias.name
-                if alias.name in BOUNDARY_CALLS[node.module]:
-                    self.boundary_direct[local] = node.module
-                if node.module == "yaml" and alias.name in SAFE_YAML_LOADERS:
-                    self.safe_yaml_loaders.add(local)
         self.generic_visit(node)
 
     def _starts_process(self, func: ast.AST) -> bool:
@@ -183,42 +234,43 @@ class Visitor(ast.NodeVisitor):
     def _add(self, node: ast.AST, code: str, message: str) -> None:
         self.findings.append(Finding(self.path, node.lineno, code, message))
 
-    def _boundary_module(self, func: ast.AST) -> str | None:
+    def _boundary_modules(self, func: ast.AST) -> set[str]:
         if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
-            module = self.boundary_modules.get(func.value.id)
-            if module and func.attr in BOUNDARY_CALLS[module]:
-                return module
+            return {
+                module
+                for module in self.boundary_modules.get(func.value.id, set())
+                if func.attr in BOUNDARY_CALLS[module]
+            }
         if isinstance(func, ast.Name):
             resolved = self.boundary_direct.get(func.id)
             if resolved:
                 return resolved
             if func.id in BOUNDARY_CALLS["builtins"]:
-                return "builtins"
-        return None
+                return {"builtins"}
+        return set()
 
     def _safe_yaml_loader(self, loader: ast.AST) -> bool:
         if isinstance(loader, ast.Attribute) and isinstance(loader.value, ast.Name):
             return (
-                self.boundary_modules.get(loader.value.id) == "yaml"
+                loader.value.id in self.safe_yaml_modules
                 and loader.attr in SAFE_YAML_LOADERS
             )
         return isinstance(loader, ast.Name) and loader.id in self.safe_yaml_loaders
 
     def _check_p008(self, node: ast.Call) -> None:
-        module = self._boundary_module(node.func)
-        if not module:
+        loader = next(
+            (keyword.value for keyword in node.keywords if keyword.arg == "Loader"),
+            node.args[1] if len(node.args) > 1 else None,
+        )
+        for module in sorted(self._boundary_modules(node.func)):
+            if module == "yaml":
+                if loader is not None and self._safe_yaml_loader(loader):
+                    continue
+            elif module == "builtins":
+                if not node.args or _is_dynamic_literal(node.args[0]):
+                    continue
+            self._add(node, "P008", P008_MESSAGES[module])
             return
-        if module == "yaml":
-            loader = next(
-                (keyword.value for keyword in node.keywords if keyword.arg == "Loader"),
-                node.args[1] if len(node.args) > 1 else None,
-            )
-            if loader is not None and self._safe_yaml_loader(loader):
-                return
-        elif module == "builtins":
-            if not node.args or _is_dynamic_literal(node.args[0]):
-                return
-        self._add(node, "P008", P008_MESSAGES[module])
 
     def visit_Call(self, node: ast.Call) -> None:
         self._check_p008(node)
@@ -262,7 +314,7 @@ def check_python(path: Path, text: str) -> list[Finding]:
         tree = ast.parse(text)
     except SyntaxError as err:
         return [Finding(path, err.lineno or 1, "P000", f"could not parse: {err.msg}")]
-    visitor = Visitor(path)
+    visitor = Visitor(path, tree)
     visitor.visit(tree)
     return visitor.findings
 

--- a/plugins/hexaemeron/skills/phylax/scripts/phylax.py
+++ b/plugins/hexaemeron/skills/phylax/scripts/phylax.py
@@ -212,7 +212,9 @@ def _boundary_bindings(
                 families.add(module)
             else:
                 families.add(None)
-        if local in BOUNDARY_CALLS["builtins"] and local not in direct:
+        # a direct import elsewhere in the file does not prove that it shadows
+        # a bare built-in at this call site; scope analysis is outside P008.
+        if local in BOUNDARY_CALLS["builtins"]:
             families.add("builtins")
         if len(families) > 1:
             ambiguous_calls.add(local)
@@ -276,11 +278,10 @@ class Visitor(ast.NodeVisitor):
                 if func.attr in BOUNDARY_CALLS[module]
             }
         if isinstance(func, ast.Name):
-            resolved = self.boundary_direct.get(func.id)
-            if resolved:
-                return resolved
+            resolved = set(self.boundary_direct.get(func.id, set()))
             if func.id in BOUNDARY_CALLS["builtins"]:
-                return {"builtins"}
+                resolved.add("builtins")
+            return resolved
         return set()
 
     def _safe_yaml_loader(self, loader: ast.AST) -> bool:

--- a/plugins/hexaemeron/tests/test_phylax_checker.py
+++ b/plugins/hexaemeron/tests/test_phylax_checker.py
@@ -101,6 +101,52 @@ class UnsafeDeserialization(unittest.TestCase):
             ),
         })
 
+    def test_imports_after_function_definitions_still_resolve(self):
+        self.assert_p008({
+            "module": (
+                "def decode(payload):\n"
+                "    return pickle.loads(payload)\n"
+                "import pickle\n"
+            ),
+            "direct": (
+                "def decode(payload):\n"
+                "    return decode_pickle(payload)\n"
+                "from pickle import loads as decode_pickle\n"
+            ),
+        })
+
+    def test_import_rebinding_does_not_hide_boundary_evidence(self):
+        self.assertEqual(["P008"], codes(
+            "import pickle as codec\n"
+            "import json as codec\n"
+            "codec.loads(payload)\n"
+        ))
+        self.assertEqual(["P008"], codes(
+            "from pickle import loads as decode\n"
+            "from json import loads as decode\n"
+            "decode(payload)\n"
+        ))
+        self.assertEqual(["P008"], codes(
+            "from yaml import load, SafeLoader as Loader\n"
+            "from yaml import FullLoader as Loader\n"
+            "load(payload, Loader=Loader)\n"
+        ))
+        self.assertEqual(["P008"], codes(
+            "import yaml as parser\n"
+            "import custom as parser\n"
+            "parser.load(payload, Loader=parser.SafeLoader)\n"
+        ))
+        self.assertEqual(["P008"], codes(
+            "import pickle as codec\n"
+            "import yaml as codec\n"
+            "codec.loads(payload)\n"
+        ))
+        self.assertEqual(["P008"], codes(
+            "from builtins import eval as decode\n"
+            "from yaml import load as decode\n"
+            "decode('literal')\n"
+        ))
+
     def test_safe_yaml_loaders_are_allowed_in_keyword_and_positional_forms(self):
         specimens = {
             "module-safe-keyword": (
@@ -136,6 +182,42 @@ class UnsafeDeserialization(unittest.TestCase):
         for label, source in specimens.items():
             with self.subTest(label=label):
                 self.assertEqual([], codes(source))
+
+    def test_yaml_loader_keyword_takes_precedence_over_second_position(self):
+        self.assertEqual([], codes(
+            "import yaml\n"
+            "yaml.load(payload, yaml.FullLoader, Loader=yaml.SafeLoader)\n"
+        ))
+        self.assertEqual(["P008"], codes(
+            "import yaml\n"
+            "yaml.load(payload, yaml.SafeLoader, Loader=yaml.FullLoader)\n"
+        ))
+
+    def test_argument_shape_edges_follow_the_stated_grammar(self):
+        self.assert_p008({
+            "pickle-no-args": "import pickle\npickle.load()\n",
+            "yaml-no-args": "import yaml\nyaml.load()\n",
+        })
+        self.assertEqual([], codes("eval()\nexec(source=payload)\n"))
+        self.assertEqual(["P008"], codes(
+            "def eval(value):\n"
+            "    return value\n"
+            "eval(payload)\n"
+        ))
+
+    def test_nested_boundary_calls_each_report_once(self):
+        result = findings(
+            "import pickle\n"
+            "eval(pickle.loads(payload))\n",
+            "sample.py",
+        )
+        self.assertEqual(
+            [
+                "dynamic execution receives non-literal source",
+                "pickle deserialization may execute untrusted code",
+            ],
+            [finding.message for finding in result],
+        )
 
     def test_named_safe_and_out_of_scope_neighbours_are_allowed(self):
         source = (

--- a/plugins/hexaemeron/tests/test_phylax_checker.py
+++ b/plugins/hexaemeron/tests/test_phylax_checker.py
@@ -147,6 +147,43 @@ class UnsafeDeserialization(unittest.TestCase):
             "decode('literal')\n"
         ))
 
+    def test_conflicting_imports_do_not_claim_one_call_family(self):
+        sentinel = "conflicting-import-sentinel"
+        specimens = {
+            "module-boundaries": (
+                "import pickle as codec\n"
+                "import yaml as codec\n"
+                "codec.load(payload)\n"
+            ),
+            "direct-boundaries": (
+                "from pickle import load as decode\n"
+                "from yaml import load as decode\n"
+                "decode(payload)\n"
+            ),
+            "boundary-and-neighbour": (
+                "from pickle import load as decode\n"
+                "from json import load as decode\n"
+                "decode(payload)\n"
+            ),
+            "explicit-bare-shadow": (
+                "from ast import literal_eval as eval\n"
+                "eval(payload)\n"
+            ),
+        }
+        for label, source in specimens.items():
+            with self.subTest(label=label):
+                result = findings(
+                    f'payload = "{sentinel}"\n' + source,
+                    "sample.py",
+                )
+                self.assertEqual(["P008"], [finding.code for finding in result])
+                self.assertEqual(
+                    "source-local bindings leave the boundary call family unresolved",
+                    result[0].message,
+                )
+                self.assertNotIn(sentinel, str(result[0]))
+                self.assertNotIn(sentinel, json.dumps(result[0].as_dict()))
+
     def test_safe_yaml_loaders_are_allowed_in_keyword_and_positional_forms(self):
         specimens = {
             "module-safe-keyword": (

--- a/plugins/hexaemeron/tests/test_phylax_checker.py
+++ b/plugins/hexaemeron/tests/test_phylax_checker.py
@@ -184,6 +184,32 @@ class UnsafeDeserialization(unittest.TestCase):
                 self.assertNotIn(sentinel, str(result[0]))
                 self.assertNotIn(sentinel, json.dumps(result[0].as_dict()))
 
+    def test_bare_dynamic_calls_survive_cross_scope_yaml_aliases(self):
+        specimens = {
+            "eval": (
+                "def run(payload, SafeLoader):\n"
+                "    return eval(payload, SafeLoader)\n"
+                "def imports_elsewhere():\n"
+                "    from yaml import load as eval\n"
+                "    from yaml import SafeLoader\n"
+            ),
+            "exec": (
+                "def run(payload, SafeLoader):\n"
+                "    exec(payload, SafeLoader)\n"
+                "def imports_elsewhere():\n"
+                "    from yaml import load as exec\n"
+                "    from yaml import SafeLoader\n"
+            ),
+        }
+        for label, source in specimens.items():
+            with self.subTest(label=label):
+                result = findings(source, "sample.py")
+                self.assertEqual(["P008"], [finding.code for finding in result])
+                self.assertEqual(
+                    "source-local bindings leave the boundary call family unresolved",
+                    result[0].message,
+                )
+
     def test_safe_yaml_loaders_are_allowed_in_keyword_and_positional_forms(self):
         specimens = {
             "module-safe-keyword": (


### PR DESCRIPTION
# audit: close P008 import-binding gaps

Refs #324. This PR stacks on the P008 implementation branch.

## what changed

The audit fixes collect import identities before call classification, keep
conflicting bindings conservative, emit a family-neutral diagnostic when the
source cannot resolve one boundary family, and preserve bare `eval` and `exec`
as candidates beside cross-scope imports. Regression guards cover late imports,
module and direct conflicts, YAML loader aliases, deterministic diagnostics,
one finding per call, and payload secrecy.

## why

The initial visitor could miss a call inside a function defined before its
import. Its first conflict fix could also trust a rebound loader, name the wrong
deserializer family, or let cross-scope YAML evidence hide bare non-literal
dynamic execution. Those are enforcement defects, not accepted dataflow or
scope exclusions.

## audit

Rounds under `Phylax unsafe deserialization` in `audit/AUDIT.md` found
`2 -> 1 -> 1 -> 0` issues. `S1-R1-01`, `S1-R1-02`, `S1-R2-01`, and
`S1-R3-01` are fixed and guarded; round 4 is clean across all thirteen study
risks. The remaining leads are the exclusions already named by the receipted
study.

## proof

| command | result | scope |
| --- | --- | --- |
| `/usr/bin/python3 -B -m unittest plugins.hexaemeron.tests.test_phylax_checker` | 80/80 | Python 3.9.6 |
| `uv run --python 3.12.13 python -m unittest plugins.hexaemeron.tests.test_phylax_checker` | 80/80 | Python 3.12.13 |
| `uv run --python 3.12.13 python plugins/hexaemeron/tests/run_tests.py` | 852/852 | checksum-verified Node v26.6.0 first on `PATH` |
| `uv run --python 3.12.13 python -m unittest discover -s tests` | 118/118 | root suite |
| `uv run --python 3.12.13 python -m unittest tests.test_evolution_contract` | 8/8 | evolution contract |
| `uv run --python 3.12.13 python plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests` | exit 0, `clean` | repository scan |
| `uv run --python 3.12.13 python scripts/promise_machine.py check` | exit 0 | contracts and overlays |
| `uv run --python 3.12.13 python plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests` | exit 0 | telemetry lint |
| `uv run --python 3.12.13 python plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs` | exit 0 | record pointers |

<!-- wildcat-origin: shoggoth -->
