### PR TITLE
audit: verify the issue 327 legacy and release proof

### DIFF
--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -9315,3 +9315,78 @@ Elenchus result; issue 453 owns any later blocking policy. Issues 429, 369, 453
 and 363 remain open downstream work. The clean replay now depends only on
 tracked release bytes and its configured signing key. No further step-3 lead
 remained after the repair.
+
+## Elenchus audit-round verdict, step 3, round 3 -- 2026-08-22
+
+### Suite disposition
+
+The controller waiver remains exact: `waived: issue 327 changes Python
+controller state, Elenchus integration, tests, and governed prose; it has no
+Solidity target`. No Solidity path changed. X-Ray, Solidity Auditor and Fizz
+did not run. The active-plugin Phylax, Ephoros and Hypomnema lints each exit 0.
+
+### Finding table
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R3-review | none | full `024a64d9..017a7418` step diff | No proof, source-bound packet, legacy-reader, release, cleanup, trailer-scope or record fault was confirmed. | clean |
+| S3-R3-proof | none | `plugins/hexaemeron/docs/elenchus-audit-round-verdict/proof.md` | The concatenated replay succeeds from a clean detached checkout with no active Fiat state and leaves that checkout clean. | clean |
+| S3-R3-round2 | none | `27f78d96` and round 2 log | Both round-2 findings are fixed, the fix is signed with the two exact final provenance lines, and its exact Elenchus result is `unguarded`. | clean |
+
+Finding count: 0. This round has no fixes commit and therefore no Elenchus
+verdict.
+
+### Risk coverage
+
+| risk id | evidence checked | disposition |
+| --- | --- | --- |
+| `fix-claim-confusion` | The clean replay requires a verdict only beside a non-empty verified fix range. Missing, unbound and unknown values each exit 2 without changing state or ledger bytes. | clean |
+| `enum-drift` | State and ledger retain explicit null, a missing legacy key, and the four distinct values `guarded`, `unguarded`, `passed` and `inconclusive`. | clean |
+| `command-substitution` | The replay reads tracked study and runbook files, reconstructs the receipted terminal newline, checks the full runbook digest and requires equal five-field Mason and Warden step packets. | clean |
+| `legacy-round-breakage` | The replay repairs the state fingerprint and ledger tail after removing both keys, then requires `status`, `next`, `verify`, a later fix round, audit close and final phase `prose`. | clean |
+| `receipt-overclaim` | Fixed hashes cover stable source bytes. Generated packet, state, ledger and commit hashes stay run-local, and no recorded verdict is called report-byte attestation. | clean |
+| `downstream-loss` | The proof preserves every accepted value independently. The step diff changes no issue 429, 369, 453 or 363 owned surface. | clean |
+| `frontier-drift` | The 14 evolution/version checks pass. Elenchus, Fiat and Protasis retain their prior frontier digests and Hexaemeron package surfaces agree on `1.5.5`. | clean |
+
+### Evidence
+
+A detached checkout at `017a74189b15b95af72d16c79c48ec07730b7e7e`
+started without `.hexaemeron`. The proof's concatenated Bash blocks exited 0,
+asserted the three refusal cases independently, exercised null and missing-key
+rounds, stored all four verdicts, verified each single-commit range, closed the
+audit and removed the generated boundary. The checkout had no tracked change
+or untracked file afterward. The proof and study blobs at `27f78d96` equal
+their current-head blobs, so the replay covers the round-2 fix rather than a
+later rewrite.
+
+The proof scopes its trailer claim to the receipted implementation and four
+fix commits. Its executable check requires each message to end in one exact
+copy of both consecutive provenance lines and requires `git verify-commit` to
+exit 0. The delivery's five commits from `1ad770c2` through `017a7418` also
+have valid local signatures and the same two final lines. Running the exact
+runbook Elenchus invocation on signed fix `27f78d96` returns `unguarded`
+because that commit changes no test file.
+
+Under pinned Node v26.6.0, the full Hexaemeron suite passes 872/872 in 158.756
+seconds. The root suite passes 118/118, Imprimatur's suite passes 62/62, and
+the evolution/version gate passes 14/14. Promise Machine verification, both
+Protasis checks, the Horos boundary check, all three active-plugin lints and
+`git diff --check` exit 0. The current proof and this step's audit additions
+pass Imprimatur and Brevitas.
+
+The committed study's 888-byte amendment hashes to
+`51e378a68b0c39a59b8ba0051b35a8b8ecc6a691446c5862bfbe34eae095debb`.
+The tracked runbook is 11,429 bytes; one terminal newline reconstructs the
+11,430-byte receipted file and SHA-256
+`82f1952def5d8658c2c8207d4c170632c0f14180cf8e5a554f980a85b7bf6f85`.
+The controller source hashes to
+`01efd29fcc0b1198aa62989291c1dbe4713d7c26cccbba40a1fbe4b210884870`,
+matching the three Fiat runtime bindings checked by Promise Machine.
+
+### Leads not pursued
+
+Leads not pursued: `unguarded` is the expected exact result for the
+documentation-only round-2 fix, and issue 453 owns any later blocking policy.
+Issues 429, 369, 453 and 363 remain separately owned downstream work. The
+checked proof needs Python 3.12, the named shell tools and a configured signing
+key; none is hidden in active Fiat state. No further step-3 lead remained.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -9244,3 +9244,74 @@ Issues 429, 369, 453 and 363 remain open downstream work. Historical run-local
 hashes are not retained as evidence after their bytes are deleted; the replay
 instead proves the relations that carry the acceptance claim. No further
 step-3 lead remained.
