### PR TITLE
audit: harden Elenchus report output after test execution

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8954,3 +8954,76 @@ declared output. Mechanical red-parent classification for an implementation
 under a test directory remains an evidence discrepancy; changing Elenchus's
 test-file boundary is outside step 1, and issue 453 owns the blocking policy.
 No further step-1 lead remained after the full diff review.
+
+## Elenchus audit-round verdict, step 1, round 2 -- 2026-08-22
+
+### Suite disposition
+
+The controller waiver remains exact: `waived: issue 327 changes Python
+controller state, Elenchus integration, tests, and governed prose; it has no
+Solidity target`. No Solidity path changed. X-Ray, Solidity Auditor and Fizz
+did not run. The active-plugin Phylax, Ephoros and Hypomnema lints each exit 0
+on their repository scopes.
+
+### Finding table
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R2-01 | medium | `plugins/hexaemeron/tests/run_tests.py:13` | The round-1 fix held its worktree directory descriptor across arbitrary in-process tests. A test could close that descriptor and reopen an outside directory in the same numeric slot; the report writer then trusted the rebound slot and wrote outside the worktree. | fixed in `cc984ba`; manual guard red, Elenchus verdict `passed` |
+| S1-R2-02 | low | `plugins/hexaemeron/tests/run_tests.py:68` | The unsupported-platform gate collapsed every absent secure-directory primitive into one generic error, so an operator could not identify which required control was missing. | fixed in `cc984ba`; manual guard red |
+| S1-R2-review | none | full `454bf3c..cc984ba` diff | No further schema, exit-semantics, containment, descriptor-lifetime or record finding was confirmed. | clean |
+| S1-R2-records | none | study, runbook and generation rows | The changed contracts still describe a four-state declaration rather than report-byte attestation, and the governed frontiers remain fixed. | clean |
+
+Finding count: 2.
+
+### Risk coverage
+
+| risk id | evidence checked | disposition |
+| --- | --- | --- |
+| `fix-claim-confusion` | This round has a signed fixes commit. Step 1 cannot yet store the verdict in Fiat state, so the audit record preserves `passed` without claiming a controller receipt that does not exist. | clean within step 1 |
+| `enum-drift` | The exact runbook invocation returned the existing `passed` status. The classifier and `elenchus.unittest.v1` fields are unchanged. | clean |
+| `command-substitution` | The comparison used the source runbook's exact command, `unittest-json-v1` format and `.elenchus/hexaemeron-unittest.json` path under pinned Node v26.6.0. | clean |
+| `legacy-round-breakage` | Step 1 still changes no Fiat state reader or writer. Legacy-round behavior remains step 2 work. | reviewed; not applicable |
+| `receipt-overclaim` | The audit record keeps mechanical `passed` separate from the two manual red-parent guards and does not relabel it `guarded`. | clean |
+| `downstream-loss` | No issue 429, 369 or 453 consumer changed in this step. | reviewed; not applicable |
+| `frontier-drift` | The evolution/version tests pass 14/14; Elenchus and Protasis retain their prior revision, digest, status and held target while advancing generation only. | clean |
+
+### Evidence
+
+The descriptor reproducer on `0eacf593` observed root slot 3 closed and an
+outside directory reopened as slot 3. `write_report` then left no inside file
+and created the declared nested report outside. The new black-box guard fails
+on that parent at `assertTrue(report.is_file())`. A second parent run fails
+because the old refusal names none of `os.open(dir_fd)`, `os.mkdir(dir_fd)`,
+`os.stat(dir_fd)`, `os.unlink(dir_fd)` or `os.stat(follow_symlinks)`.
+
+The fix retains the canonical root and its `(st_dev, st_ino)` identity rather
+than a live descriptor. It reopens and verifies that directory only after the
+suite, walks report parents through owned directory descriptors with
+`O_NOFOLLOW`, and closes root, parent and report handles on success and error
+paths. A partial write loops until complete; a zero, exception or failed close
+cannot produce a parseable complete report through this path. Unsupported
+hosts now fail before test discovery and name every missing primitive.
+
+The ten focused report-adapter cases pass on the fixed tree. Under offline,
+pinned Node v26.6.0, the Elenchus/Fiat/Protasis focus passes 155/155 and the
+complete Hexaemeron suite passes 862/862 in 153.871 seconds. The root suite
+passes 118/118. The evolution/version tests pass 14/14. Both Protasis checks,
+Promise Machine verification, all three active-plugin lints and
+`git diff --check` exit 0. The exact runbook Elenchus comparison on signed
+commit `cc984ba840d45105a20479331cec8622fc38fbe2` returns `passed`.
+
+The receipted study still hashes to
+`06f8e81b95c7ceba26ada998fe62b57a87d9afa3eea10a31813862842851abe0`.
+Every one of its seven risk ids has a disposition above.
+
+### Leads not pursued
+
+Leads not pursued: issue 429's audit schema, issue 453's evidence binding and
+production `guarded` gate, Fiat's step-2 controller field, and hostile
+background threads that continue manipulating descriptors after the suite
+returns. In-process tests already share the runner's operating-system
+authority; this fix removes the deterministic descriptor inherited across the
+whole suite and fails closed when the recorded root identity changes. A crash
+can still leave a partial fresh file, but Elenchus rejects malformed or
+incomplete JSON rather than accepting it as a completed report.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -9027,3 +9027,70 @@ authority; this fix removes the deterministic descriptor inherited across the
 whole suite and fails closed when the recorded root identity changes. A crash
 can still leave a partial fresh file, but Elenchus rejects malformed or
 incomplete JSON rather than accepting it as a completed report.
