### PR TITLE
add P008 unsafe-deserialization checks to Phylax

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8647,3 +8647,80 @@ findings with the reason-bearing pragma as the escape. An exploratory
 whole-file Hypomnema scan reported H003 at `audit/AUDIT.md:6119` and
 `audit/AUDIT.md:6269`; both are quoted prior findings outside the step paths,
 so neither enters this round's required lint exits.
+
+## Phylax unsafe deserialization, step 1, round 2 -- 2026-08-22
+
+### Suite disposition
+
+The controller waiver remains exact: `waived: issue 324 changes the Python
+Phylax lint, fixtures, and governed prose; it has no Solidity target`. The
+complete base-to-stacked diff and the round 2 fix contain no `.sol` path.
+X-Ray and Solidity Auditor did not run. Their active instruction digests match
+the Promise Machine overlays; the waiver applies only to those two operations.
+
+The active-plugin Phylax, Ephoros and Hypomnema lints each exit 0 on the
+repository-mandated scopes. The manual pass re-read the full diff and checked
+all thirteen receipted risks against the fixed tree.
+
+### Finding table
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R2-01 | low | `plugins/hexaemeron/skills/phylax/scripts/phylax.py:305` | Conflicting imports retained several possible call identities, but sorted iteration let the first unsafe candidate supply a false family-specific diagnostic. | fixed and guarded in round 2 |
+| S1-R2-review | none | full base-to-stacked diff | No other code, test, record or payload-disclosure finding was confirmed. | clean |
+| S1-R2-records | none | study, runbook, evolution and Promise Machine binding | The committed records still match their receipted bytes and generation-only boundary. | clean |
+
+Finding count: 1.
+
+### Risk coverage
+
+| risk id | evidence checked | disposition |
+| --- | --- | --- |
+| `source-parse` | P008 uses `ast.parse`, `ast.walk` and the existing visitor; no target import, deserialization or execution was added. | clean |
+| `call-identity` | Late module and direct imports resolve from functions and class bodies; nested imports remain conservative source-local evidence. | clean |
+| `pickle-scope` | `load` and `loads` report; dump calls, JSON and unrelated readers remain clean. | clean |
+| `marshal-scope` | `load` reports and the named `loads` exclusion stays clean. | clean |
+| `yaml-loader` | Positional and keyword safe-loader forms pass; absent, unsafe, unknown and conflicting loader bindings report. | clean |
+| `dynamic-source` | Names, calls and f-strings report; inline string and bytes constants pass. | clean |
+| `alias-rebinding` | Conflicting import identities retain one conservative finding without inventing one family; assignment and lexical-scope dataflow remain excluded. | fixed by S1-R2-01 |
+| `suppression-line` | Reason-bearing and bare pragmas retain opposite results. | clean |
+| `diagnostic-output` | Text and JSON use a fixed unresolved-family message for ambiguous imports and omit the sentinel payload. | fixed by S1-R2-01 |
+| `classification-drift` | P000 through P007 guards and the full focused, plugin and root suites pass. | clean |
+| `analysis-work` | Binding classification adds one bounded pass over the import identities already collected; no recursion, dataflow or target execution enters. | clean |
+| `partial-run` | Every result below reached a terminal zero exit; no partial dot stream was counted. | clean |
+| `ledger-integrity` | `phylax-v1.3.0`, the mature frontier fields and its digest remain unchanged; Promise Machine verification is clean. | clean |
+
+### Evidence
+
+The review started on the exact stacked branch at signed commit
+`116819e77574e116e5f5ddcaed57ef4e22d2c4af` and inspected all eight paths in
+the full diff from `64096f4d89fc821ab9d91d075cd86be7e7bb92b5`.
+The tracked and receipted study copies both hash to
+`5eac7e9c171969933bf9d08a07a50aefd0e3f52ff353fada05691271373f397f`;
+the runbook copies both hash to
+`678e406845563e2bb51cae9dbbcc6d0b3d6f048ee3d3e8a68ceb84b71decdf07`.
+
+The reduced guard
+`UnsafeDeserialization.test_conflicting_imports_do_not_claim_one_call_family`
+failed on the unfixed tree for all four module, direct, neighbour and explicit
+bare-shadow specimens. It passes after the fix, which records ambiguity from
+all visible import identities and emits one fixed unresolved-family message.
+The same guard checks text and JSON for the sentinel payload.
+
+The focused Phylax suite passes 79/79 on Python 3.9.6 and 3.12.13. With the
+checksum-verified Node v26.6.0 fixture first on `PATH`, the full Hexaemeron
+suite passes 851/851. The root suite passes 118/118 and the evolution contract
+passes 8/8. The full Promise Machine check, both Protasis checks, the Horos
+boundary check, the changed-tree Phylax scan and `git diff --check` each exit
+0. The active-plugin Phylax, Ephoros and Hypomnema lint exits are `0`, `0` and
+`0`.
+
+### Leads not pursued
+
+Leads not pursued: `marshal.loads`; wildcard and dynamic imports; assignment,
+lexical-scope, taint and control-flow analysis; custom-loader proofs; the
+accepted pragma-in-string quirk; and Python file-size policy. In particular,
+reassigning an imported safe YAML alias or importing it in another lexical
+scope can retain source-local trust. The study names both limits, and the
+public contract says assignments are not followed, so changing either requires
+a study amendment rather than an audit-side widening.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8799,3 +8799,77 @@ can still retain source-local trust for an actual `yaml.load` call. Those
 limits are inside the receipted exact-import grammar; widening them requires a
 study amendment. Bare `eval` and `exec` are no longer allowed to disappear
 behind that exclusion.
+
+## Phylax unsafe deserialization, step 1, round 4 -- 2026-08-22
+
+### Suite disposition
+
+The controller waiver remains exact: `waived: issue 324 changes the Python
+Phylax lint, fixtures, and governed prose; it has no Solidity target`. No
+`.sol` path appears in the complete `main`-to-stacked diff. X-Ray and Solidity
+Auditor did not run; the waiver applies only to that pair.
+
+The active-plugin Phylax, Ephoros and Hypomnema lints each exit 0 on the
+repository-mandated scopes. The manual pass read the complete diff from
+`64096f4d89fc821ab9d91d075cd86be7e7bb92b5` through signed head
+`dec65fcf1dc52b055d5d188633eb3b3c226f8007` and checked all thirteen
+receipted risks against the accumulated fixes.
+
+### Finding table
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R4-review | none | full base-to-stacked diff | No new code, test or payload-disclosure finding was confirmed. | clean |
+| S1-R4-tests | none | P008 focused and round-4 probe suites | No classification, ordering or diagnostic-secrecy failure was confirmed. | clean |
+| S1-R4-records | none | study, runbook, evolution and Promise Machine binding | No record drift or unreceipted boundary change was confirmed. | clean |
+
+Finding count: 0.
+
+### Risk coverage
+
+| risk id | evidence checked | disposition |
+| --- | --- | --- |
+| `source-parse` | P008 still uses `ast.parse`, `ast.walk` and the existing visitor; the checker neither imports nor runs target source. | clean |
+| `call-identity` | Same-scope, late and cross-scope module/direct imports, neighbour conflicts and boundary-family conflicts retain one conservative result. | clean |
+| `pickle-scope` | Module/direct `load` and `loads` report once; dump calls and unrelated readers stay clean. | clean |
+| `marshal-scope` | `load` reports once and the receipted `loads` exclusion stays clean. | clean within scope |
+| `yaml-loader` | Positional and keyword `SafeLoader`/`CSafeLoader` forms pass; absent, unsafe, unknown and conflicting loader evidence reports. | clean |
+| `dynamic-source` | Bare and resolved `eval`/`exec` report names, calls and f-strings; inline string/bytes constants pass. | clean |
+| `alias-rebinding` | Conflicting identities retain one unresolved-family result, and bare built-ins survive YAML aliases from another scope. Assignment and general scope analysis remain excluded. | clean within scope |
+| `suppression-line` | Reason-bearing and bare pragma fixtures retain opposite results. | clean |
+| `diagnostic-output` | Conflict probes emit one fixed message, omit payload text and return identical JSON under hash seeds 1 and 947. | clean |
+| `classification-drift` | The 61 pre-existing cases inside the 80-test focused suite pass on Python 3.9.6 and 3.12.13; P000 through P007 remain guarded. | clean |
+| `analysis-work` | Import collection is one linear AST walk, followed by constant-size candidate checks per call; no dataflow or target execution enters. | clean |
+| `partial-run` | Both focused runs, all three required lints and every supporting check below reached terminal exit 0. | clean |
+| `ledger-integrity` | Receipted and tracked artifacts match, `phylax-v1.3.0` advances generation only, the mature frontier fields stay fixed, and Promise Machine verification passes. | clean |
+
+### Evidence
+
+The focused Phylax suite passes 80/80 on Python 3.9.6 and 3.12.13. A separate
+round-4 matrix passes 28 same/cross-scope call cases and four ambiguous-message
+guards. The root suite passes 118/118 and the evolution contract passes 8/8.
+The repository Phylax scan, Promise Machine check, both Protasis checks, Horos
+boundary check and `git diff --check` each exit 0. Active-plugin lint exits are
+Phylax 0, Ephoros 0 and Hypomnema 0.
+
+The receipted and tracked study copies both hash to
+`5eac7e9c171969933bf9d08a07a50aefd0e3f52ff353fada05691271373f397f`;
+the runbook copies both hash to
+`678e406845563e2bb51cae9dbbcc6d0b3d6f048ee3d3e8a68ceb84b71decdf07`.
+The checked `SKILL.md` hashes to
+`fc3fdf6bf76cd24bf602d39ae30d1b77b1f196a34e0207522fec7ff9115007ca`,
+matching its Promise Machine pin.
+
+No retained Node v26.6.0 binary was present, so round 4 did not repeat the
+supplementary full Hexaemeron suite. Round 3's 852/852 run remains the latest
+full-suite evidence for this exact code head; it is not counted as a round-4
+execution.
+
+### Leads not pursued
+
+Leads not pursued: `marshal.loads`; relative, wildcard, dynamic and dotted
+imports; assignment, general lexical-scope, taint and control-flow analysis;
+custom-loader proofs; the accepted pragma-in-string quirk; and Python file-size
+policy. Cross-scope YAML module and loader aliases can retain source-local
+trust for an actual `yaml.load` call. The receipted study excludes that scope,
+so changing it would require an amendment rather than an audit-side widening.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8572,3 +8572,78 @@ separately assigned argv, star-expanded call forms, `**kwargs`, runner-name
 rebinding and flag interpretation remain outside the receipted source-local
 boundary. Widening any of them would change the approved finding grammar or
 runner-resolution contract rather than repair this implementation.