+
+## Elenchus audit-round verdict, step 3, round 2 -- 2026-08-22
+
+### Suite disposition
+
+The controller waiver remains exact: `waived: issue 327 changes Python
+controller state, Elenchus integration, tests, and governed prose; it has no
+Solidity target`. No Solidity path changed. X-Ray, Solidity Auditor and Fizz
+did not run. The active-plugin Phylax, Ephoros and Hypomnema lints each exit 0.
+
+### Finding table
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R2-01 | medium | `plugins/hexaemeron/docs/elenchus-audit-round-verdict/proof.md:21` | The committed reproduction copied its study, runbook and step list from the active run's untracked `.hexaemeron` files and created its fixture below that pre-existing directory. A clean detached checkout failed before the demo began, so the durable proof depended on state removed by Fiat reset. | fixed in `27f78d96`; the replay now uses tracked study and runbook bytes, reconstructs the receipted terminal newline and step list, and creates then removes the ignored state directory when absent |
+| S3-R2-02 | low | `plugins/hexaemeron/docs/elenchus-audit-round-verdict/proof.md:83` | The prose said every proof-owned commit carried both provenance trailers, but the script's signed demo-base commit does not. The executable check covers the receipted implementation and four fix commits. | fixed in `27f78d96`; the claim now names only receipted implementation and fix commits |
+| S3-R2-review | none | full `024a64d9..27f78d96` step diff | No controller, receipt-schema, legacy-reader, release, cleanup or record fault remained after the proof repair. | clean |
+| S3-R2-round1 | none | round 1 log and `d55da516` | Round 1 records its two findings and `unguarded` verdict without claiming a guard. Its fix has a valid signature and the two exact final provenance lines. | clean |
+
+Finding count: 2.
+
+### Risk coverage
+
+| risk id | evidence checked | disposition |
+| --- | --- | --- |
+| `fix-claim-confusion` | The clean-checkout replay again requires a verdict only beside a non-empty signed fixes range. Each incomplete or unbound receipt exits 2 and independently preserves raw state and ledger bytes. | clean |
+| `enum-drift` | State and ledger assertions retain explicit null, a missing legacy key, and the four distinct values `guarded`, `unguarded`, `passed` and `inconclusive`. | clean |
+| `command-substitution` | Tracked runbook bytes hash to `a98c67bd`; appending the one recorded terminal newline reconstructs receipted SHA-256 `82f1952def5d8658c2c8207d4c170632c0f14180cf8e5a554f980a85b7bf6f85`. Repeated Mason and Warden packets carry the same five-field source block. This round used Step 3's command, `unittest-json-v1` format and report path for `27f78d96`. | clean |
+| `legacy-round-breakage` | The replay repairs the state fingerprint and ledger tail after omitting both keys, then requires `status`, round-2 `next`, `verify`, a later signed round, close, final `verify` and phase `prose`. | clean |
+| `receipt-overclaim` | Generated packet, state, ledger and demo-commit hashes remain run-local diagnostics. Fixed values bind only tracked source, receipted artefact, amendment and frontier bytes. The `unguarded` result remains a recorded declaration, not report-byte attestation. | clean |
+| `downstream-loss` | The replay retains all four values independently in state and ledger. The public GitHub issue pages showed 429, 369, 453 and 363 open on 2026-08-22; this step changes none of their owned surfaces. | clean |
+| `frontier-drift` | The 14 evolution/version checks pass. Elenchus, Fiat and Protasis retain frontier digests `08e77bae`, `e413d604` and `10140710`; both manifests and both marketplaces retain Hexaemeron `1.5.5`. | clean |
+
+### Evidence
+
+A clean detached checkout at `773fb670d72fde9e936d321f57779dbd056f06d0`
+had no `.hexaemeron` directory. The original concatenated Bash replay exited 1
+when `mktemp` could not create its child there. That failure localised the
+mechanism before the proof changed.
+
+Signed fix `27f78d96d2f1b1f91c9e60ab70ebe0fb338d3c71` reads only tracked
+delivery documents, checks their fixed hashes, recreates the receipted
+runbook's one missing newline, writes the three step titles, and scopes cleanup
+to the generated prefix below `.hexaemeron`. The same concatenated replay at
+that detached commit starts with no state directory, exits 0, leaves no state
+directory or symlink, and leaves the checkout clean. It asserts every refusal,
+null, legacy repair, verdict, verified range, adjacent parent, trailer,
+signature, close and final phase named by the runbook.
+
+The exact runbook Elenchus invocation on `27f78d96` returns `unguarded` because
+the fix changes no test file. Under pinned Node v26.6.0, the current-tree report
+command passes 872/872 in 156.409 seconds. Its 161-byte, mode-0600 JSON object
+records schema `elenchus.unittest.v1`, `testsRun: 872`, `complete: true`, and
+zero failures, errors, skips, expected failures or unexpected successes. Its
+SHA-256 is
+`f0b0d7a7b6943d3907c5b17bb97fc30274d7d68a42a59a4c9b462acd8692cad9`.
+The generated report was removed after inspection.
+
+The root suite passes 118/118, Imprimatur's suite passes 62/62, and the
+evolution/version gate passes 14/14. Promise Machine verification, both
+Protasis checks, the Horos boundary check, all three active-plugin lints,
+Imprimatur and Brevitas over this round and the fixed proof, and
+`git diff --check` exit 0.
+
+### Leads not pursued
+
+Leads not pursued: the fix is documentation-only, so `unguarded` is the exact
+Elenchus result; issue 453 owns any later blocking policy. Issues 429, 369, 453
+and 363 remain open downstream work. The clean replay now depends only on
+tracked release bytes and its configured signing key. No further step-3 lead
+remained after the repair.

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -9163,3 +9163,84 @@ and issue 363's delegation identity frontier. The installed v5.11.1 controller
 cannot emit step 2's new `runbook_step` field or receipt its verdict; this
 self-hosting round bound the receipted source manually and does not claim that
 the old controller recorded a field it lacks. No further step-2 lead remained.