+
+## Elenchus audit-round verdict, step 1, round 3 -- 2026-08-22
+
+### Suite disposition
+
+The controller waiver remains exact: `waived: issue 327 changes Python
+controller state, Elenchus integration, tests, and governed prose; it has no
+Solidity target`. No Solidity path changed. X-Ray, Solidity Auditor and Fizz
+did not run. The active-plugin Phylax, Ephoros and Hypomnema lints each exit 0.
+
+### Finding table
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R3-review | none | full `454bf3c..3b394541` diff | No report-schema, path-containment, descriptor-lifetime, source-contract or record finding was confirmed. | clean |
+| S1-R3-guards | none | `plugins/hexaemeron/tests/run_tests.py` | Both prior escapes remain reproducible on their parents and refused on the fixed tree; worktree replacement also fails closed. | clean |
+| S1-R3-records | none | report and governed ledgers | The report matches the runbook contract and both generation rows retain their governed frontiers. | clean |
+
+Finding count: 0.
+
+### Risk coverage
+
+| risk id | evidence checked | disposition |
+| --- | --- | --- |
+| `fix-claim-confusion` | This clean round has no fixes commit, so it records no Elenchus verdict. The full-suite report below is test evidence, not a fix receipt. | clean |
+| `enum-drift` | The pinned Elenchus/Fiat/Protasis focus exercises all four classifier strings and passes 155/155; the runner report keeps the exact `elenchus.unittest.v1` fields. | clean |
+| `command-substitution` | The pinned invocation used the receipted runbook's exact Python command, `unittest-json-v1` format and `.elenchus/hexaemeron-unittest.json` path without shell interpolation inside the runner. | clean |
+| `legacy-round-breakage` | Step 1 still changes no Fiat state reader or writer. The legacy-round path remains step 2 work. | reviewed; not applicable |
+| `receipt-overclaim` | The generated report is recorded as current-tree suite evidence only. It is not relabeled `guarded`, and no controller receipt is claimed for a field the installed controller does not have. | clean |
+| `downstream-loss` | No issue 429, 369 or 453 consumer changed in this step. | reviewed; not applicable |
+| `frontier-drift` | The 14 evolution and version checks pass; Elenchus and Protasis retain their prior revision, digest, status and held target while advancing generation only. | clean |
+
+### Evidence
+
+The review read the complete diff from entry commit
+`454bf3c9930c94985e5eb6179f3b01be2bf741c2` through pre-round head
+`3b394541599f48607edc28b6a2606a998de55b3d`. It reproduced both fixed faults
+directly from their signed parents. On `b8acf611`, replacing the missing report
+parent with an outside symlink created the report outside the worktree. On
+`0eacf593`, closing the retained root descriptor and reopening an outside
+directory into the same slot created the nested report outside.
+
+The fixed tree's ten report-adapter cases pass, including both prior faults,
+cwd rebinding, partial writes, fresh-target enforcement and the named
+unsupported-operation refusal. A separate root-replacement probe moved the
+recorded worktree aside, created a new directory at its path and observed
+`report worktree identity changed`; neither directory received a report.
+
+Under pinned Node v26.6.0, the Elenchus/Fiat/Protasis focus passes 155/155. The
+exact runbook report command passes 862/862 in 149.917 seconds. Its 161-byte,
+mode-0600 JSON object records `testsRun: 862`, zero failures, zero errors and
+schema `elenchus.unittest.v1`; its SHA-256 is
+`7f51f15b8bb35b792c348e247f85461d3f4074f41348a6fdbd64417820a4db43`.
+The generated report was removed after inspection.
+
+The root suite passes 118/118. The focused runner plus evolution/version gate
+passes 24/24. Promise Machine verification, both Protasis checks, the Horos
+boundary check, all three active-plugin lints and `git diff --check` exit 0.
+
+### Leads not pursued
+
+Leads not pursued: issue 429's audit schema, issue 453's evidence binding and
+production `guarded` gate, Fiat's step-2 controller field, and hostile
+background threads with the runner's own operating-system authority. The
+receipted runbook's extra terminal byte remains the round-1 recorded artefact
+discrepancy: the tracked copy removes only that final blank line so
+`git diff --check` can pass. Round 3 does not rewrite either source.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8873,3 +8873,84 @@ custom-loader proofs; the accepted pragma-in-string quirk; and Python file-size
 policy. Cross-scope YAML module and loader aliases can retain source-local
 trust for an actual `yaml.load` call. The receipted study excludes that scope,
 so changing it would require an amendment rather than an audit-side widening.