+
+## Phylax unsafe deserialization, step 1, round 1 -- 2026-08-22
+
+### Suite disposition
+
+The controller recorded this waiver: `waived: issue 324 changes the Python
+Phylax lint, fixtures, and governed prose; it has no Solidity target`. No
+`.sol` file appears in the full step or stacked diff. X-Ray and Solidity
+Auditor did not run; the waiver applies only to that pair.
+
+The active-plugin Phylax, Ephoros and Hypomnema lints each exit 0 over every
+step-changed path. The manual review covered the full diff and every receipted risk.
+
+### Finding table
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R1-01 | medium | `plugins/hexaemeron/skills/phylax/scripts/phylax.py:138` | Depth-first import discovery missed dangerous calls inside functions defined before their module or direct import. | fixed and guarded |
+| S1-R1-02 | low | `plugins/hexaemeron/skills/phylax/scripts/phylax.py:187` | Conflicting imports could select one safe identity and hide an unsafe loader or deserializer under the same alias. | fixed and guarded |
+| S1-R1-review | none | full step diff | No further code, test, record or payload-disclosure finding was confirmed. | clean |
+
+Finding count: 2.
+
+### Risk coverage
+
+| risk id | evidence checked | disposition |
+| --- | --- | --- |
+| `source-parse` | `ast.parse`, one `ast.walk` and the existing visitor inspect source without importing, executing or deserializing it. | clean |
+| `call-identity` | Module, module-alias, direct and direct-alias fixtures include imports after function definitions; relative imports remain excluded. | fixed by S1-R1-01 |
+| `pickle-scope` | `load` and `loads` report; `dump`, `dumps` and unrelated loaders stay clean. | clean |
+| `marshal-scope` | `load` reports and `loads` has an explicit negative fixture. | clean |
+| `yaml-loader` | Positional and keyword `SafeLoader` and `CSafeLoader` aliases pass; absent, unknown, unsafe and conflicting bindings report. | fixed by S1-R1-02 |
+| `dynamic-source` | Names, calls and f-strings report; inline string and bytes constants pass; no-argument and keyword-only shapes follow the stated first-positional-argument grammar. | clean |
+| `alias-rebinding` | Assignment rebinding remains outside analysis; conflicting import evidence is conservative, and a bare/local `eval` collision still reports. | clean within scope |
+| `suppression-line` | A reason-bearing pragma suppresses P008 and a bare pragma does not. | clean |
+| `diagnostic-output` | Text and JSON carry fixed family messages and omit the sentinel payload. | clean |
+| `classification-drift` | P000 through P007 guards and the full focused and plugin suites pass. | clean |
+| `analysis-work` | The change adds one linear AST import pass and constant-time checks per relevant call, with no dataflow or target execution. | clean |
+| `partial-run` | Every required lint and relevant test was read to completion; no interrupted result is counted as clean. | clean |
+| `ledger-integrity` | `phylax-v1.3.0` advances generation only; the mature frontier fields and digest remain unchanged, and Promise Machine verification passes. | clean |
+
+### Evidence
+
+The review read all seven files changed from
+`64096f4d89fc821ab9d91d075cd86be7e7bb92b5` through
+`3766c516bf6960945774aeaa0b2b0c819bbbde95`, then reviewed the stacked fixes.
+The tracked study matches `.hexaemeron/study.md` at
+`5eac7e9c171969933bf9d08a07a50aefd0e3f52ff353fada05691271373f397f`.
+
+The fix collects import evidence before call classification, retains exact
+absolute module and direct-import resolution, and trusts a YAML module or
+loader alias only when all explicit imports under that local name belong to
+the safe family. Guards at
+`plugins/hexaemeron/tests/test_phylax_checker.py:104` cover late module and
+direct imports; the adjacent cases cover conflicting bindings, loader
+precedence, relative imports, bare/local eval collisions, no-argument and
+keyword-only shapes, and one finding per nested boundary call.
+
+The focused Phylax suite passes 78/78 on Python 3.9.6 and 3.12.13. With the
+fixture-pinned Node v26.6.0 first on `PATH`, the full Hexaemeron suite passes
+850/850. The root suite passes 118/118, the evolution contract passes 8/8,
+the full Promise Machine check is clean, the Horos boundary matches the tree,
+and `git diff --check` exits 0. The ambient Node v22.22.3 run stopped at the
+fixture's exact-version assertion before the pinned-version rerun passed.
+
+### Leads not pursued
+
+Leads not pursued: `marshal.loads`; wildcard and dynamic imports; assignment,
+scope, taint and control-flow analysis; custom-loader proofs; the accepted
+pragma-in-string quirk; and Python file-size policy. The receipted study names
+these as exclusions. Bare/local `eval` collisions remain conservative P008
+findings with the reason-bearing pragma as the escape. An exploratory
+whole-file Hypomnema scan reported H003 at `audit/AUDIT.md:6119` and
+`audit/AUDIT.md:6269`; both are quoted prior findings outside the step paths,
+so neither enters this round's required lint exits.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8724,3 +8724,78 @@ reassigning an imported safe YAML alias or importing it in another lexical
 scope can retain source-local trust. The study names both limits, and the
 public contract says assignments are not followed, so changing either requires
 a study amendment rather than an audit-side widening.
+
+## Phylax unsafe deserialization, step 1, round 3 -- 2026-08-22
+
+### Suite disposition
+
+The controller waiver remains exact: `waived: issue 324 changes the Python
+Phylax lint, fixtures, and governed prose; it has no Solidity target`. No
+`.sol` path appears from `main` through the accumulated fixed tree. X-Ray and
+Solidity Auditor did not run; the waiver applies only to that pair.
+
+The active-plugin Phylax, Ephoros and Hypomnema lints each exit 0 on the
+repository-mandated scopes. The manual pass read the complete base-to-stacked
+diff and checked all thirteen receipted risks against the round 2 fixes.
+
+### Finding table
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R3-01 | medium | `plugins/hexaemeron/skills/phylax/scripts/phylax.py:215` | A direct YAML boundary import under bare `eval` or `exec`, collected from another lexical scope, displaced the built-in candidate; paired safe-loader evidence could make an outer non-literal dynamic call produce no P008. | fixed and guarded in round 3 |
+| S1-R3-review | none | full base-to-stacked diff | No other code, test, record or payload-disclosure finding was confirmed. | clean |
+| S1-R3-records | none | study, runbook, evolution and Promise Machine binding | The tracked study remains byte-identical to the receipted artifact, and generation-only bookkeeping remains unchanged. | clean |
+
+Finding count: 1.
+
+### Risk coverage
+
+| risk id | evidence checked | disposition |
+| --- | --- | --- |
+| `source-parse` | P008 still uses `ast.parse`, `ast.walk` and the existing visitor without importing, executing or deserializing target source. | clean |
+| `call-identity` | Same-family, boundary-to-boundary and boundary-to-neighbour conflicts were exercised; bare built-ins now remain candidates beside direct imports. | fixed by S1-R3-01 |
+| `pickle-scope` | Module and direct aliases for `load` and `loads` report once; dumps and unrelated readers remain clean. | clean |
+| `marshal-scope` | `load` reports once while the receipted `loads` exclusion remains clean. | clean within scope |
+| `yaml-loader` | Module and loader aliases for `SafeLoader` and `CSafeLoader` pass; unsafe and conflicting evidence reports. Lexical-scope trust remains an explicit exclusion. | bounded by the receipted exclusion |
+| `dynamic-source` | Bare `eval` and `exec` with non-literal source report even when another scope imports YAML boundaries under those names. Literal source remains clean. | fixed by S1-R3-01 |
+| `alias-rebinding` | Conflicts now keep every possible call family, including the implicit built-in family. Assignment and general scope analysis remain excluded. | clean within scope |
+| `suppression-line` | The existing reason-bearing and bare pragma cases retain opposite results. | clean |
+| `diagnostic-output` | Conflict cases emit one fixed unresolved-family message per call, omit payload text in text and JSON, and retain stable order under two hash seeds. | clean |
+| `classification-drift` | P000 through P007 guards, both focused interpreter runs and the full plugin suite pass. | clean |
+| `analysis-work` | The fix adds one set member and a constant-size union per bare dynamic call; it adds no recursive walk, dataflow or target execution. | clean |
+| `partial-run` | Every recorded test and lint reached a terminal zero exit; the two expected red guard runs are identified separately. | clean |
+| `ledger-integrity` | `phylax-v1.3.0`, the mature frontier fields and its digest are unchanged; Promise Machine verification exits 0. | clean |
+
+### Evidence
+
+The review started from exact signed stacked head
+`f5a2ef2c23c22840dd8f06af62cc759d6a3fd1e3` and re-read all eight paths from
+`64096f4d89fc821ab9d91d075cd86be7e7bb92b5`. The tracked and receipted study
+copies still hash to
+`5eac7e9c171969933bf9d08a07a50aefd0e3f52ff353fada05691271373f397f`.
+
+The reduced guard
+`UnsafeDeserialization.test_bare_dynamic_calls_survive_cross_scope_yaml_aliases`
+failed twice on the unfixed tree, for both `eval` and `exec`. Each specimen
+places a YAML boundary and safe-loader import in another function while the
+outer function passes non-literal source and a globals mapping to the actual
+built-in. The fix retains the built-in family beside direct-import evidence,
+so both calls now emit one ambiguous P008 instead of escaping the rule.
+
+The focused Phylax suite passes 80/80 on Python 3.9.6 and 3.12.13. With the
+retained Node v26.6.0 fixture first on `PATH`, the full Hexaemeron suite passes
+852/852. The root suite passes 118/118 and the evolution contract passes 8/8.
+The full Promise Machine check, both Protasis checks, the Horos boundary check,
+the changed-tree Phylax scan and `git diff --check` each exit 0. The
+active-plugin Phylax, Ephoros and Hypomnema lint exits are `0`, `0` and `0`.
+
+### Leads not pursued
+
+Leads not pursued: `marshal.loads`; relative, wildcard, dynamic and dotted
+imports such as `import yaml.loader`; assignment, general lexical-scope, taint
+and control-flow analysis; custom-loader proofs; the accepted pragma-in-string
+quirk; and Python file-size policy. Cross-scope YAML module and loader aliases
+can still retain source-local trust for an actual `yaml.load` call. Those
+limits are inside the receipted exact-import grammar; widening them requires a
+study amendment. Bare `eval` and `exec` are no longer allowed to disappear
+behind that exclusion.