+
+## Elenchus audit-round verdict, step 3, round 1 -- 2026-08-22
+
+### Suite disposition
+
+The controller waiver remains exact: `waived: issue 327 changes Python
+controller state, Elenchus integration, tests, and governed prose; it has no
+Solidity target`. No Solidity path changed. X-Ray, Solidity Auditor and Fizz
+did not run. The active-plugin Phylax, Ephoros and Hypomnema lints each exit 0.
+
+### Finding table
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S3-R1-01 | medium | `plugins/hexaemeron/docs/elenchus-audit-round-verdict/proof.md:13` | The proof deleted its disposable repository after publishing packet, state, ledger and commit hashes that depended on generated paths, timestamps and signing metadata. It retained no hashed bytes or complete definition of the hash inputs. A fresh reader had a behavioral replay with no way to verify those fixed values. | fixed in `d55da516`; replay now asserts within-run relations, prints run-local digests and fixes source-byte hashes across runs; Elenchus verdict `unguarded` |
+| S3-R1-02 | low | `plugins/hexaemeron/docs/elenchus-audit-round-verdict/proof.md:68` | The reproduction used a separate `git commit -m` paragraph for each required provenance trailer. Git inserted a blank line between them while the prose claimed consecutive final lines. | fixed in `d55da516`; one message paragraph carries both lines and the replay checks all five signed commits |
+| S3-R1-review | none | full `024a64d9..d55da516` step diff | No controller, schema, legacy-reader, release, boundary or record fault remained after the proof repair. | clean |
+| S3-R1-release | none | all mutable Hexaemeron release surfaces | Skill, package, marketplace, Promise coverage and frontier values agree. | clean |
+
+Finding count: 2.
+
+### Risk coverage
+
+| risk id | evidence checked | disposition |
+| --- | --- | --- |
+| `fix-claim-confusion` | The real controller demo ties the verdict obligation only to a non-empty signed fixes range. Each unbound or incomplete receipt exits 2 before state or ledger drift. | clean |
+| `enum-drift` | State and ledger assertions preserve `guarded`, `unguarded`, `passed` and `inconclusive` as four distinct values, plus explicit null and a missing legacy key. | clean |
+| `command-substitution` | Mason and Warden reconstruct the same five-field Step 1 source block from runbook SHA-256 `82f1952def5d8658c2c8207d4c170632c0f14180cf8e5a554f980a85b7bf6f85`. This round used Step 3's exact Python command, `unittest-json-v1` format and report path for `d55da516`. | clean |
+| `legacy-round-breakage` | The replay removes the key from state and ledger, repairs the canonical state fingerprint and ledger tail, then requires `status`, audit-round 2 `next`, `verify`, a later signed round, close and final `prose`. | clean |
+| `receipt-overclaim` | Run-local digests are labeled diagnostics, fixed hashes bind only stable source bytes, and the `unguarded` declaration is not called report-byte attestation. | clean |
+| `downstream-loss` | Official GitHub issue state still shows 429, 369, 453 and 363 open in that order. No downstream schema or gate changed; all four values remain available to them. | clean |
+| `frontier-drift` | Elenchus, Fiat and Protasis retain frontier digests `08e77bae`, `e413d604` and `10140710`; version tests pass 14/14 and Hexaemeron package surfaces agree on `1.5.5`. | clean |
+
+### Evidence
+
+The review read the complete step diff from parent
+`024a64d9265ca21551cfab4a969657e7cefef2ad` through implementation
+`1ad770c296621de55ad99f3368439c0c25fe67e9`, then repaired only the proof in
+signed commit `d55da516fcd652beddcad82219170079c5491129`. That commit has the two
+required consecutive provenance lines and a valid local signature.
+
+The final proof's Bash blocks replay clean as one script. They create a fresh
+repository, compare repeated Mason and Warden packets, require all three
+exit-2 refusals to preserve raw state and ledger bytes, assert explicit null,
+repair and exercise a missing-key legacy round, and record four sequential
+single-commit signed ranges. State and ledger both expose `missing`, `guarded`,
+`unguarded`, `passed` and `inconclusive` in order. Each range contains only its
+named head in `verified_commits`; close moves the step to `prose`; final
+`verify` succeeds. The cleanup checks the generated parent and prefix before
+removal, then proves the boundary is absent. No credential or raw signature
+bytes enter the record.
+
+The exact runbook Elenchus invocation on `d55da516` returns `unguarded` because
+the proof repair changes no test file. Under pinned Node v26.6.0, the exact
+runbook report command passes 872/872 in 157.807 seconds. Its fresh 161-byte,
+mode-0600 JSON object records schema `elenchus.unittest.v1`, `testsRun: 872`
+and zero failures or errors; SHA-256 is
+`f0b0d7a7b6943d3907c5b17bb97fc30274d7d68a42a59a4c9b462acd8692cad9`.
+The generated report was removed after inspection.
+
+The root suite passes 118/118, Imprimatur's suite passes 62/62, and the
+evolution/version gate passes 14/14. Promise Machine verification, both
+Protasis checks, all three active-plugin lints, the Horos boundary check,
+Imprimatur and Brevitas over the repaired proof, and `git diff --check` exit 0.
+
+The amended receipted study keeps its original bytes at
+`06f8e81b95c7ceba26ada998fe62b57a87d9afa3eea10a31813862842851abe0`
+and its exact 888-byte suffix at
+`51e378a68b0c39a59b8ba0051b35a8b8ecc6a691446c5862bfbe34eae095debb`.
+The committed copy changes only five links before the same suffix. The tracked
+runbook is exactly the receipted 11,430-byte file without its final byte, as
+already recorded.
+
+### Leads not pursued
+
+Leads not pursued: the exact Elenchus result is `unguarded`, as expected for a
+documentation-only fix; issue 453 owns any later policy that blocks that value.
+Issues 429, 369, 453 and 363 remain open downstream work. Historical run-local
+hashes are not retained as evidence after their bytes are deleted; the replay
+instead proves the relations that carry the acceptance claim. No further
+step-3 lead remained.

--- a/plugins/hexaemeron/docs/elenchus-audit-round-verdict/proof.md
+++ b/plugins/hexaemeron/docs/elenchus-audit-round-verdict/proof.md
@@ -18,18 +18,33 @@ metadata.
 
 ## Reproduction boundary
 