+
+## Elenchus audit-round verdict, step 1, round 1 -- 2026-08-22
+
+### Suite disposition
+
+The controller waiver is exact: `waived: issue 327 changes Python controller
+state, Elenchus integration, tests, and governed prose; it has no Solidity
+target`. No `.sol` path appears in `454bf3c..b8acf611` or the stacked fix.
+X-Ray, Solidity Auditor and Fizz did not run. The active-plugin Phylax,
+Ephoros and Hypomnema lints each exit 0 on their repository scopes.
+
+### Finding table
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R1-01 | medium | `plugins/hexaemeron/tests/run_tests.py:13` | Report containment was checked before arbitrary tests ran, but the later write reused a relative path and followed ancestor components. A test could change the process directory or replace a validated parent with a symlink, redirecting the report outside the worktree. | fixed; manual guard red, Elenchus verdict `passed` |
+| S1-R1-review | none | full `454bf3c..b8acf611` diff plus stacked fix | No other report-schema, exit-semantics, source-contract or path-control finding was confirmed. | clean |
+| S1-R1-records | none | study, runbook and generation rows | The three governed frontiers and their held targets retain the prior revision and digest. The tracked artifact differences are recorded below. | clean |
+
+Finding count: 1.
+
+### Risk coverage
+
+| risk id | evidence checked | disposition |
+| --- | --- | --- |
+| `fix-claim-confusion` | Step 1 does not change `audit-round`; the study keeps `--fixes-commit` as the only machine fix claim for step 2. | reviewed; not applicable to this step's code |
+| `enum-drift` | The Elenchus classifier and its four result strings are unchanged; report fixtures retain the exact unittest schema. | clean |
+| `command-substitution` | The runbook owns the exact command/report triplet. The runner parses one path and never evaluates it through a shell. | clean |
+| `legacy-round-breakage` | Step 1 changes no Fiat state reader or writer. Legacy-round fixtures belong to step 2. | reviewed; not applicable |
+| `receipt-overclaim` | The Elenchus contract calls the future field a declaration and says it does not attest report bytes or command execution. | clean |
+| `downstream-loss` | Step 1 adds no issue 429 schema or issue 369 synopsis path. Both remain named dependent work. | reviewed; not applicable |
+| `frontier-drift` | `elenchus-v1.2.0` and `protasis-v4.6.0` advance generation only; prior frontier revision, digest, status and target bytes are retained. | clean |
+
+### Evidence
+
+The review read the complete eight-path diff from
+`454bf3c9930c94985e5eb6179f3b01be2bf741c2` through
+`b8acf61151b60484a8477786ef5a7f0c2b9c6035`. The reduced cwd-rebinding and
+parent-symlink cases both failed on that unfixed head. The first wrote the
+relative report under the suite-selected directory; the second returned 0
+after creating the report through the outside symlink.
+
+The fix pins the resolved worktree with a directory descriptor, opens or
+creates every report-parent component relative to that descriptor with
+`O_NOFOLLOW`, and creates the final file with `O_EXCL`. Short writes continue
+until complete; an error removes only the inode this invocation created.
+Eight focused runner-result cases pass, including cwd rebinding, ancestor
+replacement, dangling targets and a forced partial write.
+
+The exact runbook Elenchus invocation under pinned Node v26.6.0 returns
+`passed`: 860 executed tests, zero assertion failures and zero errors. This is
+not mechanical red-parent evidence. `changed_tests()` classifies both changed
+paths under `plugins/hexaemeron/tests/` as tests, so it overlays the fixed
+`run_tests.py` beside the new guards on the parent. The two focused manual red
+runs above remain separate evidence and the recorded verdict is not relabeled.
+
+Under pinned Node v26.6.0, the focused Elenchus/Fiat/Protasis suite passes
+153/153 and the full Hexaemeron suite passes 860/860. The root suite passes
+118/118. Both Protasis checks, the three active-plugin lints and
+`git diff --check` exit 0. The unwrapped focused command reaches host Node
+v22.22.3 and fails only the fixture's exact v26.6.0 assertion; it is recorded
+as environment evidence, not a green gate.
+
+The receipted study hashes to
+`06f8e81b95c7ceba26ada998fe62b57a87d9afa3eea10a31813862842851abe0`.
+Its tracked copy changes only five links to remain relative to the committed
+directory. The receipted runbook hashes to
+`82f1952def5d8658c2c8207d4c170632c0f14180cf8e5a554f980a85b7bf6f85`;
+the tracked copy removes one terminal blank line after the exact copy failed
+`git diff --check`.
+
+### Leads not pursued
+
+Leads not pursued: issue 429's audit schema, issue 453's evidence binding and
+production `guarded` gate, and Fiat's step-2 controller field. Tests run with
+the caller's operating-system authority and can write elsewhere directly;
+this fix establishes only that the report writer does not redirect its own
+declared output. Mechanical red-parent classification for an implementation
+under a test directory remains an evidence discrepancy; changing Elenchus's
+test-file boundary is outside step 1, and issue 453 owns the blocking policy.
+No further step-1 lead remained after the full diff review.