--- a/docs/phylax-unsafe-deserialization/runbook.md
+++ b/docs/phylax-unsafe-deserialization/runbook.md
@@ -1,0 +1,86 @@
+# runbook: add unsafe deserialization to Phylax's mechanical subset
+
+This runbook derives from `.hexaemeron/study.md` at the receipted digest. The
+topic is one source-local Python lint capability, so one auditable step both
+scaffolds and demonstrates it. The repository already supplies the layout,
+root and plugin licences, standard-library Python 3.9/3.12 compatibility, and
+CI workflows; issue #324 does not authorize replacing those foundations or
+touching CI. This step verifies them and commits the study and runbook copies.
+
+## Step 1: add and demonstrate P008 unsafe-deserialization lint
+
+**Goal.** Add one import-aware `P008` AST rule for the exact unsafe
+deserialization and dynamic-execution calls in issue #324, with public prose,
+generation bookkeeping and guards for every claimed hostile and safe shape.
+
+**Entry.** The clean run branch at
+`64096f4d89fc821ab9d91d075cd86be7e7bb92b5`, with the Fiat study and this
+runbook receipted, the existing focused Phylax suite green at 61/61 on Python
+3.9.6 and 3.12.13, and the pre-change tree-wide Phylax scan clean. The root and
+Hexaemeron licences, current repository layout and existing workflows remain
+the scaffold; no dependency, toolchain-pin or CI change enters this step.
+
+**Exit.** `P008` reports the exact import-resolved `pickle.load`,
+`pickle.loads`, `marshal.load`, unsafe `yaml.load`, and non-literal `eval` or
+`exec` shapes in the study; all named safe neighbours remain clean; diagnostics
+do not contain payload text; `phylax-v1.3.0` retains the mature frontier bytes;
+the study and runbook are committed under
+`docs/phylax-unsafe-deserialization/`; and every command in this demo path
+exits zero:
+
+```bash
+/usr/bin/python3 -B -m unittest plugins.hexaemeron.tests.test_phylax_checker
+uv run --python 3.12.13 python -m unittest plugins.hexaemeron.tests.test_phylax_checker
+uv run --python 3.12.13 python plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+uv run --python 3.12.13 python plugins/hexaemeron/tests/run_tests.py
+uv run --python 3.12.13 python -m unittest discover -s tests
+uv run --python 3.12.13 python -m unittest tests.test_evolution_contract
+uv run --python 3.12.13 python scripts/promise_machine.py check
+uv run --python 3.12.13 python plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/phylax-unsafe-deserialization/study.md
+uv run --python 3.12.13 python plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/phylax-unsafe-deserialization/runbook.md
+uv run --python 3.12.13 python plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/phylax-unsafe-deserialization/*.md plugins/hexaemeron/skills/phylax/SKILL.md plugins/hexaemeron/skills/phylax/EVOLUTION.md
+uv run --python 3.12.13 python plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+uv run --python 3.12.13 python plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs
+uv run --python 3.12.13 python plugins/horos/skills/horos/scripts/horos.py check .
+git diff --check
+```
+
+**Files.** Change
+`plugins/hexaemeron/skills/phylax/scripts/phylax.py`,
+`plugins/hexaemeron/tests/test_phylax_checker.py`,
+`plugins/hexaemeron/skills/phylax/SKILL.md`,
+`plugins/hexaemeron/skills/phylax/EVOLUTION.md`, and
+`tests/promise_machine_coverage.json`; create exact committed copies at
+`docs/phylax-unsafe-deserialization/study.md` and
+`docs/phylax-unsafe-deserialization/runbook.md`; append the Fiat audit record
+to `audit/AUDIT.md`; and regenerate `.horos/boundary.json` only if its scan
+changes that tracked file. No other path is in scope without a study amendment.
+
+**Tests.** First add hostile fixtures for every named call family and observe
+the focused suite fail because `P008` is absent. Then add safe neighbours for
+module and direct-import aliases, `SafeLoader` and `CSafeLoader` in positional
+and keyword forms, `yaml.safe_load`, literal string and bytes dynamic source,
+`marshal.loads`, JSON and unrelated `.load` methods. Cover reason-bearing and
+bare pragmas, fixed text/JSON diagnostics with a sentinel payload, alias
+rebinding as an explicit source-local limitation, and unchanged `P000` through
+`P007` classifications. The 61 existing focused tests plus every new named
+case must pass on Python 3.9.6 and 3.12.13; the command output records the final
+count.
+
+**Disciplines.** phylax: this step changes the parser-settled hostile-source
+boundary and must remain parse-only with fixed diagnostics. ephoros: none,
+because the local CLI adds no unattended service or telemetry path and its
+existing path/line/code/exit signals are tested. metron: none, because the
+issue makes no performance claim and the design adds no recursive analysis.
+elenchus: reproduce the missing-rule failures before the fix, then retain
+fixtures that fail if the cause-level visitor logic is removed. hypomnema:
+record the public grammar and source-local trade in `SKILL.md`, `EVOLUTION.md`
+and the committed study/runbook instead of adding a repository-wide ADR.
+
+Implementation order inside the step is fixed: preserve the red fixture
+output; add the smallest import-aware visitor grammar; turn the focused suite
+green on both Python versions; update the public contract, generation row and
+digest pin; copy the receipted documents; run the full demo; then enter the
+Fiat audit and prose gates. Any need for `marshal.loads`, scope/dataflow
+analysis, a dependency, CI, another call family or changed mature-frontier
+bytes stops the step for a study amendment.