-Run these commands from the repository root with Python 3.12 and a configured
-Git signing key. The names below keep the generated repository under the
-current run's ignored `.hexaemeron` directory.
+Run these commands from a clean repository root with Python 3.12 and a
+configured Git signing key. The fixture uses tracked delivery documents and a
+generated directory under the repository's ignored `.hexaemeron` boundary; it
+does not depend on active Fiat state.
 
 ```bash
 set -euo pipefail
-PROJECT_ROOT=$(git rev-parse --show-toplevel)
-DEMO_ROOT=$(mktemp -d "$PROJECT_ROOT/.hexaemeron/issue327-step3-XXXXXX")
+PROJECT_ROOT=$(cd "$(git rev-parse --show-toplevel)" && pwd -P)
+DEMO_PARENT="$PROJECT_ROOT/.hexaemeron"
+DEMO_PARENT_CREATED=0
+test ! -L "$DEMO_PARENT"
+if [ ! -e "$DEMO_PARENT" ]; then
+  mkdir "$DEMO_PARENT"
+  DEMO_PARENT_CREATED=1
+fi
+test -d "$DEMO_PARENT"
+DEMO_ROOT=$(mktemp -d "$DEMO_PARENT/issue327-step3-XXXXXX")
 DEMO_ORIGIN="$DEMO_ROOT/origin"
 HEXCTL="$PROJECT_ROOT/plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
+STUDY_SOURCE="$PROJECT_ROOT/plugins/hexaemeron/docs/elenchus-audit-round-verdict/study.md"
+RUNBOOK_SOURCE="$PROJECT_ROOT/plugins/hexaemeron/docs/elenchus-audit-round-verdict/runbook.md"
 test "$(sha256sum "$HEXCTL" | awk '{print $1}')" = \
   "01efd29fcc0b1198aa62989291c1dbe4713d7c26cccbba40a1fbe4b210884870"
+test "$(sha256sum "$STUDY_SOURCE" | awk '{print $1}')" = \
+  "425152f8d8573197f33dcb491892f937798d4fe3b66ec612d8ce8ea05967852f"
+test "$(sha256sum "$RUNBOOK_SOURCE" | awk '{print $1}')" = \
+  "a98c67bda303bac1b3aea09817059a07d9dc45a64472847854be7547c4bd555c"
 mkdir "$DEMO_ORIGIN"
 git -C "$DEMO_ORIGIN" init -b main
 git -C "$DEMO_ORIGIN" config user.name "Dave Coleman"
@@ -38,9 +53,26 @@ git -C "$DEMO_ORIGIN" commit -S --allow-empty -m "demo base"
 python3.12 "$HEXCTL" --dir "$DEMO_ORIGIN" init \
   --topic "issue 327 proof" --base main
 DEMO_RUN="$DEMO_ORIGIN/tmp/fiat/fiat-issue-327-proof"
-cp "$PROJECT_ROOT/.hexaemeron/study.md" "$DEMO_RUN/.hexaemeron/study.md"
-cp "$PROJECT_ROOT/.hexaemeron/runbook.md" "$DEMO_RUN/.hexaemeron/runbook.md"
-cp "$PROJECT_ROOT/.hexaemeron/steps.json" "$DEMO_RUN/.hexaemeron/steps.json"
+```
+
+```bash
+cp "$STUDY_SOURCE" "$DEMO_RUN/.hexaemeron/study.md"
+cp "$RUNBOOK_SOURCE" "$DEMO_RUN/.hexaemeron/runbook.md"
+printf '\n' >> "$DEMO_RUN/.hexaemeron/runbook.md"
+test "$(sha256sum "$DEMO_RUN/.hexaemeron/runbook.md" | awk '{print $1}')" = \
+  "82f1952def5d8658c2c8207d4c170632c0f14180cf8e5a554f980a85b7bf6f85"
+python3.12 - "$DEMO_RUN/.hexaemeron/steps.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+steps = [
+    "Bind the runbook test command to the Elenchus contract",
+    "Receipt the four verdicts and source-bind Warden",
+    "Demonstrate legacy and release compatibility",
+]
+Path(sys.argv[1]).write_text(json.dumps(steps, indent=2) + "\n")
+PY
 python3.12 "$HEXCTL" --dir "$DEMO_RUN" done study \
   --artifact "$DEMO_RUN/.hexaemeron/study.md" \
   --skills hexaemeron:protasis,hexaemeron:imprimatur
@@ -51,8 +83,9 @@ python3.12 "$HEXCTL" --dir "$DEMO_RUN" done runbook \
 
 Call `next` twice before the implementation receipt. Decode both JSON objects,
 require them to be equal, and retain only the Mason `brief.runbook_step`.
-Create the branch and implementation commit named by that packet. Every
-commit owned by the proof uses one exact copy of each required trailer.
+Create the branch and implementation commit named by that packet. Each
+receipted implementation or fix commit uses one exact copy of each required
+trailer.
 
 ```bash
 MASON_ONE=$(python3.12 "$HEXCTL" --dir "$DEMO_RUN" next)
@@ -343,7 +376,7 @@ state and ledger digests. The successful generated boundary was removed after
 these assertions.
 
 ```bash
-python3.12 - "$DEMO_ROOT" "$PROJECT_ROOT/.hexaemeron" <<'PY'
+python3.12 - "$DEMO_ROOT" "$DEMO_PARENT" <<'PY'
 from pathlib import Path
 import shutil, sys
 boundary = Path(sys.argv[1]).resolve()
@@ -353,6 +386,12 @@ assert boundary.name.startswith("issue327-step3-")
 shutil.rmtree(boundary)
 PY
 test ! -e "$DEMO_ROOT"
+test ! -L "$DEMO_ROOT"
+if [ "$DEMO_PARENT_CREATED" -eq 1 ]; then
+  rmdir "$DEMO_PARENT"
+  test ! -e "$DEMO_PARENT"
+  test ! -L "$DEMO_PARENT"
+fi
 ```
 
 ## Study and release reconciliation

--- a/plugins/hexaemeron/docs/elenchus-audit-round-verdict/proof.md
+++ b/plugins/hexaemeron/docs/elenchus-audit-round-verdict/proof.md
@@ -9,6 +9,13 @@ The run exercised a fresh repository and the worktree created by `hexctl init`.
 No network, credential, Solidity target, or raw signature output entered the
 record.
 
+The controller writes absolute worktree paths, UTC timestamps, and signed
+commit ids into its packets, state, and ledger. Hashes over those values are
+run-local diagnostics, not cross-run oracles. The commands below print them
+and compare them only inside one replay. Fixed hashes are stated only for
+source bytes that do not depend on the generated path, clock, or signing
+metadata.
+
 ## Reproduction boundary
 
 Run these commands from the repository root with Python 3.12 and a configured
