### PR TITLE
Define Lazarus multi-provider chain-anchor formats

### DIFF
--- a/audit/rounds/fiat-386-record-a-structured-multi-provider-chain-anc.md
+++ b/audit/rounds/fiat-386-record-a-structured-multi-provider-chain-anc.md
@@ -1,0 +1,38 @@
+# Issue 386: record a structured multi-provider chain anchor
+
+## Step 1, round 1 -- 2026-08-25
+
+Non-Solidity round over commit
+`d917f41034743cb9d27db5e2da6eb27319f59ffb` on
+`fiat/386-record-a-structured-multi-provider-chain-anc-step-1-define-the-anchor-formats`
+against parent branch `fiat/386-record-a-structured-multi-provider-chain-anc`
+at `0f835d5f5f7c95ad2716eb63bd9bdd8f68b0a841`. Security receipt:
+`waived: issue 386 changes Lazarus Python, JSON schemas, tests, and documentation; no Solidity or Pashov security-suite target applies`.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+Zero findings. The review covered all 16 changed paths against Step 1 at
+effective SHA-256
+`d861773977ffd121ac84e8b1da8b0e160396d1951869e3888293c0ab92f643a6`
+and the risk register in `.hexaemeron/study.md` at SHA-256
+`f16d14e2182f872d95e56b4485218a264286a845f80b2857960dcd32c14442fd`.
+Plan v2 retains the complete plan-v1 shape and adds only 1 to 32 sorted, unique
+source identifiers. Anchor records are closed, bounded, schema-digest-pinned,
+UTC-checked, source-sorted, and source-unique; neither plan nor record admits a
+provider URL, header, raw error, independence claim, or canonical-chain claim.
+The temporary capture guard refuses plan v2 before client construction or
+staging. The tracked study and runbook match the receipted bytes, and existing
+manifest and release schemas are unchanged.
+
+The focused schema, record, scaffold, and runner set reports 61/61. The source-
+owned runner reports 386/386 Lazarus tests, and the root suite reports 350/350.
+Phylax exits 0 over `plugins tests`; Ephoros exits 0 over `plugins tests`;
+Hypomnema exits 0 over `README.md AGENTS.md .agents plugins docs`.
+
+Leads not pursued: live provider disagreement, runtime secret scanning, shared
+network budgets, atomic multi-provider finalisation, digest-bound one-read
+verification, exact plan-to-record coverage, and anchored release compatibility
+are not reachable in this format-only step. Step 1 refuses plan-v2 capture;
+Steps 2 and 3 own those transitions. These remain required risk-register
+checks, not accepted risks.

--- a/docs/lazarus-multi-provider-chain-anchor/runbook.md
+++ b/docs/lazarus-multi-provider-chain-anchor/runbook.md
@@ -1,0 +1,71 @@
+# Runbook: structured multi-provider chain anchors
+
+This runbook derives from the receipted study at SHA-256
+`f16d14e2182f872d95e56b4485218a264286a845f80b2857960dcd32c14442fd`.
+Run every Python command in an environment populated from
+`plugins/lazarus/requirements.lock`; the run-local CPython 3.12 baseline passed
+all 364 existing Lazarus tests after that lock was installed. Each step keeps
+plan-v1, manifest-v1, release-v1, the Goldfinch fixture bytes, the writer
+`tool_version`, and the held `receipt-inclusion-proofs` frontier unchanged.
+
+## Step 1: Define the anchor formats
+
+**Goal.** Add the versioned plan and anchor-record contracts, their canonical helpers, the tracked specification copies, and the structured unittest runner required by later audit rounds.
+
+**Entry.** Run branch `fiat/386-record-a-structured-multi-provider-chain-anc` at `0f835d5f5f7c95ad2716eb63bd9bdd8f68b0a841`, with the study receipt above and the 364-test locked-environment baseline green.
+
+**Exit.** `plan-v2` copies the complete plan-v1 contract and requires one sorted, unique array of 1 to 32 objects containing only a `source_id` matching `^[a-z][a-z0-9_.-]{0,127}$`; plan-v1 still declares no anchors. `anchor-record-v1` admits only `schema_version`, `source_id`, `observed_at`, the exact `eth_getBlockByNumber` method and parameters, and the returned mainnet chain ID, block number, and block hash. The schema registry digest-pins both formats, semantic validation refuses non-UTC timestamps and plan ordering or uniqueness drift, canonical JSONL helpers sort and de-duplicate records by source ID, and `validate` accepts the new record kind. Exact study and runbook copies live under `docs/lazarus-multi-provider-chain-anchor/`. A repository-owned unittest runner emits one fresh `elenchus.unittest.v1` file without following links or accepting a path outside its worktree. Prove the exit with `python3 plugins/lazarus/scripts/lazarus.py validate schemas`, `python3 -m unittest plugins.lazarus.tests.test_schemas plugins.lazarus.tests.test_records plugins.lazarus.tests.test_scaffold plugins.lazarus.tests.test_runner -v`, `python3 -m unittest discover -s plugins/lazarus/tests -t plugins/lazarus -v`, `python3 -m unittest discover -s tests -v`, `python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/lazarus-multi-provider-chain-anchor/study.md`, and `python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/lazarus-multi-provider-chain-anchor/runbook.md`.
+
+**Files.** Create `docs/lazarus-multi-provider-chain-anchor/{study.md,runbook.md}`, `plugins/lazarus/schemas/{plan-v2.json,anchor-record-v1.json}`, `plugins/lazarus/tests/{run_tests.py,test_runner.py}`; change `plugins/lazarus/scripts/lazarus.py`, `plugins/lazarus/scripts/lazarus_lib/{schemas.py,records.py}`, and `plugins/lazarus/tests/{support.py,test_schemas.py,test_records.py,test_scaffold.py}`.
+
+**Tests.** Add positive, malformed, unknown-version, digest-substitution, source-ID grammar, 1/32/33-source, sorted/duplicate-plan, timestamp, method/parameter, returned-field, canonical-byte, sorted-record, duplicate-record, and runner path/report cases. The step audit runner contract is test command `python3 plugins/lazarus/tests/run_tests.py --elenchus-report {report}`, report format `unittest-json-v1`, report file `tmp/elenchus/lazarus-step-1.json`. Record the new full-suite count at implementation time; all 364 baseline cases must remain green.
+
+**Disciplines.** phylax: schemas and the report path accept untrusted data, so closed fields, caps, no-follow traversal, fresh-file creation, and stable value-free refusals apply. ephoros: the runner's complete counters and stable schema/version errors answer whether a check actually ran; no metrics backend is added. metron: none, there is no performance claim. elenchus: the report emitter is the guard transport for every later fix, and its hostile path cases must fail before its safe case passes. hypomnema: the two public byte formats and runtime syntax are expensive to reverse; the committed study is their rationale and the schemas are their authority.
+
+## Step 2: Verify anchor records offline
+
+**Goal.** Extend manifest and whole-fixture verification so a declared anchor component is digest-bound, exactly covered, separately counted, and never promoted into a proof or canonical-chain claim.
+
+**Entry.** The controller-receipted Step 1 commit with both new formats registered, canonical helpers green, and the full Lazarus and root Python suites passing.
+
+**Exit.** Manifest-v1 accepts `anchors.jsonl` as a recognised optional component without changing its schema or three `evidence_counts`; plan-v2 requires that component and plan-v1 refuses it. Whole-fixture verification performs one digest-bound read, requires exact plan-to-record source coverage, rejects missing, extra, duplicate, malformed, wrong-chain, wrong-height, or header-disagreeing records, and returns `chain_anchors: {records: N, canonical_chain_claim: false, provider_independence_claim: false}`. CLI verification prints `chain-anchor-records: N`. Release-v1 and Ariadne-facing binding remain structurally unchanged while accepting the fixture digest and component inventory of an anchored fixture. Prove the exit with `python3 -m unittest plugins.lazarus.tests.test_manifest plugins.lazarus.tests.test_verifier plugins.lazarus.tests.test_binding plugins.lazarus.tests.test_release -v`, `python3 plugins/lazarus/scripts/lazarus.py verify plugins/lazarus/examples/goldfinch-v0`, `python3 plugins/lazarus/examples/preservation-release-demo.py`, `python3 -m unittest discover -s plugins/lazarus/tests -t plugins/lazarus -v`, and `python3 -m unittest discover -s tests -v`.
+
+**Files.** Change `plugins/lazarus/scripts/lazarus.py`, `plugins/lazarus/scripts/lazarus_lib/{manifest.py,verifier.py}`, and `plugins/lazarus/tests/{support.py,test_manifest.py,test_verifier.py,test_binding.py,test_release.py,test_preservation_release.py}`.
+
+**Tests.** Build plan-v1 and plan-v2 fixtures from local test material; cover zero and 1/32 records, component presence parity, exact source coverage, duplicate and reordered records, every returned identity disagreement, post-manifest mutation, recomputed count, both false claim booleans, unchanged evidence counts, CLI output, release round trip, and the unchanged Goldfinch digest. The step audit runner contract is test command `python3 plugins/lazarus/tests/run_tests.py --elenchus-report {report}`, report format `unittest-json-v1`, report file `tmp/elenchus/lazarus-step-2.json`. Record the new full-suite count; no test may depend on a live RPC.
+
+**Disciplines.** phylax: manifest paths and provider-authored anchor bytes cross the filesystem and parser boundaries, so bounded no-follow reads, schema validation, digest binding, and one coherent report apply. ephoros: `chain-anchor-records`, the two false booleans, and source-specific stable refusals answer coverage and epistemic-boundary questions. metron: none, component limits are safety budgets and no speed claim is made. elenchus: every false claim, coverage drift, and one-read mutation begins as a failing test and closes only at the verifier cause. hypomnema: the separate count and refusal to alter release evidence classes implement the study's recorded decision; no second decision home is added.
+
+## Step 3: Capture and demonstrate anchors
+
+**Goal.** Wire declared runtime providers into atomic capture, document the operator contract, and ship a reproducible anchored-fixture demonstration under Lazarus generation `v1.2.0`.
+
+**Entry.** The controller-receipted Step 2 commit whose offline verifier accepts only exact, digest-bound anchor coverage and whose legacy fixture and release demonstrations are green.
+
+**Exit.** `capture` accepts repeated `--anchor-rpc-env SOURCE_ID=ENV_VAR`, requires its identifier set to equal the plan, reads only explicitly named non-empty environment variables, and never puts their values in argv, output, diagnostics, or fixture bytes. One client per source shares the existing request, response-byte, component-byte, total-byte, and elapsed-time limits; each calls `eth_chainId` and `eth_getBlockByNumber` for the fixed block. Capture writes source-sorted records with an injected UTC wall clock, scans the union of primary and anchor secrets, and leaves no output or stage on any mapping, transport, chain, height, hash, schema, limit, secret, or final verification failure. A checked-in synthetic fixture demonstrates two matching recorded observations while retaining both false claims; `python3 plugins/lazarus/scripts/lazarus.py verify plugins/lazarus/examples/multi-provider-anchor-v0` prints `chain-anchor-records: 2`. README, runtime contract, canonical skill, and chain-anchor guide state the mapping, evidence boundary, limits, refusals, and non-claims. The skill and ledger advance once to generation `lazarus-v1.2.0`, retaining the prior frontier revision, digest, status, current text, and held job byte for byte. Prove the exit with `python3 -m unittest plugins.lazarus.tests.test_capture plugins.lazarus.tests.test_limits plugins.lazarus.tests.test_scrub plugins.lazarus.tests.test_goldfinch plugins.lazarus.tests.test_scaffold -v`, `python3 plugins/lazarus/scripts/lazarus.py verify plugins/lazarus/examples/multi-provider-anchor-v0`, `python3 plugins/lazarus/scripts/lazarus.py verify plugins/lazarus/examples/goldfinch-v0`, `python3 plugins/lazarus/examples/preservation-release-demo.py`, `python3 -m unittest discover -s plugins/lazarus/tests -t plugins/lazarus -v`, and `python3 -m unittest discover -s tests -v`.
+
+**Files.** Create `plugins/lazarus/docs/chain-anchors.md` and `plugins/lazarus/examples/multi-provider-anchor-v0/`; change `plugins/lazarus/{AGENTS.md,README.md}`, `plugins/lazarus/scripts/lazarus.py`, `plugins/lazarus/scripts/lazarus_lib/{capture.py,scrub.py}`, `plugins/lazarus/tests/{fake_rpc.py,support.py,test_capture.py,test_limits.py,test_scrub.py,test_goldfinch.py,test_scaffold.py}`, and `plugins/lazarus/skills/lazarus/{SKILL.md,EVOLUTION.md}`.
+
+**Tests.** Add CLI and direct-capture cases for exact/missing/extra/duplicate mappings, absent and empty environment variables, argument/output/error secrecy, deterministic source order under reversed CLI order, fixed injected timestamps, shared request/byte/time exhaustion, provider redirects and sanitised errors, wrong chain/height/hash, disagreement after partial success, final secret scan, interrupted finalisation, and no destination or stage after every refusal. The step audit runner contract is test command `python3 plugins/lazarus/tests/run_tests.py --elenchus-report {report}`, report format `unittest-json-v1`, report file `tmp/elenchus/lazarus-step-3.json`. Record the final full-suite count and exact anchored and Goldfinch fixture digests.
+
+**Disciplines.** phylax: environment names, URL values, provider responses, errors, limits, staging, and finalisation are the live trust boundaries, with exact mapping, existing transport controls, union secret scanning, and atomic cleanup. ephoros: capture and verify expose declared/verified counts plus a non-secret source ID and bounded stage on refusal; the example preserves the two false claim booleans. metron: none, provider caps are safety bounds and no latency gain is claimed. elenchus: every new refusal is observed red against the unfixed parent before its cause-level guard is accepted, then the full suites and demonstrations rerun. hypomnema: `docs/chain-anchors.md`, the versioned schemas, the committed study, and one generation ledger row are the durable homes; release and Ariadne contracts stay untouched.
+
+### Amendment -- 2026-08-25
+
+**What changed.** Complete replacement Files: Create `docs/lazarus-multi-provider-chain-anchor/{study.md,runbook.md}`, `plugins/lazarus/schemas/{plan-v2.json,anchor-record-v1.json}`, `plugins/lazarus/tests/{run_tests.py,test_runner.py}`; change `plugins/lazarus/scripts/lazarus.py`, `plugins/lazarus/scripts/lazarus_lib/{schemas.py,records.py}`, `plugins/lazarus/tests/{support.py,test_schemas.py,test_records.py,test_scaffold.py}`, and `tests/promise_machine_coverage.json`.
+
+**Why.** The exact root suite returned three PM071 failures because changing `plugins/lazarus/scripts/lazarus.py` changes the source digest recorded for Lazarus's three covered runtime promises. Root verification cannot be green until the coverage record names the implemented bytes.
+
+**Steps touched.** Step 1's Files field.
+
+**Still holding.** Step 1: entry holds; exit holds. Step 2: entry holds; exit holds. Step 3: entry holds; exit holds.
+
+### Amendment -- 2026-08-25
+
+**What changed.** Complete replacement Files: Create `docs/lazarus-multi-provider-chain-anchor/{study.md,runbook.md}`, `plugins/lazarus/schemas/{plan-v2.json,anchor-record-v1.json}`, `plugins/lazarus/tests/{run_tests.py,test_runner.py}`; change `plugins/lazarus/scripts/lazarus.py`, `plugins/lazarus/scripts/lazarus_lib/{capture.py,schemas.py,records.py}`, `plugins/lazarus/tests/{support.py,test_capture.py,test_schemas.py,test_records.py,test_scaffold.py}`, and `tests/promise_machine_coverage.json`.
+
+**Why.** Once plan-v2 is registered, the pre-anchor `capture_fixture()` path would otherwise accept its valid `anchor_sources` field and silently produce a fixture with no anchors. Step 1 must refuse that unsupported capture version until Step 3 replaces the refusal with complete anchor capture.
+
+**Steps touched.** Step 1's Files field.
+
+**Still holding.** Step 1: entry holds; exit holds. Step 2: entry holds; exit holds. Step 3: entry holds; exit holds.