--- a/plugins/hexaemeron/tests/run_tests.py
+++ b/plugins/hexaemeron/tests/run_tests.py
@@ -11,7 +11,7 @@ import unittest
 
 
 def report_target(argv):
-    """Parse one fresh report path contained by the current worktree."""
+    """Parse one fresh report path and pin its worktree directory."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--elenchus-report",
@@ -29,11 +29,33 @@ def report_target(argv):
     raw = values[0]
     if not raw or "\x00" in raw:
         parser.error("--elenchus-report requires a non-empty path")
-    target = Path(raw)
-    try:
-        target.resolve(strict=False).relative_to(Path.cwd().resolve())
-    except (OSError, ValueError):
+    supplied = Path(raw)
+    if ".." in supplied.parts:
         parser.error("--elenchus-report must stay inside the current worktree")
+    try:
+        cwd = Path.cwd()
+        root = cwd.resolve(strict=True)
+        lexical_target = supplied if supplied.is_absolute() else cwd / supplied
+        if lexical_target.is_symlink():
+            parser.error("--elenchus-report target must not already exist")
+        target = (
+            supplied if supplied.is_absolute() else root / supplied
+        ).resolve(strict=False)
+        relative = target.relative_to(root)
+    except (OSError, RuntimeError, ValueError):
+        parser.error("--elenchus-report must stay inside the current worktree")
+
+    current = root
+    for part in relative.parts[:-1]:
+        current /= part
+        try:
+            current_stat = current.lstat()
+        except FileNotFoundError:
+            break
+        except OSError:
+            parser.error("--elenchus-report cannot be inspected")
+        if not stat.S_ISDIR(current_stat.st_mode):
+            parser.error("--elenchus-report parent is not a directory")
     try:
         existing = target.lstat()
     except FileNotFoundError:
@@ -43,15 +65,32 @@ def report_target(argv):
     if existing is not None:
         parser.error("--elenchus-report target must not already exist")
 
-    ancestor = target.parent
-    while not ancestor.exists() and ancestor != ancestor.parent:
-        ancestor = ancestor.parent
+    required = (os.open, os.mkdir, os.stat, os.unlink)
+    if (
+        not hasattr(os, "O_DIRECTORY")
+        or not hasattr(os, "O_NOFOLLOW")
+        or any(operation not in os.supports_dir_fd for operation in required)
+        or os.stat not in os.supports_follow_symlinks
+    ):
+        parser.error("--elenchus-report requires secure directory operations")
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
     try:
-        if not ancestor.is_dir():
-            parser.error("--elenchus-report parent is not a directory")
+        root_stat = root.stat()
+        root_fd = os.open(root, directory_flags)
     except OSError:
-        parser.error("--elenchus-report parent cannot be inspected")
-    return target
+        parser.error("--elenchus-report worktree cannot be opened")
+    try:
+        opened_stat = os.fstat(root_fd)
+    except OSError:
+        os.close(root_fd)
+        parser.error("--elenchus-report worktree cannot be inspected")
+    if (opened_stat.st_dev, opened_stat.st_ino) != (
+        root_stat.st_dev,
+        root_stat.st_ino,
+    ):
+        os.close(root_fd)
+        parser.error("--elenchus-report worktree changed during inspection")
+    return root_fd, relative.parts
 
 
 def result_payload(result):
@@ -68,49 +107,102 @@ def result_payload(result):
     }
 
 
-def write_report(target, payload):
-    """Create the declared report without following or replacing a path."""
-    target.parent.mkdir(parents=True, exist_ok=True)
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
-    descriptor = os.open(target, flags, 0o600)
+def report_parent(root_fd, parts):
+    """Open or create report directories without following a symlink."""
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    current_fd = os.dup(root_fd)
     try:
-        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+        for part in parts:
+            try:
+                next_fd = os.open(part, flags, dir_fd=current_fd)
+            except FileNotFoundError:
+                try:
+                    os.mkdir(part, 0o700, dir_fd=current_fd)
+                except FileExistsError:
+                    pass
+                next_fd = os.open(part, flags, dir_fd=current_fd)
+            os.close(current_fd)
+            current_fd = next_fd
+        return current_fd
+    except OSError:
+        os.close(current_fd)
+        raise
+
+
+def remove_created_report(parent_fd, name, created):
+    """Remove a failed write only while the target is still our inode."""
+    try:
+        current = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError:
+        return
+    if (current.st_dev, current.st_ino) != (created.st_dev, created.st_ino):
+        return
+    try:
+        os.unlink(name, dir_fd=parent_fd)
+    except OSError:
+        pass
+
+
+def write_report(target, payload):
+    """Create the declared report through its pinned worktree descriptor."""
+    root_fd, parts = target
+    if not parts:
+        raise OSError("report path has no filename")
+    parent_fd = report_parent(root_fd, parts[:-1])
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    flags |= os.O_NOFOLLOW
+    descriptor = None
+    created = None
+    try:
+        descriptor = os.open(parts[-1], flags, 0o600, dir_fd=parent_fd)
+        created = os.fstat(descriptor)
+        if not stat.S_ISREG(created.st_mode):
             raise OSError("report target is not a regular file")
         body = (json.dumps(payload, sort_keys=True) + "\n").encode("utf-8")
-        with os.fdopen(descriptor, "wb") as output:
-            descriptor = None
-            output.write(body)
+        remaining = memoryview(body)
+        while remaining:
+            written = os.write(descriptor, remaining)
+            if written <= 0:
+                raise OSError("report write made no progress")
+            remaining = remaining[written:]
+        os.close(descriptor)
+        descriptor = None
     except OSError:
         if descriptor is not None:
-            os.close(descriptor)
-        try:
-            target.unlink()
-        except OSError:
-            pass
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        if created is not None:
+            remove_created_report(parent_fd, parts[-1], created)
         raise
+    finally:
+        os.close(parent_fd)
 
 
 def main(argv=None):
     """Run the suite, optionally emit its report, and preserve suite exits."""
     target = report_target(sys.argv[1:] if argv is None else argv)
-    here = os.path.dirname(os.path.abspath(__file__))
-    suite = unittest.defaultTestLoader.discover(here, pattern="test_*.py")
-    runner = unittest.TextTestRunner(verbosity=1)
-    result = runner.run(suite)
-    total = result.testsRun
-    failed = len(result.failures) + len(result.errors)
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        suite = unittest.defaultTestLoader.discover(here, pattern="test_*.py")
+        runner = unittest.TextTestRunner(verbosity=1)
+        result = runner.run(suite)
+        total = result.testsRun
+        failed = len(result.failures) + len(result.errors)
 
-    if target is not None:
-        try:
-            write_report(target, result_payload(result))
-        except OSError:
-            print("run_tests.py: report write failed", file=sys.stderr)
-            return 2
+        if target is not None:
+            try:
+                write_report(target, result_payload(result))
+            except OSError:
+                print("run_tests.py: report write failed", file=sys.stderr)
+                return 2
 
-    print(f"{total - failed}/{total} tests passed")
-    return 1 if failed else 0
+        print(f"{total - failed}/{total} tests passed")
+        return 1 if failed else 0
+    finally:
+        if target is not None:
+            os.close(target[0])
 
 
 if __name__ == "__main__":

--- a/plugins/hexaemeron/tests/run_tests.py
+++ b/plugins/hexaemeron/tests/run_tests.py
@@ -11,7 +11,7 @@ import unittest
 
 
 def report_target(argv):
-    """Parse one fresh report path and pin its worktree directory."""
+    """Parse one fresh report path and bind its worktree identity."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--elenchus-report",
@@ -65,32 +65,43 @@ def report_target(argv):
     if existing is not None:
         parser.error("--elenchus-report target must not already exist")
 