@@ -16,10 +23,13 @@ Git signing key. The names below keep the generated repository under the
 current run's ignored `.hexaemeron` directory.
 
 ```bash
+set -euo pipefail
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 DEMO_ROOT=$(mktemp -d "$PROJECT_ROOT/.hexaemeron/issue327-step3-XXXXXX")
 DEMO_ORIGIN="$DEMO_ROOT/origin"
 HEXCTL="$PROJECT_ROOT/plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
+test "$(sha256sum "$HEXCTL" | awk '{print $1}')" = \
+  "01efd29fcc0b1198aa62989291c1dbe4713d7c26cccbba40a1fbe4b210884870"
 mkdir "$DEMO_ORIGIN"
 git -C "$DEMO_ORIGIN" init -b main
 git -C "$DEMO_ORIGIN" config user.name "Dave Coleman"
@@ -57,8 +67,7 @@ STEP_BASE=$(python3.12 -c \
 git -C "$DEMO_RUN" switch -c "$STEP_BRANCH" "$STEP_BASE"
 git -C "$DEMO_RUN" commit -S --allow-empty \
   -m "issue 327 proof implementation" \
-  -m "Co-authored-by: Shoggoth <shoggoth@wildcat.finance>" \
-  -m "Wildcat-Origin: shoggoth"
+  -m $'Co-authored-by: Shoggoth <shoggoth@wildcat.finance>\nWildcat-Origin: shoggoth'
 IMPLEMENTATION=$(git -C "$DEMO_RUN" rev-parse HEAD)
 python3.12 "$HEXCTL" --dir "$DEMO_RUN" done implement \
   --branch "$STEP_BRANCH" --commit "$IMPLEMENTATION" \
@@ -68,7 +77,11 @@ python3.12 "$HEXCTL" --dir "$DEMO_RUN" record security_suite \
 WARDEN_ONE=$(python3.12 "$HEXCTL" --dir "$DEMO_RUN" next)
 WARDEN_TWO=$(python3.12 "$HEXCTL" --dir "$DEMO_RUN" next)
 test "$WARDEN_ONE" = "$WARDEN_TWO"
+```
+
+```bash
 python3.12 - "$MASON_ONE" "$WARDEN_ONE" <<'PY'
+import hashlib
 import json
 import sys
 mason = json.loads(sys.argv[1])
@@ -77,6 +90,19 @@ assert mason["brief"]["runbook_step"] == warden["brief"]["runbook_step"]
 assert sorted(warden["brief"]["runbook_step"]) == [
     "markdown", "number", "path", "sha256", "title",
 ]
+compact = lambda value: json.dumps(
+    value, sort_keys=True, separators=(",", ":")
+).encode()
+step = warden["brief"]["runbook_step"]
+assert hashlib.sha256(step["markdown"].encode()).hexdigest() == (
+    "4da25cd2d9e8e046016501d69dd0289de2cf3dad78f0e486f59dc7d4fd7515ef"
+)
+assert step["sha256"] == (
+    "82f1952def5d8658c2c8207d4c170632c0f14180cf8e5a554f980a85b7bf6f85"
+)
+print("mason packet", hashlib.sha256(compact(mason)).hexdigest())
+print("warden packet", hashlib.sha256(compact(warden)).hexdigest())
+print("runbook step", hashlib.sha256(compact(step)).hexdigest())
 PY
 ```
 
@@ -85,13 +111,13 @@ The decoded Mason and Warden packets carried the same five-field
 up to the Step 2 heading in the receipted runbook. The observed packet evidence
 was:
 
-| Subject | Schema or status | SHA-256 |
+| Subject | Replay assertion | Cross-run digest |
 | --- | --- | --- |
-| Mason packet | repeated object equal | `02478d8912af6c67a0686f1a624eb2faedae02996e2a3fea93005cd0992fd248` |
-| Warden packet | repeated object equal | `422cde350000b866a8e97b4627710603b19cfc8a69c3b3c2743c4c2c6e09fe3c` |
-| `runbook_step` | `markdown`, `number`, `path`, `sha256`, `title` | `f26bc20915be744183a6f572b2758f0442dc22607b95dd7bd6b174b11d1c6524` |
+| Mason packet | repeated compact JSON objects are equal | run-local; printed by the replay |
+| Warden packet | repeated compact JSON objects are equal | run-local; printed by the replay |
+| `runbook_step` | both packets carry the same five fields | run-local; its path is generated |
 | Step 1 Markdown | exact source bytes | `4da25cd2d9e8e046016501d69dd0289de2cf3dad78f0e486f59dc7d4fd7515ef` |
-| Receipted runbook | source artefact | `82f1952def5d8658c2c8207d4c170632c0f14180cf8e5a554f980a85b7bf6f85` |
+| Receipted runbook | exact source artefact | `82f1952def5d8658c2c8207d4c170632c0f14180cf8e5a554f980a85b7bf6f85` |
 
 The Warden brief had exactly `audit_log_path`, `plugin_root`, `risk_register`,
 `round`, `runbook_step`, `security_suite`, `stacked_branch`, and
@@ -102,65 +128,81 @@ command to the Elenchus contract`.
 
 Create one signed candidate fix from the implementation head, then take
 SHA-256 digests of `.hexaemeron/state.json` and
-`.hexaemeron/ledger.jsonl`. Invoke these three commands with the non-Solidity
-lint receipts appended to each command:
+`.hexaemeron/ledger.jsonl`. `expect_refusal` requires exit 2 and compares both
+raw files after each refused command, rather than assuming three commands
+cannot cancel one another's mutations:
 
 ```bash
 signed_fix() {
   git -C "$DEMO_RUN" commit -S --allow-empty -m "$1" \
-    -m "Co-authored-by: Shoggoth <shoggoth@wildcat.finance>" \
-    -m "Wildcat-Origin: shoggoth" >/dev/null
+    -m $'Co-authored-by: Shoggoth <shoggoth@wildcat.finance>\nWildcat-Origin: shoggoth' \
+    >/dev/null
   git -C "$DEMO_RUN" rev-parse HEAD
 }
 LINT_ARGS=(--phylax-exit 0 --ephoros-exit 0 --hypomnema-exit 0)
 FIX_1=$(signed_fix "issue 327 proof fix guarded")