--- a/docs/lazarus-multi-provider-chain-anchor/study.md
+++ b/docs/lazarus-multi-provider-chain-anchor/study.md
@@ -1,0 +1,395 @@
+# Study: structured multi-provider chain anchors
+
+Assuming, unless corrected:
+
+1. Issue [#386](https://github.com/wildcat-finance/skills/issues/386) is a
+   generation job. It must leave Lazarus's `receipt-inclusion-proofs` frontier,
+   its held `lazarus-next` job, and their digest unchanged.
+2. "Independent providers" is an operator assertion represented by distinct
+   source identifiers. Lazarus can record separate answers; it cannot establish
+   that two URLs have separate operators, infrastructure, upstream clients, or
+   failure domains.
+3. The requested count is a separately named chain-anchor-record count. It is
+   not a fourth proof class and does not increase `proof_backed`,
+   `header_bound`, or `recorded_rpc`.
+4. A declared anchor source is required. A transport failure, malformed answer,
+   wrong chain, wrong block number, or hash disagreement aborts the staged
+   capture, matching the existing primary-provider rule.
+5. Existing plan-v1 fixtures and the shipped Goldfinch release remain valid
+   without byte changes. The extension uses new versioned documents rather than
+   editing a released v1 schema in place.
+
+## 1. Problem statement
+
+Lazarus currently stores `plan.block.hash_source` as prose and verifies only
+that one captured header is internally self-consistent. A fixture therefore has
+no structured place for the block-hash answers obtained from other providers at
+capture time. Protocol engineers preserving a historical fixture need those
+answers retained with the fixture while keeping their evidence class honest.
+
+A working prototype does all of the following:
+
+- a plan declares between 1 and 32 opaque anchor source identifiers;
+- `capture` resolves an exact runtime URL for every declared identifier through
+  an explicitly named environment variable, queries each source for Ethereum
+  mainnet chain ID and the fixed block, and writes no URL, credential, request
+  header, or raw provider error;
+- successful capture writes a digest-bound `anchors.jsonl` whose records name
+  the source identifier, local observation time, exact method and parameters,
+  returned chain ID, block number, and block hash;
+- `verify` recomputes exact plan-to-record coverage and prints
+  `chain-anchor-records: N` while retaining `canonical_chain_claim: false` and
+  `provider_independence_claim: false`; and
+- any missing, extra, duplicate, malformed, cross-chain, wrong-height, or
+  disagreeing record is refused offline, while a failed live anchor query leaves
+  no final fixture.
+
+The proving paths are:
+
+```bash
+python3 -m unittest discover -s plugins/lazarus/tests -t plugins/lazarus -v
+python3 plugins/lazarus/scripts/lazarus.py verify <anchored-fixture>
+python3 plugins/lazarus/scripts/lazarus.py verify \
+  plugins/lazarus/examples/goldfinch-v0
+```
+
+The first command must cover capture, schema, manifest, verification, secret,
+resource-limit, and compatibility cases. The second must print the structured
+count. The third must keep the existing fixture's digest and three evidence
+counts unchanged.
+
+## 2. Prior art
+
+### Repository state
+
+- `plugins/lazarus/schemas/plan-v1.json` requires an unstructured
+  `block.hash_source` and has no provider inventory.
+- `plugins/lazarus/scripts/lazarus_lib/capture.py` brackets a capture with two
+  reads from one primary provider, requires its chain ID and block hash to match
+  the plan, stages all output, scans staged bytes for provider secrets, and
+  finalises atomically only after `verify_fixture` succeeds.
+- `plugins/lazarus/scripts/lazarus_lib/manifest.py` digests every listed
+  component and recomputes three evidence counts from recognised formats.
+- `plugins/lazarus/scripts/lazarus_lib/verifier.py` performs a second bounded
+  read of digest-bound components, reports one header-bound header, and fixes
+  `canonical_chain_claim` at `false`.
+- `plugins/lazarus/scripts/lazarus_lib/rpc.py` already supplies redirect refusal,
+  bounded responses, JSON-RPC shape checks, and sanitised transport failures.
+- `plugins/lazarus/scripts/lazarus_lib/scrub.py` derives provider secrets from
+  URLs and headers and refuses any such byte found in the staged fixture.
+- `plugins/lazarus/scripts/lazarus_lib/release.py` and
+  `plugins/lazarus/schemas/release-v1.json` bind only the existing three evidence
+  counts. An anchor component is still protected by the fixture digest without
+  becoming an Ariadne predicate claim.
+
+### Merged work and carried-forward evidence
+
+The last two merged domain pull requests were read in full:
+
+- [#227](https://github.com/wildcat-finance/skills/pull/227) shipped the
+  preservation release. Its carried boundary is that counts must be recomputed
+  from verified bytes, every stated field must be read, paths and refusals must
+  be bounded, one verification pass must supply one coherent report, and no
+  release may claim canonical-chain membership.
+- [#59](https://github.com/wildcat-finance/skills/pull/59) introduced the
+  audited capture, verifier, and exact replay plugin. Its carried boundary is
+  that capture is the only provider-backed operation, credentials never enter a
+  fixture, state-proof-backed and recorded evidence remain separate, and replay
+  has no live fallback.
+
+The two most recent repository pull requests that physically touched Lazarus
+surfaces were also checked. [#596](https://github.com/wildcat-finance/skills/pull/596)
+refreshed collective documentation, and
+[#577](https://github.com/wildcat-finance/skills/pull/577) propagated the root
+Promise Machine contract. Neither body carries unfinished Lazarus product work
+into #386.
+
+The in-scope historical audit is the `Goldfinch preservation release` sequence
+in `audit/AUDIT.md` (21 rounds across five steps, as recorded by #227). The
+relevant findings and guards are retained here: refuse fields that are present
+but unread; cap both input and diagnostic size; protect against symlink and
+path races; derive counts rather than trust manifests; keep one coherent
+verification read; preserve exact failure boundaries; and leave
+`canonical_chain_claim` false. The issue-386 audit path
+`audit/rounds/fiat-386-record-a-structured-multi-provider-chain-anc.md` does not
+exist yet, so it carries no prior finding.
+
+### Organisation and external standards
+
+Issue #386 names Tabularium's unproved-chain-boundary language and Ariadne's
+fixture predicate as neighbouring work. This run consumes that boundary but
+does not change either sibling. The Ethereum Execution APIs specification for
+[`eth_getBlockByNumber`](https://ethereum.github.io/execution-apis/api/methods/eth_getBlockByNumber/)
+defines a fixed quantity plus `false` as the block query used here.
+[EIP-1474](https://eips.ethereum.org/EIPS/eip-1474) and EIP-1898 distinguish a
+provider's canonicality check from proof of global canonical-chain membership.
+Several agreeing JSON-RPC answers are corroborating recorded observations, not
+a consensus proof.
+
+## 3. Constraints and non-goals
+
+The run started from `main` at
+`0f835d5f5f7c95ad2716eb63bd9bdd8f68b0a841`. Lazarus supports CPython 3.11 and
+newer and CI runs 3.11 and 3.13 using
+`plugins/lazarus/requirements.lock`. No dependency addition is needed. The
+current skill label is `lazarus-v1.1.0`; under
+`plugins/hexaemeron/skills/VERSIONING.md`, this meaningful non-frontier behavior
+change becomes generation `lazarus-v1.2.0`, retaining the existing frontier
+revision, digest, status, and held job byte for byte.
+
+Constraints:
+
+- accept old plan-v1 fixtures and releases unchanged;
+- use a plan-v2 schema for declared source identifiers and an
+  anchor-record-v1 schema for stored answers;
+- preserve the existing manifest-v1 three-class `evidence_counts` shape;
+- keep anchor URLs and headers runtime-only, keep their values out of argv, and
+  include their secrets in the final staged-tree scan;
+- share the plan's request, byte, and elapsed-time limits across primary and
+  anchor clients;
+- sort sources and records by identifier so fixture bytes do not depend on CLI
+  argument order; and
+- use injected clients and clocks for tests, with no public RPC dependency in
+  CI.
+
+Non-goals:
+
+- proving provider independence, Ethereum consensus, finality, or canonical
+  membership;
+- proving receipts or logs against `receiptsRoot`, which remains issue #383;
+- replaying anchor queries through the exact-request replay server;
+- changing Ariadne or Tabularium schemas, predicates, or claims;
+- changing the package version, writer `tool_version`, existing released
+  fixture bytes, or `manifest-v1.json`; and
+- retaining failed captures or raw provider disagreements as a partial
+  fixture.
+
+Always: run the Lazarus and root Python suites before a commit; validate every
+new schema and example; run Imprimatur on shipped prose; and re-run the
+Goldfinch verification and preservation-release demonstrations. Ask first:
+add a dependency, alter an existing v1 schema, touch CI, add optional/fail-open
+anchor semantics, widen release or Ariadne claims, or rewrite a released
+digest. Never: persist a provider URL, header, credential, or raw error; edit a
+vendored tree; delete a failing test; claim source independence or canonical
+membership; or report a command that did not run.
+
+## 4. Design options and selection
+
+### Option A: plan-v2 plus one optional anchor component
+
+Add a plan-v2 document with a required, sorted, unique `anchor_sources` array
+of 1 to 32 source identifiers. `capture` accepts repeated
+`--anchor-rpc-env SOURCE_ID=ENV_VAR` mappings whose identifier set must equal
+the plan, then reads each URL from only that named variable. It writes one
+`anchors.jsonl` component under a new
+anchor-record-v1 schema. Manifest v1 digests the component; verifier code
+recognises it, checks coverage and reports its count outside `evidence_counts`.
+
+Trade: this adds one plan version, one record format, and a runtime mapping
+surface, but keeps old bytes and all three evidence-class interfaces stable.
+
+### Option B: mutate plan-v1 and add a fourth manifest evidence count
+
+Add optional provider fields to plan v1 and `chain_anchor` to
+manifest/release evidence counts.
+
+Trade: fewer new schema files, but it edits a released version in place,
+changes fixture identity semantics, forces release and Ariadne reconciliation,
+and invites readers to treat corroboration as a stronger evidence class.
+
+### Option C: run a separate post-capture anchor command
+
+Let `lazarus anchor` query providers after a fixture exists and rewrite its
+manifest.
+
+Trade: a simpler capture path, but the answers no longer share capture's block
+bracket or atomic finalisation. It also rewrites an already verified fixture
+and creates a second networked mutation path.
+
+### Selected design
+
+Choose Option A. It is the smallest construction that gives structured,
+digest-bound, offline-verifiable records without changing existing evidence
+classes or released formats.
+
+The exact contract is:
+
+1. Plan v2 copies plan v1 and adds `anchor_sources`, each containing only a
+   `source_id` matching `^[a-z][a-z0-9_.-]{0,127}$`. The array is sorted,
+   unique, and capped at 32. Plan v1 continues to mean no anchors.
+2. `capture --anchor-rpc-env SOURCE_ID=ENV_VAR` splits only the first `=` and
+   requires exactly one non-empty named environment variable for each declared
+   identifier and no undeclared identifier. Environment values never enter
+   argv, output, or diagnostics. The legacy primary `--rpc-url` is unchanged
+   and is not inferred to be an independent anchor.
+3. Each anchor client uses the existing transport and shared `CaptureLimits` to
+   call `eth_chainId` and `eth_getBlockByNumber` with the plan's fixed quantity
+   and `false`. Every result must name chain `0x1`, the fixed number, and the
+   expected hash. Any failure aborts the staged capture.
+4. Each anchor record stores only schema version, source identifier, a local
+   UTC observation timestamp, method, parameters, returned chain ID, returned
+   block number, and returned block hash. It stores neither URL nor response
+   payload beyond those answer fields. The timestamp is recorded local-clock
+   evidence, not provider attestation.
+5. `anchors.jsonl` is present exactly when plan v2 declares sources. Records
+   are sorted by `source_id`; their source set must exactly cover the plan.
+6. `verify_manifest` schema-checks and digest-checks the optional component.
+   `verify_fixture` reads it once through the manifest claim, rechecks exact
+   coverage and header agreement, and returns
+   `chain_anchors: {records: N, canonical_chain_claim: false, provider_independence_claim: false}`.
+7. CLI `verify` prints `chain-anchor-records: N`. Existing
+   `evidence_counts`, release-v1, and Ariadne binding fields remain unchanged.
+
+## 5. Risk register seed
+
+```risk-register
+provider-secret | runtime primary URL, anchor environment values, headers, and provider failures | anchor URL values stay out of argv, no URL or raw error enters a record, and every provider secret is included in the staged-tree scan
+provider-identity-overclaim | operator-chosen source identifiers | distinct identifiers are recorded assertions and no output claims separate ownership or infrastructure
+canonicality-overclaim | several providers returning the expected hash | header-bound stays one, both anchor claim booleans stay false, and no anchor enters a proof-backed count
+anchor-coverage | the join between plan source identifiers, runtime mappings, and stored records | missing, extra, duplicate, or reordered sources are refused and exact set equality is tested
+provider-disagreement | an anchor provider returns another chain, height, or hash | capture aborts before finalisation and the minimal mismatch guard fails without that check
+resource-exhaustion | up to 32 providers making network calls and returning hostile payloads | shared request, elapsed-time, component, response, and total-byte limits cover every anchor call and record
+partial-write | capture interruption after some providers answer | anchors remain in the temporary stage and no destination exists until complete verification and atomic finalisation
+schema-drift | new plan and record schemas plus the built-in digest registry | schema digests, semantic validators, fixture copies, and compatibility tests agree exactly
+one-read-race | a component changing between manifest and semantic verification | anchor bytes are reread through their manifest size and digest claim and one report carries the resulting count
+release-compatibility | an anchored fixture passing through release-v1 | the fixture digest binds anchors while release evidence counts and canonical-chain claims remain unchanged
+```
+
+## 6. Glossary seeds
+
+- **Anchor source:** one operator-declared identifier mapped to one runtime RPC
+  URL for this capture.
+- **Anchor record:** the bounded stored answer from one declared source for the
+  fixed block query.
+- **Anchor count:** the number of structurally and semantically verified anchor
+  records; not an independence, consensus, or canonicality score.
+- **Primary provider:** the existing provider used for the header bracket,
+  declared requests, and state proofs; not automatically an anchor source.
+- **Recorded corroboration:** matching provider observations preserved as
+  recorded evidence without a proof relation.
+- **Canonical-chain claim:** a conclusion that the captured header belongs to
+  Ethereum's canonical chain; always false in this run.
+
+## 7. Sources
+
+- Issue [#386](https://github.com/wildcat-finance/skills/issues/386), including
+  its generation boundary and named sibling handoffs.
+- `plugins/lazarus/AGENTS.md` and
+  `plugins/lazarus/skills/lazarus/{SKILL.md,EVOLUTION.md}`.
+- `plugins/lazarus/schemas/{plan-v1.json,manifest-v1.json,release-v1.json}`.
+- `plugins/lazarus/scripts/lazarus.py` and
+  `plugins/lazarus/scripts/lazarus_lib/{capture,manifest,verifier,rpc,scrub,schemas,release,binding}.py`.
+- `plugins/lazarus/tests/` and the checked-in Goldfinch fixture and release.
+- `plugins/lazarus/docs/{study.md,runbook.md,preservation-release.md}` and
+  `docs/lazarus-goldfinch-preservation-release/`.
+- `audit/AUDIT.md`, especially `Goldfinch preservation release` steps 1 to 5.
+- Merged pull requests [#59](https://github.com/wildcat-finance/skills/pull/59),
+  [#227](https://github.com/wildcat-finance/skills/pull/227),
+  [#577](https://github.com/wildcat-finance/skills/pull/577), and
+  [#596](https://github.com/wildcat-finance/skills/pull/596).
+- [Ethereum Execution APIs: `eth_getBlockByNumber`](https://ethereum.github.io/execution-apis/api/methods/eth_getBlockByNumber/)
+  and [EIP-1474](https://eips.ethereum.org/EIPS/eip-1474).
+- `plugins/hexaemeron/skills/{protasis,phylax,ephoros,metron,elenchus,hypomnema}/SKILL.md`
+  and `plugins/hexaemeron/skills/VERSIONING.md`.
+
+## 8. Signals and their questions
+
+This is a bounded CLI capture rather than a resident service, so Ephoros's
+contract applies to deterministic command output and stable refusals, not a new
+metrics backend.
+
+- How many anchor sources were declared, queried, stored, and verified? Capture
+  and verify expose the declared and verified record counts.
+- Which source stopped capture, and at which bounded stage? Stable errors name
+  the non-secret `source_id` and one of mapping, transport, chain, height, hash,
+  schema, or coverage without echoing provider data.
+- Did verification preserve the epistemic boundary? The report and CLI retain
+  both false claim booleans and the unchanged three evidence counts.
+- Did the compatibility path move? The Goldfinch demo reports its existing
+  digest and counts, while a focused anchored-fixture demo reports the new
+  count.
+
+The runbook must cite `hexaemeron:ephoros` for the implementation step that
+adds these outputs and guard tests.
+
+## 9. Boundaries per capability
+
+Under `hexaemeron:phylax`, the new boundaries and controls are:
+
+- **Plan to runtime mapping:** untrusted source identifiers and repeated CLI
+  environment-name mappings are normalised, bounded, unique, required to match
+  exactly, and resolve only the explicitly named non-empty variables.
+- **Network transport:** each anchor URL uses the existing redirect-refusing,
+  size-bounded JSON-RPC client and shared capture limits.
+- **Provider response:** JSON-RPC envelopes, chain ID, block object, number,
+  and hash are type-checked before any record is constructed.
+- **Secret handling:** all primary and anchor secrets are collected before
+  capture, raw errors are discarded, and the union is scanned against every
+  staged component before finalisation.
+- **Filesystem:** only canonical JSONL enters the existing confined staged
+  directory; manifest size and digest bind it before semantic verification.
+- **Evidence interpretation:** anchor records remain recorded observations,
+  source independence stays an operator assertion, and canonical-chain status
+  stays unknown.
+
+## 10. Budget or its absence
+
+There is no latency optimization claim, so `hexaemeron:metron` does not require
+a before-and-after timing experiment. Provider latency is external and a wall
+clock target would not isolate this change. Resource budgets do apply: at most
+32 anchor sources, two planned calls per source, and the existing plan limits
+for request count, elapsed seconds, component bytes, total fixture bytes, and
+provider response bytes. Focused limit tests run with:
+
+```bash
+python3 -m unittest \
+  plugins.lazarus.tests.test_capture \
+  plugins.lazarus.tests.test_limits \
+  plugins.lazarus.tests.test_records \
+  plugins.lazarus.tests.test_verifier -v
+```
+
+Any implementation justified as faster must stop and add a Metron baseline
+before that change.
+
+## 11. Fail-closed posture
+
+Capture stops before destination finalisation on an unsafe or duplicate runtime
+mapping, unavailable declared source, redirect, timeout, oversized response,
+malformed JSON-RPC envelope, wrong chain, missing block, wrong height, hash
+disagreement, schema failure, secret scan hit, component mismatch, limit breach,
+or failed whole-fixture verification. Offline verification stops on an absent or
+unexpected anchor component, plan-record coverage drift, duplicate source,
+non-canonical bytes, digest drift, or any anchor/header disagreement. It never
+silently drops a source, reduces the count, or treats partial agreement as
+success.
+
+Under `hexaemeron:elenchus`, each failure found during implementation or audit
+first receives a minimal test that reproduces the exact bad transition. The fix
+must make that test green while the corresponding positive case remains green;
+the full Lazarus suite then guards the cause. A test-only failure is reported as
+such rather than used to claim the product was guarded.
+
+## 12. Decisions and their homes
+
+The expensive-to-reverse decisions are the plan-v2 source declaration, the
+anchor-record-v1 bytes, the runtime mapping syntax, the refusal of partial
+anchors, the separate count location, and the promise not to promote matching
+answers. Their durable homes are:
+
+- `docs/lazarus-multi-provider-chain-anchor/study.md` and `runbook.md` for the
+  full rationale, rejected options, constraints, and build evidence;
+- `plugins/lazarus/schemas/plan-v2.json` and `anchor-record-v1.json` for the
+  public byte formats;
+- `plugins/lazarus/docs/chain-anchors.md` for the operator contract, evidence
+  boundary, runtime mapping, refusals, and examples;
+- `plugins/lazarus/{README.md,AGENTS.md}` and
+  `plugins/lazarus/skills/lazarus/SKILL.md` for discoverable command and promise
+  surfaces; and
+- `plugins/lazarus/skills/lazarus/EVOLUTION.md` for the single
+  `lazarus-v1.2.0` generation row, with the prior frontier revision and digest
+  unchanged.
+
+Hypomnema decides during the prose phase whether the public-format choice also
+needs a root ADR. Absent a repository-wide policy change, the focused study and
+versioned schemas are the lower-complexity durable record.

--- a/plugins/lazarus/schemas/anchor-record-v1.json
+++ b/plugins/lazarus/schemas/anchor-record-v1.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lazarus.wildcat.finance/schemas/anchor-record-v1.json",
+  "title": "Lazarus multi-provider chain anchor record v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "source_id",
+    "observed_at",
+    "method",
+    "params",
+    "returned"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "source_id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_.-]{0,127}$"
+    },
+    "observed_at": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 32
+    },
+    "method": {
+      "const": "eth_getBlockByNumber"
+    },
+    "params": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "prefixItems": [
+        {
+          "$ref": "#/$defs/quantity"
+        },
+        {
+          "const": false
+        }
+      ],
+      "items": false
+    },
+    "returned": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "chain_id",
+        "number",
+        "hash"
+      ],
+      "properties": {
+        "chain_id": {
+          "const": "0x1"
+        },
+        "number": {
+          "$ref": "#/$defs/quantity"
+        },
+        "hash": {
+          "$ref": "#/$defs/hash32"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "quantity": {
+      "type": "string",
+      "pattern": "^0x(?:0|[1-9a-f][0-9a-f]{0,63})$"
+    },
+    "hash32": {
+      "type": "string",
+      "pattern": "^0x[0-9a-fA-F]{64}$"
+    }
+  }
+}

--- a/plugins/lazarus/schemas/plan-v2.json
+++ b/plugins/lazarus/schemas/plan-v2.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lazarus.wildcat.finance/schemas/plan-v2.json",
+  "title": "Lazarus capture plan v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "chain",
+    "block",
+    "requests",
+    "proof_targets",
+    "limits",
+    "anchor_sources"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 2
+    },
+    "chain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "chain_id",
+        "network"
+      ],
+      "properties": {
+        "chain_id": {
+          "const": "0x1"
+        },
+        "network": {
+          "const": "ethereum-mainnet"
+        }
+      }
+    },
+    "block": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "number",
+        "hash",
+        "hash_source"
+      ],
+      "properties": {
+        "number": {
+          "$ref": "#/$defs/quantity"
+        },
+        "hash": {
+          "$ref": "#/$defs/hash32"
+        },
+        "hash_source": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        }
+      }
+    },
+    "requests": {
+      "type": "array",
+      "maxItems": 100000,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "method",
+          "params",
+          "required",
+          "evidence"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_.-]{0,127}$"
+          },
+          "method": {
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9_]{0,127}$"
+          },
+          "params": {
+            "type": [
+              "array",
+              "object"
+            ]
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "evidence": {
+            "enum": [
+              "proof-backed",
+              "header-bound",
+              "recorded-rpc"
+            ]
+          }
+        }
+      }
+    },
+    "proof_targets": {
+      "type": "array",
+      "maxItems": 100000,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "address",
+          "slots"
+        ],
+        "properties": {
+          "address": {
+            "$ref": "#/$defs/address"
+          },
+          "slots": {
+            "type": "array",
+            "maxItems": 100000,
+            "items": {
+              "$ref": "#/$defs/slot"
+            }
+          }
+        }
+      }
+    },
+    "limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "max_requests",
+        "max_component_bytes",
+        "max_total_bytes"
+      ],
+      "properties": {
+        "max_requests": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100000
+        },
+        "max_component_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 536870912
+        },
+        "max_total_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 2147483648
+        },
+        "max_elapsed_seconds": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 86400
+        }
+      }
+    },
+    "anchor_sources": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "source_id"
+        ],
+        "properties": {
+          "source_id": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_.-]{0,127}$"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "quantity": {
+      "type": "string",
+      "pattern": "^0x(?:0|[1-9a-f][0-9a-f]{0,63})$"
+    },
+    "address": {
+      "type": "string",
+      "pattern": "^0x[0-9a-fA-F]{40}$"
+    },
+    "slot": {
+      "type": "string",
+      "pattern": "^0x[0-9a-fA-F]{64}$"
+    },
+    "hash32": {
+      "type": "string",
+      "pattern": "^0x[0-9a-fA-F]{64}$"
+    }
+  }
+}

