### PR TITLE
Verify Lazarus chain-anchor records offline

### DIFF
--- a/audit/rounds/fiat-386-record-a-structured-multi-provider-chain-anc.md
+++ b/audit/rounds/fiat-386-record-a-structured-multi-provider-chain-anc.md
@@ -36,3 +36,45 @@ verification, exact plan-to-record coverage, and anchored release compatibility
 are not reachable in this format-only step. Step 1 refuses plan-v2 capture;
 Steps 2 and 3 own those transitions. These remain required risk-register
 checks, not accepted risks.
+
+## Step 2, round 1 -- 2026-08-25
+
+Non-Solidity round over implementation range
+`5529225625e407d93563c67729206d2e0f260518..1a49a3c6cf865641e2a0abdad3a05d7de0623fb8`
+on `fiat/386-record-a-structured-multi-provider-chain-anc-step-2-verify-anchor-records-offline`.
+Security receipt: `waived: issue 386 changes Lazarus Python, JSON schemas, tests, and documentation; no Solidity or Pashov security-suite target applies`.
+
+| id | severity | file | finding | status |
+| --- | --- | --- | --- | --- |
+
+### Review
+
+Zero findings. The review covered all 10 changed paths against Step 2 at
+effective SHA-256
+`6c3ee49bbf158ff32148cc6c4be5c188605f400bc1f1b45a9593feda2b39531c`
+and the risk register in `.hexaemeron/study.md` at SHA-256
+`f16d14e2182f872d95e56b4485218a264286a845f80b2857960dcd32c14442fd`.
+After manifest verification, `anchors.jsonl` receives one digest-bound semantic
+reread through `_read_bound`; `read_confined_bytes` supplies no-follow, size,
+and stable-file controls. Schema and record checks refuse malformed, duplicate,
+or reordered records. Plan and record source sets must match exactly, and chain,
+height, or verified-header disagreements fail closed. The report adds only
+`chain_anchors: {records: N, canonical_chain_claim: false, provider_independence_claim: false}`;
+`proof_backed`, `header_bound`, and `recorded_rpc` stay unchanged. Release-v1
+and the Ariadne-facing binding keep their structure while their component
+inventory binds `anchors.jsonl`.
+
+### Verification
+
+The focused set reports 217/217. The Lazarus suite and source-owned structured
+runner each report 399/399. The root suite reports 350/350, and its 1,258-case
+inoculation reports 0 crashes and 0 unexpected clean results. Goldfinch verifies
+at fixture digest
+`d93cd09fcb2c6bd689a223398ebd4ae4dc480ec7d8fd8e64283b88341d0a7e49`;
+the preservation-release demonstration exits 0 with both refusals held.
+Phylax, Ephoros, Hypomnema, and `git diff --check` each exit 0.
+
+Leads not pursued: runtime provider-secret handling, live provider identity,
+shared network and resource budgets, and atomic multi-provider finalisation are
+not reachable in this offline verification step. Step 3 owns those controls;
+they remain required risk-register checks, not accepted risks.

--- a/plugins/lazarus/scripts/lazarus.py
+++ b/plugins/lazarus/scripts/lazarus.py
@@ -182,6 +182,7 @@ def run(argv: list[str] | None = None) -> int:
     print(f"proof-backed: {report['evidence_counts']['proof_backed']}")
     print(f"header-bound: {report['evidence_counts']['header_bound']}")
     print(f"recorded-rpc: {report['evidence_counts']['recorded_rpc']}")
+    print(f"chain-anchor-records: {report['chain_anchors']['records']}")
     return 0
 
 

--- a/plugins/lazarus/scripts/lazarus_lib/manifest.py
+++ b/plugins/lazarus/scripts/lazarus_lib/manifest.py
@@ -14,7 +14,12 @@ from .paths import (
     read_confined_bytes,
     validate_relative_path,
 )
-from .records import loads_proof_records, loads_rpc_records, request_key
+from .records import (
+    loads_anchor_records,
+    loads_proof_records,
+    loads_rpc_records,
+    request_key,
+)
 from .schemas import validate_document
 from .version import __version__
 