--- a/docs/phylax-unsafe-deserialization/study.md
+++ b/docs/phylax-unsafe-deserialization/study.md
@@ -1,0 +1,424 @@
+# study: add unsafe deserialization to Phylax's mechanical subset
+
+## assumptions
+
+Assuming, unless corrected:
+
+1. The run starts from `main` at
+   `64096f4d89fc821ab9d91d075cd86be7e7bb92b5`; the run branch and local
+   `main` resolved to that commit before this study.
+2. Issue #324 authorizes one Python rule under the next free code, `P008`, for
+   exactly `pickle.load`, `pickle.loads`, `marshal.load`, `yaml.load` without
+   a safe loader, and `eval` or `exec` over a non-literal first argument.
+   `marshal.loads` is conspicuously close but not named, so it stays outside
+   this packet rather than arriving by typo correction.
+3. The rule is source-local and import-aware, not a taint analysis. A literal
+   for `eval` or `exec` means an inline `str` or `bytes` `ast.Constant`;
+   f-strings, names, calls and other expressions are non-literal even when a
+   human can infer their value from nearby code.
+4. The safe YAML family is `SafeLoader` and `CSafeLoader`, whether passed as
+   the second positional argument or `Loader=` through a resolved module or
+   direct-import alias. `safe_load` stays clean. `FullLoader`, `Loader`,
+   `UnsafeLoader`, a locally assigned loader name and an unknown subclass do
+   not satisfy the mechanically visible exception.
+5. This is generation work on mature `phylax-v1.2.0`, not a frontier
+   reopening. The implementation remains standard-library-only, supports
+   Python 3.9 and 3.12.13, contains no Solidity, and should record
+   `phylax-v1.3.0` while retaining the current frontier line and digest.
+
+These readings make one independently testable lint capability. No module
+decomposition is needed. The one material wording ambiguity is
+`marshal.load` versus `marshal.loads`; this study takes the literal issue scope
+and records the latter as an open exclusion.
+
+## 1. problem statement
+
+Phylax says never to unpickle external data and never to parse JSON with
+`eval`, but its parser implements no deserialization or dynamic-execution
+finding. `Visitor.visit_Call` currently classifies subprocess calls and output
+writers only. A file containing any of the following reaches a clean Phylax
+result today:
+
+```python
+import pickle
+import yaml
+
+payload = pickle.loads(download())
+document = yaml.load(receive(), Loader=yaml.FullLoader)
+result = eval(request_text)
+```
+
+The users are contributors running the Phylax gate and reviewers relying on
+its stated mechanical boundary. A working prototype emits `P008` at each
+recognized unsafe call, keeps named safe neighbours clean, preserves
+`P000`-`P007`, and never imports, executes or deserializes target source.
+
+The final demo path is:
+
+```bash
+uv run --python 3.12.13 python -m unittest plugins.hexaemeron.tests.test_phylax_checker
+uv run --python 3.12.13 python plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+uv run --python 3.12.13 python plugins/hexaemeron/tests/run_tests.py
+uv run --python 3.12.13 python -m unittest discover -s tests
+uv run --python 3.12.13 python -m unittest tests.test_evolution_contract
+uv run --python 3.12.13 python scripts/promise_machine.py check
+uv run --python 3.12.13 python plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/phylax-unsafe-deserialization/study.md
+uv run --python 3.12.13 python plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/phylax-unsafe-deserialization/runbook.md
+uv run --python 3.12.13 python plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/phylax-unsafe-deserialization/*.md plugins/hexaemeron/skills/phylax/SKILL.md plugins/hexaemeron/skills/phylax/EVOLUTION.md
+uv run --python 3.12.13 python plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+uv run --python 3.12.13 python plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs
+uv run --python 3.12.13 python plugins/horos/skills/horos/scripts/horos.py check .
+git diff --check
+```
+
+The prototype is demonstrated only when all five conditions hold:
+
+- Module, module-alias, direct-import and direct-import-alias forms report
+  `P008` for the exact pickle, marshal and YAML calls named above.
+- Bare `eval` and `exec`, plus resolved `builtins` aliases, report only when
+  the first argument is not an inline string or bytes constant.
+- `yaml.safe_load`, `yaml.load` with resolved `SafeLoader` or `CSafeLoader`,
+  JSON parsing, unrelated `.load` methods and non-target calls remain clean.
+- A reason-bearing existing pragma suppresses `P008`, a bare pragma does not,
+  diagnostics contain no inspected payload text, and `P000`-`P007` fixtures
+  keep their classifications.
+- Every demo command exits zero, including the focused tests on Python 3.9
+  and 3.12.13 and the tree-wide Phylax scan.
+
+Before implementation, the focused Phylax suite passes 61/61 on Python 3.9.6
+and 3.12.13, and `phylax.py plugins tests` exits zero. Those facts establish a
+green starting point and the absent rule; they are not implementation proof.
+
+## 2. prior art
+
+### in this repository
+
+- `plugins/hexaemeron/skills/phylax/scripts/phylax.py` already supplies an AST
+  visitor, import-alias sets, source-local call resolution, fixed findings and
+  the reason-bearing line suppression filter. The new rule belongs in that
+  Python visitor; no target import or runtime library is needed.
+- `plugins/hexaemeron/tests/test_phylax_checker.py` pairs hostile specimens
+  with safe neighbours and checks both text and JSON secrecy. Its current
+  subprocess tests show the house preference for import-bound resolution and
+  explicit exclusions rather than a broad name match.
+- `plugins/hexaemeron/skills/phylax/SKILL.md` states the two never-rules while
+  describing only seven parser-settled rules. `EVOLUTION.md` and
+  `skills/VERSIONING.md` show that a meaningful non-frontier behavior change
+  increments generation and retains the mature frontier digest.
+- `plugins/ariadne/tests/test_untrusted_input.py` is the nearest marketplace
+  hostile-input precedent: bounded JSON parsing rejects oversized, deeply
+  nested and duplicate-key documents. `plugins/lemma/chunkers/markdown.py`
+  already uses `yaml.safe_load` as a clean repository neighbour.
+
+The last two merged pull requests touching the Phylax surface were read before
+the options below:
+
+- PR #481, `flag credential-named values in subprocess argv`, established the
+  current source-local Python visitor at this base. Its carried-forward alias
+  rebinding, attribute/subscript, assigned-value and `**kwargs` exclusions stay
+  outside P008; the new rule must not imply dataflow merely because it resolves
+  imports. Its generation row is the direct bookkeeping precedent.
+- PR #442, `Ephoros catches telemetry keyed by wallet address across Python
+  and TypeScript`, changed Phylax's boundary prose. Its accepted Python
+  limitation remains: a pragma-shaped `#` inside a string can satisfy the
+  line-based suppression filter. Its TypeScript lexer recursion lead is still
+  open but unrelated to this Python AST rule, so this run does not absorb it.
+
+The configured audit record, `audit/AUDIT.md`, was also read before design:
+
+- `Phylax TypeScript boundaries`, rounds 1 and 2, found and fixed an unbounded
+  TypeScript read with a 1 MiB cap, then closed with zero further findings.
+  P008 adds no TypeScript work and does not alter that cap.
+- `Phylax credential argv`, step 1 round 1, closed with zero findings while
+  preserving source-local exclusions. Its diagnostic-secrecy and
+  classification-regression checks apply directly to the new rule.
+
+### in the organisation
+
+Authenticated public GitHub code searches over `wildcat-finance` returned no
+Python hits for `pickle.load`, `pickle.loads`, `marshal.load`, `yaml.load`,
+`eval(` or `exec(`. No reusable public organization implementation was
+established. This says nothing about private or unindexed repositories;
+Ariadne's in-marketplace hostile-input tests remain the closest observed
+organizational precedent.
+
+### outside the organisation
+
+- Python's `pickle` documentation says malicious pickle data can execute
+  arbitrary code during unpickling and distinguishes untrusted JSON parsing
+  from that execution risk.
+- Python's `marshal` documentation says the format is not secure against
+  malicious data and rejects unmarshalling from an untrusted or
+  unauthenticated source.
+- Python's built-in function documentation warns that both `eval` and `exec`
+  execute arbitrary code when handed untrusted input.
+- PyYAML's documentation directs untrusted input to `safe_load`; its loader
+  table names `SafeLoader` and the LibYAML-backed `CSafeLoader` as the safe
+  family.
+- Bandit's official B506 implementation is useful parser prior art: it flags
+  `yaml.load` unless `SafeLoader` or `CSafeLoader` is supplied by keyword or
+  second position. Phylax can adopt that narrow grammar without adopting
+  Bandit as a dependency.
+
+## 3. constraints and non-goals
+
+### constraints
+
+- Start from `main` at
+  `64096f4d89fc821ab9d91d075cd86be7e7bb92b5` and stay within issue #324.
+- Allocate `P008`; preserve the CLI, output schemas, exit codes, suppression
+  syntax and the meaning of `P000` through `P007`.
+- Resolve only exact module/direct-import aliases for `pickle`, `marshal`,
+  `yaml` and `builtins`, plus bare `eval` and `exec`. Do not claim runtime
+  identity after reassignment or infer where the first argument came from.
+- Add no dependency, subprocess, network call, target-source import,
+  deserialization or checker write. Findings carry path, line, code and a
+  fixed explanation, never argument contents.
+- Record `phylax-v1.3.0` on the generation axis while retaining status
+  `mature`, revision `off-chain-boundary-controls`, current-frontier text,
+  next job `None -- mature`, and digest
+  `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604`.
+
+### non-goals
+
+- Taint, control-flow or interprocedural analysis; following input through a
+  name, attribute, subscript, container, assignment, return value or
+  `**kwargs`.
+- `marshal.loads`, `pickle.Unpickler.load`, YAML `load_all`,
+  `unsafe_load`/`full_load`, `ast.literal_eval`, dynamic imports or another
+  serializer not named by issue #324.
+- Proving that input is external, that an inline `eval` string is benign, or
+  that a custom YAML loader subclass is safe. P008 settles syntax, not runtime
+  provenance or behavior.
+- Repairing the TypeScript lexer recursion lead, the line-based pragma-in-a-
+  string limitation, Python file-size policy, CI or another plugin's surface.
+- Reopening the mature frontier, changing its digest, advancing evolution or
+  epoch, or minting a held job.
+
+### explicit unknowns
+
+- Whether omission of `marshal.loads` in the issue was deliberate is unknown.
+  The build excludes it; adding it requires a study change or later ticket.
+- Public organization search cannot establish private-repository practice.
+- A bare local callable named `eval` or `exec` is syntactically indistinguishable
+  from the built-in without scope analysis. P008 treats the bare spelling as
+  the built-in boundary; the existing reason-bearing pragma is the escape for
+  a deliberate local collision.
+- A loader held in a local name may be safe at runtime, but source-local alias
+  resolution cannot establish that fact. P008 reports it unless the accepted
+  loader binding is visible in the call expression.
+
+### operating boundaries
+
+**Always.** Add hostile fixtures and observe them fail before changing the
+visitor. Keep a safe neighbour for every call family. Run the focused tests,
+full Hexaemeron and root suites, evolution and Promise Machine checks, the
+tree-wide Phylax/Ephoros/Hypomnema lints, prose gates and Horos check before
+commit.
+
+**Ask first.** Add a dependency; include `marshal.loads` or another call;
+widen into dataflow, scope resolution or target execution; change a public
+finding field or suppression behavior; touch CI; or alter any mature-frontier
+field.
+
+**Never.** Deserialize or execute a fixture to classify it; import inspected
+source; place live secrets or payload data in tests or diagnostics; delete a
+safe neighbour; weaken `P000`-`P007`; edit vendored source; or claim an unrun
+command passed.
+
+Expected implementation and record paths are:
+
+- `plugins/hexaemeron/skills/phylax/scripts/phylax.py` and
+  `plugins/hexaemeron/tests/test_phylax_checker.py`.
+- `plugins/hexaemeron/skills/phylax/SKILL.md`, `EVOLUTION.md`, and
+  `tests/promise_machine_coverage.json`.
+- `docs/phylax-unsafe-deserialization/study.md` and
+  `docs/phylax-unsafe-deserialization/runbook.md`.
+- `audit/AUDIT.md` for rounds and `.horos/boundary.json` if regeneration
+  changes the classified tracked tree.
+
+## 4. design options
+
+### option A: import-aware AST classification (chosen)
+
+Extend the existing visitor with canonical bindings for the named modules,
+functions and safe YAML loaders. Resolve a call only from those bindings or a
+bare `eval`/`exec`. Classify its first argument and YAML loader expression from
+the current call node, emit `P008`, then let the existing suppression and
+rendering paths handle the result.
+
+This construction reuses the checker's existing AST and alias idiom, can test
+every claimed shape directly, and never runs target code. It trades away
+runtime provenance, assignment following, custom safe loaders and semantic
+name resolution.
+
+### option B: spelling-only call matching
+
+Match terminal names such as `.load`, `eval` and `exec` without import
+resolution. The patch would be shorter, but ordinary file readers and local
+methods would become findings while aliased unsafe calls would escape. The
+lower line count buys a rule contributors will learn to suppress.
+
+### option C: dataflow or an external analyzer
+
+Track values from inputs into dangerous calls, or add Bandit/Semgrep and map
+its findings into Phylax. This can distinguish external data and cover more
+aliases, but it opens scope, dependency, version, output-mapping and false-
+positive questions absent from the issue. It also costs more to understand
+than the surrounding checker.
+
+Option A is the lowest-comprehension-cost design that meets the literal issue.
+It gives up semantic completeness in exchange for one visible source-local
+grammar beside the existing rules. Option B is too noisy; Option C pretends a
+larger security claim than this generation packet can support.
+
+## 5. risk register seed
+
+```risk-register
+source-parse | tracked Python source crossing the checker boundary | source is parsed as AST only and is never imported executed or deserialized
+call-identity | imported names crossing into dangerous-call classification | only exact module and direct-import bindings plus bare eval and exec receive P008
+pickle-scope | pickle call syntax at the deserialization boundary | load and loads report while dumps and unrelated load methods remain clean
+marshal-scope | marshal call syntax at the deserialization boundary | load reports and the excluded loads spelling has a named negative fixture
+yaml-loader | the Loader argument deciding YAML object construction | SafeLoader and CSafeLoader aliases pass while absent unknown and unsafe loaders report
+dynamic-source | the first eval or exec argument at the code-execution boundary | inline string and bytes constants stay clean while names calls and f-strings report
+alias-rebinding | source-local binding evidence beside runtime reassignment | tests state that imports are resolved but assignment and scope dataflow are not
+suppression-line | P008 crossing the existing reason-bearing pragma filter | a stated reason suppresses and a bare pragma does not while the accepted string quirk stays unchanged
+diagnostic-output | inspected source influencing text and JSON findings | messages name the call family but never repeat the argument or payload value
+classification-drift | new visitor branches beside P000 through P007 | the full existing fixture suite retains every prior code and safe neighbour
+analysis-work | extra AST traversal on a parsed Python file | the implementation visits each relevant call locally and adds no recursive dataflow or target execution
+partial-run | an interrupted or failed lint test or prose command | no clean result commit or receipt is accepted from an incomplete or non-zero command
+ledger-integrity | generation bookkeeping at the mature Phylax frontier | only generation advances while the revision frontier next job and digest remain unchanged
+```
+
+There is no funds arithmetic, external service call, upgrade path or signing-
+key custody in this change. The checker adds no subprocess, network fetch or
+filesystem write. Secret and payload custody is limited to not copying
+inspected argument contents into diagnostics. Existing Python reads and
+`ast.parse` remain the input path; the audit should review work amplification,
+but this issue makes no new file-size policy.
+
+## 6. glossary seeds
+
+- `P008`: the proposed single finding code for the exact unsafe loader and
+  dynamic-execution syntax in issue #324.
+- `dangerous call`: a call resolved to an in-scope pickle, marshal, YAML or
+  built-in execution function by the visitor's source-local binding table.
+- `literal dynamic source`: an inline string or bytes `ast.Constant` passed as
+  the first argument to `eval` or `exec`.
+- `safe loader family`: PyYAML `SafeLoader` and `CSafeLoader`, including
+  module and direct-import aliases visible in the call.
+- `source-local`: classified from imports and the current call expression,
+  without following assignments, control flow, values or runtime rebinding.
+
+## 7. sources and checks
+
+- Task and base: issue #324,
+  <https://github.com/wildcat-finance/skills/issues/324>, and
+  `main` at `64096f4d89fc821ab9d91d075cd86be7e7bb92b5`.
+- Repository authority: `phylax.py`, `test_phylax_checker.py`, Phylax
+  `SKILL.md`/`EVOLUTION.md`, `skills/VERSIONING.md`, Ariadne's
+  `test_untrusted_input.py`, and Lemma's `markdown.py` safe YAML call.
+- Change history: merged PRs #481 and #442; `audit/AUDIT.md` sections
+  `Phylax credential argv` and `Phylax TypeScript boundaries`.
+- Language and library authority: Python `pickle`, `marshal`, `eval` and
+  `exec` documentation at <https://docs.python.org/3/library/> and PyYAML's
+  documentation at <https://pyyaml.org/wiki/PyYAMLDocumentation>.
+- Parser prior art: Bandit B506 documentation and implementation at
+  <https://bandit.readthedocs.io/en/latest/plugins/b506_yaml_load.html> and
+  <https://github.com/PyCQA/bandit/blob/main/bandit/plugins/yaml_load.py>.
+
+Checks run for this study:
+
+- `git rev-parse HEAD`, `main` and `origin/main` each returned the base commit
+  above; the run worktree was clean before this artifact was written.
+- `/usr/bin/python3 -B -m unittest plugins.hexaemeron.tests.test_phylax_checker`
+  passed 61/61 on Python 3.9.6; the same suite independently passed 61/61 on
+  Python 3.12.13.
+- `/usr/bin/python3 -B plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests`
+  exited zero and printed `clean`.
+- Public issue and pull-request records supplied the exact scope, generation
+  note, carried-forward limits and merge commits; public organization code
+  search returned no reusable hit.
+
+These checks establish the current state and a buildable syntax boundary. They
+do not establish that Option A is implemented, that its future fixtures pass,
+or that a clean P008 scan proves inspected data trustworthy.
+
+## 8. signals and the questions behind them
+
+`plugins/hexaemeron/skills/ephoros/SKILL.md` adds no telemetry gate because
+this is a local lint, not an unattended service. The expected single runbook
+step preserves two existing signals:
+
+1. "Which call failed, and where?" Text output carries `path:line`, `P008` and
+   a fixed family-specific message; JSON carries the same fields separately.
+2. "Did the exact scan finish cleanly?" Exit zero plus `clean` answers yes.
+   A finding, parse/read failure, bad invocation or interrupted command cannot
+   supply that signal.
+
+No event, metric, trace, correlation id or alert is warranted. The step tests
+the current CLI signal shape instead of inventing an on-call surface.
+
+## 9. boundaries per capability
+
+`plugins/hexaemeron/skills/phylax/SKILL.md` governs the capability. The primary
+boundary is hostile Python source entering `ast.parse` and influencing a gate
+result. Code execution and checker integrity are worth taking there; parse-
+only inspection, exact call bindings and negative fixtures close it.
+
+The second boundary is YAML's loader expression. Arbitrary object
+construction is worth taking; only a mechanically resolved `SafeLoader` or
+`CSafeLoader` closes it. Unknown custom loaders fail closed into a finding and
+can use the existing reason-bearing exception when a reviewer has evidence.
+
+The third boundary is output. Payload contents and confidence in a clean scan
+are worth taking; fixed messages, no AST value rendering, preserved `P000`
+failures and non-zero findings close it. The risk ids `source-parse` through
+`diagnostic-output` enumerate these checks.
+
+No new host, dependency, subprocess, model output, agent tool, external API,
+output path or persistent write boundary is introduced.
+
+## 10. budget or its absence
+
+`plugins/hexaemeron/skills/metron/SKILL.md` has no performance gate here.
+Issue #324 makes no latency, memory or throughput claim, and the selected
+design adds local classification to an AST already built for each Python
+file. No speed-motivated change is authorized, so there is no before/after
+budget to manufacture. The focused test command is a correctness gate, not a
+benchmark. `analysis-work` remains an audit concern so a hidden recursive or
+dataflow walk cannot masquerade as the chosen design.
+
+## 11. fail-closed posture
+
+`plugins/hexaemeron/skills/elenchus/SKILL.md` governs the failure already in
+hand. Each hostile family fixture must be observed red against the current
+visitor and green only after the cause-level P008 change. Every family also
+gets a safe neighbour: safe loaders, literal dynamic source, unrelated methods
+and excluded spellings must remain clean.
+
+A changed prior code, safe-neighbour finding, payload value in output, target
+execution, ledger mismatch, failed lint or any non-zero demo command stops the
+step. Existing unreadable and invalid Python inputs remain `P000`; no new rule
+may convert an incomplete analysis into `clean`. The guard tests stay in
+`test_phylax_checker.py` and must fail when the P008 implementation is removed.
+
+## 12. decisions and their homes
+
+`plugins/hexaemeron/skills/hypomnema/SKILL.md` puts the behavior decision in
+`plugins/hexaemeron/skills/phylax/EVOLUTION.md`. Its generation row should name
+P008's exact call grammar, source-local trade and fixture evidence while
+retaining the mature frontier bytes. `SKILL.md` owns the public mechanical-
+subset description; changing it requires repinning its Promise Machine digest
+in `tests/promise_machine_coverage.json`.
+
+Exact committed copies of the receipted artifacts belong at
+`docs/phylax-unsafe-deserialization/study.md` and
+`docs/phylax-unsafe-deserialization/runbook.md`. Audit rounds append their
+enumerated review to `audit/AUDIT.md`. No repository-wide ADR is warranted:
+the change adds no shared schema, dependency, storage format or cross-plugin
+ownership decision.
+
+If implementation needs `marshal.loads`, semantic scope resolution, dataflow,
+a custom-loader proof or another call family, amend this study before code.
+The current generation row cannot silently widen a mature skill's claim.

