### PR TITLE
docs: say who closes a delivered issue and what an open one proves

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,11 @@ in [ADR-009](docs/decisions/ADR-009-four-issue-queues-and-their-titles.md).
 Filing an issue merely to satisfy a workflow remains forbidden; these
 conventions say how to title one that was worth filing.
 
+Closing a delivered issue belongs to whoever merges its pull request. The
+Atlas draws from open issues alone, so one whose delivery has merged keeps
+being allocated until it is closed, and a contributor working from a fork
+cannot close it.
+
 ## Issue and comment publication
 
 Before an agent publishes a GitHub issue title and body or a GitHub issue

--- a/docs/how-to-help-shoggoth.md
+++ b/docs/how-to-help-shoggoth.md
@@ -109,10 +109,18 @@ inspect the change, the tests and checks that ran, any limits that remain, and
 the issue the work belongs to. If the pull request is merged with your human
 authorship intact, GitHub records you in the repository's contributor history.
 
+Closing the issue is not your step. It takes write access to this repository,
+which a contributor working from a fork does not have, so a comment saying the
+work is delivered records the claim without acting on it. Name the issue in the
+pull-request body and expect a maintainer to close it after the merge. Issue
+#462 stayed open after its delivery merged in #571, and the Atlas went on
+allocating it until a maintainer closed it by hand.
+
 ## When something goes wrong
 
 - If no job returns, stop. Do not invent a number or choose a Wave yourself.
 - If the issue is already in progress, ask the Atlas for a new allocation before Fiat starts.
+- If the work on your issue has already merged, ask the Atlas for another allocation and say so on the issue. An open issue is not proof the work is outstanding.
 - If installation or access is missing, state exactly what is missing and ask before changing the repository.
 - If a check fails, keep the repository state and failure output, follow the named recovery, and rerun the same check.
 - If you must interrupt the run, preserve only what Fiat says is safe to commit or push and mark the run incomplete. That is damage control, not a supported hand-off.


### PR DESCRIPTION
An external delivery merges and nothing closes the issue it delivered. The Atlas draws at random from every open issue in its pool, so the issue stays drawable and the next contributor spends a draw finding out. Issue #462 sat open for a day after #571 merged and was drawn again.

The contributor guide now says closing is not the contributor's step, that it takes write access a fork contributor does not have, and that a comment saying the work is delivered records the claim without acting on it. Its recovery list gains the case Dave hit: work already merged, ask for another allocation and say so on the issue.

AGENTS.md places the duty on whoever merges the pull request, beside the queue conventions the merging party already reads.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: https://github.com/wildcat-finance/skills/issues/462
Root-Issue-Successor: none-recorded
Root-Issue-Fiat-Required: 1
Root-Issue-Route: fiat-required
Root-Issue-Classification-Source: live-contract
<!-- root-issue-analytics:v1:end -->