@@ -215,6 +220,10 @@ def _inspect_components(
             observed["rpc"] = loads_rpc_records(data, max_bytes=MAX_JSONL_BYTES)
         elif relative == "proofs.jsonl":
             observed["proofs"] = loads_proof_records(data, max_bytes=MAX_JSONL_BYTES)
+        elif relative == "anchors.jsonl":
+            observed["anchors"] = loads_anchor_records(
+                data, max_bytes=MAX_JSONL_BYTES
+            )
     return components, observed
 
 
@@ -254,12 +263,67 @@ def _validate_observed(observed: dict[str, Any], manifest: dict[str, Any]) -> No
         raise IntegrityError("header number disagrees with manifest")
     if header["hash"] != manifest["block"]["hash"]:
         raise IntegrityError("header hash disagrees with manifest")
+    anchor_records = observed.get("anchors")
+    if plan["schema_version"] == 1:
+        if anchor_records is not None:
+            raise IntegrityError("plan-v1 refuses anchors.jsonl")
+    else:
+        if anchor_records is None:
+            raise IntegrityError("plan-v2 requires anchors.jsonl")
+        validate_anchor_records(
+            plan,
+            anchor_records,
+            chain_id=manifest["chain_id"],
+            block_number=manifest["block"]["number"],
+            block_hash=manifest["block"]["hash"],
+        )
     _validate_plan_coverage(plan, observed)
     counts, failures = _coverage(observed)
     if counts != manifest["evidence_counts"]:
         raise IntegrityError("manifest evidence counts disagree with fixture records")
     if failures != manifest["optional_failures"]:
         raise IntegrityError("manifest optional failures disagree with RPC records")
+
+
+def validate_anchor_records(
+    plan: dict[str, Any],
+    records: list[dict[str, Any]],
+    *,
+    chain_id: str,
+    block_number: str,
+    block_hash: str,
+) -> None:
+    """Hold anchor observations to their plan and verified block identity."""
+    planned = {item["source_id"] for item in plan["anchor_sources"]}
+    recorded = {item["source_id"] for item in records}
+    missing = sorted(planned - recorded)
+    extra = sorted(recorded - planned)
+    if missing or extra:
+        detail = []
+        if missing:
+            detail.append("missing " + ", ".join(missing))
+        if extra:
+            detail.append("extra " + ", ".join(extra))
+        raise IntegrityError(
+            "anchor records do not exactly cover plan sources: "
+            + "; ".join(detail)
+        )
+    for record in records:
+        source_id = record["source_id"]
+        returned = record["returned"]
+        if returned["chain_id"] != chain_id:
+            raise IntegrityError(f"anchor source {source_id} names another chain")
+        if (
+            record["params"][0] != block_number
+            or returned["number"] != block_number
+        ):
+            raise IntegrityError(
+                f"anchor source {source_id} names another block number"
+            )
+        if returned["hash"].lower() != block_hash.lower():
+            raise IntegrityError(
+                f"anchor source {source_id} disagrees with the verified header"
+            )
 
 
 def _validate_plan_coverage(plan: dict[str, Any], observed: dict[str, Any]) -> None:

--- a/plugins/lazarus/scripts/lazarus_lib/verifier.py
+++ b/plugins/lazarus/scripts/lazarus_lib/verifier.py
@@ -10,10 +10,15 @@ from .canonical import MAX_JSON_BYTES, MAX_JSONL_BYTES, loads
 from .errors import FormatError, IntegrityError
 from .header import verify_header
 from .hexvalue import hash32_bytes, hex_bytes, quantity
-from .manifest import verify_manifest
+from .manifest import validate_anchor_records, verify_manifest
 from .paths import read_confined_bytes
 from .proofs import verify_proof_record
-from .records import loads_proof_records, loads_rpc_records, request_key
+from .records import (
+    loads_anchor_records,
+    loads_proof_records,
+    loads_rpc_records,
+    request_key,
+)
 from .schemas import validate_document
 from .text import listed
 
@@ -43,6 +48,25 @@ def verify_fixture(root: str | Path) -> dict[str, Any]:
         "header", loads(_read_bound(root, "header.json", claims, MAX_JSON_BYTES))
     )
     header_report = verify_header(header)