--- a/plugins/hexaemeron/skills/phylax/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/phylax/EVOLUTION.md
@@ -4,7 +4,7 @@
 
 Policy: [../VERSIONING.md](../VERSIONING.md)
 
-- Current version: `phylax-v1.2.0`
+- Current version: `phylax-v1.3.0`
 
 ## Frontier
 
@@ -20,3 +20,4 @@ Policy: [../VERSIONING.md](../VERSIONING.md)
 | `phylax-v0.1.0` | baseline | `off-chain-boundary-controls` | `ce1e5ed764d74b77b7a8608305353de47ebd0b1ef6fb0091bd7590140e188fb6` | [ariadne untrusted-input tests](../../../ariadne/tests/test_untrusted_input.py) | Phylax starts here, holding the off-chain surface that the Solidity audit skills do not cover. |
 | `phylax-v1.1.0` | evolution | `off-chain-boundary-controls` | `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604` | [TypeScript boundary fixtures](../../tests/test_phylax_checker.py), [shared lexer fixtures](../../tests/test_typescript_lexer.py), [study](../../../../docs/phylax-typescript-boundaries/study.md) | The lint absorbs Horos's lexer contract inside Hexaemeron and adds `P005` through `P007`; the held job is complete and no evidenced next frontier remains. |
 | `phylax-v1.2.0` | generation | `off-chain-boundary-controls` | `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604` | [credential argv fixtures](../../tests/test_phylax_checker.py), [study](../../../../docs/phylax-credential-argv/study.md) | P004 now walks only the inline argv expression of a resolved subprocess runner for credential-named values; assignment dataflow remains deliberately out of scope. |
+| `phylax-v1.3.0` | generation | `off-chain-boundary-controls` | `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604` | [unsafe-deserialization fixtures](../../tests/test_phylax_checker.py), [study](../../../../docs/phylax-unsafe-deserialization/study.md) | P008 adds source-local import resolution for the issue's pickle, marshal, YAML and dynamic-execution calls; assignment dataflow, custom-loader proofs and `marshal.loads` remain deliberately out of scope. |

--- a/plugins/hexaemeron/skills/phylax/SKILL.md
+++ b/plugins/hexaemeron/skills/phylax/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   it to diagnose a failure that has already happened, which belongs to
   elenchus.
 metadata:
-  version: "1.2.0"
+  version: "1.3.0"
 ---
 
 # Phylax
@@ -266,7 +266,7 @@ draws that line once, over the same TypeScript files both lints read.
 
 ## The mechanical subset
 