--- a/plugins/lazarus/scripts/lazarus.py
+++ b/plugins/lazarus/scripts/lazarus.py
@@ -10,7 +10,11 @@ import sys
 from lazarus_lib.canonical import load
 from lazarus_lib.errors import LazarusError
 from lazarus_lib.manifest import build_manifest, verify_manifest, write_manifest
-from lazarus_lib.records import read_proof_records, read_rpc_records
+from lazarus_lib.records import (
+    read_anchor_records,
+    read_proof_records,
+    read_rpc_records,
+)
 from lazarus_lib.schemas import validate_builtin_schemas, validate_document
 from lazarus_lib.verifier import verify_fixture
 
@@ -34,6 +38,7 @@ def parser() -> argparse.ArgumentParser:
             "header",
             "rpc-records",
             "proof-records",
+            "anchor-records",
             "manifest",
             "release",
         ),
@@ -106,6 +111,8 @@ def _validate(kind: str, path: Path | None) -> None:
         read_rpc_records(path)
     elif kind == "proof-records":
         read_proof_records(path)
+    elif kind == "anchor-records":
+        read_anchor_records(path)
     else:
         validate_document(kind, load(path))
 

--- a/plugins/lazarus/scripts/lazarus_lib/capture.py
+++ b/plugins/lazarus/scripts/lazarus_lib/capture.py
@@ -322,6 +322,8 @@ def _normalise_slot(value: Any) -> str:
 
 
 def _validate_capture_plan(plan: dict[str, Any]) -> None:
+    if plan["schema_version"] != 1:
+        raise FormatError("capture does not support plan-v2")
     if "max_elapsed_seconds" not in plan["limits"]:
         raise FormatError("capture plan must declare max_elapsed_seconds")
     for item in plan["requests"]:

--- a/plugins/lazarus/scripts/lazarus_lib/records.py
+++ b/plugins/lazarus/scripts/lazarus_lib/records.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import hashlib
+from itertools import islice
 from pathlib import Path
 from typing import Any, Iterable
 
 from .canonical import dumps, dump_jsonl, load_jsonl, loads_jsonl
-from .errors import FormatError
+from .errors import FormatError, ResourceLimitError
 from .schemas import validate_document
 
 
@@ -66,6 +67,47 @@ def _check_rpc_records(records: list[Any]) -> list[dict[str, Any]]:
     _unique(checked, "request_key", "RPC request key")
     if checked != sorted(checked, key=lambda item: item["request_key"]):
         raise FormatError("RPC records are not sorted by request_key")
+    return checked
+
+
+MAX_ANCHOR_RECORDS = 32
+
+
+def write_anchor_records(path: str | Path, records: Iterable[dict[str, Any]]) -> bytes:
+    materialised = list(islice(records, MAX_ANCHOR_RECORDS + 1))
+    if len(materialised) > MAX_ANCHOR_RECORDS:
+        raise ResourceLimitError(
+            f"anchor record count exceeds {MAX_ANCHOR_RECORDS}"
+        )
+    checked = [validate_document("anchor-record", record) for record in materialised]
+    _unique(checked, "source_id", "anchor source ID")
+    return dump_jsonl(
+        path,
+        checked,
+        sort_key=lambda item: item["source_id"],
+        max_records=MAX_ANCHOR_RECORDS,
+    )
+
+
+def read_anchor_records(path: str | Path, **limits: int) -> list[dict[str, Any]]:
+    limits["max_records"] = min(
+        limits.get("max_records", MAX_ANCHOR_RECORDS), MAX_ANCHOR_RECORDS
+    )
+    return _check_anchor_records(load_jsonl(path, **limits))
+
+
+def loads_anchor_records(data: bytes, **limits: int) -> list[dict[str, Any]]:
+    limits["max_records"] = min(
+        limits.get("max_records", MAX_ANCHOR_RECORDS), MAX_ANCHOR_RECORDS
+    )
+    return _check_anchor_records(loads_jsonl(data, **limits))
+
+
+def _check_anchor_records(records: list[Any]) -> list[dict[str, Any]]:
+    checked = [validate_document("anchor-record", record) for record in records]
+    _unique(checked, "source_id", "anchor source ID")
+    if checked != sorted(checked, key=lambda item: item["source_id"]):
+        raise FormatError("anchor records are not sorted by source_id")
     return checked
 
 