-sha256sum "$DEMO_RUN/.hexaemeron/state.json" \
-  "$DEMO_RUN/.hexaemeron/ledger.jsonl"
-```
-
-```bash
-python3.12 "$HEXCTL" --dir "$DEMO_RUN" audit-round --findings 1 \
-  --fixes-commit "$FIX_1" "${LINT_ARGS[@]}"
-python3.12 "$HEXCTL" --dir "$DEMO_RUN" audit-round --findings 1 \
-  --elenchus-verdict guarded "${LINT_ARGS[@]}"
-python3.12 "$HEXCTL" --dir "$DEMO_RUN" audit-round --findings 1 \
-  --fixes-commit "$FIX_1" --elenchus-verdict unknown "${LINT_ARGS[@]}"
-sha256sum "$DEMO_RUN/.hexaemeron/state.json" \
-  "$DEMO_RUN/.hexaemeron/ledger.jsonl"
+digest_pair() {
+  sha256sum "$DEMO_RUN/.hexaemeron/state.json" \
+    "$DEMO_RUN/.hexaemeron/ledger.jsonl" | awk '{print $1}' | paste -sd : -
+}
+expect_refusal() {
+  before=$(digest_pair)
+  set +e
+  "$@"
+  status=$?
+  set -e
+  test "$status" -eq 2
+  after=$(digest_pair)
+  test "$before" = "$after"
+  printf 'exit=%s state:ledger=%s\n' "$status" "$after"
+}
+expect_refusal python3.12 "$HEXCTL" --dir "$DEMO_RUN" audit-round \
+  --findings 1 --fixes-commit "$FIX_1" "${LINT_ARGS[@]}"
+expect_refusal python3.12 "$HEXCTL" --dir "$DEMO_RUN" audit-round \
+  --findings 1 --elenchus-verdict guarded "${LINT_ARGS[@]}"
+expect_refusal python3.12 "$HEXCTL" --dir "$DEMO_RUN" audit-round \
+  --findings 1 --fixes-commit "$FIX_1" --elenchus-verdict unknown \
+  "${LINT_ARGS[@]}"
 ```
 
 Each command exited 2. The first named the missing verdict and all four
 accepted values, the second named the missing fix, and the third was rejected
-by the closed command-line enum. The raw file digests before and after each
-refusal were identical:
+by the closed command-line enum. Each printed the same run-local state and
+ledger digest pair it observed before the command:
 
-| Case | Exit | State SHA-256 | Ledger SHA-256 |
-| --- | ---: | --- | --- |
-| fix without verdict | 2 | `a900979d51daa29cbdc7099782150aaa18c8d4f02beeff675c3f26e241111544` | `71c3510f2085c6b5f95e9da1b962ddfa8451498943cd07959634f9ad04e4f10b` |
-| verdict without fix | 2 | `a900979d51daa29cbdc7099782150aaa18c8d4f02beeff675c3f26e241111544` | `71c3510f2085c6b5f95e9da1b962ddfa8451498943cd07959634f9ad04e4f10b` |
-| unknown verdict | 2 | `a900979d51daa29cbdc7099782150aaa18c8d4f02beeff675c3f26e241111544` | `71c3510f2085c6b5f95e9da1b962ddfa8451498943cd07959634f9ad04e4f10b` |
+| Case | Exit | File relation |
+| --- | ---: | --- |
+| fix without verdict | 2 | state and ledger bytes unchanged |
+| verdict without fix | 2 | state and ledger bytes unchanged |
+| unknown verdict | 2 | state and ledger bytes unchanged |
 
 A no-fix round with one finding and the three zero lint exits then recorded an
-explicit JSON null in both state and ledger. State SHA-256 was
-`e22594db09b2d94491ed5740785ef5c798c5b7ebd51a9a18312dd6956ed7c983`;
-ledger SHA-256 was
-`150bd0093ebe95b60e52a9261bb3892f34534af74f35fce863069f8c3895af42`.
+explicit JSON null in both state and ledger. The check prints their run-local
+digests after asserting both fields exist and are null.
 
 ```bash
 python3.12 "$HEXCTL" --dir "$DEMO_RUN" audit-round --findings 1 \
   "${LINT_ARGS[@]}"
+python3.12 - "$DEMO_RUN" <<'PY'
+import json, sys
+from pathlib import Path
+meta = Path(sys.argv[1]) / ".hexaemeron"
+state = json.loads((meta / "state.json").read_text())
+event = json.loads((meta / "ledger.jsonl").read_text().splitlines()[-1])
+round_entry = state["steps"][0]["audit"]["rounds"][-1]
+assert "elenchus_verdict" in round_entry
+assert round_entry["elenchus_verdict"] is None
+assert "elenchus_verdict" in event["data"]
+assert event["data"]["elenchus_verdict"] is None
+PY
+printf 'null state:ledger=%s\n' "$(digest_pair)"
 ```
 
 The proof removed that round's `elenchus_verdict` key from both files to model
 a pre-generation round. It recomputed the canonical compact state fingerprint,
 replaced the last ledger entry's `state`, and recomputed that entry's hash over
-the entry without its old `hash` field. The resulting state fingerprint was
-`8d91511463c9291b778b4ae7651bec59b10fbe83746274a9379b5dbad91b30bd`;
-the ledger tail hash was
-`10f38d4d5931e8f0efa201656c69053cc30f2f39579b89da3d3f815454370ebb`.
-Raw state and ledger file digests were respectively
-`b4b5b109d3a78b8c98ccddb53121853f8b8269102f87d4bd26ef064e88c82a42`
-and `c7ef85eeb9a7172c1f748eb2a4d53618b6d87977c8d7445336d21a0d14e0681a`.
+the entry without its old `hash` field. The script prints those run-local
+digests after it writes the legacy fixture.
 
 ```bash
 python3.12 - "$DEMO_RUN" <<'PY'
@@ -183,7 +225,10 @@ entries[-1]["hash"] = hashlib.sha256(compact(unsigned)).hexdigest()
 ledger_path.write_text("".join(
     json.dumps(entry, sort_keys=True) + "\n" for entry in entries
 ))
+print("legacy state fingerprint", state_fingerprint)
+print("legacy ledger tail", entries[-1]["hash"])
 PY