-Seven of these rules are settled by a parser rather than by reading. Run the
+Eight of these rules are settled by a parser rather than by reading. Run the
 lint over the paths a step touched, and require exit 0.
 
 ```bash
@@ -275,8 +275,18 @@ python3 "$PLUGIN_ROOT/skills/phylax/scripts/phylax.py" src tests
 
 For Python and requirements files it reports a shell invocation, a subprocess
 command passed as a string rather than an argument list, a requirement with no
-exact pin, and a credential in source, in command arguments or handed to
-something that writes output.
+exact pin, a credential in source, in command arguments or handed to something
+that writes output, and import-resolved unsafe deserialization or dynamic
+execution.
+
+The last rule resolves module and direct-import aliases for `pickle.load`,
+`pickle.loads`, `marshal.load`, `yaml.load`, and `builtins.eval` or
+`builtins.exec`; bare `eval` and `exec` are also inside the grammar. A
+`yaml.load` call stays clean only when its second positional argument or
+`Loader=` value resolves directly to `SafeLoader` or `CSafeLoader`. An `eval`
+or `exec` call stays clean only when its first argument is an inline string or
+bytes constant. The parser does not follow assignments, prove input
+provenance, inspect custom loader classes or include `marshal.loads`.
 
 For tracked `.ts` and `.tsx` source it reports three source-local cases. A
 `rehype-raw` binding in a rendered plugin array needs a later
@@ -302,7 +312,7 @@ credential is the usual honest case, and a lint with no pragma to answer it is
 a lint people learn to bypass.
 
 Everything else in this skill stays judgement, and a clean exit says only that
-these seven found nothing.
+these eight found nothing.
 
 ## Rationalisations
 

--- a/plugins/hexaemeron/skills/phylax/scripts/phylax.py
+++ b/plugins/hexaemeron/skills/phylax/scripts/phylax.py
@@ -46,6 +46,9 @@ P008_MESSAGES = {
     "yaml": "yaml.load has no resolved SafeLoader or CSafeLoader",
     "builtins": "dynamic execution receives non-literal source",
 }
+P008_AMBIGUOUS_MESSAGE = (
+    "source-local bindings leave the boundary call family unresolved"
+)
 
 CREDENTIAL = re.compile(
     r"(?:^|_)(?:priv(?:ate)?_?key|secret|passwd|password|mnemonic|seed_?phrase"
@@ -137,7 +140,13 @@ def _is_dynamic_literal(node: ast.AST) -> bool:
 
 def _boundary_bindings(
     tree: ast.AST,
-) -> tuple[dict[str, set[str]], dict[str, set[str]], set[str], set[str]]:
+) -> tuple[
+    dict[str, set[str]],
+    dict[str, set[str]],
+    set[str],
+    set[str],
+    set[str],
+]:
     """Collect source-local import evidence before descending function bodies.
 
     A depth-first visitor reaches a function's calls before module imports that
@@ -189,7 +198,31 @@ def _boundary_bindings(
             for level, module, name in imported
         )
     }
-    return modules, direct, safe_yaml_modules, safe_yaml_loaders
+    ambiguous_calls = set()
+    for local, imported in identities.items():
+        families = set()
+        for level, module, name in imported:
+            if level == -1 and module in BOUNDARY_CALLS:
+                families.add(module)
+            elif (
+                level == 0
+                and module in BOUNDARY_CALLS
+                and name in BOUNDARY_CALLS[module]
+            ):
+                families.add(module)
+            else:
+                families.add(None)
+        if local in BOUNDARY_CALLS["builtins"] and local not in direct:
+            families.add("builtins")
+        if len(families) > 1:
+            ambiguous_calls.add(local)
+    return (
+        modules,
+        direct,
+        safe_yaml_modules,
+        safe_yaml_loaders,
+        ambiguous_calls,
+    )
 
 
 class Visitor(ast.NodeVisitor):
@@ -209,6 +242,7 @@ class Visitor(ast.NodeVisitor):
             self.boundary_direct,
             self.safe_yaml_modules,
             self.safe_yaml_loaders,
+            self.ambiguous_boundary_calls,
         ) = _boundary_bindings(tree)
 
     def visit_Import(self, node: ast.Import) -> None:
@@ -258,6 +292,12 @@ class Visitor(ast.NodeVisitor):
         return isinstance(loader, ast.Name) and loader.id in self.safe_yaml_loaders
 
     def _check_p008(self, node: ast.Call) -> None:
+        binding = (
+            node.func.value.id
+            if isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            else node.func.id if isinstance(node.func, ast.Name) else None
+        )
         loader = next(
             (keyword.value for keyword in node.keywords if keyword.arg == "Loader"),
             node.args[1] if len(node.args) > 1 else None,
@@ -269,7 +309,12 @@ class Visitor(ast.NodeVisitor):
             elif module == "builtins":
                 if not node.args or _is_dynamic_literal(node.args[0]):
                     continue
-            self._add(node, "P008", P008_MESSAGES[module])
+            message = (
+                P008_AMBIGUOUS_MESSAGE
+                if binding in self.ambiguous_boundary_calls
+                else P008_MESSAGES[module]
+            )
+            self._add(node, "P008", message)
             return
 
     def visit_Call(self, node: ast.Call) -> None:

--- a/plugins/hexaemeron/skills/phylax/scripts/phylax.py
+++ b/plugins/hexaemeron/skills/phylax/scripts/phylax.py
@@ -135,6 +135,63 @@ def _is_dynamic_literal(node: ast.AST) -> bool:
     )
 
 
+def _boundary_bindings(
+    tree: ast.AST,
+) -> tuple[dict[str, set[str]], dict[str, set[str]], set[str], set[str]]:
+    """Collect source-local import evidence before descending function bodies.
+
+    A depth-first visitor reaches a function's calls before module imports that
+    follow its definition, even though those imports bind before normal calls.
+    Conflicting imports remain conservative evidence because scope and runtime
+    rebinding are outside this rule.
+    """
+    modules: dict[str, set[str]] = {}
+    direct: dict[str, set[str]] = {}
+    identities: dict[str, set[tuple[int, str | None, str]]] = {}
+    imports = (
+        node for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+    )
+    for node in imports:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                local = alias.asname or alias.name.split(".", 1)[0]
+                identities.setdefault(local, set()).add((-1, alias.name, ""))
+                if alias.name in BOUNDARY_CALLS:
+                    modules.setdefault(local, set()).add(alias.name)
+            continue
+
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            local = alias.asname or alias.name
+            identities.setdefault(local, set()).add(
+                (node.level, node.module, alias.name)
+            )
+            if node.level != 0 or node.module not in BOUNDARY_CALLS:
+                continue
+            if alias.name in BOUNDARY_CALLS[node.module]:
+                direct.setdefault(local, set()).add(node.module)
+
+    safe_yaml_modules = {
+        local
+        for local, imported in identities.items()
+        if all(
+            level == -1 and module == "yaml"
+            for level, module, _name in imported
+        )
+    }
+    safe_yaml_loaders = {
+        local
+        for local, imported in identities.items()
+        if all(
+            level == 0 and module == "yaml" and name in SAFE_YAML_LOADERS
+            for level, module, name in imported
+        )
+    }
+    return modules, direct, safe_yaml_modules, safe_yaml_loaders
+
+
 class Visitor(ast.NodeVisitor):
     """Flag only calls resolved by the source-local import grammar.
 
@@ -142,21 +199,22 @@ class Visitor(ast.NodeVisitor):
     `run` and `.call` methods must stay outside the rule that owns each name.
     """
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path, tree: ast.AST) -> None:
         self.path = path
         self.findings: list[Finding] = []
         self.modules: set[str] = set()
         self.direct: set[str] = set()
-        self.boundary_modules: dict[str, str] = {}
-        self.boundary_direct: dict[str, str] = {}
-        self.safe_yaml_loaders: set[str] = set()
+        (
+            self.boundary_modules,
+            self.boundary_direct,
+            self.safe_yaml_modules,
+            self.safe_yaml_loaders,
+        ) = _boundary_bindings(tree)
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
             if alias.name == "subprocess":
                 self.modules.add(alias.asname or "subprocess")
-            if alias.name in BOUNDARY_CALLS:
-                self.boundary_modules[alias.asname or alias.name] = alias.name
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
@@ -164,13 +222,6 @@ class Visitor(ast.NodeVisitor):
             for alias in node.names:
                 if alias.name in RUNNERS:
                     self.direct.add(alias.asname or alias.name)
-        if node.level == 0 and node.module in BOUNDARY_CALLS:
-            for alias in node.names:
-                local = alias.asname or alias.name
-                if alias.name in BOUNDARY_CALLS[node.module]:
-                    self.boundary_direct[local] = node.module
-                if node.module == "yaml" and alias.name in SAFE_YAML_LOADERS:
-                    self.safe_yaml_loaders.add(local)
         self.generic_visit(node)
 
     def _starts_process(self, func: ast.AST) -> bool:
@@ -183,42 +234,43 @@ class Visitor(ast.NodeVisitor):
     def _add(self, node: ast.AST, code: str, message: str) -> None:
         self.findings.append(Finding(self.path, node.lineno, code, message))
 
-    def _boundary_module(self, func: ast.AST) -> str | None:
+    def _boundary_modules(self, func: ast.AST) -> set[str]:
         if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
-            module = self.boundary_modules.get(func.value.id)
-            if module and func.attr in BOUNDARY_CALLS[module]:
-                return module
+            return {
+                module
+                for module in self.boundary_modules.get(func.value.id, set())
+                if func.attr in BOUNDARY_CALLS[module]
+            }
         if isinstance(func, ast.Name):
             resolved = self.boundary_direct.get(func.id)
             if resolved:
                 return resolved
             if func.id in BOUNDARY_CALLS["builtins"]:
-                return "builtins"
-        return None
+                return {"builtins"}
+        return set()
 
     def _safe_yaml_loader(self, loader: ast.AST) -> bool:
         if isinstance(loader, ast.Attribute) and isinstance(loader.value, ast.Name):
             return (
-                self.boundary_modules.get(loader.value.id) == "yaml"
+                loader.value.id in self.safe_yaml_modules
                 and loader.attr in SAFE_YAML_LOADERS
             )
         return isinstance(loader, ast.Name) and loader.id in self.safe_yaml_loaders
 
     def _check_p008(self, node: ast.Call) -> None:
-        module = self._boundary_module(node.func)
-        if not module:
+        loader = next(
+            (keyword.value for keyword in node.keywords if keyword.arg == "Loader"),
+            node.args[1] if len(node.args) > 1 else None,
+        )
+        for module in sorted(self._boundary_modules(node.func)):
+            if module == "yaml":
+                if loader is not None and self._safe_yaml_loader(loader):
+                    continue
+            elif module == "builtins":
+                if not node.args or _is_dynamic_literal(node.args[0]):
+                    continue
+            self._add(node, "P008", P008_MESSAGES[module])
             return
-        if module == "yaml":
-            loader = next(
-                (keyword.value for keyword in node.keywords if keyword.arg == "Loader"),
-                node.args[1] if len(node.args) > 1 else None,
-            )
-            if loader is not None and self._safe_yaml_loader(loader):
-                return
-        elif module == "builtins":
-            if not node.args or _is_dynamic_literal(node.args[0]):
-                return
-        self._add(node, "P008", P008_MESSAGES[module])
 
     def visit_Call(self, node: ast.Call) -> None:
         self._check_p008(node)
@@ -262,7 +314,7 @@ def check_python(path: Path, text: str) -> list[Finding]:
         tree = ast.parse(text)
     except SyntaxError as err:
         return [Finding(path, err.lineno or 1, "P000", f"could not parse: {err.msg}")]
-    visitor = Visitor(path)
+    visitor = Visitor(path, tree)
     visitor.visit(tree)
     return visitor.findings
 

--- a/plugins/hexaemeron/skills/phylax/scripts/phylax.py
+++ b/plugins/hexaemeron/skills/phylax/scripts/phylax.py
@@ -212,7 +212,9 @@ def _boundary_bindings(
                 families.add(module)
             else:
                 families.add(None)
-        if local in BOUNDARY_CALLS["builtins"] and local not in direct:
+        # a direct import elsewhere in the file does not prove that it shadows
+        # a bare built-in at this call site; scope analysis is outside P008.
+        if local in BOUNDARY_CALLS["builtins"]:
             families.add("builtins")
         if len(families) > 1:
             ambiguous_calls.add(local)
@@ -276,11 +278,10 @@ class Visitor(ast.NodeVisitor):
                 if func.attr in BOUNDARY_CALLS[module]
             }
         if isinstance(func, ast.Name):
-            resolved = self.boundary_direct.get(func.id)
-            if resolved:
-                return resolved
+            resolved = set(self.boundary_direct.get(func.id, set()))
             if func.id in BOUNDARY_CALLS["builtins"]:
-                return {"builtins"}
+                resolved.add("builtins")
+            return resolved
         return set()
 
     def _safe_yaml_loader(self, loader: ast.AST) -> bool:

--- a/plugins/hexaemeron/skills/phylax/scripts/phylax.py
+++ b/plugins/hexaemeron/skills/phylax/scripts/phylax.py
@@ -11,6 +11,7 @@ reading intent. Everything else in SKILL.md stays a judgement.
   P005  raw HTML reaches a renderer without a later trusted sanitiser
   P006  a session credential reaches persisted browser storage
   P007  a runtime-selected absolute fetch host has no prior allowlist check
+  P008  unsafe deserialization or non-literal dynamic execution
 
 Exit 0 clean, 1 findings, 2 bad invocation.
 """
@@ -32,6 +33,19 @@ from lib.typescript_lexer import lex  # noqa: E402
 
 RUNNERS = {"run", "call", "check_call", "check_output", "Popen"}
 WRITERS = {"print", "debug", "info", "warning", "warn", "error", "critical", "exception"}
+BOUNDARY_CALLS = {
+    "pickle": frozenset({"load", "loads"}),
+    "marshal": frozenset({"load"}),
+    "yaml": frozenset({"load"}),
+    "builtins": frozenset({"eval", "exec"}),
+}
+SAFE_YAML_LOADERS = frozenset({"SafeLoader", "CSafeLoader"})
+P008_MESSAGES = {
+    "pickle": "pickle deserialization may execute untrusted code",
+    "marshal": "marshal deserialization accepts untrusted data",
+    "yaml": "yaml.load has no resolved SafeLoader or CSafeLoader",
+    "builtins": "dynamic execution receives non-literal source",
+}
 
 CREDENTIAL = re.compile(
     r"(?:^|_)(?:priv(?:ate)?_?key|secret|passwd|password|mnemonic|seed_?phrase"
@@ -114,12 +128,18 @@ def _is_string(node: ast.AST) -> bool:
     return _is_str_literal(node) or _is_formatted(node)
 
 
-class Visitor(ast.NodeVisitor):
-    """Flag only calls that resolve to subprocess.
+def _is_dynamic_literal(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, (str, bytes))
+    )
 
-    A bare name match is worthless here: this marketplace has a test helper
-    called `run` and an RPC client with a `.call`, and neither starts a
-    process.
+
+class Visitor(ast.NodeVisitor):
+    """Flag only calls resolved by the source-local import grammar.
+
+    A broad terminal-name match is worthless here: ordinary `.load`, `.loads`,
+    `run` and `.call` methods must stay outside the rule that owns each name.
     """
 
     def __init__(self, path: Path) -> None:
@@ -127,11 +147,16 @@ class Visitor(ast.NodeVisitor):
         self.findings: list[Finding] = []
         self.modules: set[str] = set()
         self.direct: set[str] = set()
+        self.boundary_modules: dict[str, str] = {}
+        self.boundary_direct: dict[str, str] = {}
+        self.safe_yaml_loaders: set[str] = set()
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
             if alias.name == "subprocess":
                 self.modules.add(alias.asname or "subprocess")
+            if alias.name in BOUNDARY_CALLS:
+                self.boundary_modules[alias.asname or alias.name] = alias.name
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
@@ -139,6 +164,13 @@ class Visitor(ast.NodeVisitor):
             for alias in node.names:
                 if alias.name in RUNNERS:
                     self.direct.add(alias.asname or alias.name)
+        if node.level == 0 and node.module in BOUNDARY_CALLS:
+            for alias in node.names:
+                local = alias.asname or alias.name
+                if alias.name in BOUNDARY_CALLS[node.module]:
+                    self.boundary_direct[local] = node.module
+                if node.module == "yaml" and alias.name in SAFE_YAML_LOADERS:
+                    self.safe_yaml_loaders.add(local)
         self.generic_visit(node)
 
     def _starts_process(self, func: ast.AST) -> bool:
@@ -151,7 +183,45 @@ class Visitor(ast.NodeVisitor):
     def _add(self, node: ast.AST, code: str, message: str) -> None:
         self.findings.append(Finding(self.path, node.lineno, code, message))
 
+    def _boundary_module(self, func: ast.AST) -> str | None:
+        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+            module = self.boundary_modules.get(func.value.id)
+            if module and func.attr in BOUNDARY_CALLS[module]:
+                return module
+        if isinstance(func, ast.Name):
+            resolved = self.boundary_direct.get(func.id)
+            if resolved:
+                return resolved
+            if func.id in BOUNDARY_CALLS["builtins"]:
+                return "builtins"
+        return None
+
+    def _safe_yaml_loader(self, loader: ast.AST) -> bool:
+        if isinstance(loader, ast.Attribute) and isinstance(loader.value, ast.Name):
+            return (
+                self.boundary_modules.get(loader.value.id) == "yaml"
+                and loader.attr in SAFE_YAML_LOADERS
+            )
+        return isinstance(loader, ast.Name) and loader.id in self.safe_yaml_loaders
+
+    def _check_p008(self, node: ast.Call) -> None:
+        module = self._boundary_module(node.func)
+        if not module:
+            return
+        if module == "yaml":
+            loader = next(
+                (keyword.value for keyword in node.keywords if keyword.arg == "Loader"),
+                node.args[1] if len(node.args) > 1 else None,
+            )
+            if loader is not None and self._safe_yaml_loader(loader):
+                return
+        elif module == "builtins":
+            if not node.args or _is_dynamic_literal(node.args[0]):
+                return
+        self._add(node, "P008", P008_MESSAGES[module])
+
     def visit_Call(self, node: ast.Call) -> None:
+        self._check_p008(node)
         if self._starts_process(node.func):
             for kw in node.keywords:
                 if kw.arg == "shell" and isinstance(kw.value, ast.Constant) and kw.value.value is True:

--- a/plugins/hexaemeron/tests/test_phylax_checker.py
+++ b/plugins/hexaemeron/tests/test_phylax_checker.py
@@ -101,6 +101,52 @@ class UnsafeDeserialization(unittest.TestCase):
             ),
         })
 
+    def test_imports_after_function_definitions_still_resolve(self):
+        self.assert_p008({
+            "module": (
+                "def decode(payload):\n"
+                "    return pickle.loads(payload)\n"
+                "import pickle\n"
+            ),
+            "direct": (
+                "def decode(payload):\n"
+                "    return decode_pickle(payload)\n"
+                "from pickle import loads as decode_pickle\n"
+            ),
+        })
+
+    def test_import_rebinding_does_not_hide_boundary_evidence(self):
+        self.assertEqual(["P008"], codes(
+            "import pickle as codec\n"
+            "import json as codec\n"
+            "codec.loads(payload)\n"
+        ))
+        self.assertEqual(["P008"], codes(
+            "from pickle import loads as decode\n"
+            "from json import loads as decode\n"
+            "decode(payload)\n"
+        ))
+        self.assertEqual(["P008"], codes(
+            "from yaml import load, SafeLoader as Loader\n"
+            "from yaml import FullLoader as Loader\n"
+            "load(payload, Loader=Loader)\n"
+        ))
+        self.assertEqual(["P008"], codes(
+            "import yaml as parser\n"
+            "import custom as parser\n"
+            "parser.load(payload, Loader=parser.SafeLoader)\n"
+        ))
+        self.assertEqual(["P008"], codes(
+            "import pickle as codec\n"
+            "import yaml as codec\n"
+            "codec.loads(payload)\n"
+        ))
+        self.assertEqual(["P008"], codes(
+            "from builtins import eval as decode\n"
+            "from yaml import load as decode\n"
+            "decode('literal')\n"
+        ))
+
     def test_safe_yaml_loaders_are_allowed_in_keyword_and_positional_forms(self):
         specimens = {
             "module-safe-keyword": (
@@ -136,6 +182,42 @@ class UnsafeDeserialization(unittest.TestCase):
         for label, source in specimens.items():
             with self.subTest(label=label):
                 self.assertEqual([], codes(source))
+
+    def test_yaml_loader_keyword_takes_precedence_over_second_position(self):
+        self.assertEqual([], codes(
+            "import yaml\n"
+            "yaml.load(payload, yaml.FullLoader, Loader=yaml.SafeLoader)\n"
+        ))
+        self.assertEqual(["P008"], codes(
+            "import yaml\n"
+            "yaml.load(payload, yaml.SafeLoader, Loader=yaml.FullLoader)\n"
+        ))
+
+    def test_argument_shape_edges_follow_the_stated_grammar(self):
+        self.assert_p008({
+            "pickle-no-args": "import pickle\npickle.load()\n",
+            "yaml-no-args": "import yaml\nyaml.load()\n",
+        })
+        self.assertEqual([], codes("eval()\nexec(source=payload)\n"))
+        self.assertEqual(["P008"], codes(
+            "def eval(value):\n"
+            "    return value\n"
+            "eval(payload)\n"
+        ))
+
+    def test_nested_boundary_calls_each_report_once(self):
+        result = findings(
+            "import pickle\n"
+            "eval(pickle.loads(payload))\n",
+            "sample.py",
+        )
+        self.assertEqual(
+            [
+                "dynamic execution receives non-literal source",
+                "pickle deserialization may execute untrusted code",
+            ],
+            [finding.message for finding in result],
+        )
 
     def test_named_safe_and_out_of_scope_neighbours_are_allowed(self):
         source = (

--- a/plugins/hexaemeron/tests/test_phylax_checker.py
+++ b/plugins/hexaemeron/tests/test_phylax_checker.py
@@ -1,4 +1,4 @@
-"""The Phylax boundary lint catches its four rules and nothing else.
+"""The Phylax boundary lint catches its eight rules and nothing else.
 
 Every rule carries a specimen it must flag and a neighbour it must not. The
 neighbours are the point: this marketplace has a test helper named `run` and
@@ -34,6 +34,207 @@ def findings(source, name="sample.ts"):
         path = Path(directory) / name
         path.write_text(source, encoding="utf-8")
         return phylax.check(path)
+
+
+class UnsafeDeserialization(unittest.TestCase):
+    def assert_p008(self, specimens):
+        for label, source in specimens.items():
+            with self.subTest(label=label):
+                self.assertEqual(["P008"], codes(source))
+
+    def test_pickle_load_and_loads_import_shapes_are_p008(self):
+        self.assert_p008({
+            "module-load": "import pickle\npickle.load(stream)\n",
+            "module-loads": "import pickle\npickle.loads(payload)\n",
+            "module-alias-load": "import pickle as codec\ncodec.load(stream)\n",
+            "module-alias-loads": "import pickle as codec\ncodec.loads(payload)\n",
+            "direct-load": "from pickle import load\nload(stream)\n",
+            "direct-loads": "from pickle import loads\nloads(payload)\n",
+            "direct-alias-load": "from pickle import load as decode\ndecode(stream)\n",
+            "direct-alias-loads": "from pickle import loads as decode\ndecode(payload)\n",
+        })
+
+    def test_marshal_load_import_shapes_are_p008(self):
+        self.assert_p008({
+            "module": "import marshal\nmarshal.load(stream)\n",
+            "module-alias": "import marshal as codec\ncodec.load(stream)\n",
+            "direct": "from marshal import load\nload(stream)\n",
+            "direct-alias": "from marshal import load as decode\ndecode(stream)\n",
+        })
+
+    def test_yaml_load_without_safe_loader_import_shapes_is_p008(self):
+        self.assert_p008({
+            "module": "import yaml\nyaml.load(payload)\n",
+            "module-alias": "import yaml as parser\nparser.load(payload)\n",
+            "direct": "from yaml import load\nload(payload)\n",
+            "direct-alias": "from yaml import load as parse\nparse(payload)\n",
+        })
+
+    def test_yaml_load_with_unsafe_loader_is_p008(self):
+        self.assert_p008({
+            "full-loader": (
+                "import yaml\nyaml.load(payload, Loader=yaml.FullLoader)\n"
+            ),
+            "loader-positional": "import yaml\nyaml.load(payload, yaml.Loader)\n",
+            "direct-unsafe-loader": (
+                "from yaml import load, UnsafeLoader\n"
+                "load(payload, Loader=UnsafeLoader)\n"
+            ),
+            "unknown-loader": (
+                "from yaml import load\nload(payload, Loader=trusted_loader)\n"
+            ),
+        })
+
+    def test_dynamic_execution_nonliteral_input_is_p008(self):
+        self.assert_p008({
+            "bare-eval": "eval(payload)\n",
+            "bare-exec": "exec(receive())\n",
+            "builtins-eval": "import builtins\nbuiltins.eval(payload)\n",
+            "builtins-alias-exec": (
+                "import builtins as runtime\nruntime.exec(f\"run({payload})\")\n"
+            ),
+            "direct-alias-eval": (
+                "from builtins import eval as evaluate\nevaluate(payload)\n"
+            ),
+            "direct-alias-exec": (
+                "from builtins import exec as execute\nexecute(payload)\n"
+            ),
+        })
+
+    def test_safe_yaml_loaders_are_allowed_in_keyword_and_positional_forms(self):
+        specimens = {
+            "module-safe-keyword": (
+                "import yaml\nyaml.load(payload, Loader=yaml.SafeLoader)\n"
+            ),
+            "module-safe-positional": (
+                "import yaml\nyaml.load(payload, yaml.SafeLoader)\n"
+            ),
+            "module-csafe-keyword": (
+                "import yaml as parser\n"
+                "parser.load(payload, Loader=parser.CSafeLoader)\n"
+            ),
+            "module-csafe-positional": (
+                "import yaml as parser\nparser.load(payload, parser.CSafeLoader)\n"
+            ),
+            "direct-safe-keyword": (
+                "from yaml import load, SafeLoader\n"
+                "load(payload, Loader=SafeLoader)\n"
+            ),
+            "direct-safe-positional": (
+                "from yaml import load as parse, SafeLoader as Safe\n"
+                "parse(payload, Safe)\n"
+            ),
+            "direct-csafe-keyword": (
+                "from yaml import load, CSafeLoader\n"
+                "load(payload, Loader=CSafeLoader)\n"
+            ),
+            "direct-csafe-positional": (
+                "from yaml import load as parse, CSafeLoader as FastSafe\n"
+                "parse(payload, FastSafe)\n"
+            ),
+        }
+        for label, source in specimens.items():
+            with self.subTest(label=label):
+                self.assertEqual([], codes(source))
+
+    def test_named_safe_and_out_of_scope_neighbours_are_allowed(self):
+        source = (
+            "import json\n"
+            "import marshal\n"
+            "import pickle\n"
+            "import yaml\n"
+            "from marshal import loads as decode_marshaled\n"
+            "from yaml import safe_load as parse_yaml\n"
+            "yaml.safe_load(payload)\n"
+            "parse_yaml(payload)\n"
+            "marshal.loads(payload)\n"
+            "decode_marshaled(payload)\n"
+            "json.load(stream)\n"
+            "json.loads(payload)\n"
+            "pickle.dump(value, stream)\n"
+            "pickle.dumps(value)\n"
+            "reader.load(payload)\n"
+            "from .pickle import load as local_load\n"
+            "local_load(stream)\n"
+        )
+        self.assertEqual([], codes(source))
+
+    def test_literal_string_and_bytes_dynamic_sources_are_allowed(self):
+        source = (
+            "import builtins as runtime\n"
+            "from builtins import exec as execute\n"
+            "eval('1 + 1')\n"
+            "exec(b'pass')\n"
+            "runtime.eval(b'1 + 1')\n"
+            "execute('value = 1')\n"
+        )
+        self.assertEqual([], codes(source))
+
+    def test_reason_bearing_p008_pragma_suppresses_but_a_bare_one_does_not(self):
+        self.assertEqual([], codes(
+            "import pickle\n"
+            "pickle.loads(payload)  # phylax: allow reviewed compatibility fixture\n"
+        ))
+        self.assertEqual(["P008"], codes(
+            "import pickle\npickle.loads(payload)  # phylax: allow\n"
+        ))
+
+    def test_p008_diagnostics_are_fixed_and_do_not_repeat_payload(self):
+        sample_value = "unsafe-deserialization-sentinel"
+        result = findings(
+            "import pickle\n"
+            f'payload = "{sample_value}"\n'
+            "pickle.loads(payload)\n",
+            "sample.py",
+        )
+        self.assertEqual(["P008"], [finding.code for finding in result])
+        self.assertEqual(
+            "pickle deserialization may execute untrusted code",
+            result[0].message,
+        )
+        rendered = "\n".join(str(finding) for finding in result)
+        encoded = json.dumps([finding.as_dict() for finding in result])
+        self.assertNotIn(sample_value, rendered)
+        self.assertNotIn(sample_value, encoded)
+
+    def test_import_alias_rebinding_is_not_followed(self):
+        self.assertEqual(["P008"], codes(
+            "import pickle as codec\ncodec = local_reader\ncodec.loads(payload)\n"
+        ))
+        self.assertEqual([], codes(
+            "from yaml import load as parse, SafeLoader as Safe\n"
+            "Safe = custom_loader\nparse(payload, Loader=Safe)\n"
+        ))
+
+    def test_p000_through_p007_classifications_remain_available(self):
+        specimens = {
+            "P000": ("(", "sample.py"),
+            "P001": (
+                "import subprocess\nsubprocess.run(['tool'], shell=True)\n",
+                "sample.py",
+            ),
+            "P002": ("import subprocess\nsubprocess.run('tool')\n", "sample.py"),
+            "P003": ("package>=1\n", "requirements.txt"),
+            "P004": ('SECRET = "fixture-value"\n', "sample.py"),
+            "P005": (
+                'import raw from "rehype-raw"\n'
+                "const view = <Markdown rehypePlugins={[raw]} />\n",
+                "sample.tsx",
+            ),
+            "P006": (
+                'localStorage.setItem("authToken", authToken)\n',
+                "sample.ts",
+            ),
+            "P007": (
+                "async function load(host: string) {\n"
+                "  return fetch(`https://${host}/api`)\n"
+                "}\n",
+                "sample.ts",
+            ),
+        }
+        for expected, (source, name) in specimens.items():
+            with self.subTest(code=expected):
+                self.assertEqual([expected], codes(source, name))
 
 
 class ShellInvocation(unittest.TestCase):