+    anchor_records: list[dict[str, Any]] = []
+    has_anchor_component = "anchors.jsonl" in paths
+    if plan["schema_version"] == 1:
+        if has_anchor_component:
+            raise IntegrityError("plan-v1 refuses anchors.jsonl")
+    else:
+        if not has_anchor_component:
+            raise IntegrityError("plan-v2 requires anchors.jsonl")
+        anchor_records = loads_anchor_records(
+            _read_bound(root, "anchors.jsonl", claims, MAX_JSONL_BYTES),
+            max_bytes=MAX_JSONL_BYTES,
+        )
+        validate_anchor_records(
+            plan,
+            anchor_records,
+            chain_id=manifest["chain_id"],
+            block_number=header_report["number"],
+            block_hash=header_report["hash"],
+        )
     rpc_records = loads_rpc_records(
         _read_bound(root, "rpc.jsonl", claims, MAX_JSONL_BYTES)
     )
@@ -106,6 +130,11 @@ def verify_fixture(root: str | Path) -> dict[str, Any]:
             "storage_absent": storage_absent,
         },
         "header_bound": {"headers": 1, "canonical_chain_claim": False},
+        "chain_anchors": {
+            "records": len(anchor_records),
+            "canonical_chain_claim": False,
+            "provider_independence_claim": False,
+        },
         "recorded_rpc": {
             "records": len(rpc_records),
             "optional_failures": len(manifest["optional_failures"]),

--- a/plugins/lazarus/tests/support.py
+++ b/plugins/lazarus/tests/support.py
@@ -107,17 +107,24 @@ def sample_plan_v2(source_ids=("archive-a",)):
     return plan
 
 
-def sample_anchor_record(source_id="archive-a"):
+def sample_anchor_record(
+    source_id="archive-a",
+    *,
+    chain_id="0x1",
+    block_number="0x10",
+    block_hash=None,
+):
+    block_hash = hash32("11") if block_hash is None else block_hash
     return {
         "schema_version": 1,
         "source_id": source_id,
         "observed_at": "2026-08-25T08:30:45.123456Z",
         "method": "eth_getBlockByNumber",
-        "params": ["0x10", False],
+        "params": [block_number, False],
         "returned": {
-            "chain_id": "0x1",
-            "number": "0x10",
-            "hash": hash32("11"),
+            "chain_id": chain_id,
+            "number": block_number,
+            "hash": block_hash,
         },
     }
 

--- a/plugins/lazarus/tests/test_binding.py
+++ b/plugins/lazarus/tests/test_binding.py
@@ -130,6 +130,37 @@ class CleanBindingTests(unittest.TestCase):
         for name in made:
             self.assertTrue(name and name.strip())
 
+    def test_anchor_inventory_binds_without_changing_the_ariadne_contract(self):
+        manifest = sample_manifest()
+        report = sample_report()
+        statement = sample_statement()
+        anchor = {
+            "path": "anchors.jsonl",
+            "bytes": 512,
+            "sha256": "e" * 64,
+        }
+        manifest["components"].append(anchor)
+        report["chain_anchors"] = {
+            "records": 2,
+            "canonical_chain_claim": False,
+            "provider_independence_claim": False,
+        }
+        statement["predicate"]["fixture_subjects"].append(
+            {
+                "name": anchor["path"],
+                "path": anchor["path"],
+                "digest": {"sha256": anchor["sha256"]},
+                "bytes": anchor["bytes"],
+            }
+        )
+        statement["subject"].append(
+            {"name": anchor["path"], "digest": {"sha256": anchor["sha256"]}}
+        )
+        original_evidence = copy.deepcopy(statement["predicate"]["evidence"])
+        self.assertEqual(bound(statement, manifest, report), list(CHECKS))
+        self.assertEqual(statement["predicate"]["evidence"], original_evidence)
+        self.assertNotIn("chain_anchors", statement["predicate"])
+
     def test_a_block_hash_in_the_other_case_still_binds(self):
         """Two spellings of one value. Lazarus writes lowercase and a producer
         may not."""

--- a/plugins/lazarus/tests/test_manifest.py
+++ b/plugins/lazarus/tests/test_manifest.py
@@ -15,13 +15,19 @@ from lazarus_lib.manifest import (
     verify_manifest,
     write_manifest,
 )
-from lazarus_lib.records import make_rpc_record, write_proof_records, write_rpc_records
+from lazarus_lib.records import (
+    make_rpc_record,
+    write_anchor_records,
+    write_proof_records,
+    write_rpc_records,
+)
 
 from . import support
 from lazarus import run
 
 
 COMPONENTS = ("header.json", "plan.json", "proofs.jsonl", "rpc.jsonl")
+ANCHORED_COMPONENTS = (*COMPONENTS, "anchors.jsonl")
 
 
 def write_components(root: Path) -> None:
@@ -43,10 +49,19 @@ def write_components(root: Path) -> None:
     write_proof_records(root / "proofs.jsonl", [support.sample_proof_record()])
 
 
-def make_manifest(root: Path):
+def write_anchored_components(root: Path, source_ids=("archive-a",)) -> None:
+    write_components(root)
+    dump(root / "plan.json", support.sample_plan_v2(source_ids))
+    write_anchor_records(
+        root / "anchors.jsonl",
+        [support.sample_anchor_record(source_id) for source_id in source_ids],
+    )
+
+
+def make_manifest(root: Path, components=COMPONENTS):
     manifest = build_manifest(
         root,
-        COMPONENTS,
+        components,
         chain_id="0x1",
         block_number="0x10",
         block_hash=support.hash32("11"),
@@ -57,6 +72,51 @@ def make_manifest(root: Path):
 
 
 class ManifestTests(unittest.TestCase):
+    def test_manifest_v1_accepts_the_optional_anchor_component_without_new_counts(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_anchored_components(root)
+            manifest = make_manifest(root, ANCHORED_COMPONENTS)
+            self.assertEqual(
+                set(manifest),
+                {
+                    "schema_version",
+                    "tool_version",
+                    "chain_id",
+                    "block",
+                    "components",
+                    "evidence_counts",
+                    "optional_failures",
+                    "fixture_digest",
+                },
+            )
+            self.assertEqual(
+                manifest["evidence_counts"],
+                {"proof_backed": 2, "header_bound": 1, "recorded_rpc": 1},
+            )
+            self.assertIn(
+                "anchors.jsonl",
+                {component["path"] for component in manifest["components"]},
+            )
+            self.assertEqual(verify_manifest(root), manifest)
+
+    def test_anchor_component_presence_tracks_the_plan_version(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_components(root)
+            dump(root / "plan.json", support.sample_plan_v2())
+            with self.assertRaisesRegex(IntegrityError, "plan-v2 requires anchors.jsonl"):
+                make_manifest(root)
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_components(root)
+            write_anchor_records(
+                root / "anchors.jsonl", [support.sample_anchor_record()]
+            )
+            with self.assertRaisesRegex(IntegrityError, "plan-v1 refuses anchors.jsonl"):
+                make_manifest(root, ANCHORED_COMPONENTS)
+
     def test_repeated_builds_and_writes_are_byte_identical(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/plugins/lazarus/tests/test_preservation_release.py
+++ b/plugins/lazarus/tests/test_preservation_release.py
@@ -38,6 +38,26 @@ def document():
 
 
 class ShippedReleaseTests(unittest.TestCase):
+    def test_the_legacy_fixture_has_no_anchor_records_or_new_release_fields(self):
+        report = verify_fixture(FIXTURE)
+        self.assertIn("chain_anchors", report)
+        self.assertEqual(
+            report["chain_anchors"],
+            {
+                "records": 0,
+                "canonical_chain_claim": False,
+                "provider_independence_claim": False,
+            },
+        )
+        self.assertNotIn(
+            "anchors.jsonl",
+            {component["path"] for component in report["manifest"]["components"]},
+        )
+        self.assertEqual(
+            set(document()["verified"]),
+            {"block_hash", "evidence_counts", "canonical_chain_claim"},
+        )
+
     def test_the_shipped_release_verifies(self):
         report = verify_release(SHIPPED)
         self.assertEqual(report["release_digest"], document()["release_digest"])

--- a/plugins/lazarus/tests/test_release.py
+++ b/plugins/lazarus/tests/test_release.py
@@ -21,7 +21,11 @@ from lazarus_lib.binding import CHECKS
 from lazarus_lib.canonical import dump, dumps, loads
 from lazarus_lib.errors import FormatError, IntegrityError, LazarusError, PathError
 from lazarus_lib.manifest import build_manifest, write_manifest
-from lazarus_lib.records import write_proof_records, write_rpc_records
+from lazarus_lib.records import (
+    write_anchor_records,
+    write_proof_records,
+    write_rpc_records,
+)
 from lazarus_lib.release import (
     FIXTURE_DIRECTORY,
     RELEASE_NAME,
@@ -36,11 +40,12 @@ from lazarus_lib.verifier import verify_fixture
 from . import support
 
 COMPONENTS = ("header.json", "plan.json", "proofs.jsonl", "rpc.jsonl")
+ANCHORED_COMPONENTS = (*COMPONENTS, "anchors.jsonl")
 STATE_FIXTURE_TYPE = "https://ariadne.wildcat.finance/state-fixture/v1"
 CLI = support.PLUGIN_ROOT / "scripts" / "lazarus.py"
 
 
-def write_fixture(root: Path, *, hash_source=None):
+def write_fixture(root: Path, *, hash_source=None, anchor_source_ids=None):
     """A fixture that verifies, built from synthetic material.
 
     `hash_source` changes one string nothing verifies against, which is enough
@@ -49,13 +54,32 @@ def write_fixture(root: Path, *, hash_source=None):
     material = support.synthetic_fixture_material()
     if hash_source is not None:
         material["plan"]["block"]["hash_source"] = hash_source
+    components = COMPONENTS
+    if anchor_source_ids is not None:
+        material["plan"]["schema_version"] = 2
+        material["plan"]["anchor_sources"] = [
+            {"source_id": source_id} for source_id in anchor_source_ids
+        ]
+        components = ANCHORED_COMPONENTS
     dump(root / "plan.json", material["plan"])
     dump(root / "header.json", material["header"])
     write_rpc_records(root / "rpc.jsonl", material["rpc_records"])
     write_proof_records(root / "proofs.jsonl", material["proof_records"])
+    if anchor_source_ids is not None:
+        write_anchor_records(
+            root / "anchors.jsonl",
+            [
+                support.sample_anchor_record(
+                    source_id,
+                    block_number=material["header"]["number"],
+                    block_hash=material["header"]["hash"],
+                )
+                for source_id in anchor_source_ids
+            ],
+        )
     manifest = build_manifest(
         root,
-        COMPONENTS,
+        components,
         chain_id="0x1",
         block_number=material["header"]["number"],
         block_hash=material["header"]["hash"],
@@ -132,6 +156,52 @@ class Prepared:
 
 
 class WrittenReleaseTests(unittest.TestCase):
+    def test_an_anchored_fixture_round_trips_without_changing_release_v1(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture = root / "fixture-source"
+            fixture.mkdir()
+            write_fixture(
+                fixture, anchor_source_ids=("archive-a", "archive-b")
+            )
+            statement_path = root / "statement.json"
+            statement_path.write_bytes(
+                json.dumps(statement_for(fixture), indent=2).encode()
+            )
+            out = root / "release"
+            document = write_release(fixture, statement_path, out)
+            read_back = verify_release(out)
+            fixture_report = verify_fixture(out / FIXTURE_DIRECTORY)
+
+            self.assertIn("chain_anchors", fixture_report)
+            self.assertEqual(fixture_report["chain_anchors"]["records"], 2)
+            self.assertEqual(
+                set(document),
+                {
+                    "schema_version",
+                    "tool_version",
+                    "fixture",
+                    "statement",
+                    "verified",
+                    "binding",
+                    "release_digest",
+                },
+            )
+            self.assertEqual(
+                set(document["verified"]),
+                {"block_hash", "evidence_counts", "canonical_chain_claim"},
+            )
+            self.assertNotIn("chain_anchors", document)
+            self.assertNotIn("chain_anchors", read_back)
+            self.assertEqual(
+                document["fixture"]["fixture_digest"],
+                fixture_report["fixture_digest"],
+            )
+            self.assertTrue(
+                (out / FIXTURE_DIRECTORY / "anchors.jsonl").is_file()
+            )
+            self.assertEqual(document["binding"]["checks"], list(CHECKS))
+
     def test_a_release_holds_the_fixture_the_statement_and_the_document(self):
         with tempfile.TemporaryDirectory() as directory:
             prepared = Prepared(directory)

--- a/plugins/lazarus/tests/test_verifier.py
+++ b/plugins/lazarus/tests/test_verifier.py
@@ -8,27 +8,63 @@ import tempfile
 import unittest
 from unittest import mock
 
-from lazarus_lib.canonical import dump
-from lazarus_lib.errors import IntegrityError
-from lazarus_lib.manifest import build_manifest, write_manifest
-from lazarus_lib.records import make_rpc_record, write_proof_records, write_rpc_records
+from lazarus_lib.canonical import dump, dumps, load
+from lazarus_lib.errors import FormatError, IntegrityError
+from lazarus_lib.manifest import (
+    build_manifest,
+    component_claim,
+    fixture_digest,
+    write_manifest,
+)
+from lazarus_lib.records import (
+    make_rpc_record,
+    write_anchor_records,
+    write_proof_records,
+    write_rpc_records,
+)
 from lazarus_lib.verifier import verify_fixture
 
 from . import support
 
 
 COMPONENTS = ("header.json", "plan.json", "proofs.jsonl", "rpc.jsonl")
+ANCHORED_COMPONENTS = (*COMPONENTS, "anchors.jsonl")
 
 
-def write_fixture(root: Path, material=None, *, counts=None):
+def write_fixture(
+    root: Path,
+    material=None,
+    *,
+    counts=None,
+    anchor_source_ids=None,
+    anchor_records=None,
+):
     material = material or support.synthetic_fixture_material()
+    components = COMPONENTS
+    if anchor_source_ids is not None:
+        material["plan"]["schema_version"] = 2
+        material["plan"]["anchor_sources"] = [
+            {"source_id": source_id} for source_id in anchor_source_ids
+        ]
+        if anchor_records is None:
+            anchor_records = [
+                support.sample_anchor_record(
+                    source_id,
+                    block_number=material["header"]["number"],
+                    block_hash=material["header"]["hash"],
+                )
+                for source_id in anchor_source_ids
+            ]
+        components = ANCHORED_COMPONENTS
     dump(root / "plan.json", material["plan"])
     dump(root / "header.json", material["header"])
     write_rpc_records(root / "rpc.jsonl", material["rpc_records"])
     write_proof_records(root / "proofs.jsonl", material["proof_records"])
+    if anchor_source_ids is not None:
+        write_anchor_records(root / "anchors.jsonl", anchor_records)
     manifest = build_manifest(
         root,
-        COMPONENTS,
+        components,
         chain_id="0x1",
         block_number=material["header"]["number"],
         block_hash=material["header"]["hash"],
@@ -39,7 +75,206 @@ def write_fixture(root: Path, material=None, *, counts=None):
     return material
 
 
+def rebind_component(root: Path, relative: str) -> None:
+    manifest = load(root / "manifest.json")
+    replacement = component_claim(root, relative)
+    manifest["components"] = [
+        replacement if item["path"] == relative else item
+        for item in manifest["components"]
+    ]
+    manifest["fixture_digest"] = fixture_digest(manifest)
+    dump(root / "manifest.json", manifest)
+
+
+def replace_anchor_records(root: Path, records) -> None:
+    (root / "anchors.jsonl").write_bytes(
+        b"".join(dumps(record) + b"\n" for record in records)
+    )
+    rebind_component(root, "anchors.jsonl")
+
+
 class VerifierTests(unittest.TestCase):
+    def test_anchor_reports_are_separate_counts_with_no_chain_claims(self):
+        for count in (1, 32):
+            source_ids = tuple(f"source-{index:02d}" for index in range(count))
+            with self.subTest(count=count), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                write_fixture(root, anchor_source_ids=source_ids)
+                report = verify_fixture(root)
+                self.assertIn("chain_anchors", report)
+                self.assertEqual(
+                    report["chain_anchors"],
+                    {
+                        "records": count,
+                        "canonical_chain_claim": False,
+                        "provider_independence_claim": False,
+                    },
+                )
+                self.assertEqual(
+                    report["evidence_counts"],
+                    {"proof_backed": 3, "header_bound": 1, "recorded_rpc": 1},
+                )
+
+    def test_legacy_plan_reports_zero_anchors(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_fixture(root)
+            report = verify_fixture(root)
+            self.assertIn("chain_anchors", report)
+            self.assertEqual(report["chain_anchors"]["records"], 0)
+            self.assertIs(report["chain_anchors"]["canonical_chain_claim"], False)
+            self.assertIs(
+                report["chain_anchors"]["provider_independence_claim"], False
+            )
+
+    def test_anchor_sources_must_exactly_cover_the_plan(self):
+        cases = (
+            (
+                ("archive-a", "archive-b"),
+                [support.sample_anchor_record("archive-a")],
+                "missing archive-b",
+            ),
+            (
+                ("archive-a",),
+                [
+                    support.sample_anchor_record("archive-a"),
+                    support.sample_anchor_record("archive-b"),
+                ],
+                "extra archive-b",
+            ),
+        )
+        for source_ids, records, message in cases:
+            with self.subTest(message=message), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                material = write_fixture(root, anchor_source_ids=source_ids)
+                adjusted = [
+                    support.sample_anchor_record(
+                        record["source_id"],
+                        block_number=material["header"]["number"],
+                        block_hash=material["header"]["hash"],
+                    )
+                    for record in records
+                ]
+                replace_anchor_records(root, adjusted)
+                with self.assertRaisesRegex(IntegrityError, message):
+                    verify_fixture(root)
+
+    def test_duplicate_reordered_and_malformed_anchor_records_are_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            material = write_fixture(
+                root, anchor_source_ids=("archive-a", "archive-b")
+            )
+            records = [
+                support.sample_anchor_record(
+                    source_id,
+                    block_number=material["header"]["number"],
+                    block_hash=material["header"]["hash"],
+                )
+                for source_id in ("archive-a", "archive-b")
+            ]
+            hostile = (
+                ([records[0], records[0]], "duplicate anchor source ID"),
+                ([records[1], records[0]], "not sorted by source_id"),
+                ([{"schema_version": 1}], "anchor-record"),
+            )
+            for candidate, message in hostile:
+                with self.subTest(message=message):
+                    replace_anchor_records(root, candidate)
+                    with self.assertRaisesRegex(FormatError, message):
+                        verify_fixture(root)
+
+    def test_wrong_chain_height_and_header_hash_are_refused(self):
+        mutations = (
+            (
+                "wrong-chain",
+                lambda record: record["returned"].__setitem__("chain_id", "0x2"),
+                FormatError,
+                "returned.chain_id",
+            ),
+            (
+                "request-return-height-disagreement",
+                lambda record: record["returned"].__setitem__("number", "0x1"),
+                FormatError,
+                "anchor returned number disagrees with requested block number",
+            ),
+            (
+                "wrong-height",
+                lambda record: (
+                    record["params"].__setitem__(0, "0x1"),
+                    record["returned"].__setitem__("number", "0x1"),
+                ),
+                IntegrityError,
+                "anchor source archive-a names another block number",
+            ),
+            (
+                "header-disagreement",
+                lambda record: record["returned"].__setitem__(
+                    "hash", support.hash32("ff")
+                ),
+                IntegrityError,
+                "anchor source archive-a disagrees with the verified header",
+            ),
+        )
+        for name, mutate, error, message in mutations:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                material = write_fixture(root, anchor_source_ids=("archive-a",))
+                record = support.sample_anchor_record(
+                    "archive-a",
+                    block_number=material["header"]["number"],
+                    block_hash=material["header"]["hash"],
+                )
+                mutate(record)
+                replace_anchor_records(root, [record])
+                with self.assertRaisesRegex(error, message):
+                    verify_fixture(root)
+
+    def test_anchor_component_is_read_once_through_its_manifest_claim(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_fixture(root, anchor_source_ids=("archive-a",))
+            from lazarus_lib import verifier as verifier_module
+
+            original_read = verifier_module._read_bound
+            reads = []
+
+            def counted_read(fixture, relative, claims, max_bytes):
+                reads.append(relative)
+                return original_read(fixture, relative, claims, max_bytes)
+
+            with mock.patch(
+                "lazarus_lib.verifier._read_bound", side_effect=counted_read
+            ):
+                report = verify_fixture(root)
+            self.assertIn("chain_anchors", report)
+            self.assertEqual(reads.count("anchors.jsonl"), 1)
+
+    def test_anchor_mutation_after_manifest_verification_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_fixture(root, anchor_source_ids=("archive-a",))
+            from lazarus_lib import verifier as verifier_module
+
+            original_verify = verifier_module.verify_manifest
+
+            def verify_then_mutate(fixture):
+                manifest = original_verify(fixture)
+                path = root / "anchors.jsonl"
+                data = path.read_bytes()
+                path.write_bytes(data.replace(b'"archive-a"', b'"archive-z"', 1))
+                return manifest
+
+            with mock.patch(
+                "lazarus_lib.verifier.verify_manifest",
+                side_effect=verify_then_mutate,
+            ):
+                with self.assertRaisesRegex(
+                    IntegrityError,
+                    "component changed after manifest verification: anchors.jsonl",
+                ):
+                    verify_fixture(root)
+
     def test_whole_fixture_reports_each_evidence_class_separately(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -59,7 +294,12 @@ class VerifierTests(unittest.TestCase):
             root = Path(directory)
             write_fixture(root)
             result = subprocess.run(
-                [sys.executable, str(support.SCRIPTS / "lazarus.py"), "verify", str(root)],
+                [
+                    sys.executable,
+                    str(support.SCRIPTS / "lazarus.py"),
+                    "verify",
+                    str(root),
+                ],
                 text=True,
                 capture_output=True,
                 check=False,
@@ -68,6 +308,22 @@ class VerifierTests(unittest.TestCase):
             self.assertIn("proof-backed: 3", result.stdout)
             self.assertIn("header-bound: 1", result.stdout)
             self.assertIn("recorded-rpc: 1", result.stdout)
+            self.assertIn("chain-anchor-records: 0", result.stdout)
+
+    def test_cli_prints_the_verified_anchor_record_count(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_fixture(
+                root, anchor_source_ids=("archive-a", "archive-b")
+            )
+            result = subprocess.run(
+                [sys.executable, str(support.SCRIPTS / "lazarus.py"), "verify", str(root)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("chain-anchor-records: 2", result.stdout)
 
     def test_raw_component_mutation_fails_before_interpretation(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -2998,7 +2998,7 @@
         "transition": "verified replay binding joined to the canonical Authorises field",
         "unknowns": "uncaptured requests and recorded-only RPC relations"
       },
-      "sha256": "c10e21227744347d0fc8887e908a8591171b10d1ff7b8b101ee4007d3b20f2e5",
+      "sha256": "9069da793bde12666d89716202dbe42e9cbc704de350ea316515634f4728f8fc",
       "source": "plugins/lazarus/scripts/lazarus.py"
     },
     "lazarus-fixture-capture": {


### PR DESCRIPTION
## What changed

Manifest v1 now accepts and digests an optional `anchors.jsonl` component
without changing its schema or three existing evidence counts. Plan v2 requires
the component; plan v1 refuses it.

Whole-fixture verification rereads the anchor component once through its
manifest size and digest claim, requires exact plan-to-record source coverage,
and refuses missing, extra, duplicate, malformed, reordered, wrong-chain,
wrong-height, or header-disagreeing records. Its report returns
`chain_anchors: {records: N, canonical_chain_claim: false, provider_independence_claim: false}`,
and CLI verification prints `chain-anchor-records: N`.

Release v1 and the Ariadne-facing binding keep their structure and existing
evidence classes. The anchored fixture's component inventory still binds
`anchors.jsonl` through its fixture digest. Issue
[#386](https://github.com/wildcat-finance/skills/issues/386) needs this offline
check without treating matching provider observations as proofs, canonical-chain
membership, or evidence of provider independence.

## Audit

Step 2 round 1 is recorded at
`audit/rounds/fiat-386-record-a-structured-multi-provider-chain-anc.md` with
zero findings. The review covered
`5529225625e407d93563c67729206d2e0f260518..1a49a3c6cf865641e2a0abdad3a05d7de0623fb8`.
No stacked audit-fix pull request was needed because the round was clean.

This pull request is stacked on
`fiat/386-record-a-structured-multi-provider-chain-anc-step-1-define-the-anchor-formats`,
the exact base branch for [#613](https://github.com/wildcat-finance/skills/pull/613).

## Proof

- `python3 -m unittest plugins.lazarus.tests.test_manifest plugins.lazarus.tests.test_verifier plugins.lazarus.tests.test_binding plugins.lazarus.tests.test_release -v`: 217/217.
- `python3 plugins/lazarus/scripts/lazarus.py verify plugins/lazarus/examples/goldfinch-v0`: exit 0; fixture digest `d93cd09fcb2c6bd689a223398ebd4ae4dc480ec7d8fd8e64283b88341d0a7e49`.
- `python3 plugins/lazarus/examples/preservation-release-demo.py`: exit 0 with both refusals held.
- `python3 -m unittest discover -s plugins/lazarus/tests -t plugins/lazarus -v` and `python3 plugins/lazarus/tests/run_tests.py --elenchus-report tmp/elenchus/lazarus-step-2.json`: 399/399 each; the report is complete with zero failures, errors, or skips.
- `python3 -m unittest discover -s tests -v`: 350/350.

<!-- wildcat-origin: shoggoth -->
