### PR TITLE
Publish the observable run record specification

### DIFF
--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 1445
+    "files_walked": 1447
   },
   "entries": [
     {

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8883,13 +8883,10 @@ boundary metadata and Markdown only, with no Solidity path in the complete
 run-to-step diff. X-Ray, Solidity Auditor and Fizz did not run. The Phylax,
 Ephoros and repository-specified Hypomnema lint exits are `0`, `0` and `0`.
 
-### Finding table
+### Finding disposition
 
-| id | severity | file | finding | status |
-| --- | --- | --- | --- | --- |
-| S1-R1-review | none | full run-to-step diff | No Step 1 defect was confirmed. | clean |
-
-Finding count: 0.
+Finding count: 0. `S1-R1-review` covers the full run-to-step diff. No Step 1
+defect was confirmed. Status: clean.
 
 ### Risk coverage
 

--- a/audit/AUDIT.md
+++ b/audit/AUDIT.md
@@ -8873,3 +8873,77 @@ custom-loader proofs; the accepted pragma-in-string quirk; and Python file-size
 policy. Cross-scope YAML module and loader aliases can retain source-local
 trust for an actual `yaml.load` call. The receipted study excludes that scope,
 so changing it would require an amendment rather than an audit-side widening.
+
+## Issue 434 observable run record, step 1, round 1 -- 2026-08-23
+
+### Suite disposition
+
+The receipted suite waiver is exact: issue #434 Step 1 changes generated
+boundary metadata and Markdown only, with no Solidity path in the complete
+run-to-step diff. X-Ray, Solidity Auditor and Fizz did not run. The Phylax,
+Ephoros and repository-specified Hypomnema lint exits are `0`, `0` and `0`.
+
+### Finding table
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+| S1-R1-review | none | full run-to-step diff | No Step 1 defect was confirmed. | clean |
+
+Finding count: 0.
+
+### Risk coverage
+
+| risk id | evidence checked | disposition |
+| --- | --- | --- |
+| `unbounded-input` | Step 1 adds no input reader; the study records fixed byte, line, event, nesting, string and collection ceilings for Step 2. | dormant until Step 2 |
+| `unsafe-path` | The published copies contain no filesystem-absolute pointer or relative Markdown source link; paths are backticked repository names or absolute web links. | clean |
+| `unsafe-deserialisation` | Step 1 adds no deserialiser and names JSON-only, no-execution handling as a Step 2 boundary. | dormant until Step 2 |
+| `schema-drift` | No schema or runtime lands in Step 1; the runbook assigns exact schema/runtime binding to Step 2. | dormant until Step 2 |
+| `event-order` | No event validator lands in Step 1; the accepted relations and negative fixtures are stated as Step 2 exit evidence. | dormant until Step 2 |
+| `correlation-gap` | No correlation implementation lands in Step 1; backward same-run resolution remains a Step 2 requirement. | dormant until Step 2 |
+| `evidence-binding` | No evidence consumer lands in Step 1; exact subject, selector and class binding remains a Step 2 requirement. | dormant until Step 2 |
+| `evidence-promotion` | The study and ADR state that structural acceptance proves neither truth nor mutation authority and introduce no class ranking. | clean |
+| `hidden-reasoning` | The study and ADR refuse hidden model reasoning as observable data; no payload format lands in this step. | clean |
+| `sensitive-payload` | Step 1 contains specifications only and permits bounded metadata, digests and references rather than prompts, completions, output, environment or credentials. | clean |
+| `optional-host-facts` | The study and ADR require unavailable host, model and token facts to stay omitted or unknown. | clean |
+| `token-accounting` | The accepted design limits token values to optional non-negative exposed counts with source, scope and accounting identity, without cost or quality claims. | clean |
+| `deterministic-report` | No reporter lands in Step 1; one shared sorted finding model and text/JSON parity remain Step 2 exit evidence. | dormant until Step 2 |
+| `partial-record` | No record reader lands in Step 1; final-newline, malformed-tail and lifecycle refusal remain Step 2 requirements. | dormant until Step 2 |
+| `command-drift` | Every Step 1 command exits 0. The correct Horos command exits 0; the obsolete `scan . --check` spelling exits 2. A temporary specimen using the five former relative targets emits exactly five H001 findings. | clean |
+
+### Step contract and evidence
+
+The committed study and runbook are byte-identical to the receipted copies.
+Their SHA-256 digests are
+`685243b2727d0341bfce4869d1c5615fe37e052377ca3a6983ff1bc688d437b3`
+and `9eae8f964c2a081c509d29fe78a1adb3f0c837854aa2ef4d91c65b9fa199466d`.
+ADR-014 records root Promise Machine ownership, the chosen location split,
+three rejected alternatives, the structural-only authority boundary and the
+work left outside this issue.
+
+The old-link specimen used these exact former targets from a temporary
+directory: `../plugins/hexaemeron/skills/ephoros/SKILL.md`,
+`../plugins/hexaemeron/skills/phylax/SKILL.md`,
+`../plugins/hexaemeron/skills/metron/SKILL.md`,
+`../plugins/hexaemeron/skills/elenchus/SKILL.md`, and
+`../plugins/hexaemeron/skills/hypomnema/SKILL.md`. Hypomnema exits 1 with five
+H001 findings. The specimen was removed. The obsolete Horos spelling exits 2
+with `unrecognized arguments: --check`; the documented
+`python3 plugins/horos/skills/horos/scripts/horos.py check .` exits 0 and
+reports that the boundary matches the tree.
+
+Both Protasis modes, the repository Hypomnema pass, Imprimatur, all three
+Brevitas files, the exact `git diff --check`, and the full run-to-step diff
+check exit 0. Root tests pass 118/118. The implementation commit
+`19a3f2135b0317904eb91676cabf5da6cb739f35` has a valid local signature and
+exactly one required co-author and origin trailer. The diff changes only the
+two receipted copies, ADR-014 and the generated Horos boundary.
+
+### Leads not pursued
+
+The Step 2 schema, validator, fixtures, Promise declaration and demonstration
+do not exist at the Step 1 exit and were not treated as implemented. A direct
+Hypomnema scan of the historical audit log reports two old H003 specimens at
+lines 6119 and 6269; the repository's required pointer-gate scope excludes
+`audit/AUDIT.md`, and the current step neither creates nor changes those
+specimens. No other lead remains.

--- a/docs/decisions/ADR-014-define-the-promise-machine-run-observation-record.md
+++ b/docs/decisions/ADR-014-define-the-promise-machine-run-observation-record.md
@@ -1,0 +1,60 @@
+# ADR-014: Define the Promise Machine run observation record
+
+## Status
+
+Accepted, 2026-08-23. Recorded for [skills#434](https://github.com/wildcat-finance/skills/issues/434).
+
+## Context
+
+Promise Machine defines the suite-wide evidence classes and the limits on what
+their records authorise. Fiat records delivery transitions, but its controller
+ledger is not a host-neutral account of capability use, refusals, retries,
+handoffs, unknowns, or observed outcomes. Host transcripts are not a stable or
+safe interchange surface, and hidden model reasoning is not observable.
+
+Later work needs one versioned JSON Lines record whose identities, order,
+references, evidence subjects, and evidence classes can be checked offline.
+The record must preserve missing host facts as unknown, accept token counts
+only when a host or provider exposes them, and authorise no mutation or truth
+claim merely because its structure validates.
+
+## Decision
+
+The root Promise Machine owns `promise-machine-run-observation/v1`: a closed
+event schema, a bounded standard-library validator, and a narrow structural
+validation promise. The schema belongs at
+`schemas/promise-machine-run-observation-v1.schema.json`; relational checks
+belong in `scripts/run_observation.py`; operator guidance belongs in
+`docs/promise-machine/run-observation-v1.md`.
+
+Fiat may produce or consume records at its own transitions, but its ledger
+does not become the interchange format. Ephoros supplies the observability
+questions and signal discipline without becoming a suite-wide record store.
+Capture, redaction, persistence, search, Fiat receipt binding, and cross-run
+diagnosis remain separate work.
+
+## Alternatives
+
+- **Put observations in Fiat's ledger.** This would reuse ordered JSON Lines,
+  but would couple general observations to controller integrity, make Fiat the
+  only producer, and pre-empt the separate receipt-binding work.
+- **Adopt OpenTelemetry as the canonical record.** This offers existing
+  telemetry conventions, but does not supply the repository's exact Promise
+  Machine evidence semantics, offline fixtures, or closed payload boundary.
+- **Publish prose examples without an executable contract.** This avoids a
+  validator, but cannot enforce identity, order, backward references, evidence
+  binding, or refusal of hidden-reasoning fields.
+
+## Consequences
+
+Producers gain one host-neutral versioned format and deterministic findings.
+Consumers can validate structure and relations without executing record
+content, fetching a service, or importing a host SDK. Optional host, model,
+and token facts remain source-bound or unknown.
+
+The repository takes on schema/runtime drift and fixture-maintenance duties.
+Validation establishes only acceptance by the named structural rules; it does
+not establish completeness, external truth, cause, model quality, delivery
+correctness, or authority to mutate a repository. Any future capture, storage,
+receipt binding, or diagnosis surface must preserve that boundary and record
+its own promise.

--- a/docs/promise-machine/run-observation-runbook.md
+++ b/docs/promise-machine/run-observation-runbook.md
@@ -1,0 +1,146 @@
+# Observable run record runbook
+
+This runbook implements issue #434 from `main` at
+`454bf3c9930c94985e5eb6179f3b01be2bf741c2`. It changes no skill frontier,
+package version, manifest, or CI workflow.
+
+## Delivery boundary
+
+- Step 1 publishes the accepted specification and standing decision.
+- Step 2 builds, binds, hardens, documents, and demonstrates the complete v1 validator.
+
+Every existing command surface below is checked before this runbook is
+receipted. The Horos currency gate is `horos.py check .`; the known invalid
+`horos.py scan . --check` spelling is not a runbook command.
+
+## Step 1: Publish the observation specification
+
+**Goal.** Commit byte-identical study and runbook copies, record the root
+Promise Machine ownership decision in ADR-014, and refresh Horos.
+
+**Entry.** Run branch `fiat/434-observable-run-record` at
+`454bf3c9930c94985e5eb6179f3b01be2bf741c2`, with both artefacts receipted and
+the controller returning this Step 1 packet.
+
+- Evidence is limited to the receipted bytes, decision index, old failed-link
+  and failed-command specimens, and named gates.
+
+**Exit.** Tracked study and runbook bytes exactly match their receipts;
+ADR-014 records the chosen ownership and rejected alternatives; source
+pointers remain location-independent; the old five-link specimen yields five
+H001 findings and the obsolete Horos spelling exits 2; accepted bytes and the
+correct Horos command pass. Protasis, Hypomnema, Imprimatur, Brevitas, root
+tests, Horos currency, and diff checks are green.
+
+```bash
+cmp .hexaemeron/study.md docs/promise-machine/run-observation-study.md
+cmp .hexaemeron/runbook.md docs/promise-machine/run-observation-runbook.md
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/promise-machine/run-observation-study.md
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/promise-machine/run-observation-runbook.md
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/promise-machine/run-observation-study.md docs/promise-machine/run-observation-runbook.md docs/decisions/ADR-014-define-the-promise-machine-run-observation-record.md
+python3 plugins/brevitas/skills/brevitas/scripts/brevitas.py docs/promise-machine/run-observation-study.md
+python3 plugins/brevitas/skills/brevitas/scripts/brevitas.py docs/promise-machine/run-observation-runbook.md
+python3 plugins/brevitas/skills/brevitas/scripts/brevitas.py docs/decisions/ADR-014-define-the-promise-machine-run-observation-record.md
+python3 plugins/horos/skills/horos/scripts/horos.py check .
+python3 -m unittest discover -s tests
+git diff --check
+```
+
+**Files.** Create `docs/promise-machine/run-observation-study.md`,
+`docs/promise-machine/run-observation-runbook.md`, and
+`docs/decisions/ADR-014-define-the-promise-machine-run-observation-record.md`.
+Refresh `.horos/boundary.json` only through Horos. Modify no executable,
+Promise declaration, version, manifest, or CI file.
+
+**Tests.** Run exact comparisons, both Protasis modes, Hypomnema, Imprimatur,
+Brevitas, correct Horos currency, root tests, and `git diff --check`. In a
+temporary directory only, reproduce the old five relative links as five H001
+findings and the obsolete Horos spelling as exit 2, then remove the specimens.
+
+**Disciplines.** phylax: bounded Markdown and generated boundary only.
+ephoros: none, nothing runs unattended. metron: none, no speed claim.
+elenchus: the two prior runbook failures are preserved red and their corrected
+forms run green. hypomnema: ADR-014 owns the decision; study and runbook own
+the accepted specification and delivery order.
+
+## Step 2: Build and demonstrate the v1 validator
+
+**Goal.** Add the closed event schema, bounded standard-library validator,
+root Promise declaration and copies, operator documentation, valid and invalid
+fixtures, combined hostile probes, and one complete demonstration.
+
+**Entry.** Step 1's stacked branch with the accepted records and ADR published
+and every Step 1 gate green.
+
+- Evidence is limited to the accepted study, schema, validator,
+  documentation, fixtures, Promise binding, tests, and named checks.
+
+**Exit.** The validator accepts success, refusal, retry, and handoff records.
+It emits stable `RO` findings for missing identity, bad order, unbound evidence,
+subject/class strengthening, hidden reasoning, unsafe or unbounded input,
+duplicate keys, closed-shape violations, lifecycle gaps, unsafe paths, raw
+payloads, invalid optional host facts, and invalid token counts. All references
+resolve backward within one run; one start and finish bound the record; unknown
+facts stay non-authorising; token counts are optional and source-bound. Text
+and canonical JSON share one finding model. The root Promise authorises only
+structural validation, generated copies are identical, and coverage binds the
+exact runtime, schema, fixtures, tests, docs, and transition.
+
+One focused test command demonstrates all valid flows, required refusals, token
+recorded/unknown cases, and combined probes: oversized final line, symlinked
+input, nested duplicate keys, cross-run retry, changed handoff subject, Boolean
+tokens, hidden-reasoning names at depth, truncation, and events after finish.
+It does not present fixtures as captured production runs or validation as
+truth, completeness, quality, cause, or mutation authority.
+
+```bash
+python3 -m unittest tests.test_run_observation -v
+python3 scripts/run_observation.py check tests/fixtures/run-observation/valid/success.jsonl
+python3 scripts/run_observation.py check tests/fixtures/run-observation/valid/refusal.jsonl
+python3 scripts/run_observation.py check tests/fixtures/run-observation/valid/retry.jsonl
+python3 scripts/run_observation.py check tests/fixtures/run-observation/valid/handoff.jsonl
+python3 -m unittest discover -s tests
+python3 scripts/promise_machine.py sync
+python3 scripts/promise_machine.py check
+python3 scripts/promise_machine.py coverage --check
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins scripts tests
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins scripts tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents plugins docs schemas scripts
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py PROMISE_MACHINE.md docs/promise-machine/run-observation-v1.md
+python3 plugins/brevitas/skills/brevitas/scripts/brevitas.py docs/promise-machine/run-observation-v1.md
+python3 plugins/horos/skills/horos/scripts/horos.py check .
+git diff --check
+```
+
+Expected-refusal fixture exits are asserted by the focused unittest rather
+than chained into this all-green gate list.
+
+**Files.** Create
+`schemas/promise-machine-run-observation-v1.schema.json`,
+`scripts/run_observation.py`, `docs/promise-machine/run-observation-v1.md`,
+`tests/test_run_observation.py`, and fixtures below
+`tests/fixtures/run-observation/`. Modify `PROMISE_MACHINE.md`, its generated
+plugin copies through `scripts/promise_machine.py sync`,
+`tests/promise_machine_coverage.json`, and
+`tests/test_promise_machine_contract.py`. Refresh `.horos/boundary.json` only
+if its exact scan changes. Modify no Fiat state/ledger semantics, capture,
+redaction, storage, dashboard, version, manifest, or CI file.
+
+**Tests.** Observe missing command/schema guards red on the Step 1 parent.
+Give each event and relation a minimal positive or negative fixture. Bind the
+five issue acceptance faults to distinct codes; test all study bounds and
+combined probes; compare text and JSON finding objects exactly. Run the
+focused demonstration, root suite, Promise checks, three discipline lints,
+prose gates, correct Horos command, and diff check. Record actual counts and
+expected-refusal exits.
+
+**Disciplines.** phylax: confined regular input, streaming limits, safe JSON,
+duplicate keys, paths, raw payloads, and bounded diagnostics are security
+boundaries. ephoros: results answer which contract/run/event refused, why, and
+whether tokens were recorded or unknown. metron: safety ceilings are not
+performance claims. elenchus: every accepted relationship, refusal, and
+combined fault starts red and remains guarded. hypomnema: schema owns fields,
+operator docs own use and overclaims, Promise law owns authority, tests own
+examples, and downstream capture/redaction/binding/diagnosis remain in issues
+#435, #436, and #449.

--- a/docs/promise-machine/run-observation-study.md
+++ b/docs/promise-machine/run-observation-study.md
@@ -1,0 +1,303 @@
+# Observable run record study
+
+Assuming, unless corrected:
+
+1. This ordinary issue-bound delivery starts from `main` at
+   `454bf3c9930c94985e5eb6179f3b01be2bf741c2`; it changes no skill frontier,
+   version, manifest, or CI workflow.
+2. `promise-machine-run-observation/v1` is a host-neutral JSON Lines
+   interchange format plus validator, not a recorder or transcript reader.
+3. The root Promise Machine owns the shared validation boundary. Ephoros
+   supplies observability principles without becoming a suite-wide store.
+4. Python 3 and its standard library are sufficient. No schema dependency,
+   network service, host SDK, or telemetry collector is added.
+5. Token counts are optional and recorded only when a host or provider exposes
+   them. Missing counts remain unknown and are never estimated from text.
+
+## 1. Problem statement
+
+[Issue #434](https://github.com/wildcat-finance/skills/issues/434) asks for one
+versioned, host-neutral record of observable work between Promise Machine and
+Fiat control transitions. Current controller state records transitions, but it
+does not give later reviewers a comparable event record for capability use,
+duration, exit status, retries, repository identities, evidence, refusals,
+unknowns, handoffs, or observed outcome. Host transcripts are neither stable
+nor a safe evidence interface. Hidden model reasoning is not observable and
+must refuse if presented as an observation.
+
+A working prototype provides:
+
+- a closed per-event schema identified as `promise-machine-run-observation/v1`;
+- a bounded standard-library JSONL validator with stable text and JSON findings;
+- valid success, refusal, retry, and cross-skill handoff records;
+- required negative records for missing run identity, invalid order, unbound
+  evidence, evidence-class or subject strengthening, and hidden reasoning;
+- optional source-bound token counts and explicit unknowns; and
+- one focused demonstration that exercises all accepted and refused cases.
+
+```bash
+python3 -m unittest tests.test_run_observation -v
+python3 scripts/run_observation.py check tests/fixtures/run-observation/valid/success.jsonl
+python3 scripts/run_observation.py check tests/fixtures/run-observation/invalid/hidden-reasoning.jsonl --json
+python3 -m unittest discover -s tests
+```
+
+Validator exit zero establishes only structural and relational acceptance of
+the named bytes. It establishes neither completeness, external truth, cause,
+model quality, delivery correctness, nor authority to mutate a repository.
+
+## 2. Prior art
+
+Repository conventions already provide most components:
+
+- `PROMISE_MACHINE.md` defines exact evidence classes and preserves unknowns;
+- `scripts/promise_machine.py` supplies bounded reads, duplicate-key refusal,
+  deterministic findings, and text/JSON result parity;
+- `.hexaemeron/ledger.jsonl` shows JSON Lines is suitable for ordered records
+  while remaining controller state rather than general telemetry;
+- `tests/promise_machine_coverage.json` binds promises to exact evidence and
+  refuses unsupported strengthening;
+- `plugins/hexaemeron/skills/fiat/scripts/hexctl.py` supplies run, issue, step,
+  role, refusal, recovery, and handoff concepts without owning this schema; and
+- `plugins/hexaemeron/skills/metron/scripts/metron.py` preserves measured
+  durations without defining a general observation envelope.
+
+[PR #474](https://github.com/wildcat-finance/skills/pull/474) keeps receipted
+operator statements distinct from truth. [PR
+#469](https://github.com/wildcat-finance/skills/pull/469) is the precedent for
+a suite-wide root promise and generated copies. [PR
+#293](https://github.com/wildcat-finance/skills/pull/293) established stable
+finding codes, evidence preservation, and checker/report parity.
+
+The Promise Machine and issue #446 rounds in `audit/AUDIT.md` require bounded
+regular files, repository confinement, deterministic diagnostics, exact
+evidence subjects/classes, and no promotion of a recorded assertion to truth.
+The current Phylax surface also refuses unsafe deserialisation and credentials
+in subprocess arguments. This validator uses JSON only, executes no record
+content, and invokes no subprocess.
+
+External prior art is limited to the [OpenTelemetry Logs Data
+Model](https://opentelemetry.io/docs/specs/otel/logs/data-model/), [W3C Trace
+Context](https://www.w3.org/TR/trace-context/), [RFC
+3339](https://www.rfc-editor.org/info/rfc3339/), [JSON
+Lines](https://jsonlines.org/), and OpenTelemetry's [generative-AI metric
+conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-metrics.md).
+The format borrows timestamps, correlation, streaming, and optional exposed
+token counts without claiming complete compatibility.
+
+## 3. Constraints and non-goals
+
+- Every event repeats the exact schema id and run id, with a contiguous
+  positive sequence, unique event id, RFC-3339 time, stable type, and
+  correlation id.
+- One `run.started` opens the record and one `run.finished` closes it. Parent,
+  capability, retry, handoff, and evidence references point backward.
+- Repository paths are slash-separated and relative: no absolute path, `..`,
+  execution, or implicit file read follows from a recorded value.
+- Argument information is bounded metadata. Raw prompts, completions, tool
+  output, credentials, signed payloads, environment values, and hidden
+  reasoning are forbidden.
+- Evidence references name subject, source, selector or digest, and one exact
+  Promise Machine class. Outcomes and handoffs preserve class and subject.
+- Host, model, and token facts appear only when exposed. Placeholder identities
+  and estimated token counts refuse; absence stays unknown.
+- Input is a confined regular UTF-8 file with one object per line, final
+  newline, duplicate-key refusal, and fixed byte, line, event, nesting, string,
+  and collection ceilings.
+- Every source pointer in the study and runbook is a backticked repository path
+  or absolute URL, so byte-identical publication remains location-independent.
+- The correct Horos currency command is
+  `python3 plugins/horos/skills/horos/scripts/horos.py check .`. The obsolete
+  spelling `horos.py scan . --check` is a known exit-2 specimen and must not
+  appear in a receipted runbook command block.
+
+The run does not implement capture, transcript ingestion, redaction, storage,
+search, a database, dashboard, model criticism, automatic issue filing, Fiat
+receipt binding, or cross-run diagnosis. Issues #435, #436, and #449 retain
+those boundaries. No record selects a skill or authorises a tool call,
+repository mutation, deployment, security conclusion, financial conclusion,
+or model-quality conclusion.
+
+**Always.** Run focused and root tests, Promise checks, the three non-Solidity
+discipline lints, prose gates, the exact Horos command, and `git diff --check`.
+
+**Ask first.** Add a dependency, change a public field or stable finding code,
+widen paths or inline payloads, touch CI, bind Fiat receipts, or add capture.
+
+**Never.** Store secrets or transcripts, represent hidden reasoning, estimate
+tokens, accept unbound evidence, strengthen a class or subject, delete a
+refusing fixture, execute input, or claim an unrun check.
+
+The bundled `x-ray`, `solidity-auditor`, and `fizz` suite is waived because the
+delivery is JSON, Python, fixtures, and Markdown with no Solidity. Phylax,
+Ephoros, Elenchus, Hypomnema, hostile-input tests, and the audit loop remain due.
+
+## 4. Design options
+
+### A. Root schema plus standalone validator, chosen
+
+Add `schemas/promise-machine-run-observation-v1.schema.json`, a bounded
+`scripts/run_observation.py`, fixtures, tests, operator documentation, a root
+Promise declaration and generated copies. This gives later producers one
+contract without coupling it to Fiat. The trade is a new root executable and
+an explicit schema/runtime drift obligation.
+
+### B. Put observations in Fiat's ledger
+
+Rejected because it couples high-volume work events to controller integrity,
+makes Fiat the only producer, and pre-empts issue #436's separate binding job.
+
+### C. Make OpenTelemetry canonical
+
+Rejected because v1 needs an offline repository contract, exact Promise
+Machine evidence semantics, deterministic fixtures, and a narrower payload
+boundary than a general exporter envelope.
+
+### D. Publish prose examples only
+
+Rejected because examples cannot enforce identity, order, correlation,
+evidence binding, or hidden-reasoning refusal and cannot emit stable findings.
+
+The closed event union covers `run.started`, `capability.started`,
+`capability.finished`, `transition.refused`, `retry.scheduled`,
+`handoff.recorded`, and `run.finished`. Optional token usage contains only
+non-negative host/provider-reported input and output counts, source, scope, and
+an exposed accounting identity. No derived cost or quality verdict exists.
+
+Recorded facts are emitter-supplied event bytes, exposed identities, counts,
+duration, Git identities, references, refusals, recoveries, handoffs, and final
+status. Inferred facts name a deterministic rule and prior event ids. Unknowns
+name an unavailable field and reason and never satisfy a required identity,
+binding, or positive outcome.
+
+## 5. Risk register seed
+
+```risk-register
+unbounded-input | caller-supplied JSONL bytes and event count | per-line, total-byte, event-count, nesting, string, and collection limits refuse before unbounded work
+unsafe-path | caller input path and repository paths inside events | accept one confined regular file and treat recorded paths as checked strings, never instructions
+unsafe-deserialisation | caller JSON values | parse JSON with duplicate-key checks and closed typed shapes; no pickle, YAML object construction, import, eval, or execution
+schema-drift | JSON Schema and Python relational validator | tests bind schema id, required fields, enums, and every executable relation
+event-order | sequence, lifecycle, retry, and final relationships | fixtures cover gaps, duplicates, forward references, unmatched finishes, invalid retries, and events after finish
+correlation-gap | correlation, parent, capability, and handoff ids | every reference resolves backward within the same run
+evidence-binding | evidence ids, subjects, selectors, and outcomes | every consumed id resolves to an earlier definition with non-empty subject and exact class
+evidence-promotion | outcome and handoff subject/class | any mismatch refuses; no universal class ranking is introduced
+hidden-reasoning | rationale, thought, chain-of-thought, or internal-reasoning fields | closed objects and forbidden-name checks reject the claim at any depth
+sensitive-payload | arguments, output, environment, prompts, and completions | only bounded metadata, digests, and references are allowed
+optional-host-facts | unavailable host, model, or token data | omit or record unknown; placeholders and estimates refuse
+token-accounting | exposed usage counts | non-negative integers name source, scope, and accounting identity and imply neither price nor quality
+deterministic-report | stable text and JSON findings | one sorted finding model feeds both formats and parity tests compare them
+partial-record | truncation or interrupted write | missing newline, malformed last line, absent finish, and unresolved starts refuse without mutation
+command-drift | documented repository commands | execute every runbook command or its syntax/help path before receipt and retain known invalid spellings as negative evidence
+```
+
+Audit probes should combine faults: an oversized final line after valid events,
+a symlinked input, nested duplicate keys, cross-run retry, handoff subject
+change, Boolean token counts, hidden-reasoning names at depth, truncation, and
+an event after finish.
+
+## 6. Glossary seeds
+
+- `Run observation`: one checked JSONL record for one run, not a transcript.
+- `Event`: one self-identifying JSON object on one line.
+- `Correlation id`: a bounded join key, not proof that no event is missing.
+- `Capability`: a stable host-exposed operation name plus bounded metadata.
+- `Evidence reference`: a source-bound pointer with subject, selector or
+  digest, and one exact Promise Machine class.
+- `Observed outcome`: final recorded status, distinct from why an agent chose it.
+- `Unknown`: a named fact the emitter could not establish; it authorises no
+  positive transition.
+- `Token usage`: optional exposed counts, not an estimate, price, or quality
+  measure.
+- `Finding code`: a stable `RO` identifier emitted in text and JSON.
+
+## 7. Sources
+
+Repository sources: `PROMISE_MACHINE.md`, `AGENTS.md`,
+`scripts/promise_machine.py`, `tests/test_promise_machine_contract.py`,
+`tests/promise_machine_coverage.json`,
+`plugins/hexaemeron/skills/fiat/SKILL.md`,
+`plugins/hexaemeron/skills/fiat/scripts/hexctl.py`,
+`plugins/hexaemeron/skills/phylax/SKILL.md`,
+`plugins/hexaemeron/skills/phylax/scripts/phylax.py`,
+`plugins/hexaemeron/skills/ephoros/SKILL.md`,
+`plugins/hexaemeron/skills/metron/SKILL.md`,
+`plugins/hexaemeron/skills/elenchus/SKILL.md`,
+`plugins/hexaemeron/skills/hypomnema/SKILL.md`, and `audit/AUDIT.md`.
+
+Web sources: [issue #434](https://github.com/wildcat-finance/skills/issues/434),
+its [token-telemetry comment](https://github.com/wildcat-finance/skills/issues/434#issuecomment-5377113228),
+[PR #474](https://github.com/wildcat-finance/skills/pull/474), [PR
+#469](https://github.com/wildcat-finance/skills/pull/469), and [PR
+#293](https://github.com/wildcat-finance/skills/pull/293), plus the external
+standards cited in section 2.
+
+## 8. Signals, and the questions behind them
+
+Ephoros governs the persistent signal shape.
+
+1. Which event caused refusal? Stable code, line, event id, and correlation id.
+2. Did a retry follow its failed attempt? Backward retry and capability links.
+3. Did a handoff preserve subject, scope, time domain, and class? Exact
+   producer, consumer, and evidence references.
+4. Was token use exposed? Source-bound counts answer when present; otherwise an
+   unknown names the gap.
+
+The validator is a bounded command, not a service. It needs deterministic
+findings and exit status, not a metric backend, exporter, dashboard, or alert.
+
+## 9. Boundaries, per capability
+
+Phylax governs the off-chain boundary.
+
+- Input: one confined regular file, fixed limits, UTF-8, duplicate-key refusal,
+  depth/collection checks, and no rewrite.
+- Content: closed objects, metadata-only arguments, reference indirection,
+  forbidden sensitive/reasoning fields, and no execution.
+- Repository metadata: validate relative paths and full Git ids as strings;
+  do not open named paths or run Git from record content.
+- Evidence/handoff: bind backward to exact subject/class definitions.
+- Output: fixed bounded findings, no raw-value echo, canonical JSON, and parity
+  tests.
+
+No URL fetch, credential read, subprocess, model call, external service, or new
+dependency is introduced.
+
+## 10. The budget, or its absence
+
+Metron supplies no optimisation budget because no speed claim exists. The
+validator has denial-of-service ceilings for total bytes, line bytes, event
+count, nesting, strings, and collections, each exercised by a refusal test.
+Changing them for performance reasons requires a measured baseline and study
+amendment.
+
+## 11. The fail-closed posture
+
+Elenchus governs observed failures. Unsafe input identity, malformed JSONL,
+wrong schema/run identity, unknown fields, broken order, unresolved references,
+subject/class change, hidden-reasoning claims, raw payloads, and invalid
+optional telemetry each produce a stable finding and non-zero exit. The command
+never repairs, truncates, skips, or rewrites input. Every defect found in build
+or audit receives a minimal red guard before its fix.
+
+## 12. Decisions and their homes
+
+Hypomnema places the standing decision at
+`docs/decisions/ADR-014-define-the-promise-machine-run-observation-record.md`;
+ADR-014 is unused at the pinned base. The schema belongs at
+`schemas/promise-machine-run-observation-v1.schema.json`, relational checks at
+`scripts/run_observation.py`, examples under
+`tests/fixtures/run-observation/`, executable expectations at
+`tests/test_run_observation.py`, operator prose under
+`docs/promise-machine/run-observation-v1.md`, and the narrow authority in
+`PROMISE_MACHINE.md` and its generated copies. Study and runbook copies live
+under `docs/promise-machine/`; audit evidence appends to `audit/AUDIT.md`.
+
+Two dependency-ordered steps are sufficient:
+
+1. Publish byte-identical study/runbook copies, ADR-014, and the refreshed
+   Horos boundary.
+2. Build, bind, harden, document, and demonstrate the complete schema and
+   validator, including every issue acceptance case and combined audit probe.
+
+The first step leaves only reviewable prose. The second remains one capability:
+the schema has no acceptance without its validator and demonstration.


### PR DESCRIPTION
## What changed

- Published the receipted study and runbook as byte-identical repository records.
- Added ADR-014, which assigns the versioned observation record to the root Promise Machine and records the rejected alternatives.
- Refreshed the generated Horos boundary for the two new documentation paths.

This Step 1 PR is stacked on `fiat/434-observable-run-record`. It covers the specification and standing decision for issue #434. The schema, validator, fixtures, Promise declaration, and demonstration remain Step 2 work.

## Audit

The Step 1 review is recorded in `audit/AUDIT.md` under “Issue 434 observable run record, step 1, round 1”. It found no open defect in the complete run-to-step diff.

## Proof

- Root tests pass 118/118.
- The old five-link specimen exits 1 with exactly five H001 findings; the corrected, location-independent pointers pass the repository Hypomnema check.
- The obsolete `horos.py scan . --check` specimen exits 2; `python3 plugins/horos/skills/horos/scripts/horos.py check .` exits 0.
- Both Protasis modes, Hypomnema, Imprimatur, Brevitas, Horos currency, byte comparisons, and diff checks pass.

The Solidity suite is waived because this step changes only Markdown and generated Horos boundary metadata. X-Ray, Solidity Auditor, and Fizz did not run. The validator's structural checks will not establish completeness, external truth, cause, model quality, delivery correctness, or authority to mutate a repository.

<!-- wildcat-origin: shoggoth -->