--- a/plugins/hexaemeron/tests/test_phylax_checker.py
+++ b/plugins/hexaemeron/tests/test_phylax_checker.py
@@ -147,6 +147,43 @@ class UnsafeDeserialization(unittest.TestCase):
             "decode('literal')\n"
         ))
 
+    def test_conflicting_imports_do_not_claim_one_call_family(self):
+        sentinel = "conflicting-import-sentinel"
+        specimens = {
+            "module-boundaries": (
+                "import pickle as codec\n"
+                "import yaml as codec\n"
+                "codec.load(payload)\n"
+            ),
+            "direct-boundaries": (
+                "from pickle import load as decode\n"
+                "from yaml import load as decode\n"
+                "decode(payload)\n"
+            ),
+            "boundary-and-neighbour": (
+                "from pickle import load as decode\n"
+                "from json import load as decode\n"
+                "decode(payload)\n"
+            ),
+            "explicit-bare-shadow": (
+                "from ast import literal_eval as eval\n"
+                "eval(payload)\n"
+            ),
+        }
+        for label, source in specimens.items():
+            with self.subTest(label=label):
+                result = findings(
+                    f'payload = "{sentinel}"\n' + source,
+                    "sample.py",
+                )
+                self.assertEqual(["P008"], [finding.code for finding in result])
+                self.assertEqual(
+                    "source-local bindings leave the boundary call family unresolved",
+                    result[0].message,
+                )
+                self.assertNotIn(sentinel, str(result[0]))
+                self.assertNotIn(sentinel, json.dumps(result[0].as_dict()))
+
     def test_safe_yaml_loaders_are_allowed_in_keyword_and_positional_forms(self):
         specimens = {
             "module-safe-keyword": (

--- a/plugins/hexaemeron/tests/test_phylax_checker.py
+++ b/plugins/hexaemeron/tests/test_phylax_checker.py
@@ -184,6 +184,32 @@ class UnsafeDeserialization(unittest.TestCase):
                 self.assertNotIn(sentinel, str(result[0]))
                 self.assertNotIn(sentinel, json.dumps(result[0].as_dict()))
 
+    def test_bare_dynamic_calls_survive_cross_scope_yaml_aliases(self):
+        specimens = {
+            "eval": (
+                "def run(payload, SafeLoader):\n"
+                "    return eval(payload, SafeLoader)\n"
+                "def imports_elsewhere():\n"
+                "    from yaml import load as eval\n"
+                "    from yaml import SafeLoader\n"
+            ),
+            "exec": (
+                "def run(payload, SafeLoader):\n"
+                "    exec(payload, SafeLoader)\n"
+                "def imports_elsewhere():\n"
+                "    from yaml import load as exec\n"
+                "    from yaml import SafeLoader\n"
+            ),
+        }
+        for label, source in specimens.items():
+            with self.subTest(label=label):
+                result = findings(source, "sample.py")
+                self.assertEqual(["P008"], [finding.code for finding in result])
+                self.assertEqual(
+                    "source-local bindings leave the boundary call family unresolved",
+                    result[0].message,
+                )
+
     def test_safe_yaml_loaders_are_allowed_in_keyword_and_positional_forms(self):
         specimens = {
             "module-safe-keyword": (

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -394,7 +394,7 @@
     },
     "phylax-boundary-review": {
       "source": "plugins/hexaemeron/skills/phylax/SKILL.md",
-      "sha256": "64d5af79bb36e5a401daad05982413873a48eb803251aebab55a4336156321b6",
+      "sha256": "fc3fdf6bf76cd24bf602d39ae30d1b77b1f196a34e0207522fec7ff9115007ca",
       "bindings": {
         "promise_id": "coverage key joined to the canonical promise heading",
         "subject": "reviewed step, source tree and external-input boundary",


### PR DESCRIPTION
# add P008 unsafe-deserialization checks to Phylax

Closes #324.

## what changed

Phylax now reports `P008` for source-local aliases of `pickle.load`,
`pickle.loads`, `marshal.load`, unsafe `yaml.load`, and non-literal `eval` or
`exec`. It keeps resolved safe YAML loaders and literal dynamic source clean,
and its fixed diagnostics never copy inspected payload text.

The parser contract, 80-case focused suite, Promise Machine digest, and
`phylax-v1.3.0` generation record move together. The mature revision, digest,
next job, and frontier stay unchanged. The receipted study and one-step
runbook live under `docs/phylax-unsafe-deserialization/`.

## audit

The red run had 66 tests and 26 expected missing-`P008` failures. Four Warden
rounds found `2 -> 1 -> 1 -> 0` issues. The fixes pre-collect imports, preserve
conflicting call families, use a family-neutral ambiguity message, and retain
bare built-in dynamic-execution candidates across lexical scopes. The final
round reviewed all thirteen study risks and found no further defect.

The landed stack is #484 and #485. Its final code head passed 80/80 focused
tests on Python 3.9.6 and 3.12.13, 852/852 Hexaemeron tests, 118/118 root
tests, 8/8 evolution tests, the Promise Machine check, repository Phylax,
Protasis, Horos, and the required Phylax/Ephoros/Hypomnema lint scopes. The
Solidity suite is waived because this packet has no Solidity target.

## Carried forward

- `marshal.loads` remains outside `P008`; the rule covers only `marshal.load`.
- relative, wildcard, dynamic, and dotted import forms remain outside the source-local binding grammar.
- assignment, general lexical scope, taint, control flow, and cross-scope YAML-loader trust remain outside this parse-only rule.
- custom loader safety proofs remain unsupported; only resolved `SafeLoader` and `CSafeLoader` forms are accepted.
- the pragma-inside-string quirk and a Python file-size policy remain unchanged.

These boundaries and their evidence are recorded in
`docs/phylax-unsafe-deserialization/study.md` and the final leads section of
`audit/AUDIT.md`.

<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: https://github.com/wildcat-finance/skills/issues/324
Root-Issue-Successor: none-recorded
Root-Issue-Fiat-Required: 0
Root-Issue-Route: pr-only
Root-Issue-Classification-Source: live-contract
<!-- root-issue-analytics:v1:end -->
