### PR TITLE
Scaffold Synkrisis and commit its specification

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -173,6 +173,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Developer Tools"
+    },
+    {
+      "name": "synkrisis",
+      "source": {
+        "source": "local",
+        "path": "./plugins/synkrisis"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
     }
   ]
 }

--- a/.agents/skills/promise-machine/PORTABLE.md
+++ b/.agents/skills/promise-machine/PORTABLE.md
@@ -5,7 +5,7 @@
 Use this path only when the router is installed as one Agent Skills package.
 The full-source path is valid only when `../../../PROMISE_MACHINE.md` identifies
 `promise-machine/v1` and the sibling `../../../plugins/` directory holds all
-fourteen runtime contracts. A target repository's own `AGENTS.md` does not make
+fifteen runtime contracts. A target repository's own `AGENTS.md` does not make
 it a Wildcat Skills source checkout.
 
 ## Verify the copy

--- a/.agents/skills/promise-machine/SKILL.md
+++ b/.agents/skills/promise-machine/SKILL.md
@@ -11,7 +11,7 @@ work, and owns no domain promise.
 
 Choose the runtime before routing. In a full source checkout,
 `../../../PROMISE_MACHINE.md` identifies `promise-machine/v1` and
-`../../../plugins/` holds all fourteen plugin contracts; read the [root runtime
+`../../../plugins/` holds all fifteen plugin contracts; read the [root runtime
 contract](../../../AGENTS.md) first. Otherwise this is an isolated Agent Skills
 install: read `PORTABLE.md`, verify its local runtime, and use the installed-path
 substitution it defines. A target repository's unrelated `AGENTS.md` never
@@ -19,7 +19,7 @@ counts as the suite contract. Do not select a canonical skill until one of
 these two runtime paths has loaded the same law and the selected plugin
 contract.
 
-The router sees the complete collective. Thirteen first-party specialists live
+The router sees the complete collective. Fourteen first-party specialists live
 in their own plugins. Hexaemeron contains Fiat, Kronos, six phase disciplines,
 two prose masks, four Fiat worker briefs, and the untouched Pashov security
 suite. The worker briefs are packets Fiat may delegate; they are not canonical
@@ -45,6 +45,7 @@ canonical skill only when the selected workflow requires a named handoff.
 | Apply executable credit laws | [Pandects](../../../plugins/pandects/AGENTS.md) | `pandects` |
 | Build a declared-address counterparty dossier | [Probitas](../../../plugins/probitas/AGENTS.md) | `probitas` |
 | Shape the agent's own replies for an AuDHD reader, or shape durable agent-authored audit records and GitHub issue titles, bodies and comments | [Sapheneia](../../../plugins/sapheneia/AGENTS.md) | `sapheneia` |
+| Compare validated run observations across one declared cohort | [Synkrisis](../../../plugins/synkrisis/AGENTS.md) | `synkrisis` |
 | Build a venue-qualified credit-event release | [Tabularium](../../../plugins/tabularium/AGENTS.md) | `tabularium` |
 
 Hexaemeron is one plugin with several distinct owners. Use the same runtime

--- a/.agents/skills/promise-machine/runtime/.agents/skills/promise-machine/SKILL.md
+++ b/.agents/skills/promise-machine/runtime/.agents/skills/promise-machine/SKILL.md
@@ -11,7 +11,7 @@ work, and owns no domain promise.
 
 Choose the runtime before routing. In a full source checkout,
 `../../../PROMISE_MACHINE.md` identifies `promise-machine/v1` and
-`../../../plugins/` holds all fourteen plugin contracts; read the [root runtime
+`../../../plugins/` holds all fifteen plugin contracts; read the [root runtime
 contract](../../../AGENTS.md) first. Otherwise this is an isolated Agent Skills
 install: read `PORTABLE.md`, verify its local runtime, and use the installed-path
 substitution it defines. A target repository's unrelated `AGENTS.md` never
@@ -19,7 +19,7 @@ counts as the suite contract. Do not select a canonical skill until one of
 these two runtime paths has loaded the same law and the selected plugin
 contract.
 
-The router sees the complete collective. Thirteen first-party specialists live
+The router sees the complete collective. Fourteen first-party specialists live
 in their own plugins. Hexaemeron contains Fiat, Kronos, six phase disciplines,
 two prose masks, four Fiat worker briefs, and the untouched Pashov security
 suite. The worker briefs are packets Fiat may delegate; they are not canonical
@@ -45,6 +45,7 @@ canonical skill only when the selected workflow requires a named handoff.
 | Apply executable credit laws | [Pandects](../../../plugins/pandects/AGENTS.md) | `pandects` |
 | Build a declared-address counterparty dossier | [Probitas](../../../plugins/probitas/AGENTS.md) | `probitas` |
 | Shape the agent's own replies for an AuDHD reader, or shape durable agent-authored audit records and GitHub issue titles, bodies and comments | [Sapheneia](../../../plugins/sapheneia/AGENTS.md) | `sapheneia` |
+| Compare validated run observations across one declared cohort | [Synkrisis](../../../plugins/synkrisis/AGENTS.md) | `synkrisis` |
 | Build a venue-qualified credit-event release | [Tabularium](../../../plugins/tabularium/AGENTS.md) | `tabularium` |
 
 Hexaemeron is one plugin with several distinct owners. Use the same runtime

--- a/.agents/skills/promise-machine/runtime/.horos/boundary.json
+++ b/.agents/skills/promise-machine/runtime/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 838
+    "files_walked": 846
   },
   "entries": [
     {

--- a/.agents/skills/promise-machine/runtime/AGENTS.md
+++ b/.agents/skills/promise-machine/runtime/AGENTS.md
@@ -27,7 +27,7 @@ generated installation copies and must remain byte-identical to it.
 
 ## Marketplace boundaries
 
-The fourteen plugins form one marketplace, not fourteen competing descriptions
+The fifteen plugins form one marketplace, not fifteen competing descriptions
 of the same job. Alexandria preserves lending inputs; Tabularium interprets
 preserved venue records; Probitas assembles a counterparty dossier. Lazarus
 preserves the finite historical Ethereum state and exact RPC traffic a test
@@ -40,7 +40,10 @@ Hexaemeron controls a receipted delivery loop and holds each of its phases to a
 named skill, while Lemma stops after producing
 source-linked chunks. Horos decides what an agent does not read. Janus checks
 what a contract hook may observe and change around a host action, where
-Pandects supplies the economic laws such a transition must preserve. Sapheneia
+Pandects supplies the economic laws such a transition must preserve. Synkrisis
+compares validated run observations across one declared cohort and stops at
+bounded inferred findings; capture, redaction, receipt binding and causal
+triage stay with their owners. Sapheneia
 shapes the agent's replies for AuDHD readers and has one bounded operation for
 durable audit, issue, and comment prose. It does not change another skill's
 facts or gates. Brevitas controls the volume and structure of engineering prose
@@ -126,6 +129,9 @@ these instructions.
 - Sapheneia is under `plugins/sapheneia/`. Read
   `plugins/sapheneia/AGENTS.md` before running its skill or changing that
   plugin.
+- Synkrisis is under `plugins/synkrisis/`. Read
+  `plugins/synkrisis/AGENTS.md` before running its skill or changing that
+  plugin.
 - Tabularium is under `plugins/tabularium/`. Read
   `plugins/tabularium/AGENTS.md` before running its skill or changing that
   plugin.
@@ -181,6 +187,7 @@ python3 -m unittest discover -s plugins/lazarus/tests -t plugins/lazarus
 python3 -m unittest discover -s plugins/pandects/tests -t plugins/pandects
 python3 -m unittest discover -s plugins/probitas/tests -t plugins/probitas
 python3 -m unittest discover -s plugins/sapheneia/tests -t plugins/sapheneia
+python3 -m unittest discover -s plugins/synkrisis/tests -t plugins/synkrisis
 python3 -m unittest discover -s plugins/tabularium/tests -t plugins/tabularium
 ```
 

--- a/.agents/skills/promise-machine/runtime/MANIFEST.json
+++ b/.agents/skills/promise-machine/runtime/MANIFEST.json
@@ -2,8 +2,8 @@
   "schema": "promise-machine-portable-runtime/v1",
   "contract": "promise-machine/v1",
   "generated_by": "scripts/portable_promise_machine.py",
-  "file_count": 847,
-  "total_bytes": 11019121,
+  "file_count": 855,
+  "total_bytes": 11070045,
   "omissions": [
     {
       "pattern": "plugins/*/.claude-plugin/**",
@@ -36,16 +36,16 @@
   ],
   "files": [
     {
-      "bytes": 5364,
+      "bytes": 5495,
       "path": ".agents/skills/promise-machine/SKILL.md",
-      "sha256": "05e4a523b363878695ebfc0d2aeb25327ef8a7630a864fc5ddd34149d6d7f57c",
+      "sha256": "c57588a0fc02a932c200cd8ddbd8222c4be2325a134be1322bc901ded42d358a",
       "source": ".agents/skills/promise-machine/SKILL.md"
     },
     {
       "bytes": 3198,
       "generated_by": "plugins/horos/skills/horos/scripts/horos.py",
       "path": ".horos/boundary.json",
-      "sha256": "f03d1b727daef7ab7c98a2272fbf3fdfab0698b994d9ec35b8830098914dee0f",
+      "sha256": "0fd9944161af66649a501aa1dc72d43c85228ed5dd6fc0e41fd20a066ed0f87f",
       "source": null
     },
     {
@@ -55,9 +55,9 @@
       "source": ".python-version"
     },
     {
-      "bytes": 11496,
+      "bytes": 11894,
       "path": "AGENTS.md",
-      "sha256": "7d6e9d840205e5181d3e9ca1a1be90228635a853413081500d60f9de1494cc4c",
+      "sha256": "d49544138b92faeb53fbf1a91702a72f4731e705f0693e4e1344ba3d60c53212",
       "source": "AGENTS.md"
     },
     {
@@ -4721,6 +4721,54 @@
       "path": "plugins/sapheneia/skills/sapheneia/agents/openai.yaml",
       "sha256": "7dc44aaf0a94bdac8a92a86a9113a516f508b29ed0e22d98279a40f6a812504e",
       "source": "plugins/sapheneia/skills/sapheneia/agents/openai.yaml"
+    },
+    {
+      "bytes": 4405,
+      "path": "plugins/synkrisis/AGENTS.md",
+      "sha256": "8a5093f717b7fb40703623340f24d20e5dbc07a2fa3e3dd29cd64352f0e3f42d",
+      "source": "plugins/synkrisis/AGENTS.md"
+    },
+    {
+      "bytes": 11342,
+      "path": "plugins/synkrisis/LICENSE",
+      "sha256": "624ddb0910d0925eafa5ac16a65a1360417e3d7c72aff6df0f3eab475695b68d",
+      "source": "plugins/synkrisis/LICENSE"
+    },
+    {
+      "bytes": 16453,
+      "path": "plugins/synkrisis/PROMISE_MACHINE.md",
+      "sha256": "dae19b7409f7ee83a74b166c16fbc0cd117131031bff6e969a9b190205c4ab77",
+      "source": "plugins/synkrisis/PROMISE_MACHINE.md"
+    },
+    {
+      "bytes": 3710,
+      "path": "plugins/synkrisis/README.md",
+      "sha256": "71dcfa8a0af8f90723fa8bced54adc632f2d95690cd99a7134088ea046a6f1c3",
+      "source": "plugins/synkrisis/README.md"
+    },
+    {
+      "bytes": 2028,
+      "path": "plugins/synkrisis/docs/decisions/ADR-001-keep-cross-run-diagnosis-separate.md",
+      "sha256": "2caab7792e5d32b6b83866836052bb2386c6e86db4b2fc7c51972ae3c4d61fdc",
+      "source": "plugins/synkrisis/docs/decisions/ADR-001-keep-cross-run-diagnosis-separate.md"
+    },
+    {
+      "bytes": 4072,
+      "path": "plugins/synkrisis/scripts/synkrisis.py",
+      "sha256": "5895a0b72363acfde3d053a4b1db508e817e067048f8617c7314226956fdb05d",
+      "source": "plugins/synkrisis/scripts/synkrisis.py"
+    },
+    {
+      "bytes": 1595,
+      "path": "plugins/synkrisis/skills/synkrisis/EVOLUTION.md",
+      "sha256": "bd362ae9c90cea4b4b64b5b7d771b06f7324fe22de467486192042a2d7f98081",
+      "source": "plugins/synkrisis/skills/synkrisis/EVOLUTION.md"
+    },
+    {
+      "bytes": 6790,
+      "path": "plugins/synkrisis/skills/synkrisis/SKILL.md",
+      "sha256": "5813cddaf7c3732576059ae9197b0b29eef1b2a015976923f13198d291543d8b",
+      "source": "plugins/synkrisis/skills/synkrisis/SKILL.md"
     },
     {
       "bytes": 4570,

--- a/.agents/skills/promise-machine/runtime/plugins/synkrisis/AGENTS.md
+++ b/.agents/skills/promise-machine/runtime/plugins/synkrisis/AGENTS.md
@@ -1,0 +1,81 @@
+# Synkrisis runtime contract
+
+<!-- marketplace-context:start -->
+> **Marketplace context: Synkrisis.** Synkrisis compares validated Promise Machine run observations across one operator-declared cohort and recomputes bounded, evidence-linked findings. Use Ephoros to design what a step emits, Metron for controlled measurement verdicts, Elenchus to work one failure to its cause, and Horos for the reading boundary a finding may point at. **Current frontier:** Synkrisis is a committed specification with a refusing command stub, and none of its runbook's cohort, diagnosis, render or verification steps has yet landed behaviour.
+<!-- marketplace-context:end -->
+
+## Promise Machine binding
+
+Before selecting or running a skill, read the local
+[Promise Machine contract](PROMISE_MACHINE.md). This `promise-machine/v1`
+file is a generated installation copy of the suite law. A result authorises
+only the transition its canonical skill declares; missing, stale or
+insufficient evidence blocks that dependent transition while leaving recovery
+available.
+
+Synkrisis contains one Agent Skill. Select `synkrisis` to read the committed
+cross-run comparison specification, to run the scaffold's declared surface,
+or to continue the runbook's held steps, then read
+`skills/synkrisis/SKILL.md` in full. At this step every operation refuses
+with a stable code naming the runbook step that implements it; do not
+present a cohort, finding, report or verification as a Synkrisis result.
+
+`skills/synkrisis/SKILL.md` is the only canonical instruction document. Do not
+add a sibling browsing README.
+
+## Translate tool names by capability
+
+The canonical skill was written for hosts that name their tools. A local agent
+must map those names to equivalent capabilities:
+
+| Instruction term | Required capability | Preserve |
+| --- | --- | --- |
+| `Read` | Read the named file completely or at the stated range | Named range and byte content |
+| `Write` or `Edit` | Create or patch the named file | Intended path and patch scope |
+| `Bash` | Execute the command in a shell and inspect its exit status | Argument order and exit status |
+| `Glob`, `Grep`, or `find` | Enumerate or search files with the stated pattern | Pattern and matched paths |
+
+Tool names describe capabilities, not mandatory API identifiers. Preserve the
+arguments, ordering, output files, and exit codes when using an equivalent
+local tool. A non-zero exit from a check means the check failed; do not report
+a run as clean when it exited 1.
+
+## Resolve placeholders
+
+- `$SKILL_DIR` means the directory containing the active `SKILL.md`, unless
+  that file defines it differently.
+- `$PLUGIN_ROOT` means this `plugins/synkrisis/` directory.
+- The command is `scripts/synkrisis.py`, resolved against `$PLUGIN_ROOT` and
+  not the user's target repository. The interpreter is the exact pin in the
+  suite's `.python-version`.
+- Names such as `synkrisis:synkrisis` and `/synkrisis:synkrisis` are logical
+  aliases. Load the canonical path from the selection above.
+
+## Network and side effects
+
+Nothing here reaches the network. The Step 1 command parses its arguments,
+prints one refusal naming the runbook step that implements the operation, and
+exits 1; it reads no record, writes no file, executes no observed content and
+has no GitHub, Git or controller mutation path. Treat a target repository as
+the user's, and obey its own instructions before writing anything into it.
+
+## What this skill must refuse
+
+These are properties of the tool rather than reminders, and a local agent must
+not route around them:
+
+- No analytical result from the scaffold. Every operation refuses until its
+  runbook step lands; a refusal is not a cohort, finding, report or
+  verification.
+- No inferred comparability. The operator declares the comparison policy;
+  Synkrisis checks that declaration and never decides that unlike tasks,
+  models, hosts, repositories or tokenizers are comparable.
+- No evidence strengthening. Findings are specified to stay at the inferred
+  class and carry their counterevidence, unknown runs and nearest forbidden
+  claim.
+- No cause and no model judgement, in a rule, a finding or a report.
+- No autonomous transition. A suggested handoff is the whole action; filing
+  issues, editing repositories and dispatching siblings belong to a person.
+
+If an operation, a check or a suite did not run, say so plainly and do not
+describe its result.

--- a/.agents/skills/promise-machine/runtime/plugins/synkrisis/LICENSE
+++ b/.agents/skills/promise-machine/runtime/plugins/synkrisis/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Wildcat Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.agents/skills/promise-machine/runtime/plugins/synkrisis/PROMISE_MACHINE.md
+++ b/.agents/skills/promise-machine/runtime/plugins/synkrisis/PROMISE_MACHINE.md
@@ -1,0 +1,245 @@
+# Promise Machine contract
+
+<!-- promise-machine: contract=promise-machine/v1; canonical=PROMISE_MACHINE.md; copies=generated -->
+
+This document is the normative contract for every skill distributed as part of
+Wildcat Labs Skills. Plugin-local files with this name are generated,
+byte-identical installation copies. They are not separate laws.
+
+## Contract identity
+
+The shared contract identity is `promise-machine/v1`. It identifies this law's
+format and semantics. It is neither a plugin package version nor a skill
+evolution version.
+
+## Governing principle
+
+> No skill may claim more than its evidence establishes, or authorise a more
+> consequential transition than that evidence warrants.
+
+This principle applies to every answer, artefact, repository change,
+publication, deployment and external action produced through the suite. A
+passing check establishes only the promise that names it. It does not establish
+the skill's general correctness, the truth of its inputs or any neighbouring
+claim.
+
+## Scope
+
+The contract applies to first-party skills, nested skills, vendored skills,
+routers, runtime contracts, generated copies and evidence handoffs. Each
+logical skill has one canonical implementation. Routers select that
+implementation and establish no domain result of their own.
+
+Vendored instructions remain upstream-owned and byte-for-byte unmodified. A
+first-party overlay may bind a vendored operation to this contract when it
+names the upstream digest, the bounded promise and the Wildcat-owned evidence.
+
+## Vocabulary
+
+| Term | Meaning | Required binding | Nearest refusal |
+| --- | --- | --- | --- |
+| Promise | A bounded claim made by one skill operation | Stable promise id and canonical skill | An adjacent claim |
+| Promise boundary | The subject, scope and nearby conclusions the promise does not support | Subject and scope | Unexplained scope widening |
+| Promise check | Identified evidence evaluated to decide whether a promise holds | Evidence identity and result | Unchecked evidence |
+| Authorised transition | The representation or action a satisfied promise permits | Consequence level | A more consequential action |
+| Refusal | Denial of the dependent transition when the promise is not established | Blocked transition | Continuing after failure |
+| Recovery | Inspection, cure, rerun, rollback or safe exit left available after refusal | Actionable recovery path | Global halt or no exit |
+| Exception | An attributed, scoped and recorded decision to waive or narrow one gate | Authority, scope, record and expiry | Silent waiver |
+| Evidence inheritance | A consumer may narrow evidence or add separately identified evidence | Producer, consumer and original class | Unexplained strengthening |
+| Bounded conformance | Observed behaviour stayed inside a declared boundary for named inputs, adapter, recorder and search | Inputs, adapter, recorder and search | Safety proof or unobserved executions |
+
+## Evidence classes
+
+Evidence classes describe relations, not a universal strength ordering:
+
+| Class | Establishes | Does not establish |
+| --- | --- | --- |
+| `checked` | An identified deterministic rule or schema accepted the subject | Truth or completeness outside that rule |
+| `recomputed` | A result was derived again from identified inputs and method | Authority beyond those inputs and method |
+| `proved` | A named formal, cryptographic or defined proof relation accepted the subject | Any claim outside that proof relation |
+| `measured` | A value was observed under a recorded method and environment | Universal performance or causation |
+| `recorded` | Bytes or a statement were preserved from an identified source | Truth of the source assertion |
+| `attested` | An identified actor or system made the statement | Independent truth of the statement |
+| `inferred` | A conclusion follows under a stated rule from named evidence | Direct observation or proof |
+| `unknown` | The matter was not established | Any positive transition |
+
+A domain may refine a class, such as `proved: EIP-1186 account proof`, while
+keeping the base class recognisable. A consumer records any change of class and
+the evidence that supports it. Absence, ambiguity and `unknown` never pass.
+
+## Promise declarations
+
+Every governed first-party canonical skill has exactly one `## Promise Machine
+contract` section. It contains one or more stable `### <promise-id>` blocks.
+Each block carries these fields exactly once:
+
+- `Promise`
+- `Evidence`
+- `Evidence classes`
+- `Boundary`
+- `Authorises`
+- `Consequence`
+- `Refuses`
+- `Recovery`
+- `Exceptions`
+
+The promise id is stable within the skill. Operations whose claims or
+authorised transitions differ use separate promise ids. Evidence names the
+command, record, test, proof relation or observation that supports the claim.
+The boundary names the nearest tempting overclaim. Refusal names the transition
+that stops. Recovery remains usable when refusal occurs.
+
+`Exceptions: none` is explicit. A supported exception follows the rules below.
+
+## Consequence levels
+
+The consequence belongs to the authorised transition, not to the skill as a
+whole:
+
+| Level | Transition | Minimum enforcement |
+| --- | --- | --- |
+| 0 | Response or presentation only | Preserve scope, content and uncertainty |
+| 1 | Derived artefact | Validate structure, provenance and visible gaps |
+| 2 | Repository or durable-data mutation | Tests, negative evidence and recoverable change |
+| 3 | Publication, deployment, external action, security or financial conclusion | Fail-closed gate, recorded authority and independently inspectable evidence |
+
+A skill with operations at different levels declares separate promises. A
+level-3 transition cannot rest only on model judgement, unrecorded operator
+memory, an unchecked receipt or evidence whose subject does not match.
+
+## Composition
+
+Composition preserves the producer's boundary. A handoff records the producing
+skill, consuming skill, subject, scope, evidence class, time domain and any
+transformation. The consumer can add separately identified evidence. It must not
+rename narrow evidence into a stronger class or drop a conflict, gap, refusal
+or recovery path.
+
+In particular:
+
+- Lemma chunks remain source-linked retrieval material; they do not establish
+  answer truth.
+- Lazarus recorded RPC evidence remains recorded unless its named proof check
+  established a narrower proved relation.
+- Berean citations, evaluations and promotion records establish their declared
+  release gates; they do not establish factual truth or model quality.
+- Janus results remain bound to the named host adapter, manifest, recorder and
+  bounded search; they do not establish hook safety, complete liveness or
+  cross-host conformance.
+- Ariadne binds an artefact digest to declared evidence; without an external
+  signature verifier it does not establish author identity.
+- A Fiat run-observation binding preserves the observation validator and
+  capture boundaries. It attaches only the checked prefix to one receipt; it
+  does not make observation availability or event truth delivery evidence.
+
+Any unexplained strengthening is a conformance failure.
+
+## Refusal and recovery
+
+Missing, stale, malformed, mismatched or insufficient evidence fails closed.
+Failure blocks the dependent transition and no broader one. Inspection,
+diagnosis, repair, rerun, rollback and safe exit remain available unless the
+promise explains why a particular recovery cannot exist.
+
+A refusal report names the promise id, failed field or evidence, consequence
+level, blocked transition and recovery action. A checker never deletes,
+rewrites or quarantines the failing source merely to produce a passing result.
+
+## Exceptions
+
+An exception is evidence, not silence. It names:
+
+- the person or policy with authority;
+- the promise id and exact gate being waived or narrowed;
+- the affected subject and scope;
+- the durable record holding the reason;
+- the expiry, or why expiry cannot apply; and
+- the recovery or revocation path.
+
+An exception cannot claim that missing evidence exists, strengthen an evidence
+class, erase a recorded conflict or authorise a transition beyond the named
+scope. Unattributed, unrecorded, expired or over-broad exceptions fail closed.
+
+## Conformance
+
+Structural conformance establishes that the declarations, identities, copies
+and coverage records have the required shape and agree. It does not establish
+that a domain promise is true. Behavioural conformance comes from the named
+domain tests, negative specimens, proof checks, measurements and manual
+demonstrations.
+
+The checker discovers the governed universe from repository manifests and
+skill paths. A hand-maintained coverage file may classify discovered entries;
+it may not define the universe or remove an entry from it. Empty discovery,
+unclassified skills, duplicate logical identities, missing declarations,
+divergent copies and unbound vendored instructions are failures.
+
+Checker output names a stable finding code, fault class, path, promise id when
+known and the action that clears it. JSON and text reports describe the same
+findings. The checker reaches no network and executes no evidence command.
+
+## First-party licence promise
+
+### promise-machine-first-party-licence
+
+- Promise: A successful `check --only licences` establishes that the root and every first-party plugin carry the same Apache-2.0 licence bytes, and that both host manifests name Apache-2.0 and Wildcat Labs.
+- Evidence: The fixed root `LICENSE`, discovered first-party plugin set, byte comparisons, and parsed Claude and Codex plugin manifests.
+- Evidence classes: checked, recomputed
+- Boundary: The check does not establish copyright ownership, provide legal advice, or inspect, govern, or relicense vendored work; the Pashov skill trees retain their upstream MIT licence and notices.
+- Authorises: Publishing the discovered first-party plugin surfaces with the repository's Apache-2.0 and Wildcat Labs licence declaration.
+- Consequence: 3
+- Refuses: A missing, unsafe, oversized, or divergent licence, an inconsistent host manifest, or any claim that the first-party licence covers a vendored skill.
+- Recovery: Restore the canonical root licence and first-party copies, correct the host manifests, leave vendored licences untouched, and rerun the licence check.
+- Exceptions: none
+
+## Run observation promise
+
+### promise-machine-run-observation-structural-validation
+
+- Promise: A successful `python3 scripts/run_observation.py check <path>` establishes that the named regular JSON Lines file conforms to `promise-machine-run-observation/v1` under the validator's closed shapes, limits, lifecycle, backward-reference, evidence-binding, unknown-fact, optional-token, Unicode-path and final-snapshot rules.
+- Evidence: The exact input path and validated bytes, one bounded final named-path reread with matching digest and file identity, v1 schema, standard-library validator, stable finding report, valid and refusing fixtures, focused tests and zero command exit.
+- Evidence classes: checked
+- Boundary: Validation does not capture a run, prove that the record is complete or externally true, establish cause or model quality, bind a Fiat receipt, make a security conclusion, authorise mutation, or prevent a writer changing the path after the final reread.
+- Authorises: Treating only the named bytes as structurally conforming and passing that bounded result to a consumer that preserves its subject, scope, time domain, evidence class, unknowns and refusal boundary.
+- Consequence: 1
+- Refuses: Unsafe or unbounded input, a final byte or identity mismatch, malformed or duplicate-key JSON, an open event shape, missing identity, invalid order or lifecycle, a forward or cross-run reference, unbound or strengthened evidence, hidden reasoning, raw payloads, non-scalar, non-NFC, control-bearing, bidirectional or otherwise unsafe repository paths, placeholder host facts, invalid token counts or a non-zero finding report.
+- Recovery: Inspect the stable finding code, repair the source record without having the checker mutate it, preserve unknowns and evidence boundaries, then rerun the same command.
+- Exceptions: none
+
+### promise-machine-run-observation-capture
+
+- Promise: A successful `python3 scripts/run_observation_capture.py check <candidate>` establishes that the named bounded candidate was processed by `promise-machine-run-observation-capture/v1` into one accepted event, visible gap, or refusal before a durable observation exists.
+- Evidence: The named candidate, closed standard-library adapter, capture schema, direct-allowlist fixtures, hostile byte-survival tests, source-owned reporter, and zero command exit.
+- Evidence classes: checked
+- Boundary: The result does not prove the source is true or complete, detect every secret, govern another host memory, itself bind a Fiat receipt, make a security conclusion, or authorise another controller transition.
+- Authorises: Passing an accepted result to the capture writer, or recording the bounded gap or refusal without treating it as an accepted observation.
+- Consequence: 1
+- Refuses: An open or oversized candidate, raw payload family, malformed redaction, unsafe repository path, low-entropy correlation input, unknown shape, or writer bypass.
+- Recovery: Remove the unsafe field from the candidate adapter, retain only a closed redaction or safe descriptor, then rerun the same command and hostile fixture surface.
+- Exceptions: none
+
+## Contributor ranking promise
+
+### promise-machine-contributor-ranking
+
+- Promise: A successful `python3 scripts/contributors.py --check` establishes that every contributor row GitHub returned for the named repository was placed in exactly one of ranked, excluded with a named reason, or refused; that each ranked login is a valid GitHub login absent from the declared runtime-host set, is neither the Shoggoth's account nor the repository owner, and had at least one commit in a bounded sample authored by a non-host identity; that the order is merged commits, then merged pull requests, then login; and that `CONTRIBUTORS.md` and the marked region of `README.md` match that one computation byte for byte.
+- Evidence: The recorded contributors, merged-pull-request and commit-authorship reads, the host-set parity check against `hexctl.py`'s declaration, the login grammar check, the per-identity classification lines, the ranking digest, the byte comparison of both artefacts and zero command exit.
+- Evidence classes: checked, recorded
+- Boundary: Ranking does not establish that the counts fairly measure contribution, that a commit carried judgement, who wrote which line, anything about a person beyond the account they committed under, or that GitHub's resolution of author emails to accounts is correct. It does not detect a merge that discarded commit authorship before the commit reached the default branch, and its authorship corroboration samples at most twenty commits per account rather than all of them.
+- Authorises: Writing `CONTRIBUTORS.md` and the marked region of `README.md` and nothing outside those two targets, and reporting the ranking without strengthening what the counts mean.
+- Consequence: 1
+- Refuses: An account type other than User or Bot, a Bot absent from the declared host set, a login failing the GitHub login grammar, a repository argument carrying query syntax, any failed API read including a rate limit, a host set diverged from `hexctl.py` in either direction, an excluded login reaching the ranked output, a `README.md` that is absent or not UTF-8, and a read that would silently truncate.
+- Recovery: Read the stop, which names the identity or field at fault; extend the host set in `hexctl.py` and `scripts/contributors.py` together for an unknown host, set a token or wait for the named reset for a rate limit, and rerun with `--write` for a stale artefact. The generator never repairs an input.
+- Exceptions: none
+
+## Installation copies
+
+The root `PROMISE_MACHINE.md` is the authored source. Each
+`plugins/<plugin>/PROMISE_MACHINE.md` is written only by
+`scripts/promise_machine.py sync`. The destination is fixed, writes are atomic,
+symlinks and paths outside the repository are refused, and `sync --check`
+rejects a missing or byte-divergent copy.
+
+Standalone plugin runtime contracts load their local copy. Repository-wide
+work loads this root file. Both surfaces therefore read the same contract
+bytes under the same identity.

--- a/.agents/skills/promise-machine/runtime/plugins/synkrisis/README.md
+++ b/.agents/skills/promise-machine/runtime/plugins/synkrisis/README.md
@@ -1,0 +1,68 @@
+# Synkrisis
+
+<!-- marketplace-context:start -->
+## In one line
+
+Synkrisis compares validated Promise Machine run observations across one operator-declared cohort and recomputes bounded, evidence-linked findings a person can act on.
+
+**Current frontier.** Synkrisis is a committed specification with a refusing command stub, and none of its runbook's cohort, diagnosis, render or verification steps has yet landed behaviour.
+
+**Next Fiat job.** Use /hexaemeron:fiat to complete Step 2 of the committed runbook: implement observation admission and cohort construction behind synkrisis.py cohort, with the study's positive and hostile fixtures; accept it when the example manifest produces one cohort digest twice, every declared run carries its classification reason, and each named refusal class has a red-to-green guard. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
+<!-- marketplace-context:end -->
+
+## Place in the collective
+
+The Promise Machine records what one agent run observably did: the
+run-observation contract defines the record, the capture gate keeps forbidden
+material out of it, and the receipt binding ties a prefix of it to a Fiat
+receipt. None of that interprets a repeated pattern across runs. Synkrisis
+owns exactly that comparison. Ephoros designs what a step emits, Metron judges
+a controlled measurement, Elenchus works one failure to its cause, and Horos
+owns the reading boundary; a Synkrisis finding is specified to name one of
+them as its suggested next owner, and a person decides whether anything
+happens.
+
+## What this step ships
+
+This is Step 1 of the committed
+[runbook](https://github.com/wildcat-finance/skills/blob/main/docs/synkrisis/runbook.md),
+built from the committed
+[study](https://github.com/wildcat-finance/skills/blob/main/docs/synkrisis/study.md)
+for [issue 449](https://github.com/wildcat-finance/skills/issues/449):
+
+- the plugin shell, both host manifests, the marketplace entries and the
+  Promise Machine router route;
+- the canonical `skills/synkrisis/SKILL.md` carrying the complete specified
+  surface, its caps and its refusals, beside the evolution ledger;
+- the first decision record, keeping cross-run diagnosis a standalone
+  boundary; and
+- `scripts/synkrisis.py`, a stub that declares the four specified operations,
+  cohort, diagnose, render and verify, and refuses each with one stable code
+  naming the runbook step that implements it, writing nothing.
+
+## How it will work
+
+An operator declares two things: a manifest naming every run in the
+comparison universe, with each record's digest, byte count, validation,
+redaction and receipt-binding results; and a comparison policy classifying
+every run-context dimension, plus a token accounting mode. Cohort
+construction classifies every declared run as included, excluded or unknown,
+naming the policy field responsible for each exclusion. A digest-bound
+catalogue of deterministic rules recomputes bounded findings; a
+fixed-template report and whole-path byte verification close the loop.
+Association never hardens into cause; a rule or finding carrying causal or
+model-quality language is refused. The runbook's Steps 2 through 5 land that
+behaviour one gated step at a time.
+
+## Use
+
+Synkrisis needs only the exact interpreter in the suite
+[pin](https://github.com/wildcat-finance/skills/blob/main/.python-version).
+Ask:
+
+```text
+Use $synkrisis to read the cross-run comparison specification and the state of its runbook.
+```
+
+The specified operations, the caps and the refusals live in
+[Synkrisis's `SKILL.md`](./skills/synkrisis/SKILL.md).

--- a/.agents/skills/promise-machine/runtime/plugins/synkrisis/docs/decisions/ADR-001-keep-cross-run-diagnosis-separate.md
+++ b/.agents/skills/promise-machine/runtime/plugins/synkrisis/docs/decisions/ADR-001-keep-cross-run-diagnosis-separate.md
@@ -1,0 +1,46 @@
+# ADR-001: Keep cross-run diagnosis separate
+
+## Status
+
+Accepted, 2026-08-27.
+
+## Context
+
+Issues 434 to 436 gave the suite validated, redacted, receipt-bound run
+observations, and nothing interprets a repeated pattern across runs. Three
+existing owners were candidates for that work. Ephoros designs and reviews
+telemetry for a named step. The Promise Machine governs evidence and
+transitions. Fiat controls receipted delivery. Issue 449's study weighed
+extending each of them against a standalone plugin.
+
+## Decision
+
+Cross-run diagnosis lives in its own plugin, `plugins/synkrisis/`, with its
+own promises: cohort construction, bounded diagnosis and report verification.
+It consumes the issue-434 to issue-436 artefacts as declared inputs and owns
+comparison and bounded inference only.
+
+## Alternatives
+
+- Extend Ephoros. Rejected: the telemetry producer would judge what its own
+  output means across runs, crossing its named-step boundary into comparison
+  and improvement selection.
+- Add analysis to the Promise Machine. Rejected: the law governs evidence and
+  transitions without owning domain conclusions, and a diagnosis is a domain
+  conclusion.
+- Add analysis to Fiat. Rejected: issue 436 deliberately keeps observation
+  separate from the delivery control path; optional interpretation must not
+  join that path.
+- A model-authored reviewer. Rejected for the prototype: its output is not
+  deterministic, a stable negative corpus cannot pin its refusals, and it can
+  turn association into cause. A model-assisted lane needs a later study and
+  its own promise.
+
+## Consequences
+
+The marketplace carries one more package and result schema, and in exchange no
+existing skill's promise widens. Synkrisis can refuse causal and quality
+language mechanically because its rules are data over closed deterministic
+kinds. The cost is a boundary to maintain: capture, redaction, binding, causal
+triage and dispatch stay with their current owners, and requests that cross
+into them hand off rather than grow this plugin.

--- a/.agents/skills/promise-machine/runtime/plugins/synkrisis/scripts/synkrisis.py
+++ b/.agents/skills/promise-machine/runtime/plugins/synkrisis/scripts/synkrisis.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Bounded cross-run diagnosis over validated Promise Machine run observations.
+
+This is the runbook's Step 1 scaffold. The command declares the complete
+specified surface, four operations over one declared cohort of
+`promise-machine-run-observation/v1` records, and refuses each one with a
+stable code naming the runbook step that implements it. Nothing here reads a
+record, writes an artefact, calls a model, fetches a URL, executes observed
+content, files an issue, edits a repository, or dispatches another skill.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+PRODUCER_CONTRACT = "promise-machine-run-observation/v1"
+
+# The specified operations and the committed runbook step that lands each one.
+PENDING_STEPS = {
+    "cohort": "Step 2",
+    "diagnose": "Step 3",
+    "render": "Step 4",
+    "verify": "Step 4",
+}
+
+
+class Refusal(Exception):
+    """One stable finding: code, fault class, safe path, recovery."""
+
+    def __init__(self, code, fault, path, message, recovery):
+        super().__init__(message)
+        self.code = code
+        self.fault = fault
+        self.path = path
+        self.message = message
+        self.recovery = recovery
+
+
+def scaffold_refusal(operation: str) -> Refusal:
+    step = PENDING_STEPS[operation]
+    return Refusal(
+        "SK000",
+        "structural",
+        operation,
+        f"operation {operation!r} is specified and not yet implemented",
+        f"build {step} of docs/synkrisis/runbook.md, then rerun the operation",
+    )
+
+
+def emit_refusal(refusal: Refusal, as_json: bool) -> None:
+    document = {
+        "code": refusal.code,
+        "fault": refusal.fault,
+        "path": refusal.path,
+        "producer": PRODUCER_CONTRACT,
+        "message": refusal.message,
+        "recovery": refusal.recovery,
+    }
+    if as_json:
+        print(json.dumps(document, sort_keys=True, separators=(",", ":")))
+    else:
+        print(
+            f"{refusal.code} fault={refusal.fault} path={refusal.path} "
+            f"producer={PRODUCER_CONTRACT}: {refusal.message}; "
+            f"recovery: {refusal.recovery}"
+        )
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(prog="synkrisis", description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    cohort_parser = subparsers.add_parser(
+        "cohort", help="classify every declared run under one comparison policy"
+    )
+    cohort_parser.add_argument("--manifest", required=True)
+    cohort_parser.add_argument("--policy", required=True)
+    cohort_parser.add_argument("--out", required=True)
+    cohort_parser.add_argument("--json", action="store_true")
+
+    diagnose_parser = subparsers.add_parser(
+        "diagnose", help="apply the digest-bound rule catalogue to one checked cohort"
+    )
+    diagnose_parser.add_argument("--cohort", required=True)
+    diagnose_parser.add_argument("--rules", required=True)
+    diagnose_parser.add_argument("--out", required=True)
+    diagnose_parser.add_argument("--json", action="store_true")
+
+    render_parser = subparsers.add_parser(
+        "render", help="render the fixed-template report from one findings document"
+    )
+    render_parser.add_argument("findings")
+    render_parser.add_argument("--out", required=True)
+    render_parser.add_argument("--json", action="store_true")
+
+    verify_parser = subparsers.add_parser(
+        "verify", help="recompute cohort, findings and report from the original inputs"
+    )
+    verify_parser.add_argument("--manifest", required=True)
+    verify_parser.add_argument("--policy", required=True)
+    verify_parser.add_argument("--cohort", required=True)
+    verify_parser.add_argument("--rules", required=True)
+    verify_parser.add_argument("--findings", required=True)
+    verify_parser.add_argument("--report", required=True)
+    verify_parser.add_argument("--json", action="store_true")
+
+    arguments = parser.parse_args(argv)
+    emit_refusal(scaffold_refusal(arguments.command), arguments.json)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/promise-machine/runtime/plugins/synkrisis/skills/synkrisis/EVOLUTION.md
+++ b/.agents/skills/promise-machine/runtime/plugins/synkrisis/skills/synkrisis/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Synkrisis evolution ledger
+
+Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
+
+- Current version: `synkrisis-v0.1.0`
+- Frontier status: `open`
+- Frontier revision: `cohort-construction`
+- Current frontier: Synkrisis is a committed specification with a refusing command stub, and none of its runbook's cohort, diagnosis, render or verification steps has yet landed behaviour.
+- Next Fiat job: Complete Step 2 of the committed runbook: implement observation admission and cohort construction behind synkrisis.py cohort, with the study's positive and hostile fixtures. Accepted when the example manifest produces one cohort digest twice, every declared run carries its classification reason, and each named refusal class has a red-to-green guard.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `synkrisis-v0.1.0` | baseline | `cohort-construction` | `f5ecc2bea318637223d5115b76fcbe354957783ddb56fc2256c257710af80e51` | [the anchor study](../../../../docs/synkrisis/study.md) and [issue 449](https://github.com/wildcat-finance/skills/issues/449) | Versioning starts here. Synkrisis ships as the runbook's Step 1 scaffold: both host manifests, the marketplace and router surfaces, this ledger, the committed study, runbook and first decision record, and a command stub that declares the four specified operations and refuses each with a stable code naming the runbook step that implements it. The held frontier is Step 2, observation admission and cohort construction. |

--- a/.agents/skills/promise-machine/runtime/plugins/synkrisis/skills/synkrisis/SKILL.md
+++ b/.agents/skills/promise-machine/runtime/plugins/synkrisis/skills/synkrisis/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: synkrisis
+description: >
+  Compare validated Promise Machine run observations across one declared
+  cohort and recompute bounded, evidence-linked findings. Use when several
+  comparable agent runs have checked observation records and someone wants to
+  know what repeated across them: late repository-boundary consultation beside
+  higher token use, or unchanged retries before an Elenchus handoff. Do not
+  use it to capture or redact observations, to debug one failing run, to judge
+  a model, or to act on a finding; a person selects what happens next. Never
+  report a relation as a cause.
+metadata:
+  version: "0.1.0"
+---
+
+# Synkrisis
+
+## Frontier
+
+Synkrisis owns the cross-run comparison frontier. Its version, held target,
+next job, and maturity state live in [EVOLUTION.md](EVOLUTION.md). Do not
+recommend or run another frontier pass after that ledger becomes mature.
+
+<!-- marketplace-context:start -->
+## Where this sits
+
+Synkrisis turns validated observations from comparable agent runs into
+evidence-linked improvement candidates. It owns comparison and bounded
+inference only; capture, redaction, receipt binding, causal diagnosis, issue
+filing, repository mutation and Fiat dispatch stay with their own owners.
+
+**Current frontier.** Synkrisis is a committed specification with a refusing command stub, and none of its runbook's cohort, diagnosis, render or verification steps has yet landed behaviour.
+<!-- marketplace-context:end -->
+
+Synkrisis is named for comparison. The Promise Machine records what one run
+observably did: issue 434 defined the record, issue 435 the capture gate, and
+issue 436 the receipt binding. None of those steps reads a pattern across
+runs. A maintainer still has to decide whether repeated orientation work,
+unchanged retries, handoff friction or token movement amounts to an
+improvement candidate. Synkrisis exists to make that comparison deterministic
+and to keep it honest about what recorded events can and cannot say.
+
+Ephoros designs what a step emits; Metron judges a controlled measurement;
+Elenchus works one failure to its cause; Horos owns the reading boundary. A
+Synkrisis finding is specified to suggest one of them as its next owner, and
+the suggestion is the whole action: no path files an issue, edits a
+repository, or dispatches a sibling.
+
+## What this step is
+
+This is Step 1 of
+[the committed runbook](https://github.com/wildcat-finance/skills/blob/main/docs/synkrisis/runbook.md),
+built from
+[the committed study](https://github.com/wildcat-finance/skills/blob/main/docs/synkrisis/study.md): the
+plugin shell, its packaging and marketplace surfaces, this canonical
+instruction document, the evolution ledger, the first decision record, and a
+command stub. The stub declares the complete specified surface and refuses
+every operation with one stable code naming the runbook step that implements
+it. Until those steps land, Synkrisis produces no cohort, finding, report or
+verification.
+
+## The specified surface
+
+One standard-library command, `scripts/synkrisis.py`, with four operations:
+
+- `cohort` reads an operator-declared manifest of run-observation records and
+  one comparison policy, checks producer identity, declared validation,
+  redaction and binding results, digests, caps, path form and equality
+  dimensions, and writes a cohort classifying every declared run as included,
+  excluded or unknown with the exact policy field responsible. Lands with
+  Step 2.
+- `diagnose` applies a digest-bound catalogue of deterministic rules to one
+  checked cohort and emits findings carrying exact event references,
+  counterevidence, unknown runs, the nearest forbidden claim and one
+  suggested handoff. A rule is data over closed shipped kinds; no rule
+  supplies an expression, an import, a shell command or a regular
+  expression. Lands with Step 3.
+- `render` writes a fixed-template report that cannot add a number, run id,
+  causal verb or evidence class absent from the findings. Lands with Step 4.
+- `verify` recomputes the cohort, the findings and the report byte for byte
+  from the original inputs. Lands with Step 4.
+
+The study fixes the caps the implementation must hold: one cohort at a time,
+at most 100 runs and 100,000 events, 8 MiB per file and 64 MiB of declared
+input in aggregate, with a 5.0-second, 256 MiB work budget measured in Step 5.
+
+## Run it
+
+From a checkout, with the exact interpreter in the suite's
+[`.python-version`](../../../../.python-version):
+
+```text
+python3 plugins/synkrisis/scripts/synkrisis.py --help
+python3 plugins/synkrisis/scripts/synkrisis.py cohort \
+  --manifest manifest.json --policy policy.json --out cohort.json
+```
+
+The first command prints the specified surface. The second, like every
+operation at this step, exits 1 with code `SK000`, the fault class, the
+producer contract `promise-machine-run-observation/v1`, and a recovery naming
+the runbook step to build; it creates no file.
+
+## What it refuses
+
+The scaffold refuses everything except describing itself: no operation
+produces a result, and nothing is written. The specification the later steps
+must hold is already fixed:
+
+- No inferred comparability. A person declares the comparison policy;
+  Synkrisis checks the declaration and never decides that unlike tasks,
+  models, hosts, repositories or tokenizers are comparable.
+- No evidence strengthening. Findings stay at the inferred class, carry their
+  counterevidence and unknowns, and state the nearest forbidden claim rather
+  than making it.
+- No cause and no model judgement, in a rule, a finding or a report.
+- No token comparison across unlike accounting identities.
+- No autonomous transition. A handoff is a named suggestion; the command has
+  no network, GitHub, Git or controller mutation path.
+
+If an operation, a check or a suite did not run, say so plainly and do not
+describe its result.
+
+## Promise Machine contract
+
+### synkrisis-scaffold-refusal
+
+- Promise: Every specified Synkrisis operation invoked on this scaffold exits non-zero with one stable code that names the committed runbook step implementing it, and writes nothing.
+- Evidence: The command's declared argument surface, the emitted refusal code, fault class, producer contract and recovery, and the unchanged working tree after each invocation.
+- Evidence classes: checked
+- Boundary: The refusal establishes only that the scaffold cannot present a cohort, finding, report or verification; it says nothing about how the later steps will behave.
+- Authorises: Selecting the committed runbook's named next step as the work that lands the refused operation.
+- Consequence: 0
+- Refuses: Reporting any analytical result from the scaffold, and writing any output file.
+- Recovery: Build the runbook step the refusal names, then rerun the operation.
+- Exceptions: none

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -307,6 +307,28 @@
         "releases",
         "evaluation"
       ]
+    },
+    {
+      "name": "synkrisis",
+      "displayName": "Synkrisis",
+      "source": "./plugins/synkrisis",
+      "description": "Bounded cross-run diagnosis: deterministic findings from validated run observations in one declared cohort.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Wildcat Labs",
+        "url": "https://wildcat.finance"
+      },
+      "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/synkrisis",
+      "repository": "https://github.com/wildcat-finance/skills",
+      "category": "Developer Tools",
+      "tags": [
+        "run-observations",
+        "telemetry",
+        "diagnosis",
+        "comparison",
+        "promise-machine",
+        "agents"
+      ]
     }
   ]
 }

--- a/.github/workflows/synkrisis.yml
+++ b/.github/workflows/synkrisis.yml
@@ -1,0 +1,35 @@
+name: synkrisis
+
+on:
+  push:
+    paths:
+      - "plugins/synkrisis/**"
+      - ".python-version"
+      - "pyproject.toml"
+      - ".claude-plugin/**"
+      - ".agents/**"
+      - "AGENTS.md"
+      - ".github/workflows/synkrisis.yml"
+  pull_request:
+    paths:
+      - "plugins/synkrisis/**"
+      - ".python-version"
+      - "pyproject.toml"
+      - ".claude-plugin/**"
+      - ".agents/**"
+      - "AGENTS.md"
+      - ".github/workflows/synkrisis.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+      - name: Synkrisis scaffold suite
+        run: python3 -m unittest discover -s plugins/synkrisis/tests -t plugins/synkrisis -v

--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -2,18 +2,18 @@
   "counts": {
     "bytes_binary": 47762926,
     "bytes_content_addressed": 7844971,
-    "bytes_generated": 11295904,
+    "bytes_generated": 11348710,
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 1744
+    "files_walked": 1759
   },
   "entries": [
     {
-      "bytes": 11229110,
+      "bytes": 11281916,
       "category": "generated",
       "evidence": "linguist-generated for '.agents/skills/promise-machine/runtime/**' in .gitattributes",
-      "files": 842,
+      "files": 850,
       "grade": "hard",
       "path": ".agents/skills/promise-machine/runtime/"
     },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ generated installation copies and must remain byte-identical to it.
 
 ## Marketplace boundaries
 
-The fourteen plugins form one marketplace, not fourteen competing descriptions
+The fifteen plugins form one marketplace, not fifteen competing descriptions
 of the same job. Alexandria preserves lending inputs; Tabularium interprets
 preserved venue records; Probitas assembles a counterparty dossier. Lazarus
 preserves the finite historical Ethereum state and exact RPC traffic a test
@@ -40,7 +40,10 @@ Hexaemeron controls a receipted delivery loop and holds each of its phases to a
 named skill, while Lemma stops after producing
 source-linked chunks. Horos decides what an agent does not read. Janus checks
 what a contract hook may observe and change around a host action, where
-Pandects supplies the economic laws such a transition must preserve. Sapheneia
+Pandects supplies the economic laws such a transition must preserve. Synkrisis
+compares validated run observations across one declared cohort and stops at
+bounded inferred findings; capture, redaction, receipt binding and causal
+triage stay with their owners. Sapheneia
 shapes the agent's replies for AuDHD readers and has one bounded operation for
 durable audit, issue, and comment prose. It does not change another skill's
 facts or gates. Brevitas controls the volume and structure of engineering prose
@@ -126,6 +129,9 @@ these instructions.
 - Sapheneia is under `plugins/sapheneia/`. Read
   `plugins/sapheneia/AGENTS.md` before running its skill or changing that
   plugin.
+- Synkrisis is under `plugins/synkrisis/`. Read
+  `plugins/synkrisis/AGENTS.md` before running its skill or changing that
+  plugin.
 - Tabularium is under `plugins/tabularium/`. Read
   `plugins/tabularium/AGENTS.md` before running its skill or changing that
   plugin.
@@ -181,6 +187,7 @@ python3 -m unittest discover -s plugins/lazarus/tests -t plugins/lazarus
 python3 -m unittest discover -s plugins/pandects/tests -t plugins/pandects
 python3 -m unittest discover -s plugins/probitas/tests -t plugins/probitas
 python3 -m unittest discover -s plugins/sapheneia/tests -t plugins/sapheneia
+python3 -m unittest discover -s plugins/synkrisis/tests -t plugins/synkrisis
 python3 -m unittest discover -s plugins/tabularium/tests -t plugins/tabularium
 ```
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ turn a passing structural check into proof that a domain claim is true.
 - [Horos](./plugins/horos) writes and verifies evidence-backed repository
   boundaries and skeleton maps for oriented reading. Its exclusions reduce cost;
   they never apply during security review.
+- [Synkrisis](./plugins/synkrisis) compares validated run observations across
+  one declared cohort and recomputes bounded, evidence-linked findings. A
+  person declares what is comparable and decides what happens next; nothing
+  it emits is a cause.
 - [Sapheneia](./plugins/sapheneia) shapes the collective's own replies and
   bounded audit records, issues, or comments for AuDHD readers without changing
   their protected evidence.

--- a/docs/synkrisis/runbook.md
+++ b/docs/synkrisis/runbook.md
@@ -1,0 +1,92 @@
+# Runbook: Synkrisis, bounded diagnosis across agent runs
+
+Derived from [the committed study](study.md) and the runbook attached to
+[issue #449](https://github.com/wildcat-finance/skills/issues/449). Five
+steps, dependency order, each landing only with its exit gates green. Step 1
+is delivered; Steps 2 through 5 are held, and the evolution ledger's Next
+Fiat job names the next one.
+
+## Step 1: Scaffold Synkrisis and commit its specification (delivered)
+
+**Goal.** The standalone plugin with its contracts, packaging, study,
+runbook, first decision record and a refusing command stub.
+**Exit, held at delivery.** Both host manifests and the marketplace entries
+agree at `0.1.0`; the Promise Machine router reaches
+`plugins/synkrisis/AGENTS.md`; the canonical `skills/synkrisis/SKILL.md`,
+`EVOLUTION.md`, byte-identical `LICENSE` and generated `PROMISE_MACHINE.md`
+copy are present; ADR-001 records the standalone boundary; this study and
+runbook are committed; `synkrisis.py --help` prints the four specified
+operations and every operation refuses with `SK000`, naming the runbook step
+that implements it and writing nothing; the scaffold suite under
+`plugins/synkrisis/tests/`, the root suite, `scripts/promise_machine.py
+check` and `coverage --check` exit 0, with the plugin discovered from disk
+and the scaffold's single refusal promise bound to evidence.
+
+## Step 2: Validate observations and construct one declared cohort (held)
+
+**Goal.** One deterministic cohort from a complete declared manifest and one
+comparison policy, without interpreting events.
+**Exit.** `synkrisis.py cohort` checks producer identity, declared
+validation, redaction and binding results, recomputed digests and bound
+prefixes, run and event identity, path form, caps and equality dimensions;
+classifies every declared run as included, excluded or unknown with the
+responsible policy field; writes atomically only after the whole universe is
+classified; the example manifest produces one cohort digest twice; positive
+fixtures cover a refused transition retained in the cohort, a valid
+unavailable observer recorded as unknown, and recorded token accounting;
+hostile fixtures cover replaced and truncated records, prefix digest and
+count mismatches, duplicate keys and run ids, unsafe paths, cap breaches,
+unlike token accounting, empty eligibility and partial-output discipline.
+The cohort and policy schemas land under `references/` with the
+schema-compatibility record, and the comparability decision record lands
+beside ADR-001.
+
+## Step 3: Add the bounded diagnostic rule catalogue (held)
+
+**Goal.** Evidence-linked candidate findings recomputed from one checked
+cohort, with no cause, quality judgement or action.
+**Exit.** `synkrisis.py diagnose` validates the digest-bound
+`references/rules-v1.json`, applies only rules whose required dimensions and
+minimum sample counts hold, records every refused rule with its reason, and
+emits deterministic findings carrying cohort and rule digests, exact event
+references, counterevidence, unknown runs, the nearest forbidden claim and
+one handoff naming `ephoros`, `metron`, `elenchus`, `protasis`, `phylax`,
+`horos` or `human-review`. The example produces
+`late-boundary-consultation/v1` and `unchanged-retry-before-handoff/v1`, and
+fingerprints survive harmless manifest reordering. Negative fixtures cover
+unknown kinds and fields, evidence strengthening, causal and model-quality
+language, template escapes, handoffs outside the named owner set, improper
+fractions, duplicate rule ids, tampered cohorts and drifted records. The
+checked-rule and issue-437 decision records land, and all Step 2 gates stay
+green.
+
+## Step 4: Render and verify the exact report (held)
+
+**Goal.** A readable report whose every claim reconstructs from the
+findings, then whole-path verification.
+**Exit.** `synkrisis.py render` uses fixed templates and refuses findings
+carrying causal language, a strengthened evidence class or unknown fields;
+`synkrisis.py verify` independently recomputes the cohort, findings and
+report bytes from the original manifest, policy, records and catalogue, and
+refuses replacement, truncation, reordering, wrong-run association, a stale
+rule digest, an unsupported producer identity and an edited narrative, each
+with a stable code and recovery. The committed example report is
+byte-recomputed in the suite, and all earlier gates stay green.
+
+## Step 5: Measure, publish and demonstrate the refusal boundary (held)
+
+**Goal.** The completed plugin held to its work budget, its three specified
+promises bound to evidence, and the demonstration path proved from clean
+inputs.
+**Exit.** The benchmark materialises the 100-run, 100,000-event universe
+from the committed fixture specification and holds cohort, diagnose and
+verify to 5.0 seconds and 256 MiB on the recorded runner, printing
+interpreter, platform, specification digest, repetitions and observed
+maxima; the canonical `SKILL.md` replaces the scaffold promise with
+`synkrisis-cohort-construction`, `synkrisis-bounded-diagnosis` and
+`synkrisis-report-verification`, each bound in
+`tests/promise_machine_coverage.json` to positive, missing-evidence, stale,
+overclaim and recovery selectors; the complete demonstration path exits 0
+twice with byte-identical outputs and the two negative demonstrations exit
+non-zero; the root suite, the plugin suite, Promise Machine check and
+coverage, the prose and tree lints and a fresh Horos boundary all exit 0.

--- a/docs/synkrisis/study.md
+++ b/docs/synkrisis/study.md
@@ -1,0 +1,110 @@
+# Study: Synkrisis, bounded diagnosis across agent runs
+
+This is the committed form of the study attached to
+[issue #449](https://github.com/wildcat-finance/skills/issues/449),
+reconfirmed against the landed run-observation surface before the build
+started. The original filing is preserved in the issue; this copy is the
+anchor the evolution ledger cites, and it records the assumptions as they
+resolved and the design the runbook's steps must hold.
+
+## Assumptions, as they resolved
+
+1. "Domain agent" means a separately installable Wildcat Labs skill and one
+   deterministic standard-library command, not an always-on process or an
+   agent allowed to change its own instructions.
+2. Issues 434, 435 and 436 landed first with stable checked identities:
+   `promise-machine-run-observation/v1`
+   (`docs/promise-machine/run-observation-v1.md`, schema under `schemas/`),
+   `promise-machine-run-observation-capture/v1`
+   (`docs/promise-machine/run-observation-capture-v1.md`) and
+   `fiat-run-observation-binding/v1`
+   (`docs/fiat-run-observation-binding-v1.md`). A manifest row pins the
+   first, names the capture profile for its declared redaction result, and
+   carries the run's receipt binding as a bound prefix or a reasoned
+   unavailable state.
+3. Issue 437 stays out. Reachability candidates and run observations say
+   different things about different subjects; admitting the former needs its
+   own study and promise
+   (`plugins/synkrisis/docs/decisions/ADR-001-keep-cross-run-diagnosis-separate.md`
+   records the standalone boundary, and a later record fixes the exclusion
+   when the schemas it protects exist).
+4. Offline, standard library only, on the exact interpreter in the suite's
+   `.python-version`. No model call, no URL fetch, no raw transcript, no
+   execution of anything an observation names.
+5. A person declares the comparison policy. Synkrisis checks that the
+   selected runs satisfy it; it does not infer that unlike tasks, models,
+   hosts, repositories or tokenizers are comparable.
+6. Findings are bounded inferences from named observations. They remain
+   candidates for human selection and cannot file issues, edit a repository,
+   change a skill, dispatch Fiat, judge model quality, or state a cause.
+7. The build starts from current `main` under the repository owner's direct
+   instruction of 2026-08-27, which also closes the study's dependency gate:
+   the owner approved the assumptions and the new CI surface.
+
+## The chosen design
+
+Option A of the proposal: a standalone `plugins/synkrisis/` package owning
+cohort construction, rule evaluation, report rendering and verification,
+with three specified promises:
+
+- `synkrisis-cohort-construction`: checked producer identities, manifest
+  completeness, declared equality dimensions, exclusions and a cohort digest
+  authorise rule evaluation over that cohort only.
+- `synkrisis-bounded-diagnosis`: a rule match recomputed from exact event
+  references authorises a candidate finding with inferred evidence and
+  visible conflicts and unknowns.
+- `synkrisis-report-verification`: recomputation of the exact cohort,
+  findings and renderer bytes authorises handing the report to a person; it
+  does not authorise the recommended handoff itself.
+
+Each promise is declared in the canonical `SKILL.md` when the step that
+implements it lands, so coverage always binds a declared promise to passing
+evidence. Until then the scaffold declares one promise of its own,
+`synkrisis-scaffold-refusal`: every specified operation refuses with a
+stable code naming the runbook step that implements it, and writes nothing.
+
+Design commitments the steps must hold:
+
+- **Explicit comparability.** A policy classifies every run-context
+  dimension as match-with-this-value or may-differ, plus a token accounting
+  mode; a mismatching run is excluded with the field named, and an
+  incompletely classified policy refuses.
+- **Rules are data over closed kinds.** The catalogue is schema-checked and
+  digest-bound; a rule names one shipped deterministic kind and closed
+  integer parameters. No expression, import, shell, regular expression or
+  format specification enters from input, and thresholds are integer
+  fractions so no floating-point comparison decides a verdict.
+- **Bounded admission.** One cohort at a time; at most 100 runs and 100,000
+  events; 8 MiB per file and 64 MiB of declared input in aggregate; one
+  descriptor per read; atomic outputs that never overwrite different bytes;
+  no partial output behind a refusal. Records stream into compact per-run
+  features so admission holds the memory budget.
+- **Honest narratives.** Findings carry counterevidence, unknown runs and
+  the nearest forbidden claim; rule and finding prose is held against a
+  fixed list of causal and model-quality word sequences; the renderer adds
+  no field absent from the findings.
+- **A measured budget.** On a deterministic 100-run, 100,000-event generated
+  scale fixture, cohort, diagnose and verify together finish within 5.0
+  seconds and 256 MiB peak resident memory on the recorded runner. The
+  committed artefact is the small fixture specification; the benchmark
+  materialises the universe from it and records the specification digest.
+
+## The first proof
+
+The runbook's demonstration path is fixed now so the steps build toward it:
+an example cohort under `plugins/synkrisis/examples/cross-run-v0/` whose
+records pass `scripts/run_observation.py check`, emitting one finding for
+each shipped rule kind, `late-boundary-consultation/v1` and
+`unchanged-retry-before-handoff/v1`, with byte-identical outputs across two
+runs, plus two negative demonstrations: an incompatible cohort refuses, and
+a finding whose narrative strengthens association into cause refuses.
+
+## Boundaries, unchanged from the proposal
+
+Capture, redaction, storage, dashboards, causality, hidden reasoning, safety
+or quality scoring, automatic issue filing, repository mutation, skill
+editing, Fiat or Kronos dispatch, controlled performance verdicts, and
+issue-437 dead-code triage all stay outside Synkrisis, with their owners as
+the proposal named them. The nearest forbidden claim is part of every
+specified finding so a reader sees the line rather than trusting that it was
+drawn.

--- a/plugins/synkrisis/.claude-plugin/plugin.json
+++ b/plugins/synkrisis/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "synkrisis",
+  "displayName": "Synkrisis",
+  "version": "0.1.0",
+  "description": "Bounded cross-run diagnosis: deterministic findings from validated run observations in one declared cohort.",
+  "author": {
+    "name": "Wildcat Labs",
+    "url": "https://wildcat.finance"
+  },
+  "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/synkrisis",
+  "repository": "https://github.com/wildcat-finance/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "run-observations",
+    "telemetry",
+    "diagnosis",
+    "comparison",
+    "promise-machine",
+    "agents"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/synkrisis/.codex-plugin/plugin.json
+++ b/plugins/synkrisis/.codex-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "name": "synkrisis",
+  "version": "0.1.0",
+  "description": "Bounded cross-run diagnosis: deterministic findings from validated run observations in one declared cohort.",
+  "author": {
+    "name": "Wildcat Labs",
+    "url": "https://wildcat.finance"
+  },
+  "homepage": "https://github.com/wildcat-finance/skills/tree/main/plugins/synkrisis",
+  "repository": "https://github.com/wildcat-finance/skills",
+  "keywords": [
+    "run-observations",
+    "telemetry",
+    "diagnosis",
+    "comparison",
+    "promise-machine",
+    "agents"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Synkrisis",
+    "shortDescription": "Bounded cross-run diagnosis: deterministic findings from validated run observations in one declared cohort.",
+    "longDescription": "The Promise Machine records what one agent run observably did; nothing interprets a repeated pattern across runs. Synkrisis owns that comparison and nothing past it. Its committed specification declares the surface: an operator names a manifest of validated, redacted, receipt-bound run-observation records and a comparison policy; cohort construction checks the producer contract, digests, bindings, caps and equality dimensions and classifies every declared run as included, excluded or unknown; a digest-bound catalogue of deterministic rules recomputes bounded findings; a fixed-template report and whole-path verification close the loop. A finding is specified as a bounded inferred relation carrying its evidence, counterevidence, unknowns, the nearest claim it refuses to make, and one suggested handoff a person may act on. The shipped command is the Step 1 scaffold: it declares the four operations and refuses each with a stable code naming the runbook step that implements it. It never calls a model, judges model quality, states a cause, files an issue, edits a repository or dispatches another skill.",
+    "developerName": "Wildcat Labs",
+    "category": "Developer Tools",
+    "capabilities": [],
+    "defaultPrompt": "Use $synkrisis to compare validated run observations across one declared cohort and recompute its bounded findings."
+  },
+  "license": "Apache-2.0"
+}

--- a/plugins/synkrisis/AGENTS.md
+++ b/plugins/synkrisis/AGENTS.md
@@ -1,0 +1,81 @@
+# Synkrisis runtime contract
+
+<!-- marketplace-context:start -->
+> **Marketplace context: Synkrisis.** Synkrisis compares validated Promise Machine run observations across one operator-declared cohort and recomputes bounded, evidence-linked findings. Use Ephoros to design what a step emits, Metron for controlled measurement verdicts, Elenchus to work one failure to its cause, and Horos for the reading boundary a finding may point at. **Current frontier:** Synkrisis is a committed specification with a refusing command stub, and none of its runbook's cohort, diagnosis, render or verification steps has yet landed behaviour.
+<!-- marketplace-context:end -->
+
+## Promise Machine binding
+
+Before selecting or running a skill, read the local
+[Promise Machine contract](PROMISE_MACHINE.md). This `promise-machine/v1`
+file is a generated installation copy of the suite law. A result authorises
+only the transition its canonical skill declares; missing, stale or
+insufficient evidence blocks that dependent transition while leaving recovery
+available.
+
+Synkrisis contains one Agent Skill. Select `synkrisis` to read the committed
+cross-run comparison specification, to run the scaffold's declared surface,
+or to continue the runbook's held steps, then read
+`skills/synkrisis/SKILL.md` in full. At this step every operation refuses
+with a stable code naming the runbook step that implements it; do not
+present a cohort, finding, report or verification as a Synkrisis result.
+
+`skills/synkrisis/SKILL.md` is the only canonical instruction document. Do not
+add a sibling browsing README.
+
+## Translate tool names by capability
+
+The canonical skill was written for hosts that name their tools. A local agent
+must map those names to equivalent capabilities:
+
+| Instruction term | Required capability | Preserve |
+| --- | --- | --- |
+| `Read` | Read the named file completely or at the stated range | Named range and byte content |
+| `Write` or `Edit` | Create or patch the named file | Intended path and patch scope |
+| `Bash` | Execute the command in a shell and inspect its exit status | Argument order and exit status |
+| `Glob`, `Grep`, or `find` | Enumerate or search files with the stated pattern | Pattern and matched paths |
+
+Tool names describe capabilities, not mandatory API identifiers. Preserve the
+arguments, ordering, output files, and exit codes when using an equivalent
+local tool. A non-zero exit from a check means the check failed; do not report
+a run as clean when it exited 1.
+
+## Resolve placeholders
+
+- `$SKILL_DIR` means the directory containing the active `SKILL.md`, unless
+  that file defines it differently.
+- `$PLUGIN_ROOT` means this `plugins/synkrisis/` directory.
+- The command is `scripts/synkrisis.py`, resolved against `$PLUGIN_ROOT` and
+  not the user's target repository. The interpreter is the exact pin in the
+  suite's `.python-version`.
+- Names such as `synkrisis:synkrisis` and `/synkrisis:synkrisis` are logical
+  aliases. Load the canonical path from the selection above.
+
+## Network and side effects
+
+Nothing here reaches the network. The Step 1 command parses its arguments,
+prints one refusal naming the runbook step that implements the operation, and
+exits 1; it reads no record, writes no file, executes no observed content and
+has no GitHub, Git or controller mutation path. Treat a target repository as
+the user's, and obey its own instructions before writing anything into it.
+
+## What this skill must refuse
+
+These are properties of the tool rather than reminders, and a local agent must
+not route around them:
+
+- No analytical result from the scaffold. Every operation refuses until its
+  runbook step lands; a refusal is not a cohort, finding, report or
+  verification.
+- No inferred comparability. The operator declares the comparison policy;
+  Synkrisis checks that declaration and never decides that unlike tasks,
+  models, hosts, repositories or tokenizers are comparable.
+- No evidence strengthening. Findings are specified to stay at the inferred
+  class and carry their counterevidence, unknown runs and nearest forbidden
+  claim.
+- No cause and no model judgement, in a rule, a finding or a report.
+- No autonomous transition. A suggested handoff is the whole action; filing
+  issues, editing repositories and dispatching siblings belong to a person.
+
+If an operation, a check or a suite did not run, say so plainly and do not
+describe its result.

--- a/plugins/synkrisis/LICENSE
+++ b/plugins/synkrisis/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Wildcat Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/synkrisis/PROMISE_MACHINE.md
+++ b/plugins/synkrisis/PROMISE_MACHINE.md
@@ -1,0 +1,245 @@
+# Promise Machine contract
+
+<!-- promise-machine: contract=promise-machine/v1; canonical=PROMISE_MACHINE.md; copies=generated -->
+
+This document is the normative contract for every skill distributed as part of
+Wildcat Labs Skills. Plugin-local files with this name are generated,
+byte-identical installation copies. They are not separate laws.
+
+## Contract identity
+
+The shared contract identity is `promise-machine/v1`. It identifies this law's
+format and semantics. It is neither a plugin package version nor a skill
+evolution version.
+
+## Governing principle
+
+> No skill may claim more than its evidence establishes, or authorise a more
+> consequential transition than that evidence warrants.
+
+This principle applies to every answer, artefact, repository change,
+publication, deployment and external action produced through the suite. A
+passing check establishes only the promise that names it. It does not establish
+the skill's general correctness, the truth of its inputs or any neighbouring
+claim.
+
+## Scope
+
+The contract applies to first-party skills, nested skills, vendored skills,
+routers, runtime contracts, generated copies and evidence handoffs. Each
+logical skill has one canonical implementation. Routers select that
+implementation and establish no domain result of their own.
+
+Vendored instructions remain upstream-owned and byte-for-byte unmodified. A
+first-party overlay may bind a vendored operation to this contract when it
+names the upstream digest, the bounded promise and the Wildcat-owned evidence.
+
+## Vocabulary
+
+| Term | Meaning | Required binding | Nearest refusal |
+| --- | --- | --- | --- |
+| Promise | A bounded claim made by one skill operation | Stable promise id and canonical skill | An adjacent claim |
+| Promise boundary | The subject, scope and nearby conclusions the promise does not support | Subject and scope | Unexplained scope widening |
+| Promise check | Identified evidence evaluated to decide whether a promise holds | Evidence identity and result | Unchecked evidence |
+| Authorised transition | The representation or action a satisfied promise permits | Consequence level | A more consequential action |
+| Refusal | Denial of the dependent transition when the promise is not established | Blocked transition | Continuing after failure |
+| Recovery | Inspection, cure, rerun, rollback or safe exit left available after refusal | Actionable recovery path | Global halt or no exit |
+| Exception | An attributed, scoped and recorded decision to waive or narrow one gate | Authority, scope, record and expiry | Silent waiver |
+| Evidence inheritance | A consumer may narrow evidence or add separately identified evidence | Producer, consumer and original class | Unexplained strengthening |
+| Bounded conformance | Observed behaviour stayed inside a declared boundary for named inputs, adapter, recorder and search | Inputs, adapter, recorder and search | Safety proof or unobserved executions |
+
+## Evidence classes
+
+Evidence classes describe relations, not a universal strength ordering:
+
+| Class | Establishes | Does not establish |
+| --- | --- | --- |
+| `checked` | An identified deterministic rule or schema accepted the subject | Truth or completeness outside that rule |
+| `recomputed` | A result was derived again from identified inputs and method | Authority beyond those inputs and method |
+| `proved` | A named formal, cryptographic or defined proof relation accepted the subject | Any claim outside that proof relation |
+| `measured` | A value was observed under a recorded method and environment | Universal performance or causation |
+| `recorded` | Bytes or a statement were preserved from an identified source | Truth of the source assertion |
+| `attested` | An identified actor or system made the statement | Independent truth of the statement |
+| `inferred` | A conclusion follows under a stated rule from named evidence | Direct observation or proof |
+| `unknown` | The matter was not established | Any positive transition |
+
+A domain may refine a class, such as `proved: EIP-1186 account proof`, while
+keeping the base class recognisable. A consumer records any change of class and
+the evidence that supports it. Absence, ambiguity and `unknown` never pass.
+
+## Promise declarations
+
+Every governed first-party canonical skill has exactly one `## Promise Machine
+contract` section. It contains one or more stable `### <promise-id>` blocks.
+Each block carries these fields exactly once:
+
+- `Promise`
+- `Evidence`
+- `Evidence classes`
+- `Boundary`
+- `Authorises`
+- `Consequence`
+- `Refuses`
+- `Recovery`
+- `Exceptions`
+
+The promise id is stable within the skill. Operations whose claims or
+authorised transitions differ use separate promise ids. Evidence names the
+command, record, test, proof relation or observation that supports the claim.
+The boundary names the nearest tempting overclaim. Refusal names the transition
+that stops. Recovery remains usable when refusal occurs.
+
+`Exceptions: none` is explicit. A supported exception follows the rules below.
+
+## Consequence levels
+
+The consequence belongs to the authorised transition, not to the skill as a
+whole:
+
+| Level | Transition | Minimum enforcement |
+| --- | --- | --- |
+| 0 | Response or presentation only | Preserve scope, content and uncertainty |
+| 1 | Derived artefact | Validate structure, provenance and visible gaps |
+| 2 | Repository or durable-data mutation | Tests, negative evidence and recoverable change |
+| 3 | Publication, deployment, external action, security or financial conclusion | Fail-closed gate, recorded authority and independently inspectable evidence |
+
+A skill with operations at different levels declares separate promises. A
+level-3 transition cannot rest only on model judgement, unrecorded operator
+memory, an unchecked receipt or evidence whose subject does not match.
+
+## Composition
+
+Composition preserves the producer's boundary. A handoff records the producing
+skill, consuming skill, subject, scope, evidence class, time domain and any
+transformation. The consumer can add separately identified evidence. It must not
+rename narrow evidence into a stronger class or drop a conflict, gap, refusal
+or recovery path.
+
+In particular:
+
+- Lemma chunks remain source-linked retrieval material; they do not establish
+  answer truth.
+- Lazarus recorded RPC evidence remains recorded unless its named proof check
+  established a narrower proved relation.
+- Berean citations, evaluations and promotion records establish their declared
+  release gates; they do not establish factual truth or model quality.
+- Janus results remain bound to the named host adapter, manifest, recorder and
+  bounded search; they do not establish hook safety, complete liveness or
+  cross-host conformance.
+- Ariadne binds an artefact digest to declared evidence; without an external
+  signature verifier it does not establish author identity.
+- A Fiat run-observation binding preserves the observation validator and
+  capture boundaries. It attaches only the checked prefix to one receipt; it
+  does not make observation availability or event truth delivery evidence.
+
+Any unexplained strengthening is a conformance failure.
+
+## Refusal and recovery
+
+Missing, stale, malformed, mismatched or insufficient evidence fails closed.
+Failure blocks the dependent transition and no broader one. Inspection,
+diagnosis, repair, rerun, rollback and safe exit remain available unless the
+promise explains why a particular recovery cannot exist.
+
+A refusal report names the promise id, failed field or evidence, consequence
+level, blocked transition and recovery action. A checker never deletes,
+rewrites or quarantines the failing source merely to produce a passing result.
+
+## Exceptions
+
+An exception is evidence, not silence. It names:
+
+- the person or policy with authority;
+- the promise id and exact gate being waived or narrowed;
+- the affected subject and scope;
+- the durable record holding the reason;
+- the expiry, or why expiry cannot apply; and
+- the recovery or revocation path.
+
+An exception cannot claim that missing evidence exists, strengthen an evidence
+class, erase a recorded conflict or authorise a transition beyond the named
+scope. Unattributed, unrecorded, expired or over-broad exceptions fail closed.
+
+## Conformance
+
+Structural conformance establishes that the declarations, identities, copies
+and coverage records have the required shape and agree. It does not establish
+that a domain promise is true. Behavioural conformance comes from the named
+domain tests, negative specimens, proof checks, measurements and manual
+demonstrations.
+
+The checker discovers the governed universe from repository manifests and
+skill paths. A hand-maintained coverage file may classify discovered entries;
+it may not define the universe or remove an entry from it. Empty discovery,
+unclassified skills, duplicate logical identities, missing declarations,
+divergent copies and unbound vendored instructions are failures.
+
+Checker output names a stable finding code, fault class, path, promise id when
+known and the action that clears it. JSON and text reports describe the same
+findings. The checker reaches no network and executes no evidence command.
+
+## First-party licence promise
+
+### promise-machine-first-party-licence
+
+- Promise: A successful `check --only licences` establishes that the root and every first-party plugin carry the same Apache-2.0 licence bytes, and that both host manifests name Apache-2.0 and Wildcat Labs.
+- Evidence: The fixed root `LICENSE`, discovered first-party plugin set, byte comparisons, and parsed Claude and Codex plugin manifests.
+- Evidence classes: checked, recomputed
+- Boundary: The check does not establish copyright ownership, provide legal advice, or inspect, govern, or relicense vendored work; the Pashov skill trees retain their upstream MIT licence and notices.
+- Authorises: Publishing the discovered first-party plugin surfaces with the repository's Apache-2.0 and Wildcat Labs licence declaration.
+- Consequence: 3
+- Refuses: A missing, unsafe, oversized, or divergent licence, an inconsistent host manifest, or any claim that the first-party licence covers a vendored skill.
+- Recovery: Restore the canonical root licence and first-party copies, correct the host manifests, leave vendored licences untouched, and rerun the licence check.
+- Exceptions: none
+
+## Run observation promise
+
+### promise-machine-run-observation-structural-validation
+
+- Promise: A successful `python3 scripts/run_observation.py check <path>` establishes that the named regular JSON Lines file conforms to `promise-machine-run-observation/v1` under the validator's closed shapes, limits, lifecycle, backward-reference, evidence-binding, unknown-fact, optional-token, Unicode-path and final-snapshot rules.
+- Evidence: The exact input path and validated bytes, one bounded final named-path reread with matching digest and file identity, v1 schema, standard-library validator, stable finding report, valid and refusing fixtures, focused tests and zero command exit.
+- Evidence classes: checked
+- Boundary: Validation does not capture a run, prove that the record is complete or externally true, establish cause or model quality, bind a Fiat receipt, make a security conclusion, authorise mutation, or prevent a writer changing the path after the final reread.
+- Authorises: Treating only the named bytes as structurally conforming and passing that bounded result to a consumer that preserves its subject, scope, time domain, evidence class, unknowns and refusal boundary.
+- Consequence: 1
+- Refuses: Unsafe or unbounded input, a final byte or identity mismatch, malformed or duplicate-key JSON, an open event shape, missing identity, invalid order or lifecycle, a forward or cross-run reference, unbound or strengthened evidence, hidden reasoning, raw payloads, non-scalar, non-NFC, control-bearing, bidirectional or otherwise unsafe repository paths, placeholder host facts, invalid token counts or a non-zero finding report.
+- Recovery: Inspect the stable finding code, repair the source record without having the checker mutate it, preserve unknowns and evidence boundaries, then rerun the same command.
+- Exceptions: none
+
+### promise-machine-run-observation-capture
+
+- Promise: A successful `python3 scripts/run_observation_capture.py check <candidate>` establishes that the named bounded candidate was processed by `promise-machine-run-observation-capture/v1` into one accepted event, visible gap, or refusal before a durable observation exists.
+- Evidence: The named candidate, closed standard-library adapter, capture schema, direct-allowlist fixtures, hostile byte-survival tests, source-owned reporter, and zero command exit.
+- Evidence classes: checked
+- Boundary: The result does not prove the source is true or complete, detect every secret, govern another host memory, itself bind a Fiat receipt, make a security conclusion, or authorise another controller transition.
+- Authorises: Passing an accepted result to the capture writer, or recording the bounded gap or refusal without treating it as an accepted observation.
+- Consequence: 1
+- Refuses: An open or oversized candidate, raw payload family, malformed redaction, unsafe repository path, low-entropy correlation input, unknown shape, or writer bypass.
+- Recovery: Remove the unsafe field from the candidate adapter, retain only a closed redaction or safe descriptor, then rerun the same command and hostile fixture surface.
+- Exceptions: none
+
+## Contributor ranking promise
+
+### promise-machine-contributor-ranking
+
+- Promise: A successful `python3 scripts/contributors.py --check` establishes that every contributor row GitHub returned for the named repository was placed in exactly one of ranked, excluded with a named reason, or refused; that each ranked login is a valid GitHub login absent from the declared runtime-host set, is neither the Shoggoth's account nor the repository owner, and had at least one commit in a bounded sample authored by a non-host identity; that the order is merged commits, then merged pull requests, then login; and that `CONTRIBUTORS.md` and the marked region of `README.md` match that one computation byte for byte.
+- Evidence: The recorded contributors, merged-pull-request and commit-authorship reads, the host-set parity check against `hexctl.py`'s declaration, the login grammar check, the per-identity classification lines, the ranking digest, the byte comparison of both artefacts and zero command exit.
+- Evidence classes: checked, recorded
+- Boundary: Ranking does not establish that the counts fairly measure contribution, that a commit carried judgement, who wrote which line, anything about a person beyond the account they committed under, or that GitHub's resolution of author emails to accounts is correct. It does not detect a merge that discarded commit authorship before the commit reached the default branch, and its authorship corroboration samples at most twenty commits per account rather than all of them.
+- Authorises: Writing `CONTRIBUTORS.md` and the marked region of `README.md` and nothing outside those two targets, and reporting the ranking without strengthening what the counts mean.
+- Consequence: 1
+- Refuses: An account type other than User or Bot, a Bot absent from the declared host set, a login failing the GitHub login grammar, a repository argument carrying query syntax, any failed API read including a rate limit, a host set diverged from `hexctl.py` in either direction, an excluded login reaching the ranked output, a `README.md` that is absent or not UTF-8, and a read that would silently truncate.
+- Recovery: Read the stop, which names the identity or field at fault; extend the host set in `hexctl.py` and `scripts/contributors.py` together for an unknown host, set a token or wait for the named reset for a rate limit, and rerun with `--write` for a stale artefact. The generator never repairs an input.
+- Exceptions: none
+
+## Installation copies
+
+The root `PROMISE_MACHINE.md` is the authored source. Each
+`plugins/<plugin>/PROMISE_MACHINE.md` is written only by
+`scripts/promise_machine.py sync`. The destination is fixed, writes are atomic,
+symlinks and paths outside the repository are refused, and `sync --check`
+rejects a missing or byte-divergent copy.
+
+Standalone plugin runtime contracts load their local copy. Repository-wide
+work loads this root file. Both surfaces therefore read the same contract
+bytes under the same identity.

--- a/plugins/synkrisis/README.md
+++ b/plugins/synkrisis/README.md
@@ -1,0 +1,68 @@
+# Synkrisis
+
+<!-- marketplace-context:start -->
+## In one line
+
+Synkrisis compares validated Promise Machine run observations across one operator-declared cohort and recomputes bounded, evidence-linked findings a person can act on.
+
+**Current frontier.** Synkrisis is a committed specification with a refusing command stub, and none of its runbook's cohort, diagnosis, render or verification steps has yet landed behaviour.
+
+**Next Fiat job.** Use /hexaemeron:fiat to complete Step 2 of the committed runbook: implement observation admission and cohort construction behind synkrisis.py cohort, with the study's positive and hostile fixtures; accept it when the example manifest produces one cohort digest twice, every declared run carries its classification reason, and each named refusal class has a red-to-green guard. Before the run finishes, cold-read and reconcile all mutable first-party marketplace prose. Change a skill's Next Fiat job only when that exact frontier job completed; otherwise leave it unchanged.
+<!-- marketplace-context:end -->
+
+## Place in the collective
+
+The Promise Machine records what one agent run observably did: the
+run-observation contract defines the record, the capture gate keeps forbidden
+material out of it, and the receipt binding ties a prefix of it to a Fiat
+receipt. None of that interprets a repeated pattern across runs. Synkrisis
+owns exactly that comparison. Ephoros designs what a step emits, Metron judges
+a controlled measurement, Elenchus works one failure to its cause, and Horos
+owns the reading boundary; a Synkrisis finding is specified to name one of
+them as its suggested next owner, and a person decides whether anything
+happens.
+
+## What this step ships
+
+This is Step 1 of the committed
+[runbook](https://github.com/wildcat-finance/skills/blob/main/docs/synkrisis/runbook.md),
+built from the committed
+[study](https://github.com/wildcat-finance/skills/blob/main/docs/synkrisis/study.md)
+for [issue 449](https://github.com/wildcat-finance/skills/issues/449):
+
+- the plugin shell, both host manifests, the marketplace entries and the
+  Promise Machine router route;
+- the canonical `skills/synkrisis/SKILL.md` carrying the complete specified
+  surface, its caps and its refusals, beside the evolution ledger;
+- the first decision record, keeping cross-run diagnosis a standalone
+  boundary; and
+- `scripts/synkrisis.py`, a stub that declares the four specified operations,
+  cohort, diagnose, render and verify, and refuses each with one stable code
+  naming the runbook step that implements it, writing nothing.
+
+## How it will work
+
+An operator declares two things: a manifest naming every run in the
+comparison universe, with each record's digest, byte count, validation,
+redaction and receipt-binding results; and a comparison policy classifying
+every run-context dimension, plus a token accounting mode. Cohort
+construction classifies every declared run as included, excluded or unknown,
+naming the policy field responsible for each exclusion. A digest-bound
+catalogue of deterministic rules recomputes bounded findings; a
+fixed-template report and whole-path byte verification close the loop.
+Association never hardens into cause; a rule or finding carrying causal or
+model-quality language is refused. The runbook's Steps 2 through 5 land that
+behaviour one gated step at a time.
+
+## Use
+
+Synkrisis needs only the exact interpreter in the suite
+[pin](https://github.com/wildcat-finance/skills/blob/main/.python-version).
+Ask:
+
+```text
+Use $synkrisis to read the cross-run comparison specification and the state of its runbook.
+```
+
+The specified operations, the caps and the refusals live in
+[Synkrisis's `SKILL.md`](./skills/synkrisis/SKILL.md).

--- a/plugins/synkrisis/docs/decisions/ADR-001-keep-cross-run-diagnosis-separate.md
+++ b/plugins/synkrisis/docs/decisions/ADR-001-keep-cross-run-diagnosis-separate.md
@@ -1,0 +1,46 @@
+# ADR-001: Keep cross-run diagnosis separate
+
+## Status
+
+Accepted, 2026-08-27.
+
+## Context
+
+Issues 434 to 436 gave the suite validated, redacted, receipt-bound run
+observations, and nothing interprets a repeated pattern across runs. Three
+existing owners were candidates for that work. Ephoros designs and reviews
+telemetry for a named step. The Promise Machine governs evidence and
+transitions. Fiat controls receipted delivery. Issue 449's study weighed
+extending each of them against a standalone plugin.
+
+## Decision
+
+Cross-run diagnosis lives in its own plugin, `plugins/synkrisis/`, with its
+own promises: cohort construction, bounded diagnosis and report verification.
+It consumes the issue-434 to issue-436 artefacts as declared inputs and owns
+comparison and bounded inference only.
+
+## Alternatives
+
+- Extend Ephoros. Rejected: the telemetry producer would judge what its own
+  output means across runs, crossing its named-step boundary into comparison
+  and improvement selection.
+- Add analysis to the Promise Machine. Rejected: the law governs evidence and
+  transitions without owning domain conclusions, and a diagnosis is a domain
+  conclusion.
+- Add analysis to Fiat. Rejected: issue 436 deliberately keeps observation
+  separate from the delivery control path; optional interpretation must not
+  join that path.
+- A model-authored reviewer. Rejected for the prototype: its output is not
+  deterministic, a stable negative corpus cannot pin its refusals, and it can
+  turn association into cause. A model-assisted lane needs a later study and
+  its own promise.
+
+## Consequences
+
+The marketplace carries one more package and result schema, and in exchange no
+existing skill's promise widens. Synkrisis can refuse causal and quality
+language mechanically because its rules are data over closed deterministic
+kinds. The cost is a boundary to maintain: capture, redaction, binding, causal
+triage and dispatch stay with their current owners, and requests that cross
+into them hand off rather than grow this plugin.

--- a/plugins/synkrisis/scripts/synkrisis.py
+++ b/plugins/synkrisis/scripts/synkrisis.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Bounded cross-run diagnosis over validated Promise Machine run observations.
+
+This is the runbook's Step 1 scaffold. The command declares the complete
+specified surface, four operations over one declared cohort of
+`promise-machine-run-observation/v1` records, and refuses each one with a
+stable code naming the runbook step that implements it. Nothing here reads a
+record, writes an artefact, calls a model, fetches a URL, executes observed
+content, files an issue, edits a repository, or dispatches another skill.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+PRODUCER_CONTRACT = "promise-machine-run-observation/v1"
+
+# The specified operations and the committed runbook step that lands each one.
+PENDING_STEPS = {
+    "cohort": "Step 2",
+    "diagnose": "Step 3",
+    "render": "Step 4",
+    "verify": "Step 4",
+}
+
+
+class Refusal(Exception):
+    """One stable finding: code, fault class, safe path, recovery."""
+
+    def __init__(self, code, fault, path, message, recovery):
+        super().__init__(message)
+        self.code = code
+        self.fault = fault
+        self.path = path
+        self.message = message
+        self.recovery = recovery
+
+
+def scaffold_refusal(operation: str) -> Refusal:
+    step = PENDING_STEPS[operation]
+    return Refusal(
+        "SK000",
+        "structural",
+        operation,
+        f"operation {operation!r} is specified and not yet implemented",
+        f"build {step} of docs/synkrisis/runbook.md, then rerun the operation",
+    )
+
+
+def emit_refusal(refusal: Refusal, as_json: bool) -> None:
+    document = {
+        "code": refusal.code,
+        "fault": refusal.fault,
+        "path": refusal.path,
+        "producer": PRODUCER_CONTRACT,
+        "message": refusal.message,
+        "recovery": refusal.recovery,
+    }
+    if as_json:
+        print(json.dumps(document, sort_keys=True, separators=(",", ":")))
+    else:
+        print(
+            f"{refusal.code} fault={refusal.fault} path={refusal.path} "
+            f"producer={PRODUCER_CONTRACT}: {refusal.message}; "
+            f"recovery: {refusal.recovery}"
+        )
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(prog="synkrisis", description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    cohort_parser = subparsers.add_parser(
+        "cohort", help="classify every declared run under one comparison policy"
+    )
+    cohort_parser.add_argument("--manifest", required=True)
+    cohort_parser.add_argument("--policy", required=True)
+    cohort_parser.add_argument("--out", required=True)
+    cohort_parser.add_argument("--json", action="store_true")
+
+    diagnose_parser = subparsers.add_parser(
+        "diagnose", help="apply the digest-bound rule catalogue to one checked cohort"
+    )
+    diagnose_parser.add_argument("--cohort", required=True)
+    diagnose_parser.add_argument("--rules", required=True)
+    diagnose_parser.add_argument("--out", required=True)
+    diagnose_parser.add_argument("--json", action="store_true")
+
+    render_parser = subparsers.add_parser(
+        "render", help="render the fixed-template report from one findings document"
+    )
+    render_parser.add_argument("findings")
+    render_parser.add_argument("--out", required=True)
+    render_parser.add_argument("--json", action="store_true")
+
+    verify_parser = subparsers.add_parser(
+        "verify", help="recompute cohort, findings and report from the original inputs"
+    )
+    verify_parser.add_argument("--manifest", required=True)
+    verify_parser.add_argument("--policy", required=True)
+    verify_parser.add_argument("--cohort", required=True)
+    verify_parser.add_argument("--rules", required=True)
+    verify_parser.add_argument("--findings", required=True)
+    verify_parser.add_argument("--report", required=True)
+    verify_parser.add_argument("--json", action="store_true")
+
+    arguments = parser.parse_args(argv)
+    emit_refusal(scaffold_refusal(arguments.command), arguments.json)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/synkrisis/skills/synkrisis/EVOLUTION.md
+++ b/plugins/synkrisis/skills/synkrisis/EVOLUTION.md
@@ -1,0 +1,15 @@
+# Synkrisis evolution ledger
+
+Policy: [../../../hexaemeron/skills/VERSIONING.md](../../../hexaemeron/skills/VERSIONING.md)
+
+- Current version: `synkrisis-v0.1.0`
+- Frontier status: `open`
+- Frontier revision: `cohort-construction`
+- Current frontier: Synkrisis is a committed specification with a refusing command stub, and none of its runbook's cohort, diagnosis, render or verification steps has yet landed behaviour.
+- Next Fiat job: Complete Step 2 of the committed runbook: implement observation admission and cohort construction behind synkrisis.py cohort, with the study's positive and hostile fixtures. Accepted when the example manifest produces one cohort digest twice, every declared run carries its classification reason, and each named refusal class has a red-to-green guard.
+
+## History
+
+| Version | Axis | Frontier revision | Frontier SHA-256 | Evidence | Change |
+| --- | --- | --- | --- | --- | --- |
+| `synkrisis-v0.1.0` | baseline | `cohort-construction` | `f5ecc2bea318637223d5115b76fcbe354957783ddb56fc2256c257710af80e51` | [the anchor study](../../../../docs/synkrisis/study.md) and [issue 449](https://github.com/wildcat-finance/skills/issues/449) | Versioning starts here. Synkrisis ships as the runbook's Step 1 scaffold: both host manifests, the marketplace and router surfaces, this ledger, the committed study, runbook and first decision record, and a command stub that declares the four specified operations and refuses each with a stable code naming the runbook step that implements it. The held frontier is Step 2, observation admission and cohort construction. |

--- a/plugins/synkrisis/skills/synkrisis/SKILL.md
+++ b/plugins/synkrisis/skills/synkrisis/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: synkrisis
+description: >
+  Compare validated Promise Machine run observations across one declared
+  cohort and recompute bounded, evidence-linked findings. Use when several
+  comparable agent runs have checked observation records and someone wants to
+  know what repeated across them: late repository-boundary consultation beside
+  higher token use, or unchanged retries before an Elenchus handoff. Do not
+  use it to capture or redact observations, to debug one failing run, to judge
+  a model, or to act on a finding; a person selects what happens next. Never
+  report a relation as a cause.
+metadata:
+  version: "0.1.0"
+---
+
+# Synkrisis
+
+## Frontier
+
+Synkrisis owns the cross-run comparison frontier. Its version, held target,
+next job, and maturity state live in [EVOLUTION.md](EVOLUTION.md). Do not
+recommend or run another frontier pass after that ledger becomes mature.
+
+<!-- marketplace-context:start -->
+## Where this sits
+
+Synkrisis turns validated observations from comparable agent runs into
+evidence-linked improvement candidates. It owns comparison and bounded
+inference only; capture, redaction, receipt binding, causal diagnosis, issue
+filing, repository mutation and Fiat dispatch stay with their own owners.
+
+**Current frontier.** Synkrisis is a committed specification with a refusing command stub, and none of its runbook's cohort, diagnosis, render or verification steps has yet landed behaviour.
+<!-- marketplace-context:end -->
+
+Synkrisis is named for comparison. The Promise Machine records what one run
+observably did: issue 434 defined the record, issue 435 the capture gate, and
+issue 436 the receipt binding. None of those steps reads a pattern across
+runs. A maintainer still has to decide whether repeated orientation work,
+unchanged retries, handoff friction or token movement amounts to an
+improvement candidate. Synkrisis exists to make that comparison deterministic
+and to keep it honest about what recorded events can and cannot say.
+
+Ephoros designs what a step emits; Metron judges a controlled measurement;
+Elenchus works one failure to its cause; Horos owns the reading boundary. A
+Synkrisis finding is specified to suggest one of them as its next owner, and
+the suggestion is the whole action: no path files an issue, edits a
+repository, or dispatches a sibling.
+
+## What this step is
+
+This is Step 1 of
+[the committed runbook](https://github.com/wildcat-finance/skills/blob/main/docs/synkrisis/runbook.md),
+built from
+[the committed study](https://github.com/wildcat-finance/skills/blob/main/docs/synkrisis/study.md): the
+plugin shell, its packaging and marketplace surfaces, this canonical
+instruction document, the evolution ledger, the first decision record, and a
+command stub. The stub declares the complete specified surface and refuses
+every operation with one stable code naming the runbook step that implements
+it. Until those steps land, Synkrisis produces no cohort, finding, report or
+verification.
+
+## The specified surface
+
+One standard-library command, `scripts/synkrisis.py`, with four operations:
+
+- `cohort` reads an operator-declared manifest of run-observation records and
+  one comparison policy, checks producer identity, declared validation,
+  redaction and binding results, digests, caps, path form and equality
+  dimensions, and writes a cohort classifying every declared run as included,
+  excluded or unknown with the exact policy field responsible. Lands with
+  Step 2.
+- `diagnose` applies a digest-bound catalogue of deterministic rules to one
+  checked cohort and emits findings carrying exact event references,
+  counterevidence, unknown runs, the nearest forbidden claim and one
+  suggested handoff. A rule is data over closed shipped kinds; no rule
+  supplies an expression, an import, a shell command or a regular
+  expression. Lands with Step 3.
+- `render` writes a fixed-template report that cannot add a number, run id,
+  causal verb or evidence class absent from the findings. Lands with Step 4.
+- `verify` recomputes the cohort, the findings and the report byte for byte
+  from the original inputs. Lands with Step 4.
+
+The study fixes the caps the implementation must hold: one cohort at a time,
+at most 100 runs and 100,000 events, 8 MiB per file and 64 MiB of declared
+input in aggregate, with a 5.0-second, 256 MiB work budget measured in Step 5.
+
+## Run it
+
+From a checkout, with the exact interpreter in the suite's
+[`.python-version`](../../../../.python-version):
+
+```text
+python3 plugins/synkrisis/scripts/synkrisis.py --help
+python3 plugins/synkrisis/scripts/synkrisis.py cohort \
+  --manifest manifest.json --policy policy.json --out cohort.json
+```
+
+The first command prints the specified surface. The second, like every
+operation at this step, exits 1 with code `SK000`, the fault class, the
+producer contract `promise-machine-run-observation/v1`, and a recovery naming
+the runbook step to build; it creates no file.
+
+## What it refuses
+
+The scaffold refuses everything except describing itself: no operation
+produces a result, and nothing is written. The specification the later steps
+must hold is already fixed:
+
+- No inferred comparability. A person declares the comparison policy;
+  Synkrisis checks the declaration and never decides that unlike tasks,
+  models, hosts, repositories or tokenizers are comparable.
+- No evidence strengthening. Findings stay at the inferred class, carry their
+  counterevidence and unknowns, and state the nearest forbidden claim rather
+  than making it.
+- No cause and no model judgement, in a rule, a finding or a report.
+- No token comparison across unlike accounting identities.
+- No autonomous transition. A handoff is a named suggestion; the command has
+  no network, GitHub, Git or controller mutation path.
+
+If an operation, a check or a suite did not run, say so plainly and do not
+describe its result.
+
+## Promise Machine contract
+
+### synkrisis-scaffold-refusal
+
+- Promise: Every specified Synkrisis operation invoked on this scaffold exits non-zero with one stable code that names the committed runbook step implementing it, and writes nothing.
+- Evidence: The command's declared argument surface, the emitted refusal code, fault class, producer contract and recovery, and the unchanged working tree after each invocation.
+- Evidence classes: checked
+- Boundary: The refusal establishes only that the scaffold cannot present a cohort, finding, report or verification; it says nothing about how the later steps will behave.
+- Authorises: Selecting the committed runbook's named next step as the work that lands the refused operation.
+- Consequence: 0
+- Refuses: Reporting any analytical result from the scaffold, and writing any output file.
+- Recovery: Build the runbook step the refusal names, then rerun the operation.
+- Exceptions: none

--- a/plugins/synkrisis/tests/test_scaffold.py
+++ b/plugins/synkrisis/tests/test_scaffold.py
@@ -1,0 +1,213 @@
+"""Step 1 scaffold contract: packaging, routing, ledger, spec, refusing stub."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+PLUGIN = Path(__file__).resolve().parents[1]
+REPO_ROOT = PLUGIN.parents[1]
+SKILL = PLUGIN / "skills" / "synkrisis" / "SKILL.md"
+LEDGER = PLUGIN / "skills" / "synkrisis" / "EVOLUTION.md"
+COMMAND = PLUGIN / "scripts" / "synkrisis.py"
+
+sys.path.insert(0, str(REPO_ROOT))
+from repo_contract import (  # noqa: E402  (repository-root shared assertions)
+    assert_host_descriptions_agree,
+    assert_marketplace_source_path,
+    assert_router_reaches,
+    assert_version_agreement,
+)
+
+
+def read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_cli(*arguments, cwd):
+    return subprocess.run(  # phylax: allow subprocess: fixed argv local script, no shell
+        [sys.executable, str(COMMAND), *arguments],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+
+
+class HostSurfaceTests(unittest.TestCase):
+    def test_manifest_versions_agree_across_hosts_and_marketplace(self):
+        assert_version_agreement(self, "synkrisis", expected="0.1.0")
+
+    def test_host_descriptions_agree(self):
+        assert_host_descriptions_agree(self, "synkrisis")
+
+    def test_router_reaches_the_runtime_contract(self):
+        assert_router_reaches(self, "synkrisis")
+
+    def test_marketplace_source_paths_are_local(self):
+        assert_marketplace_source_path(self, "synkrisis")
+
+    def test_canonical_skill_names_its_parent_directory(self):
+        text = SKILL.read_text(encoding="utf-8")
+        match = re.search(r"(?m)^name:\s*(\S+)$", text)
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(1), "synkrisis")
+
+    def test_skill_metadata_version_matches_the_ledger(self):
+        text = SKILL.read_text(encoding="utf-8")
+        metadata = re.search(r'(?m)^  version: "(\d+\.\d+\.\d+)"$', text)
+        self.assertIsNotNone(metadata)
+        ledger = LEDGER.read_text(encoding="utf-8")
+        self.assertIn(f"- Current version: `synkrisis-v{metadata.group(1)}`", ledger)
+
+    def test_promise_machine_copy_is_byte_identical_to_the_root_law(self):
+        self.assertEqual(
+            (PLUGIN / "PROMISE_MACHINE.md").read_bytes(),
+            (REPO_ROOT / "PROMISE_MACHINE.md").read_bytes(),
+        )
+
+    def test_licence_is_byte_identical_to_the_root_licence(self):
+        self.assertEqual(
+            (PLUGIN / "LICENSE").read_bytes(),
+            (REPO_ROOT / "LICENSE").read_bytes(),
+        )
+
+    def test_package_and_skill_versions_are_independently_declared(self):
+        package = read_json(PLUGIN / ".claude-plugin" / "plugin.json")["version"]
+        ledger = LEDGER.read_text(encoding="utf-8")
+        skill = re.search(r"- Current version: `synkrisis-v(\d+\.\d+\.\d+)`", ledger)
+        self.assertRegex(package, r"^\d+\.\d+\.\d+$")
+        self.assertIsNotNone(skill)
+
+    def test_contract_section_declares_exactly_the_scaffold_promise(self):
+        text = SKILL.read_text(encoding="utf-8")
+        contract = text.split("## Promise Machine contract", 1)[1]
+        declared = {
+            line.removeprefix("### ")
+            for line in contract.splitlines()
+            if line.startswith("### ")
+        }
+        self.assertEqual(declared, {"synkrisis-scaffold-refusal"})
+
+
+class SpecificationTests(unittest.TestCase):
+    def test_study_runbook_and_first_decision_record_are_committed(self):
+        for path in (
+            REPO_ROOT / "docs" / "synkrisis" / "study.md",
+            REPO_ROOT / "docs" / "synkrisis" / "runbook.md",
+            PLUGIN / "docs" / "decisions"
+            / "ADR-001-keep-cross-run-diagnosis-separate.md",
+        ):
+            with self.subTest(path=path.relative_to(REPO_ROOT)):
+                self.assertTrue(path.is_file())
+
+    def test_the_skill_links_resolve_to_the_committed_specification(self):
+        text = SKILL.read_text(encoding="utf-8")
+        for link in re.findall(r"\]\(((?:\.\./)+[^)]+)\)", text):
+            with self.subTest(link=link):
+                self.assertTrue((SKILL.parent / link).resolve().is_file())
+
+    def test_the_runbook_names_every_specified_operation_step(self):
+        runbook = (REPO_ROOT / "docs" / "synkrisis" / "runbook.md").read_text(
+            encoding="utf-8"
+        )
+        for heading in ("Step 1", "Step 2", "Step 3", "Step 4", "Step 5"):
+            self.assertIn(f"## {heading}:", runbook)
+        self.assertIn("(delivered)", runbook)
+        self.assertEqual(runbook.count("(held)"), 4)
+
+
+class ScaffoldRefusalTests(unittest.TestCase):
+    """The stub's one promise: refuse with the step named, and write nothing."""
+
+    def operations(self, root):
+        return {
+            "cohort": ("cohort", "--manifest", "manifest.json", "--policy",
+                       "policy.json", "--out", "out/cohort.json"),
+            "diagnose": ("diagnose", "--cohort", "cohort.json", "--rules",
+                         "rules.json", "--out", "out/findings.json"),
+            "render": ("render", "findings.json", "--out", "out/report.md"),
+            "verify": ("verify", "--manifest", "manifest.json", "--policy",
+                       "policy.json", "--cohort", "cohort.json", "--rules",
+                       "rules.json", "--findings", "findings.json",
+                       "--report", "report.md"),
+        }
+
+    def test_help_prints_the_specified_surface_without_writing(self):
+        with tempfile.TemporaryDirectory() as scratch:
+            completed = run_cli("--help", cwd=scratch)
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            for operation in ("cohort", "diagnose", "render", "verify"):
+                self.assertIn(operation, completed.stdout)
+            self.assertEqual(os.listdir(scratch), [])
+
+    def test_every_operation_refuses_with_the_scaffold_code(self):
+        with tempfile.TemporaryDirectory() as scratch:
+            for operation, arguments in self.operations(scratch).items():
+                with self.subTest(operation=operation):
+                    completed = run_cli(*arguments, cwd=scratch)
+                    self.assertEqual(completed.returncode, 1)
+                    self.assertIn("SK000", completed.stdout)
+                    self.assertIn(
+                        "promise-machine-run-observation/v1", completed.stdout
+                    )
+
+    def test_operations_refuse_even_with_plausible_inputs(self):
+        with tempfile.TemporaryDirectory() as scratch:
+            root = Path(scratch)
+            for name in ("manifest.json", "policy.json", "cohort.json",
+                         "rules.json", "findings.json"):
+                (root / name).write_text("{}\n", encoding="utf-8")
+            (root / "report.md").write_text("# report\n", encoding="utf-8")
+            for operation, arguments in self.operations(scratch).items():
+                with self.subTest(operation=operation):
+                    completed = run_cli(*arguments, cwd=scratch)
+                    self.assertEqual(completed.returncode, 1)
+                    self.assertIn("SK000", completed.stdout)
+
+    def test_no_operation_writes_an_output(self):
+        with tempfile.TemporaryDirectory() as scratch:
+            before = sorted(os.listdir(scratch))
+            for arguments in self.operations(scratch).values():
+                run_cli(*arguments, cwd=scratch)
+            self.assertEqual(sorted(os.listdir(scratch)), before)
+
+    def test_refusal_names_the_pending_runbook_step(self):
+        expected = {
+            "cohort": "Step 2",
+            "diagnose": "Step 3",
+            "render": "Step 4",
+            "verify": "Step 4",
+        }
+        with tempfile.TemporaryDirectory() as scratch:
+            for operation, arguments in self.operations(scratch).items():
+                with self.subTest(operation=operation):
+                    completed = run_cli(*arguments, "--json", cwd=scratch)
+                    document = json.loads(completed.stdout)
+                    self.assertIn(expected[operation], document["recovery"])
+                    self.assertIn("docs/synkrisis/runbook.md", document["recovery"])
+
+    def test_refusal_output_names_code_producer_path_and_recovery(self):
+        with tempfile.TemporaryDirectory() as scratch:
+            completed = run_cli(
+                *self.operations(scratch)["cohort"], "--json", cwd=scratch
+            )
+            self.assertEqual(completed.returncode, 1)
+            document = json.loads(completed.stdout)
+            self.assertEqual(
+                sorted(document),
+                ["code", "fault", "message", "path", "producer", "recovery"],
+            )
+            self.assertEqual(document["code"], "SK000")
+            self.assertEqual(
+                document["producer"], "promise-machine-run-observation/v1"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -1140,6 +1140,26 @@
       "evidence_class": "inferred",
       "path": "plugins/hexaemeron/tests/test_promise_evaluation_cases.py",
       "selector": "test_labelled_subject_mismatch_cases"
+    },
+    "synkrisis-scaffold-p": {
+      "claim": "The declared scaffold behaviour, one stable refusal per specified operation, is exercised positively.",
+      "path": "plugins/synkrisis/tests/test_scaffold.py",
+      "selector": "test_every_operation_refuses_with_the_scaffold_code"
+    },
+    "synkrisis-scaffold-m": {
+      "claim": "Plausible-looking inputs do not stand in for an implementation; the refusal still fires.",
+      "path": "plugins/synkrisis/tests/test_scaffold.py",
+      "selector": "test_operations_refuse_even_with_plausible_inputs"
+    },
+    "synkrisis-scaffold-o": {
+      "claim": "The nearest overclaim, a written artefact from an unbuilt operation, remains unavailable.",
+      "path": "plugins/synkrisis/tests/test_scaffold.py",
+      "selector": "test_no_operation_writes_an_output"
+    },
+    "synkrisis-scaffold-r": {
+      "claim": "Every refusal names the committed runbook step whose delivery recovers the operation.",
+      "path": "plugins/synkrisis/tests/test_scaffold.py",
+      "selector": "test_refusal_names_the_pending_runbook_step"
     }
   },
   "handoffs": [
@@ -2412,6 +2432,25 @@
       "group": "prompt",
       "promise_id": "sapheneia-session-shape",
       "skill_path": "plugins/sapheneia/skills/sapheneia/SKILL.md"
+    },
+    {
+      "cases": {
+        "M": "synkrisis-scaffold-m",
+        "O": "synkrisis-scaffold-o",
+        "P": "synkrisis-scaffold-p",
+        "R": "synkrisis-scaffold-r",
+        "S": {
+          "not_applicable": true,
+          "reason": "The scaffold holds no earlier artefact that could go stale."
+        },
+        "X": {
+          "not_applicable": true,
+          "reason": "The canonical declaration supports no exception for this promise."
+        }
+      },
+      "group": "executable",
+      "promise_id": "synkrisis-scaffold-refusal",
+      "skill_path": "plugins/synkrisis/skills/synkrisis/SKILL.md"
     },
     {
       "cases": {

--- a/tests/test_marketplace_prose.py
+++ b/tests/test_marketplace_prose.py
@@ -27,6 +27,7 @@ PLUGINS = (
     "pandects",
     "probitas",
     "sapheneia",
+    "synkrisis",
     "tabularium",
 )
 CANONICAL_SKILLS = {
@@ -43,6 +44,7 @@ CANONICAL_SKILLS = {
     "pandects": ROOT / "plugins" / "pandects" / "skills" / "pandects" / "SKILL.md",
     "probitas": ROOT / "plugins" / "probitas" / "skills" / "probitas" / "SKILL.md",
     "sapheneia": ROOT / "plugins" / "sapheneia" / "skills" / "sapheneia" / "SKILL.md",
+    "synkrisis": ROOT / "plugins" / "synkrisis" / "skills" / "synkrisis" / "SKILL.md",
     "tabularium": ROOT / "plugins" / "tabularium" / "skills" / "tabularium" / "SKILL.md",
 }
 NEXT_JOB_PREFIX = "**Next Fiat job.** Use /hexaemeron:fiat to "
@@ -264,7 +266,7 @@ class MarketplaceProseTests(unittest.TestCase):
             for skill in (ROOT / "plugins").glob("*/skills/**/SKILL.md")
             if (skill.parent / "EVOLUTION.md").is_file()
         )
-        self.assertEqual(len(governed), 23)
+        self.assertEqual(len(governed), 24)
         for skill in governed:
             plugin = skill.parents[2]
             target = skill.parent if plugin.name == "hexaemeron" else plugin
@@ -339,7 +341,7 @@ class MarketplaceProseTests(unittest.TestCase):
     def test_plugin_landing_readmes_publish_unique_rolling_fiat_jobs(self):
         landings = plugin_landing_readmes()
         self.assertEqual(set(landings), set(PLUGINS))
-        self.assertEqual(len(landings), 14)
+        self.assertEqual(len(landings), 15)
 
         topics = {}
         for name, path in landings.items():

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -210,7 +210,7 @@ class PromiseLawTests(unittest.TestCase):
     def test_repository_law_and_copies_are_clean(self):
         completed = run_cli("check", "--only", "law,copies")
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
-        self.assertIn("clean: 14 plugin(s), 14 copy/copies", completed.stdout)
+        self.assertIn("clean: 15 plugin(s), 15 copy/copies", completed.stdout)
 
     def test_sync_check_is_read_only_and_clean(self):
         before = {path: path.read_bytes() for path in ROOT.glob("plugins/*/PROMISE_MACHINE.md")}
@@ -222,7 +222,7 @@ class PromiseLawTests(unittest.TestCase):
     def test_all_plugin_copies_are_exact_and_marked(self):
         law = LAW.read_bytes()
         copies = sorted(ROOT.glob("plugins/*/PROMISE_MACHINE.md"))
-        self.assertEqual(len(copies), 14)
+        self.assertEqual(len(copies), 15)
         for copy in copies:
             with self.subTest(copy=copy):
                 self.assertEqual(copy.read_bytes(), law)
@@ -240,7 +240,7 @@ class PromiseLicenceTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["licensed_plugins"], 14)
+        self.assertEqual(report["counts"]["licensed_plugins"], 15)
 
     def test_missing_root_licence_is_refused(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -300,7 +300,7 @@ class PromiseLicenceTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(report["contract"], "promise-machine/v1")
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["plugins"], 14)
+        self.assertEqual(report["counts"]["plugins"], 15)
         self.assertEqual(report["findings"], [])
 
     def test_divergent_copy_fixture_is_refused(self):
@@ -396,9 +396,9 @@ class PromiseInventoryTests(unittest.TestCase):
         completed = run_cli("inventory", "--json")
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
-        self.assertEqual(report["counts"]["plugins"], 14)
-        self.assertEqual(report["counts"]["canonical_skills"], 28)
-        self.assertEqual(report["counts"]["governed_skills"], 23)
+        self.assertEqual(report["counts"]["plugins"], 15)
+        self.assertEqual(report["counts"]["canonical_skills"], 29)
+        self.assertEqual(report["counts"]["governed_skills"], 24)
         self.assertEqual(report["counts"]["vendored_skills"], 5)
         self.assertEqual(report["counts"]["routers"], 1)
 
@@ -572,6 +572,9 @@ class PromiseStructureTests(unittest.TestCase):
                 "sapheneia-deactivation",
                 "sapheneia-durable-record-shape",
             },
+            "plugins/synkrisis/skills/synkrisis/SKILL.md": {
+                "synkrisis-scaffold-refusal",
+            },
             "plugins/tabularium/skills/tabularium/SKILL.md": {
                 "tabularium-release-build",
                 "tabularium-release-verification",
@@ -597,7 +600,7 @@ class PromiseStructureTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["promises"], 67)
+        self.assertEqual(report["counts"]["promises"], 68)
 
     def test_hexaemeron_contract_population_is_complete(self):
         expected = {
@@ -665,7 +668,7 @@ class PromiseOverlayTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["promises"], 72)
+        self.assertEqual(report["counts"]["promises"], 73)
         self.assertEqual(report["counts"]["overlays"], 1)
 
     def test_one_byte_vendored_mutation_is_refused(self):
@@ -867,12 +870,12 @@ class PromiseIdentityTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["canonical_skills"], 28)
+        self.assertEqual(report["counts"]["canonical_skills"], 29)
         self.assertEqual(report["counts"]["routers"], 1)
-        self.assertEqual(report["counts"]["claude_plugins"], 14)
-        self.assertEqual(report["counts"]["codex_plugins"], 14)
-        self.assertEqual(report["counts"]["package_versions"], 14)
-        self.assertEqual(report["counts"]["skill_versions"], 23)
+        self.assertEqual(report["counts"]["claude_plugins"], 15)
+        self.assertEqual(report["counts"]["codex_plugins"], 15)
+        self.assertEqual(report["counts"]["package_versions"], 15)
+        self.assertEqual(report["counts"]["skill_versions"], 24)
 
     def test_unresolved_router_fixture_is_refused(self):
         completed = run_cli(
@@ -1041,8 +1044,8 @@ class PromiseCoverageTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["coverage_rows"], 72)
-        self.assertEqual(report["counts"]["coverage_selected"], 55)
+        self.assertEqual(report["counts"]["coverage_rows"], 73)
+        self.assertEqual(report["counts"]["coverage_selected"], 56)
 
     def test_berean_and_janus_boundaries_are_explicit(self):
         coverage = json.loads(
@@ -1316,7 +1319,7 @@ class PromiseCoverageTests(unittest.TestCase):
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(report["ok"])
-        self.assertEqual(report["counts"]["coverage_rows"], 72)
+        self.assertEqual(report["counts"]["coverage_rows"], 73)
         self.assertEqual(report["counts"]["coverage_selected"], 17)
 
     def test_prompt_and_vendored_evaluations_never_claim_proof(self):

--- a/tests/test_python_contract.py
+++ b/tests/test_python_contract.py
@@ -35,6 +35,7 @@ PYTHON_WORKFLOWS = {
     "lazarus.yml",
     "pandects.yml",
     "repo.yml",
+    "synkrisis.yml",
 }
 PULL_REQUEST_WORKFLOWS = PYTHON_WORKFLOWS - {"contributors.yml"}
 DEPENDENCY_FILES = {

--- a/tests/test_version_propagation.py
+++ b/tests/test_version_propagation.py
@@ -50,6 +50,7 @@ DELIVERY_PACKAGE_VERSIONS = {
     "pandects": "0.1.1",
     "probitas": "0.1.1",
     "sapheneia": "0.1.2",
+    "synkrisis": "0.1.0",
     "tabularium": "0.3.1",
 }
 


### PR DESCRIPTION
## What changed

Step 1 of the committed runbook for issue #449, delivered under the repository owner's direct instruction of 2026-08-27, which closed the study's dependency gate and approved the new CI workflow.

- `plugins/synkrisis/`: both host manifests at `0.1.0`, byte-identical `LICENSE` and generated `PROMISE_MACHINE.md` copies, the runtime contract, the landing README, the canonical `skills/synkrisis/SKILL.md`, the evolution ledger opening at `synkrisis-v0.1.0`, ADR-001, and `scripts/synkrisis.py`: a stub that declares the four specified operations (cohort, diagnose, render, verify) and refuses each with `SK000`, naming the runbook step that implements it and writing nothing.
- `docs/synkrisis/study.md` and `docs/synkrisis/runbook.md`: the committed specification, with Step 1 recorded as delivered and Steps 2 to 5 held.
- Marketplace entries on both hosts, the Promise Machine router route, the root runtime contract and README roster, the `synkrisis` CI workflow, the regenerated portable runtime and Horos boundary, and the scaffold promise `synkrisis-scaffold-refusal` bound in `tests/promise_machine_coverage.json`.

## Step 1 exit, held at this head

- `python3 -m unittest discover -s plugins/synkrisis/tests -t plugins/synkrisis`: 19/19.
- `python3 -m unittest discover -s tests`: 437/438; the one failure is the exact-interpreter pin on a local runner carrying CPython 3.13.12 against the 3.13.15 pin, which CI satisfies through actions/setup-python.
- `python3 scripts/promise_machine.py check`: clean, 15 plugins, 15 copies. `coverage --check`: clean, 73 promises, 73 rows, 73 selected. `python3 scripts/portable_promise_machine.py check`: clean.
- Imprimatur: 0 defects on all seven changed prose files. Brevitas: clean, apart from the ledger-shape B010/B011 diagnostics every governed ledger shares (janus emits the identical pair). Phylax, Ephoros and Hypomnema: clean over plugins, tests and docs, on the checker as amended by #684.
- The four hexaemeron failures visible in the build environment (forge absent, node fixture, signing) reproduce identically on pristine `origin/main` there and are untouched by this change.

## Held for later steps

A complete draft of Steps 2 to 5 (cohort construction, the two-rule catalogue, render and verify, the scale-fixture benchmark) was built and validated during this run and is preserved as carryover material outside this pull request; the runbook's held steps land it one gated step at a time.

Refs #449.

---
_Generated by [Claude Code](https://claude.ai/code/session_0182hauFCycxnoknv2srTrtp)_

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: https://github.com/wildcat-finance/skills/issues/449
Root-Issue-Successor: none-recorded
Root-Issue-Fiat-Required: 1
Root-Issue-Route: fiat-required
Root-Issue-Classification-Source: live-contract
<!-- root-issue-analytics:v1:end -->