+printf 'legacy state:ledger=%s\n' "$(digest_pair)"
 ```
 
 `status`, `next`, and `verify` each exited 0 after the edit. `next` returned
@@ -192,7 +237,10 @@ later exited 0 without adding the missing legacy field.
 
 ```bash
 python3.12 "$HEXCTL" --dir "$DEMO_RUN" status
-python3.12 "$HEXCTL" --dir "$DEMO_RUN" next
+LEGACY_NEXT=$(python3.12 "$HEXCTL" --dir "$DEMO_RUN" next)
+python3.12 -c \
+  'import json,sys; p=json.loads(sys.argv[1]); assert (p["do"],p["round"]) == ("audit-round",2)' \
+  "$LEGACY_NEXT"
 python3.12 "$HEXCTL" --dir "$DEMO_RUN" verify
 ```
 
@@ -206,38 +254,93 @@ in `verified_commits`.
 ```bash
 python3.12 "$HEXCTL" --dir "$DEMO_RUN" audit-round --findings 1 \
   --fixes-commit "$FIX_1" --elenchus-verdict guarded "${LINT_ARGS[@]}"
+printf 'round 2 state:ledger=%s\n' "$(digest_pair)"
 FIX_2=$(signed_fix "issue 327 proof fix unguarded")
 python3.12 "$HEXCTL" --dir "$DEMO_RUN" audit-round --findings 1 \
   --fixes-commit "$FIX_2" --elenchus-verdict unguarded "${LINT_ARGS[@]}"
+printf 'round 3 state:ledger=%s\n' "$(digest_pair)"
 FIX_3=$(signed_fix "issue 327 proof fix passed")
 python3.12 "$HEXCTL" --dir "$DEMO_RUN" audit-round --findings 1 \
   --fixes-commit "$FIX_3" --elenchus-verdict passed "${LINT_ARGS[@]}"
+printf 'round 4 state:ledger=%s\n' "$(digest_pair)"
 FIX_4=$(signed_fix "issue 327 proof fix inconclusive")
 python3.12 "$HEXCTL" --dir "$DEMO_RUN" audit-round --findings 0 \
   --fixes-commit "$FIX_4" --elenchus-verdict inconclusive \
   "${LINT_ARGS[@]}"