-    required = (os.open, os.mkdir, os.stat, os.unlink)
-    if (
-        not hasattr(os, "O_DIRECTORY")
-        or not hasattr(os, "O_NOFOLLOW")
-        or any(operation not in os.supports_dir_fd for operation in required)
-        or os.stat not in os.supports_follow_symlinks
+    missing = []
+    for name in ("O_DIRECTORY", "O_NOFOLLOW"):
+        if not hasattr(os, name):
+            missing.append(f"os.{name}")
+    supports_dir_fd = getattr(os, "supports_dir_fd", ())
+    for operation, name in (
+        (os.open, "os.open(dir_fd)"),
+        (os.mkdir, "os.mkdir(dir_fd)"),
+        (os.stat, "os.stat(dir_fd)"),
+        (os.unlink, "os.unlink(dir_fd)"),
     ):
-        parser.error("--elenchus-report requires secure directory operations")
+        if operation not in supports_dir_fd:
+            missing.append(name)
+    supports_follow_symlinks = getattr(os, "supports_follow_symlinks", ())
+    if os.stat not in supports_follow_symlinks:
+        missing.append("os.stat(follow_symlinks)")
+    if missing:
+        parser.error(
+            "--elenchus-report requires secure directory operations: "
+            + ", ".join(missing)
+        )
     directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
     try:
         root_stat = root.stat()
         root_fd = os.open(root, directory_flags)
+        try:
+            opened_stat = os.fstat(root_fd)
+        finally:
+            os.close(root_fd)
     except OSError:
-        parser.error("--elenchus-report worktree cannot be opened")
-    try:
-        opened_stat = os.fstat(root_fd)
-    except OSError:
-        os.close(root_fd)
-        parser.error("--elenchus-report worktree cannot be inspected")
+        parser.error("--elenchus-report worktree cannot be opened and inspected")
     if (opened_stat.st_dev, opened_stat.st_ino) != (
         root_stat.st_dev,
         root_stat.st_ino,
     ):
-        os.close(root_fd)
         parser.error("--elenchus-report worktree changed during inspection")
-    return root_fd, relative.parts
+    return root, (opened_stat.st_dev, opened_stat.st_ino), relative.parts
 
 
 def result_payload(result):
@@ -129,6 +140,20 @@ def report_parent(root_fd, parts):
         raise
 
 
+def report_root(root, identity):
+    """Reopen the bound worktree and refuse a replaced directory."""
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    descriptor = os.open(root, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if (opened.st_dev, opened.st_ino) != identity:
+            raise OSError("report worktree identity changed")
+        return descriptor
+    except OSError:
+        os.close(descriptor)
+        raise
+
+
 def remove_created_report(parent_fd, name, created):
     """Remove a failed write only while the target is still our inode."""
     try:
@@ -144,65 +169,64 @@ def remove_created_report(parent_fd, name, created):
 
 
 def write_report(target, payload):
-    """Create the declared report through its pinned worktree descriptor."""
-    root_fd, parts = target
+    """Create the declared report through its bound worktree identity."""
+    root, identity, parts = target
     if not parts:
         raise OSError("report path has no filename")
-    parent_fd = report_parent(root_fd, parts[:-1])
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-    flags |= os.O_NOFOLLOW
-    descriptor = None
-    created = None
+    root_fd = report_root(root, identity)
     try:
-        descriptor = os.open(parts[-1], flags, 0o600, dir_fd=parent_fd)
-        created = os.fstat(descriptor)
-        if not stat.S_ISREG(created.st_mode):
-            raise OSError("report target is not a regular file")
-        body = (json.dumps(payload, sort_keys=True) + "\n").encode("utf-8")
-        remaining = memoryview(body)
-        while remaining:
-            written = os.write(descriptor, remaining)
-            if written <= 0:
-                raise OSError("report write made no progress")
-            remaining = remaining[written:]
-        os.close(descriptor)
+        parent_fd = report_parent(root_fd, parts[:-1])
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
         descriptor = None
-    except OSError:
-        if descriptor is not None:
-            try:
-                os.close(descriptor)
-            except OSError:
-                pass
-        if created is not None:
-            remove_created_report(parent_fd, parts[-1], created)
-        raise
+        created = None
+        try:
+            descriptor = os.open(parts[-1], flags, 0o600, dir_fd=parent_fd)
+            created = os.fstat(descriptor)
+            if not stat.S_ISREG(created.st_mode):
+                raise OSError("report target is not a regular file")
+            body = (json.dumps(payload, sort_keys=True) + "\n").encode("utf-8")
+            remaining = memoryview(body)
+            while remaining:
+                written = os.write(descriptor, remaining)
+                if written <= 0:
+                    raise OSError("report write made no progress")
+                remaining = remaining[written:]
+            os.close(descriptor)
+            descriptor = None
+        except OSError:
+            if descriptor is not None:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+            if created is not None:
+                remove_created_report(parent_fd, parts[-1], created)
+            raise
+        finally:
+            os.close(parent_fd)
     finally:
-        os.close(parent_fd)
+        os.close(root_fd)
 
 
 def main(argv=None):
     """Run the suite, optionally emit its report, and preserve suite exits."""
     target = report_target(sys.argv[1:] if argv is None else argv)
-    try:
-        here = os.path.dirname(os.path.abspath(__file__))
-        suite = unittest.defaultTestLoader.discover(here, pattern="test_*.py")
-        runner = unittest.TextTestRunner(verbosity=1)
-        result = runner.run(suite)
-        total = result.testsRun
-        failed = len(result.failures) + len(result.errors)
+    here = os.path.dirname(os.path.abspath(__file__))
+    suite = unittest.defaultTestLoader.discover(here, pattern="test_*.py")
+    runner = unittest.TextTestRunner(verbosity=1)
+    result = runner.run(suite)
+    total = result.testsRun
+    failed = len(result.failures) + len(result.errors)
 
-        if target is not None:
-            try:
-                write_report(target, result_payload(result))
-            except OSError:
-                print("run_tests.py: report write failed", file=sys.stderr)
-                return 2
+    if target is not None:
+        try:
+            write_report(target, result_payload(result))
+        except OSError:
+            print("run_tests.py: report write failed", file=sys.stderr)
+            return 2
 
-        print(f"{total - failed}/{total} tests passed")
-        return 1 if failed else 0
-    finally:
-        if target is not None:
-            os.close(target[0])
+    print(f"{total - failed}/{total} tests passed")
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":

--- a/plugins/hexaemeron/tests/test_elenchus_checker.py
+++ b/plugins/hexaemeron/tests/test_elenchus_checker.py
@@ -620,6 +620,77 @@ class HexaemeronUnittestReport(unittest.TestCase):
         self.assertTrue((root / "result.json").is_file())
         self.assertFalse((outside_root / "result.json").exists())
 
+    def test_suite_cannot_rebind_a_saved_report_root_descriptor(self):
+        outside = tempfile.TemporaryDirectory(prefix="hexaemeron-fd-outside-")
+        outside_root = Path(outside.name)
+        temporary, root = self.fixture("import unittest\n")
+        self.addCleanup(temporary.cleanup)
+        self.addCleanup(outside.cleanup)
+        fixture = root / "test_fixture.py"
+        fixture.write_text(
+            "import os\n"
+            "from pathlib import Path\n"
+            "import unittest\n\n"
+            f"worktree = Path({str(root)!r})\n"
+            f"outside = Path({str(outside_root)!r})\n"
+            "identity = worktree.stat()\n"
+            "for candidate in range(3, 256):\n"
+            "    try:\n"
+            "        opened = os.fstat(candidate)\n"
+            "    except OSError:\n"
+            "        continue\n"
+            "    if (opened.st_dev, opened.st_ino) == "
+            "(identity.st_dev, identity.st_ino):\n"
+            "        os.close(candidate)\n"
+            "        replacement = os.open(\n"
+            "            outside, os.O_RDONLY | os.O_DIRECTORY\n"
+            "        )\n"
+            "        if replacement != candidate:\n"
+            "            raise AssertionError('descriptor slot was not reused')\n"
+            "        break\n\n"
+            "class Pass(unittest.TestCase):\n"
+            "    def test_pass(self): self.assertTrue(True)\n",
+            encoding="utf-8",
+        )
+        report = root / "nested" / "result.json"
+
+        result = self.run_runner(root, "--elenchus-report", str(report))
+
+        self.assertEqual(0, result.returncode)
+        self.assertTrue(report.is_file())
+        self.assertFalse((outside_root / "nested" / "result.json").exists())
+
+    def test_unsupported_directory_operations_are_named_before_tests(self):
+        temporary, root = self.fixture(
+            "raise AssertionError('the suite must not run')\n"
+        )
+        self.addCleanup(temporary.cleanup)
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(hexaemeron_runner.Path, "cwd", return_value=root),
+            mock.patch.object(
+                hexaemeron_runner.os, "supports_dir_fd", set()
+            ),
+            mock.patch.object(
+                hexaemeron_runner.os, "supports_follow_symlinks", set()
+            ),
+            contextlib.redirect_stderr(stderr),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            hexaemeron_runner.main(
+                ["--elenchus-report", str(root / "result.json")]
+            )
+
+        self.assertEqual(2, raised.exception.code)
+        for name in (
+            "os.open(dir_fd)",
+            "os.mkdir(dir_fd)",
+            "os.stat(dir_fd)",
+            "os.unlink(dir_fd)",
+            "os.stat(follow_symlinks)",
+        ):
+            self.assertIn(name, stderr.getvalue())
+
     def test_report_write_failure_has_a_distinct_exit_and_no_report(self):
         with tempfile.TemporaryDirectory(prefix="hexaemeron-write-failure-") as root:
             report = Path(root) / "report.json"

--- a/plugins/hexaemeron/tests/test_elenchus_checker.py
+++ b/plugins/hexaemeron/tests/test_elenchus_checker.py
@@ -560,11 +560,14 @@ class HexaemeronUnittestReport(unittest.TestCase):
         original.write_text("keep\n", encoding="utf-8")
         symlink = root / "report-link"
         symlink.symlink_to(original)
+        dangling = root / "dangling-link"
+        dangling.symlink_to(root / "missing")
 
         for name, target in (
             ("directory", directory),
             ("regular", original),
             ("symlink", symlink),
+            ("dangling-symlink", dangling),
         ):
             with self.subTest(name=name):
                 result = self.run_runner(
@@ -573,6 +576,49 @@ class HexaemeronUnittestReport(unittest.TestCase):
                 self.assertEqual(2, result.returncode)
 
         self.assertEqual("keep\n", original.read_text(encoding="utf-8"))
+
+    def test_suite_cannot_redirect_report_through_replaced_parent(self):
+        outside = tempfile.TemporaryDirectory(prefix="hexaemeron-report-outside-")
+        outside_root = Path(outside.name)
+        temporary, root = self.fixture("import unittest\n")
+        self.addCleanup(temporary.cleanup)
+        self.addCleanup(outside.cleanup)
+        fixture = root / "test_fixture.py"
+        fixture.write_text(
+            "from pathlib import Path\n"
+            "import unittest\n\n"
+            f"report_parent = Path({str(root / 'reports')!r})\n"
+            f"report_parent.symlink_to(Path({str(outside_root)!r}), "
+            "target_is_directory=True)\n\n"
+            "class Pass(unittest.TestCase):\n"
+            "    def test_pass(self): self.assertTrue(True)\n",
+            encoding="utf-8",
+        )
+        report = root / "reports" / "result.json"
+
+        result = self.run_runner(root, "--elenchus-report", str(report))
+
+        self.assertEqual(2, result.returncode)
+        self.assertFalse((outside_root / "result.json").exists())
+
+    def test_relative_report_stays_anchored_when_suite_changes_cwd(self):
+        outside = tempfile.TemporaryDirectory(prefix="hexaemeron-cwd-outside-")
+        outside_root = Path(outside.name)
+        temporary, root = self.fixture(
+            "import os\n"
+            "import unittest\n\n"
+            f"os.chdir({str(outside_root)!r})\n\n"
+            "class Pass(unittest.TestCase):\n"
+            "    def test_pass(self): self.assertTrue(True)\n"
+        )
+        self.addCleanup(temporary.cleanup)
+        self.addCleanup(outside.cleanup)
+
+        result = self.run_runner(root, "--elenchus-report", "result.json")
+
+        self.assertEqual(0, result.returncode)
+        self.assertTrue((root / "result.json").is_file())
+        self.assertFalse((outside_root / "result.json").exists())
 
     def test_report_write_failure_has_a_distinct_exit_and_no_report(self):
         with tempfile.TemporaryDirectory(prefix="hexaemeron-write-failure-") as root:
@@ -604,6 +650,46 @@ class HexaemeronUnittestReport(unittest.TestCase):
             self.assertEqual(2, exit_code)
             self.assertFalse(report.exists())
             self.assertIn("report write failed", stderr.getvalue())
+
+    def test_partial_report_write_is_removed_before_failure_returns(self):
+        with tempfile.TemporaryDirectory(prefix="hexaemeron-partial-write-") as root:
+            report = Path(root) / "report.json"
+            suite = unittest.TestSuite([unittest.FunctionTestCase(lambda: None)])
+            real_write = os.write
+            writes = 0
+
+            def short_then_fail(descriptor, body):
+                nonlocal writes
+                writes += 1
+                if writes == 1:
+                    return real_write(descriptor, body[: max(1, len(body) // 2)])
+                raise OSError("write blocked")
+
+            with (
+                mock.patch.object(
+                    hexaemeron_runner.unittest.defaultTestLoader,
+                    "discover",
+                    return_value=suite,
+                ),
+                mock.patch.object(
+                    hexaemeron_runner.os,
+                    "write",
+                    side_effect=short_then_fail,
+                ),
+                mock.patch.object(
+                    hexaemeron_runner.Path,
+                    "cwd",
+                    return_value=Path(root),
+                ),
+                contextlib.redirect_stderr(io.StringIO()),
+            ):
+                exit_code = hexaemeron_runner.main(
+                    ["--elenchus-report", str(report)]
+                )
+
+            self.assertEqual(2, exit_code)
+            self.assertEqual(2, writes)
+            self.assertFalse(report.exists())
 
 
 class LaunchFailures(RunnerCase):


### PR DESCRIPTION

This audit-fix review belongs to [issue 327](https://github.com/wildcat-finance/skills/issues/327)
and targets the step branch
`fiat/327-elenchus-2-feed-the-guard-verdict-into-fiat-step-1-bind-the-runbook-test-command-to`.

## what changed

Round 1 found that the runner validated a report path before arbitrary tests,
then followed its relative ancestors later. The fix moved report creation to
owned directory descriptors with `O_NOFOLLOW`, `O_EXCL`, complete short-write
handling, and inode-checked cleanup.

Round 2 found that a test could close the long-lived root descriptor and
reopen an outside directory in the same numeric slot. The runner now closes
the descriptor before tests, reopens the canonical worktree afterwards, and
checks its `(st_dev, st_ino)` identity before writing. The same round changed
the unsupported-host refusal to name every missing secure-directory primitive.

Round 3 reproduced both parent faults, refused them on the fixed tree, checked
worktree replacement, and found nothing else. The complete record is under
`Elenchus audit-round verdict` in `audit/AUDIT.md`.

## evidence boundary

| round | reviewed range | result |
| --- | --- | --- |
| 1 | `454bf3c9930c94985e5eb6179f3b01be2bf741c2..b8acf61151b60484a8477786ef5a7f0c2b9c6035` | 1 medium; fixed in `0eacf5936971de026dd3080b92450e49555f7d93`; both manual guards red; Elenchus `passed` |
| 2 | `454bf3c9930c94985e5eb6179f3b01be2bf741c2..cc984ba840d45105a20479331cec8622fc38fbe2` | 1 medium and 1 low; fixed in `cc984ba840d45105a20479331cec8622fc38fbe2`; both manual guards red; Elenchus `passed` |
| 3 | `454bf3c9930c94985e5eb6179f3b01be2bf741c2..3b394541599f48607edc28b6a2606a998de55b3d` | 0 findings; clean record committed as `72309e099b5d410a8eee9390f4f6adf8cfa0a729` |

The mechanical `passed` verdict isn't red-parent evidence. The manual guards
establish the two parent failures separately. This review doesn't claim that
the report bytes were attested or that in-process tests lack the runner's
operating-system authority.

## proof

```bash
python3.12 -m unittest \
  plugins.hexaemeron.tests.test_elenchus_checker \
  plugins.hexaemeron.tests.test_fiat_skill \
  plugins.hexaemeron.tests.test_protasis_checker -q
npx --yes --package=node@26.6.0 --call \
  'python3.12 plugins/hexaemeron/tests/run_tests.py'
python3.12 -m unittest discover -s tests
```

The fixed tree passes 155/155 focused tests, 862/862 Hexaemeron tests under
pinned Node v26.6.0, and 118/118 root tests. Phylax, Ephoros, and Hypomnema
each exited 0 on their repository scopes in the closing round.

<!-- wildcat-origin: shoggoth -->