--- a/plugins/lazarus/scripts/lazarus_lib/schemas.py
+++ b/plugins/lazarus/scripts/lazarus_lib/schemas.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+from datetime import datetime, timezone
 from pathlib import Path
+import re
 from typing import Any
 
 from jsonschema import Draft202012Validator
@@ -19,6 +21,10 @@ SCHEMAS: dict[tuple[str, int], tuple[str, str]] = {
         "plan-v1.json",
         "f7081f2007ac8116215ffcb508a2ffc09d9c04fba512d87d1b69a885b72915de",
     ),
+    ("plan", 2): (
+        "plan-v2.json",
+        "4130d0349c4bf91041757fb2d36854e54a6a97af7a9f1eefa5d812e792c9b9c3",
+    ),
     ("header", 1): (
         "header-v1.json",
         "222e16df19169ae545e49ea423928ef63400ed078972e24734ac0697296fc9ac",
@@ -30,6 +36,10 @@ SCHEMAS: dict[tuple[str, int], tuple[str, str]] = {
     ("proof-record", 1): (
         "proof-record-v1.json",
         "3ed92e5ebb37ca2358e3b0b28b57333cb4f6c6bc5a2e760d81f73a226c679ee7",
+    ),
+    ("anchor-record", 1): (
+        "anchor-record-v1.json",
+        "f22459e10e0e7f3736eafeb44224b92debee30daece8c12deab37e58ee76fb8e",
     ),
     ("manifest", 1): (
         "manifest-v1.json",
@@ -90,6 +100,7 @@ def validate_document(kind: str, document: Any) -> Any:
         "header": _validate_header,
         "rpc-record": _validate_rpc_record,
         "proof-record": _validate_proof_record,
+        "anchor-record": _validate_anchor_record,
         "manifest": _validate_manifest,
         "release": _validate_release,
     }[kind]
@@ -153,6 +164,12 @@ def _validate_plan(plan: dict[str, Any]) -> None:
         slots = [slot.lower() for slot in target["slots"]]
         if slots != sorted(slots) or len(slots) != len(set(slots)):
             raise FormatError(f"proof slots must be sorted and unique: {target['address']}")
+    if plan["schema_version"] == 2:
+        source_ids = [source["source_id"] for source in plan["anchor_sources"]]
+        if source_ids != sorted(source_ids) or len(source_ids) != len(
+            set(source_ids)
+        ):
+            raise FormatError("anchor sources must be sorted and unique")
 
 
 def _validate_header(header: dict[str, Any]) -> None:
@@ -184,6 +201,24 @@ def _validate_proof_record(record: dict[str, Any]) -> None:
     keys = [item["key"].lower() for item in record["storage_proof"]]
     if keys != sorted(keys) or len(keys) != len(set(keys)):
         raise FormatError("storage proof keys must be sorted and unique")
+
+
+def _validate_anchor_record(record: dict[str, Any]) -> None:
+    observed_at = record["observed_at"]
+    utc_shape = (
+        r"[0-9]{4}-[0-9]{2}-[0-9]{2}T"
+        r"[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,6})?Z"
+    )
+    if re.fullmatch(utc_shape, observed_at) is None:
+        raise FormatError("anchor observed_at must be a UTC timestamp ending in Z")
+    try:
+        instant = datetime.fromisoformat(observed_at[:-1] + "+00:00")
+    except ValueError:
+        raise FormatError("anchor observed_at must be a valid UTC timestamp") from None
+    if instant.tzinfo != timezone.utc:
+        raise FormatError("anchor observed_at must be a UTC timestamp")
+    if record["returned"]["number"] != record["params"][0]:
+        raise FormatError("anchor returned number disagrees with requested block number")
 
 
 def _validate_manifest(manifest: dict[str, Any]) -> None:

--- a/plugins/lazarus/skills/lazarus/EVOLUTION.md
+++ b/plugins/lazarus/skills/lazarus/EVOLUTION.md
@@ -2,7 +2,7 @@
 
 Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
 
-- Current version: `lazarus-v1.1.0`
+- Current version: `lazarus-v1.2.0`
 - Frontier status: `open`
 - Frontier revision: `receipt-inclusion-proofs`
 - Current frontier: Receipts and logs are recorded RPC evidence only; nothing proves them against the captured header's receiptsRoot.
@@ -14,3 +14,4 @@ Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VE
 | --- | --- | --- | --- | --- | --- |
 | `lazarus-v0.1.0` | baseline | `ariadne-state-fixture-binding` | `94c0f87fc8dd14562e948fb5b523c9248ffa6fd21849cc433d4a5bc47966daf5` | [README marketplace-context](../../README.md) | Versioning starts here. The held frontier is adopted from the plugin's marketplace-context block unchanged. |
 | `lazarus-v1.1.0` | evolution | `receipt-inclusion-proofs` | `ebbefc52fa3dff6c3d5be57ea0d9da7afc0489e34e95cf9dedd5747e401ad1ff` | [preservation release](../../docs/preservation-release.md), [shipped release](../../examples/goldfinch-v0-release/release.json), [audit](../../../../audit/AUDIT.md) | The held job is done. A fixture now binds to an Ariadne state-fixture statement through `release`, which holds the statement to what verification recomputed rather than to what the manifest claims, and `verify-release` reads the whole thing back years later. The Goldfinch release ships. The new frontier is the evidence class this run deliberately did not touch: receipts and logs are still the provider's word. |
+| `lazarus-v1.2.0` | generation | `receipt-inclusion-proofs` | `ebbefc52fa3dff6c3d5be57ea0d9da7afc0489e34e95cf9dedd5747e401ad1ff` | [structured multi-provider chain-anchor study](../../../../docs/lazarus-multi-provider-chain-anchor/study.md), [issue #386](https://github.com/wildcat-finance/skills/issues/386) | Lazarus uses plan v2 with sorted, opaque source identifiers and keeps provider observations in a separate anchor-record format. Anchors have their own count and make no claim of canonical-chain membership or provider independence. Changing plan v1 was rejected because it breaks released-fixture compatibility. Storing provider URLs was rejected because it retains secrets. Folding anchors into recorded-RPC or proof counts was rejected because it overstates their evidence. |

--- a/plugins/lazarus/skills/lazarus/SKILL.md
+++ b/plugins/lazarus/skills/lazarus/SKILL.md
@@ -7,7 +7,7 @@ description: >
   proof-checked fixture with a fail-closed local replay boundary. Never use it
   to describe receipts, logs, calls or traces as state-proof-backed evidence.
 metadata:
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Lazarus

--- a/plugins/lazarus/tests/run_tests.py
+++ b/plugins/lazarus/tests/run_tests.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Run the Lazarus suite and optionally emit a structured audit report."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+import unittest
+
+
+def worktree_root():
+    """Resolve the owning checkout rather than trusting the caller's cwd."""
+    return Path(__file__).resolve(strict=True).parents[3]
+
+
+def report_target(argv):
+    """Parse one fresh report path and bind its worktree identity."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--elenchus-report",
+        action="append",
+        metavar="PATH",
+        help="write an elenchus.unittest.v1 result to a fresh worktree path",
+    )
+    arguments = parser.parse_args(argv)
+    values = list(arguments.elenchus_report or [])
+    if len(values) > 1:
+        parser.error("name one --elenchus-report path")
+    if not values:
+        return None
+
+    raw = values[0]
+    if not raw or "\x00" in raw:
+        parser.error("--elenchus-report requires a non-empty path")
+    supplied = Path(raw)
+    if ".." in supplied.parts:
+        parser.error("--elenchus-report must stay inside the current worktree")
+    try:
+        root = worktree_root().resolve(strict=True)
+        relative = (
+            supplied.relative_to(root) if supplied.is_absolute() else supplied
+        )
+        target = root.joinpath(*relative.parts)
+    except (OSError, RuntimeError, ValueError):
+        parser.error("--elenchus-report must stay inside the current worktree")
+
+    current = root
+    for part in relative.parts[:-1]:
+        current /= part
+        try:
+            current_stat = current.lstat()
+        except FileNotFoundError:
+            break
+        except OSError:
+            parser.error("--elenchus-report cannot be inspected")
+        if not stat.S_ISDIR(current_stat.st_mode):
+            parser.error("--elenchus-report parent is not a directory")
+    try:
+        existing = target.lstat()
+    except FileNotFoundError:
+        existing = None
+    except (OSError, ValueError):
+        parser.error("--elenchus-report cannot be inspected")
+    if existing is not None:
+        parser.error("--elenchus-report target must not already exist")
+
+    missing = []
+    for name in ("O_DIRECTORY", "O_NOFOLLOW"):
+        if not hasattr(os, name):
+            missing.append(f"os.{name}")
+    supports_dir_fd = getattr(os, "supports_dir_fd", ())
+    for operation, name in (
+        (os.open, "os.open(dir_fd)"),
+        (os.mkdir, "os.mkdir(dir_fd)"),
+        (os.stat, "os.stat(dir_fd)"),
+        (os.unlink, "os.unlink(dir_fd)"),
+    ):
+        if operation not in supports_dir_fd:
+            missing.append(name)
+    supports_follow_symlinks = getattr(os, "supports_follow_symlinks", ())
+    if os.stat not in supports_follow_symlinks:
+        missing.append("os.stat(follow_symlinks)")
+    if missing:
+        parser.error(
+            "--elenchus-report requires secure directory operations: "
+            + ", ".join(missing)
+        )
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    try:
+        root_stat = root.stat()
+        root_fd = os.open(root, directory_flags)
+        try:
+            opened_stat = os.fstat(root_fd)
+        finally:
+            os.close(root_fd)
+    except OSError:
+        parser.error("--elenchus-report worktree cannot be opened and inspected")
+    if (opened_stat.st_dev, opened_stat.st_ino) != (
+        root_stat.st_dev,
+        root_stat.st_ino,
+    ):
+        parser.error("--elenchus-report worktree changed during inspection")
+    return root, (opened_stat.st_dev, opened_stat.st_ino), relative.parts
+
+
+def result_payload(result):
+    """Return Elenchus's complete unittest counter schema."""
+    return {
+        "schema": "elenchus.unittest.v1",
+        "complete": True,
+        "testsRun": result.testsRun,
+        "failures": len(result.failures),
+        "errors": len(result.errors),
+        "skipped": len(result.skipped),
+        "expectedFailures": len(result.expectedFailures),
+        "unexpectedSuccesses": len(result.unexpectedSuccesses),
+    }
+
+
+def report_parent(root_fd, parts):
+    """Open or create report directories without following a symlink."""
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    current_fd = os.dup(root_fd)
+    try:
+        for part in parts:
+            try:
+                next_fd = os.open(part, flags, dir_fd=current_fd)
+            except FileNotFoundError:
+                try:
+                    os.mkdir(part, 0o700, dir_fd=current_fd)
+                except FileExistsError:
+                    pass
+                next_fd = os.open(part, flags, dir_fd=current_fd)
+            os.close(current_fd)
+            current_fd = next_fd
+        return current_fd
+    except OSError:
+        os.close(current_fd)
+        raise
+
+
+def report_root(root, identity):
+    """Reopen the bound worktree and refuse a replaced directory."""
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    descriptor = os.open(root, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if (opened.st_dev, opened.st_ino) != identity:
+            raise OSError("report worktree identity changed")
+        return descriptor
+    except OSError:
+        os.close(descriptor)
+        raise
+
+
+def remove_created_report(parent_fd, name, created):
+    """Remove a failed write only while the target is still our inode."""
+    try:
+        current = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError:
+        return
+    if (current.st_dev, current.st_ino) != (created.st_dev, created.st_ino):
+        return
+    try:
+        os.unlink(name, dir_fd=parent_fd)
+    except OSError:
+        pass
+
+
+def write_report(target, payload):
+    """Create the declared report through its bound worktree identity."""
+    root, identity, parts = target
+    if not parts:
+        raise OSError("report path has no filename")
+    root_fd = report_root(root, identity)
+    try:
+        parent_fd = report_parent(root_fd, parts[:-1])
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+        descriptor = None
+        created = None
+        try:
+            descriptor = os.open(parts[-1], flags, 0o600, dir_fd=parent_fd)
+            created = os.fstat(descriptor)
+            if not stat.S_ISREG(created.st_mode):
+                raise OSError("report target is not a regular file")
+            body = (json.dumps(payload, sort_keys=True) + "\n").encode("utf-8")
+            remaining = memoryview(body)
+            while remaining:
+                written = os.write(descriptor, remaining)
+                if written <= 0:
+                    raise OSError("report write made no progress")
+                remaining = remaining[written:]
+            os.close(descriptor)
+            descriptor = None
+        except OSError:
+            if descriptor is not None:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+            if created is not None:
+                remove_created_report(parent_fd, parts[-1], created)
+            raise
+        finally:
+            os.close(parent_fd)
+    finally:
+        os.close(root_fd)
+
+
+def main(argv=None):
+    """Run the suite, optionally emit its report, and preserve suite exits."""
+    target = report_target(sys.argv[1:] if argv is None else argv)
+    here = os.path.dirname(os.path.abspath(__file__))
+    plugin_root = os.path.dirname(here)
+    suite = unittest.defaultTestLoader.discover(
+        here, pattern="test_*.py", top_level_dir=plugin_root
+    )
+    runner = unittest.TextTestRunner(verbosity=1)
+    result = runner.run(suite)
+    total = result.testsRun
+    not_passed = sum(
+        len(outcomes)
+        for outcomes in (
+            result.failures,
+            result.errors,
+            result.skipped,
+            result.expectedFailures,
+            result.unexpectedSuccesses,
+        )
+    )
+
+    if target is not None:
+        try:
+            write_report(target, result_payload(result))
+        except OSError:
+            print("run_tests.py: report write failed", file=sys.stderr)
+            return 2
+
+    print(f"{total - not_passed}/{total} tests passed")
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/lazarus/tests/support.py
+++ b/plugins/lazarus/tests/support.py
@@ -100,6 +100,28 @@ def sample_plan():
     }
 
 
+def sample_plan_v2(source_ids=("archive-a",)):
+    plan = sample_plan()
+    plan["schema_version"] = 2
+    plan["anchor_sources"] = [{"source_id": source_id} for source_id in source_ids]
+    return plan
+
+
+def sample_anchor_record(source_id="archive-a"):
+    return {
+        "schema_version": 1,
+        "source_id": source_id,
+        "observed_at": "2026-08-25T08:30:45.123456Z",
+        "method": "eth_getBlockByNumber",
+        "params": ["0x10", False],
+        "returned": {
+            "chain_id": "0x1",
+            "number": "0x10",
+            "hash": hash32("11"),
+        },
+    }
+
+
 def sample_header():
     return {
         "schema_version": 1,

--- a/plugins/lazarus/tests/test_capture.py
+++ b/plugins/lazarus/tests/test_capture.py
@@ -80,6 +80,23 @@ class CaptureTests(unittest.TestCase):
                 {path.relative_to(second): path.read_bytes() for path in second.rglob("*") if path.is_file()},
             )
 
+    def test_capture_refuses_plan_v2_until_anchor_capture_is_implemented(self):
+        material = self.material()
+        material["plan"]["schema_version"] = 2
+        material["plan"]["anchor_sources"] = [{"source_id": "archive-a"}]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            plan = self.write_plan(root, material["plan"])
+            output = root / "fixture"
+            with self.assertRaisesRegex(
+                FormatError, "^capture does not support plan-v2$"
+            ):
+                capture_fixture(plan, "http://127.0.0.1:1", output)
+            self.assertFalse(output.exists())
+            self.assertEqual(
+                [path.name for path in root.iterdir()], ["capture-plan.json"]
+            )
+
     def test_runtime_bearer_and_cookie_headers_never_enter_fixture(self):
         material = self.material()
         headers = {

--- a/plugins/lazarus/tests/test_records.py
+++ b/plugins/lazarus/tests/test_records.py
@@ -2,16 +2,21 @@
 
 import copy
 from pathlib import Path
+import subprocess
+import sys
 import tempfile
 import unittest
 
 from lazarus_lib.canonical import dumps
-from lazarus_lib.errors import FormatError
+from lazarus_lib.errors import FormatError, ResourceLimitError
 from lazarus_lib.records import (
+    loads_anchor_records,
     make_rpc_record,
+    read_anchor_records,
     read_proof_records,
     read_rpc_records,
     request_key,
+    write_anchor_records,
     write_proof_records,
     write_rpc_records,
 )
@@ -97,6 +102,62 @@ class RecordTests(unittest.TestCase):
             )
             with self.assertRaisesRegex(FormatError, "duplicate"):
                 write_proof_records(path, [first, first])
+
+    def test_anchor_records_have_exact_canonical_bytes_and_source_order(self):
+        first = support.sample_anchor_record("a")
+        second = support.sample_anchor_record("z")
+        expected = dumps(first) + b"\n" + dumps(second) + b"\n"
+        with tempfile.TemporaryDirectory() as directory:
+            left = Path(directory) / "left.jsonl"
+            right = Path(directory) / "right.jsonl"
+            self.assertEqual(write_anchor_records(left, [second, first]), expected)
+            self.assertEqual(write_anchor_records(right, [first, second]), expected)
+            self.assertEqual(left.read_bytes(), expected)
+            self.assertEqual(read_anchor_records(left), [first, second])
+            self.assertEqual(loads_anchor_records(expected), [first, second])
+
+    def test_anchor_records_refuse_duplicates_and_noncanonical_order(self):
+        first = support.sample_anchor_record("a")
+        second = support.sample_anchor_record("z")
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "anchors.jsonl"
+            with self.assertRaisesRegex(FormatError, "duplicate anchor source ID"):
+                write_anchor_records(path, [first, first])
+            path.write_bytes(dumps(second) + b"\n" + dumps(first) + b"\n")
+            with self.assertRaisesRegex(FormatError, "not sorted by source_id"):
+                read_anchor_records(path)
+
+    def test_anchor_record_count_and_jsonl_shape_are_bounded(self):
+        records = [
+            support.sample_anchor_record(f"source-{index:02d}")
+            for index in range(33)
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "anchors.jsonl"
+            with self.assertRaisesRegex(ResourceLimitError, "exceeds 32"):
+                write_anchor_records(path, records)
+            path.write_bytes(b'{"schema_version":1,"schema_version":1}\n')
+            with self.assertRaisesRegex(FormatError, "duplicate JSON key"):
+                read_anchor_records(path)
+
+    def test_cli_validates_anchor_record_streams(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "anchors.jsonl"
+            write_anchor_records(path, [support.sample_anchor_record()])
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(support.SCRIPTS / "lazarus.py"),
+                    "validate",
+                    "anchor-records",
+                    str(path),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "valid anchor-records\n")
 
 
 if __name__ == "__main__":

--- a/plugins/lazarus/tests/test_runner.py
+++ b/plugins/lazarus/tests/test_runner.py
@@ -1,0 +1,187 @@
+"""The source-owned unittest report stays fresh and inside its worktree."""
+
+import contextlib
+import io
+import json
+from pathlib import Path
+from types import SimpleNamespace
+import tempfile
+import unittest
+from unittest import mock
+
+from . import run_tests as runner
+
+
+class RunnerTests(unittest.TestCase):
+    def test_bad_report_arguments_are_refused_before_a_suite_runs(self):
+        cases = (
+            ["--elenchus-report"],
+            ["--elenchus-report", "a", "--elenchus-report", "b"],
+            ["--elenchus-report", "a", "--unknown"],
+            ["--elenchus-report", ""],
+        )
+        for arguments in cases:
+            with self.subTest(arguments=arguments), contextlib.redirect_stderr(
+                io.StringIO()
+            ), self.assertRaises(SystemExit) as raised:
+                runner.report_target(arguments)
+            self.assertEqual(raised.exception.code, 2)
+
+    def test_01_hostile_report_paths_are_refused_before_a_suite_runs(self):
+        with tempfile.TemporaryDirectory(prefix="lazarus-runner-") as directory:
+            root = Path(directory).resolve()
+            outside = root.parent / f"{root.name}-outside.json"
+            existing = root / "existing.json"
+            existing.write_text("keep\n", encoding="utf-8")
+            target = root / "target"
+            target.write_text("keep\n", encoding="utf-8")
+            link = root / "link.json"
+            link.symlink_to(target)
+            linked_parent = root / "linked-parent"
+            linked_parent.symlink_to(root.parent, target_is_directory=True)
+            internal = root / "internal"
+            internal.mkdir()
+            internal_link = root / "internal-link"
+            internal_link.symlink_to(internal, target_is_directory=True)
+            cases = (
+                str(outside),
+                "../outside.json",
+                str(existing),
+                str(link),
+                str(linked_parent / "report.json"),
+                str(internal_link / "report.json"),
+            )
+            for value in cases:
+                with self.subTest(value=value), mock.patch.object(
+                    runner, "worktree_root", return_value=root
+                ), contextlib.redirect_stderr(io.StringIO()), self.assertRaises(
+                    SystemExit
+                ) as raised:
+                    runner.report_target(["--elenchus-report", value])
+                self.assertEqual(raised.exception.code, 2)
+            self.assertEqual(existing.read_text(encoding="utf-8"), "keep\n")
+            self.assertEqual(target.read_text(encoding="utf-8"), "keep\n")
+
+    def test_02_safe_report_is_exclusive_complete_and_mode_0600(self):
+        with tempfile.TemporaryDirectory(prefix="lazarus-runner-") as directory:
+            root = Path(directory).resolve()
+            report = root / "tmp" / "elenchus" / "result.json"
+            result = SimpleNamespace(
+                testsRun=8,
+                failures=[1],
+                errors=[1],
+                skipped=[1],
+                expectedFailures=[1],
+                unexpectedSuccesses=[1],
+            )
+            with mock.patch.object(runner, "worktree_root", return_value=root):
+                target = runner.report_target(["--elenchus-report", str(report)])
+            payload = runner.result_payload(result)
+            runner.write_report(target, payload)
+
+            self.assertEqual(
+                json.loads(report.read_text(encoding="utf-8")),
+                {
+                    "schema": "elenchus.unittest.v1",
+                    "complete": True,
+                    "testsRun": 8,
+                    "failures": 1,
+                    "errors": 1,
+                    "skipped": 1,
+                    "expectedFailures": 1,
+                    "unexpectedSuccesses": 1,
+                },
+            )
+            self.assertEqual(report.stat().st_mode & 0o777, 0o600)
+            with mock.patch.object(
+                runner, "worktree_root", return_value=root
+            ), contextlib.redirect_stderr(io.StringIO()), self.assertRaises(
+                SystemExit
+            ) as raised:
+                runner.report_target(["--elenchus-report", str(report)])
+            self.assertEqual(raised.exception.code, 2)
+
+    def test_report_write_failure_is_distinct_and_leaves_no_file(self):
+        with tempfile.TemporaryDirectory(prefix="lazarus-runner-") as directory:
+            root = Path(directory).resolve()
+            report = root / "report.json"
+            suite = unittest.TestSuite([unittest.FunctionTestCase(lambda: None)])
+            with mock.patch.object(
+                runner, "worktree_root", return_value=root
+            ), mock.patch.object(
+                runner.unittest.defaultTestLoader, "discover", return_value=suite
+            ), mock.patch.object(
+                runner, "write_report", side_effect=OSError("blocked")
+            ), contextlib.redirect_stderr(io.StringIO()):
+                exit_code = runner.main(["--elenchus-report", str(report)])
+            self.assertEqual(exit_code, 2)
+            self.assertFalse(report.exists())
+
+    def test_relative_report_ignores_a_caller_cwd_outside_the_worktree(self):
+        with tempfile.TemporaryDirectory(prefix="lazarus-runner-") as directory:
+            root = Path(directory).resolve()
+            with tempfile.TemporaryDirectory(
+                prefix="lazarus-runner-cwd-"
+            ) as caller_directory, mock.patch.object(
+                runner, "worktree_root", return_value=root
+            ), mock.patch.object(
+                runner.Path, "cwd", return_value=Path(caller_directory)
+            ):
+                target = runner.report_target(
+                    ["--elenchus-report", "tmp/elenchus/result.json"]
+                )
+                runner.write_report(
+                    target,
+                    runner.result_payload(
+                        SimpleNamespace(
+                            testsRun=1,
+                            failures=[],
+                            errors=[],
+                            skipped=[],
+                            expectedFailures=[],
+                            unexpectedSuccesses=[],
+                        )
+                    ),
+                )
+                self.assertTrue(
+                    (root / "tmp" / "elenchus" / "result.json").is_file()
+                )
+                self.assertFalse(
+                    (
+                        Path(caller_directory)
+                        / "tmp"
+                        / "elenchus"
+                        / "result.json"
+                    ).exists()
+                )
+
+    def test_runner_discovers_tests_from_the_plugin_root(self):
+        suite = unittest.TestSuite()
+        with mock.patch.object(
+            runner.unittest.defaultTestLoader, "discover", return_value=suite
+        ) as discover, contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(
+            io.StringIO()
+        ):
+            self.assertEqual(runner.main([]), 0)
+        here = str(Path(runner.__file__).resolve().parent)
+        discover.assert_called_once_with(
+            here, pattern="test_*.py", top_level_dir=str(Path(here).parent)
+        )
+
+    def test_unexpected_success_keeps_the_suite_exit_nonzero(self):
+        class UnexpectedSuccess(unittest.TestCase):
+            @unittest.expectedFailure
+            def test_unexpected_success(self):
+                pass
+
+        suite = unittest.defaultTestLoader.loadTestsFromTestCase(UnexpectedSuccess)
+        with mock.patch.object(
+            runner.unittest.defaultTestLoader, "discover", return_value=suite
+        ), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(
+            io.StringIO()
+        ):
+            self.assertEqual(runner.main([]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lazarus/tests/test_scaffold.py
+++ b/plugins/lazarus/tests/test_scaffold.py
@@ -1,5 +1,6 @@
 """The Lazarus shell keeps every host and document on one contract."""
 
+import hashlib
 import json
 import re
 import unittest
@@ -106,6 +107,23 @@ class ScaffoldTests(unittest.TestCase):
         self.assertIn("## Selected format and verification details", study)
         self.assertTrue(runbook.startswith("# Lazarus implementation runbook\n"))
         self.assertIn("## Step 6: Ship and run the Goldfinch demonstration", runbook)
+
+    def test_multi_provider_anchor_specification_copies_are_exact(self):
+        root = support.REPO_ROOT / "docs" / "lazarus-multi-provider-chain-anchor"
+        expected = {
+            "study.md": "f16d14e2182f872d95e56b4485218a264286a845f80b2857960dcd32c14442fd",
+            "runbook.md": "e6ad38a1b934a7d61ee81ce6b01341a863d79e4841bec7b75ca84c29f6f8d8d7",
+        }
+        for name, digest in expected.items():
+            with self.subTest(name=name):
+                self.assertEqual(
+                    hashlib.sha256((root / name).read_bytes()).hexdigest(), digest
+                )
+
+    def test_lazarus_owns_its_structured_unittest_runner(self):
+        tests = support.PLUGIN_ROOT / "tests"
+        self.assertTrue((tests / "run_tests.py").is_file())
+        self.assertTrue((tests / "test_runner.py").is_file())
 
     def test_cli_and_step_five_modules_exist(self):
         self.assertTrue((support.PLUGIN_ROOT / "scripts" / "lazarus.py").is_file())

--- a/plugins/lazarus/tests/test_schemas.py
+++ b/plugins/lazarus/tests/test_schemas.py
@@ -1,4 +1,4 @@
-"""The six versioned formats validate before they reach fixture logic."""
+"""Versioned formats validate before they reach fixture logic."""
 
 import copy
 import unittest
@@ -16,8 +16,17 @@ class SchemaTests(unittest.TestCase):
         validate_builtin_schemas()
         self.assertEqual(
             {kind for kind, version in SCHEMAS if version == 1},
-            {"plan", "header", "rpc-record", "proof-record", "manifest", "release"},
+            {
+                "plan",
+                "header",
+                "rpc-record",
+                "proof-record",
+                "anchor-record",
+                "manifest",
+                "release",
+            },
         )
+        self.assertIn(("plan", 2), SCHEMAS)
 
     def test_a_well_formed_release_document_passes(self):
         validate_document("release", support.sample_release())
@@ -143,6 +152,7 @@ class SchemaTests(unittest.TestCase):
 
     def test_valid_plan_header_rpc_and_proof_documents_pass(self):
         validate_document("plan", support.sample_plan())
+        validate_document("plan", support.sample_plan_v2())
         validate_document("header", support.sample_header())
         validate_document(
             "rpc-record",
@@ -151,16 +161,135 @@ class SchemaTests(unittest.TestCase):
             ),
         )
         validate_document("proof-record", support.sample_proof_record())
+        validate_document("anchor-record", support.sample_anchor_record())
 
     def test_unknown_schema_versions_fail_closed(self):
         for kind, document in (
-            ("plan", support.sample_plan()),
+            ("plan", support.sample_plan_v2()),
             ("header", support.sample_header()),
             ("proof-record", support.sample_proof_record()),
+            ("anchor-record", support.sample_anchor_record()),
         ):
-            document["schema_version"] = 2
+            document["schema_version"] = 3 if kind == "plan" else 2
             with self.subTest(kind=kind), self.assertRaisesRegex(FormatError, "unsupported"):
                 validate_document(kind, document)
+
+    def test_plan_v2_requires_closed_bounded_source_declarations(self):
+        validate_document("plan", support.sample_plan_v2(("a",)))
+        validate_document(
+            "plan",
+            support.sample_plan_v2(tuple(f"source-{index:02d}" for index in range(32))),
+        )
+        for source_ids in ((), tuple(f"source-{index:02d}" for index in range(33))):
+            with self.subTest(count=len(source_ids)), self.assertRaisesRegex(
+                FormatError, "anchor_sources"
+            ):
+                validate_document("plan", support.sample_plan_v2(source_ids))
+
+        plan = support.sample_plan_v2()
+        plan["anchor_sources"][0]["url"] = "https://must-not-enter-a-plan.example"
+        with self.assertRaisesRegex(FormatError, "anchor_sources"):
+            validate_document("plan", plan)
+
+        legacy = support.sample_plan()
+        legacy["anchor_sources"] = [{"source_id": "a"}]
+        with self.assertRaisesRegex(FormatError, "anchor_sources"):
+            validate_document("plan", legacy)
+
+    def test_plan_v2_copies_every_plan_v1_contract_field(self):
+        plan_v1 = support.load_json("schemas/plan-v1.json")
+        plan_v2 = support.load_json("schemas/plan-v2.json")
+        plan_v2["$id"] = plan_v1["$id"]
+        plan_v2["title"] = plan_v1["title"]
+        plan_v2["required"].remove("anchor_sources")
+        plan_v2["properties"].pop("anchor_sources")
+        plan_v2["properties"]["schema_version"] = {"const": 1}
+        self.assertEqual(plan_v2, plan_v1)
+
+    def test_source_ids_keep_the_public_grammar(self):
+        invalid = ("", "A", "-source", "source/name", "a" * 129)
+        for value in invalid:
+            with self.subTest(value=value):
+                plan = support.sample_plan_v2((value,))
+                with self.assertRaisesRegex(FormatError, "source_id"):
+                    validate_document("plan", plan)
+                record = support.sample_anchor_record(value)
+                with self.assertRaisesRegex(FormatError, "source_id"):
+                    validate_document("anchor-record", record)
+
+    def test_plan_anchor_sources_must_be_sorted_and_unique(self):
+        for source_ids in (("z", "a"), ("a", "a")):
+            with self.subTest(source_ids=source_ids), self.assertRaisesRegex(
+                FormatError, "anchor sources must be sorted and unique"
+            ):
+                validate_document("plan", support.sample_plan_v2(source_ids))
+
+    def test_anchor_record_is_closed_and_complete(self):
+        for field in (
+            "schema_version",
+            "source_id",
+            "observed_at",
+            "method",
+            "params",
+            "returned",
+        ):
+            record = support.sample_anchor_record()
+            del record[field]
+            with self.subTest(field=field), self.assertRaises(FormatError):
+                validate_document("anchor-record", record)
+        record = support.sample_anchor_record()
+        record["provider_url"] = "https://must-not-enter-a-record.example"
+        with self.assertRaises(FormatError):
+            validate_document("anchor-record", record)
+
+    def test_anchor_timestamp_must_be_a_real_utc_instant(self):
+        invalid = (
+            "2026-08-25T08:30:45+00:00",
+            "2026-08-25T01:30:45-07:00",
+            "2026-08-25T08:30:45",
+            "2026-02-30T08:30:45Z",
+            "not-a-time",
+        )
+        for value in invalid:
+            record = support.sample_anchor_record()
+            record["observed_at"] = value
+            with self.subTest(value=value), self.assertRaisesRegex(FormatError, "UTC"):
+                validate_document("anchor-record", record)
+
+    def test_anchor_method_and_parameters_are_exact(self):
+        mutations = (
+            ("method", "eth_getBlockByHash"),
+            ("params", ["0x10"]),
+            ("params", ["0x10", True]),
+            ("params", ["0x00", False]),
+        )
+        for field, value in mutations:
+            record = support.sample_anchor_record()
+            record[field] = value
+            with self.subTest(field=field, value=value), self.assertRaises(FormatError):
+                validate_document("anchor-record", record)
+
+    def test_anchor_returned_fields_are_mainnet_block_identity(self):
+        mutations = (
+            ("chain_id", "0x2"),
+            ("number", "0x11"),
+            ("number", "0x00"),
+            ("hash", "0x1234"),
+        )
+        for field, value in mutations:
+            record = support.sample_anchor_record()
+            record["returned"][field] = value
+            with self.subTest(field=field, value=value), self.assertRaises(FormatError):
+                validate_document("anchor-record", record)
+        for field in ("chain_id", "number", "hash"):
+            record = support.sample_anchor_record()
+            del record["returned"][field]
+            with self.subTest(missing=field), self.assertRaises(FormatError):
+                validate_document("anchor-record", record)
+        record = support.sample_anchor_record()
+        record["returned"]["provider"] = "extra"
+        with self.assertRaises(FormatError):
+            validate_document("anchor-record", record)
 
     def test_quantities_and_addresses_keep_exact_ethereum_shapes(self):
         plan = support.sample_plan()
@@ -236,10 +365,17 @@ class SchemaTests(unittest.TestCase):
             validate_document("proof-record", proof)
 
     def test_registry_digest_detects_schema_substitution(self):
-        filename, _ = SCHEMAS[("plan", 1)]
-        with mock.patch.dict(SCHEMAS, {("plan", 1): (filename, "0" * 64)}):
-            with self.assertRaisesRegex(IntegrityError, "digest mismatch"):
-                validate_document("plan", support.sample_plan())
+        for key, document in (
+            (("plan", 1), support.sample_plan()),
+            (("plan", 2), support.sample_plan_v2()),
+            (("anchor-record", 1), support.sample_anchor_record()),
+        ):
+            filename, _ = SCHEMAS[key]
+            with self.subTest(key=key), mock.patch.dict(
+                SCHEMAS, {key: (filename, "0" * 64)}
+            ):
+                with self.assertRaisesRegex(IntegrityError, "digest mismatch"):
+                    validate_document(key[0], document)
 
 
 if __name__ == "__main__":

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -2998,7 +2998,7 @@
         "transition": "verified replay binding joined to the canonical Authorises field",
         "unknowns": "uncaptured requests and recorded-only RPC relations"
       },
-      "sha256": "0ae280084dd2934e902b11826c12aff8247989616126c1771ae6af65e38307b2",
+      "sha256": "c10e21227744347d0fc8887e908a8591171b10d1ff7b8b101ee4007d3b20f2e5",
       "source": "plugins/lazarus/scripts/lazarus.py"
     },
     "lazarus-fixture-capture": {


### PR DESCRIPTION
## What changed

`plan-v2` now declares 1 to 32 sorted, unique source identifiers. A closed
`anchor-record-v1` format holds fixed-block provider observations. The schema
registry, canonical JSONL helpers, CLI validation, and source-owned unittest
runner cover both formats. Exact copies of the study and runbook ship with the
implementation.

`capture` rejects plan v2 before constructing a client until Step 3 supplies
the complete runtime path. Plan v1, manifest v1, release v1, the Goldfinch
fixture, and the three existing evidence counts remain unchanged. The Lazarus
ledger records the format decision as generation `lazarus-v1.2.0` and leaves
the held `receipt-inclusion-proofs` frontier unchanged.

Issue #386 needs provider observations stored in digest-bound anchor records.
Later steps can then verify them offline without calling them proofs,
canonical-chain membership, or evidence of provider independence.

## Audit

Round 1 is recorded at
`audit/rounds/fiat-386-record-a-structured-multi-provider-chain-anc.md` with
zero findings. No stacked audit-fix pull request was needed because the round
was clean.

## Proof

| command | result |
| --- | --- |
| `python3 plugins/lazarus/scripts/lazarus.py validate schemas` | exit 0 |
| `python3 -m unittest plugins.lazarus.tests.test_schemas plugins.lazarus.tests.test_records plugins.lazarus.tests.test_scaffold plugins.lazarus.tests.test_runner -v` | 61/61 |
| `python3 -m unittest discover -s plugins/lazarus/tests -t plugins/lazarus -v` | 386/386 |
| `python3 -m unittest discover -s tests -v` | 350/350 |
| `python3 plugins/lazarus/tests/run_tests.py --elenchus-report tmp/elenchus/lazarus-step-1.json` | 386/386; complete report, zero failures, errors, or skips; mode `0600` |

This pull request is based on
`fiat/386-record-a-structured-multi-provider-chain-anc`. It implements the
format portion of #386.

<!-- wildcat-origin: shoggoth -->