-python3.12 "$HEXCTL" --dir "$DEMO_RUN" next
-python3.12 "$HEXCTL" --dir "$DEMO_RUN" done audit
-python3.12 "$HEXCTL" --dir "$DEMO_RUN" verify
-for FIX in "$FIX_1" "$FIX_2" "$FIX_3" "$FIX_4"; do
-  git -C "$DEMO_RUN" verify-commit "$FIX" >/dev/null 2>&1
-done
+printf 'round 5 state:ledger=%s\n' "$(digest_pair)"
 ```
 
-| Label | Commit | Round | Findings | Verdict | State SHA-256 | Ledger SHA-256 |
-| --- | --- | ---: | ---: | --- | --- | --- |
-| `fix-1` | `0757a1ad86d46a34f7825f9545d9da85249f4585` | 2 | 1 | `guarded` | `9b7da5a3f09080a28e4c6c7177b8dc70d52465e54df0f0467bba82e041f5379d` | `508499d4f673d900a230a8092019cacc5a8d3b8d01277e5f9d725fbdd8fec8b8` |
-| `fix-2` | `7a619049738680fc9c72d8135c0f21ccb4b3d74d` | 3 | 1 | `unguarded` | `31ff495beb0119e0dafa5b888f8a70d02b8371f53b9a2f707ab9082d9f64dcde` | `28e881d35a7ac2c019c782ea0cce0faa4336ec85ace9a08aed4f48cd5504272a` |
-| `fix-3` | `8d75c7ed11a9354e77fda3e60c2d005be205c9a1` | 4 | 1 | `passed` | `6c58341dd01dbaca17ad1fd81c5fc1538ae0f12b5390ee7c79ce3e427556ca61` | `9347130c94b28cc45eaaf2fd9def98d367df6a1433f97023052e38beba9013f5` |
-| `fix-4` | `afa46b5241c17663ce1dd17033687e9e5f9c4e7c` | 5 | 0 | `inconclusive` | `e7e2ed0bcf7b07fd5257d875b61ba5c116342bfbad561067fd3e9aa22add0b8e` | `90c76851cb08f124b93a63be55fe8e5ab24c47dd89bcdf67a1bfafa7304f0137` |
+```bash
+python3.12 - "$DEMO_RUN" "$IMPLEMENTATION" \
+  "$FIX_1" "$FIX_2" "$FIX_3" "$FIX_4" <<'PY'
+import json, subprocess, sys
+from pathlib import Path
+run = Path(sys.argv[1])
+implementation, *fixes = sys.argv[2:]
+meta = run / ".hexaemeron"
+state = json.loads((meta / "state.json").read_text())
+rounds = state["steps"][0]["audit"]["rounds"]
+events = [
+    json.loads(line) for line in (meta / "ledger.jsonl").read_text().splitlines()
+    if json.loads(line)["event"] == "audit-round"
+]
+expected = ["missing", "guarded", "unguarded", "passed", "inconclusive"]
+assert [item.get("elenchus_verdict", "missing") for item in rounds] == expected
+assert [item["data"].get("elenchus_verdict", "missing") for item in events] == expected
+trailers = ["Co-authored-by: Shoggoth <shoggoth@wildcat.finance>",
+            "Wildcat-Origin: shoggoth"]
+for commit in [implementation, *fixes]:
+    message = subprocess.check_output(
+        ["git", "-C", str(run), "show", "-s", "--format=%B", commit]
+    ).decode().rstrip("\n").splitlines()
+    assert message[-2:] == trailers
+    assert all(message.count(trailer) == 1 for trailer in trailers)
+    result = subprocess.run(
+        ["git", "-C", str(run), "verify-commit", commit],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    assert result.returncode == 0
+for parent, commit, round_entry, event in zip(
+    [implementation, *fixes[:-1]], fixes, rounds[1:], events[1:]
+):
+    assert subprocess.check_output(
+        ["git", "-C", str(run), "rev-parse", f"{commit}^"]
+    ).decode().strip() == parent
+    assert round_entry["fixes_commit"] == commit
+    assert round_entry["verified_commits"] == [commit]
+    assert event["data"]["verified_commits"] == [commit]
+PY
+```
+
+```bash
+CLOSE_NEXT=$(python3.12 "$HEXCTL" --dir "$DEMO_RUN" next)
+python3.12 -c \
+  'import json,sys; assert json.loads(sys.argv[1])["do"] == "close-audit"' \
+  "$CLOSE_NEXT"
+python3.12 "$HEXCTL" --dir "$DEMO_RUN" done audit
+python3.12 "$HEXCTL" --dir "$DEMO_RUN" verify
+python3.12 -c \
+  'import json,sys,pathlib; s=json.loads((pathlib.Path(sys.argv[1])/".hexaemeron/state.json").read_text()); assert (s["version"],s["steps"][0]["phase"]) == (1,"prose")' \
+  "$DEMO_RUN"
+PROSE_NEXT=$(python3.12 "$HEXCTL" --dir "$DEMO_RUN" next)
+python3.12 -c \
+  'import json,sys; p=json.loads(sys.argv[1]); assert (p["do"],p["step"]) == ("prose",1)' \
+  "$PROSE_NEXT"
+printf 'final state:ledger=%s\n' "$(digest_pair)"
+```
+
+| Label | Commit identity | Round | Findings | Verdict |
+| --- | --- | ---: | ---: | --- |
+| `fix-1` | one signed commit above the implementation | 2 | 1 | `guarded` |
+| `fix-2` | one signed commit above `fix-1` | 3 | 1 | `unguarded` |
+| `fix-3` | one signed commit above `fix-2` | 4 | 1 | `passed` |
+| `fix-4` | one signed commit above `fix-3` | 5 | 0 | `inconclusive` |
 
 The final state remained version 1 and moved the step to `prose`. Its five
 rounds exposed `missing`, `guarded`, `unguarded`, `passed`, and `inconclusive`
-in order. Final `verify` exited 0. Final state SHA-256 was
-`d6952962cb3b8861ccbef5e9c6209e4e582a4bb57372ecbf055ebca74de97909`;
-final ledger SHA-256 was
-`0ea8be93c18297f4da48aa57e9ac5d68311de6f4f358df638b964ed90d8815ff`.
-The successful generated boundary was removed after these assertions.
+in order. Final `verify` exited 0, and the replay printed the final run-local
+state and ledger digests. The successful generated boundary was removed after
+these assertions.
 
 ```bash
 python3.12 - "$DEMO_ROOT" "$PROJECT_ROOT/.hexaemeron" <<'PY'
@@ -249,6 +352,7 @@ assert boundary.parent == expected_parent
 assert boundary.name.startswith("issue327-step3-")
 shutil.rmtree(boundary)
 PY
+test ! -e "$DEMO_ROOT"
 ```
 
 ## Study and release reconciliation


### PR DESCRIPTION
# audit: verify the issue 327 legacy and release proof

This audit review belongs to
[issue 327](https://github.com/wildcat-finance/skills/issues/327) and targets
`fiat/327-elenchus-2-feed-the-guard-verdict-into-fiat-step-3-demonstrate-legacy-and-release-c`.

## review result

Three rounds found `2 -> 2 -> 0` issues. The audit branch changes only
`plugins/hexaemeron/docs/elenchus-audit-round-verdict/proof.md` and
`audit/AUDIT.md` above implementation commit
`1ad770c296621de55ad99f3368439c0c25fe67e9`.

| round | reviewed head | result |
| ---: | --- | --- |
| 1 | `1ad770c296621de55ad99f3368439c0c25fe67e9` | 1 medium and 1 low; fixed in `d55da516fcd652beddcad82219170079c5491129`; Elenchus `unguarded` |
| 2 | `773fb670d72fde9e936d321f57779dbd056f06d0` | 1 medium and 1 low; fixed in `27f78d96d2f1b1f91c9e60ab70ebe0fb338d3c71`; Elenchus `unguarded` |
| 3 | `017a74189b15b95af72d16c79c48ec07730b7e7e` | 0 findings; clean record committed as `7c2216caca0143bf73e7de4c1197e19e98a103c7` |

Round 1 removed fixed hashes whose generated inputs were no longer retained
and made the replay compare those relations inside one run. It also made each
receipted demo commit end with the two exact consecutive provenance lines.
Round 2 made the replay start from tracked bytes with no active Fiat state and
narrowed the trailer claim to the commits the executable check covers. Round 3
replayed the fixed proof from a clean detached checkout and found no remaining
proof, packet, legacy, release, cleanup, or record fault.

## evidence boundary

The active installed Hexaemeron 1.5.4 bundle carries Fiat v5.11.1. That outer
controller cannot accept or receipt `--elenchus-verdict`, so its audit-round
receipts do not claim the new field. Checked-in Fiat v5.12.1 is the subject of
the disposable replay: it checks the closed enum, preserves the values in state
and ledger, reconstructs the Warden packet, and accepts the legacy missing-key
path. This is direct behavior evidence for the changed controller, not a claim
that the installed controller already enforced it.

The two fixes are documentation-only, so `unguarded` is their exact Elenchus
result. The record doesn't relabel either result, attest report bytes, or claim
a production guard. Issue 453 owns that later policy. Issues 429, 369, 453,
and 363 remain separately owned work.

## proof

Run the Bash blocks in
`plugins/hexaemeron/docs/elenchus-audit-round-verdict/proof.md` in one shell
from a clean repository root, then run:

```bash
python3.12 -m unittest discover -s tests
npx --yes --package=node@26.6.0 --call \
  'python3.12 plugins/hexaemeron/tests/run_tests.py'
python3.12 plugins/hexaemeron/skills/imprimatur/tests/run_tests.py
python3.12 scripts/promise_machine.py check
python3.12 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
python3.12 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
python3.12 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py \
  README.md AGENTS.md .agents plugins docs
git diff --check
```

The closing round records 872/872 Hexaemeron tests under pinned Node v26.6.0,
118/118 root tests, 62/62 Imprimatur tests, and 14/14 evolution/version tests.
The Promise Machine, Protasis, Horos, Phylax, Ephoros, Hypomnema, Imprimatur,
Brevitas, and diff checks exit 0 on their recorded scopes.

<!-- wildcat-origin: shoggoth -->
