### PR TITLE
Add the root Elenchus runner and commit the spec copies

### DIFF
--- a/docs/disposable-fixture-signing/runbook.md
+++ b/docs/disposable-fixture-signing/runbook.md
@@ -1,0 +1,645 @@
+# Runbook: isolate disposable fixture signing
+
+Derived from the receipted study at `.hexaemeron/study.md`. Task issue:
+[wildcat-finance/skills#621](https://github.com/wildcat-finance/skills/issues/621).
+The run branch is `fiat/621-isolate-disposable-fixture-signing`, cut from `main`
+at `f5d94a5f27168e6c0faecd43eee426f6ee892cdc`. Step 1 branches from the run
+branch; every later step branches from the step below it.
+
+## Host conditions every command below assumes
+
+Two facts about this machine are written into the commands rather than left to
+the reader, so each one runs exactly as printed.
+
+**The interpreter.** `AGENTS.md` defines bare `python3` as the exact patch in
+`.python-version`, which is 3.14.6. On this host bare `python3` is 3.12.13 and
+the pinned patch is `/Users/kethcode/.local/bin/python3.14`. Every command below
+spells that absolute path. A reader on another machine substitutes their own
+3.14.6 and changes nothing else.
+
+**Node 26 for the Hexaemeron suite.** Host `node` is v22.22.3, and
+`plugins/hexaemeron/tests/test_elenchus_checker.py` runs `node --version` and a
+`node:test` emitter that needs 26. Every command that runs the Hexaemeron suite
+is wrapped in `npx --yes --package=node@26.6.0 --call '...'`, spelled in full.
+
+The study's section 3 also fixes a constraint that is not a host condition and
+must not be relaxed: a hostile signing configuration is supplied to a test as a
+`GIT_CONFIG_GLOBAL` file, never through the `GIT_CONFIG_COUNT` and
+`GIT_CONFIG_KEY_n` triple, because the triple outranks repository-local config
+and reports a correct fix as broken.
+
+**The hostile configuration comes from a committed generator.** `.hexaemeron/`
+is controller state whose own `.gitignore` is a single `*`, so git never sees
+anything written there, and a step whose proof rests on a file in it cannot be
+reproduced by a reviewer who checks the branch out. Step 2 therefore commits
+`tests/hostile_signing_harness.py`; the guard imports it, so there is one
+definition of what hostile means, and every later step runs it. Each step that
+needs the configuration spells these three lines in its own exit, so no exit
+depends on a command printed under a different step:
+
+```bash
+HOSTILE_DIR="$(mktemp -d)"
+/Users/kethcode/.local/bin/python3.14 tests/hostile_signing_harness.py --emit "$HOSTILE_DIR"
+export HOSTILE_SENTINEL="$HOSTILE_DIR/sentinel.log"
+```
+
+The directory is a fresh temporary one rather than a path inside the repository,
+because `.elenchus/` is neither tracked nor ignored and generating into it would
+leave untracked files behind and dirty a tree the next step expects clean.
+
+## What Elenchus can and cannot establish for this delivery
+
+Every step declares the runner contract Protasis requires, and steps 3 and 4
+also declare their expected exact result, so Warden records it rather than
+investigating it.
+
+This delivery changes test files only. Elenchus applies a commit's changed test
+files to its parent and runs the declared command there. When the fix and the
+guard are both test files, applying the changed set carries the fix to the
+parent as well, so the guard passes there and the mechanical result is
+`unguarded`. That is a property of a test-only change, not a defect in it, and
+the repository has recorded the same expected value before: the round log for
+the Elenchus audit-round verdict step 3 names `unguarded` as "the exact
+Elenchus result, as expected for a documentation-only fix".
+
+The acceptance proof therefore does not rest on an Elenchus verdict. It rests on
+step 5's demo path, which is a command and an empty file.
+
+## Step 1: Commit the spec copies and add the root Elenchus runner
+
+**Goal.** Put the receipted study and this runbook where the repository keeps
+them, and give the repository-wide suite an Elenchus report writer, so every
+later step can declare a runner contract for a changed file under `tests/`.
+
+**Entry.** The run branch `fiat/621-isolate-disposable-fixture-signing` at
+`f5d94a5f27168e6c0faecd43eee426f6ee892cdc`, clean tree. The receipted study at
+`.hexaemeron/study.md` and this runbook at `.hexaemeron/runbook.md`.
+
+**Exit.** The two documents are committed under `docs/disposable-fixture-signing/`
+byte-identical to the receipted artefacts, and `tests/run_tests.py` writes a
+valid report. All of the following exit 0:
+
+```bash
+cmp .hexaemeron/study.md docs/disposable-fixture-signing/study.md
+cmp .hexaemeron/runbook.md docs/disposable-fixture-signing/runbook.md
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/disposable-fixture-signing/study.md
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/disposable-fixture-signing/runbook.md
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/disposable-fixture-signing/study.md docs/disposable-fixture-signing/runbook.md
+/Users/kethcode/.local/bin/python3.14 plugins/brevitas/skills/brevitas/scripts/brevitas.py docs/disposable-fixture-signing/study.md docs/disposable-fixture-signing/runbook.md
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents/skills/promise-machine/SKILL.md .agents/skills/promise-machine/PORTABLE.md plugins docs
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+/Users/kethcode/.local/bin/python3.14 -m unittest discover -s tests
+/Users/kethcode/.local/bin/python3.14 tests/run_tests.py
+/Users/kethcode/.local/bin/python3.14 tests/run_tests.py --elenchus-report .elenchus/fiat-621-step-1.json
+/Users/kethcode/.local/bin/python3.14 -c "import json,pathlib;d=json.loads(pathlib.Path('.elenchus/fiat-621-step-1.json').read_text());assert d['schema']=='elenchus.unittest.v1' and d['complete'] is True and d['failures']==0 and d['errors']==0, d"
+/Users/kethcode/.local/bin/python3.14 plugins/horos/skills/horos/scripts/horos.py check .
+```
+
+Every relative link in both committed documents resolves from
+`docs/disposable-fixture-signing/`, which the hypomnema command above proves:
+`H001` fires on a relative link that resolves to nothing.
+
+**Files.** Created: `docs/disposable-fixture-signing/study.md`,
+`docs/disposable-fixture-signing/runbook.md`, `tests/run_tests.py`,
+`tests/test_root_elenchus_runner.py`. Changed: `.horos/boundary.json` only if
+the horos check above reports drift.
+
+`tests/run_tests.py` is a faithful port of `plugins/hexaemeron/tests/run_tests.py`,
+which is 241 lines and roughly 20 of them are path containment. Port that
+containment rather than reimplementing it: reject a path containing `..`; refuse
+a target that is already a symlink or already exists; resolve against the
+worktree root and require `relative_to` to succeed; walk each parent component
+with `lstat` and refuse a non-directory; probe for `os.O_DIRECTORY`,
+`os.O_NOFOLLOW` and `dir_fd` support and refuse without them; open the root with
+`O_RDONLY | O_DIRECTORY | O_NOFOLLOW` and compare `st_dev` and `st_ino` against
+the pre-open stat to catch a worktree replaced during inspection; create report
+directories through `dir_fd` at mode `0o700` without following a symlink; and
+remove a failed write only while the target is still the inode that was created.
+The payload is the same `elenchus.unittest.v1` object with `schema`, `complete`,
+`testsRun`, `failures`, `errors`, `skipped`, `expectedFailures` and
+`unexpectedSuccesses`. The two intended divergences are the discovery root,
+which is `tests` rather than the Hexaemeron test directory, and the top-level
+directory passed to `unittest`. Any other divergence is a defect.
+
+**Tests.** `tests/test_root_elenchus_runner.py` imports the new module and
+covers the refusals rather than only the success path: a `..` component, an
+absolute path outside the worktree, an existing regular file, an existing
+symlink, a parent component that is a regular file, and two report paths named
+in one invocation. It also asserts the written payload carries every one of the
+eight schema keys and that `schema` reads exactly `elenchus.unittest.v1`.
+Expected new tests: 8 or more. The root suite's existing count must not fall.
+
+The source-bound Elenchus runner contract for any audit repair in this step:
+
+```text
+test command: /Users/kethcode/.local/bin/python3.14 tests/run_tests.py --elenchus-report {report}
+report format: unittest-json-v1
+expected report schema: elenchus.unittest.v1
+report file: .elenchus/fiat-621-step-1.json
+```
+
+The format value is `unittest-json-v1`. The string `elenchus.unittest.v1` is the
+schema written inside the report and is never a format value; the closed tuple
+of accepted formats is at `plugins/hexaemeron/skills/elenchus/scripts/elenchus.py:29`.
+
+**Disciplines.** phylax: the runner accepts a filesystem write path from the
+command line, which is a boundary this repository did not previously open under
+`tests/`, and the ported containment logic is the control that closes it.
+ephoros: the report this runner writes is the artefact every later audit round
+reads, and a missing, stale or malformed one is scored `inconclusive` rather
+than failed, so its refusal messages must name which precondition failed.
+metron: none, the step adds two documents and one runner and makes no
+performance claim. elenchus: none, no failure is in hand; the guard arrives in
+step 2. hypomnema: the committed study and runbook are the durable record of
+this delivery, and ADR-045 is deliberately deferred to step 5 because its
+content is not settled until the rule has been applied.
+
+## Step 2: Add the disposable-fixture signing guard and its hostile-configuration harness
+
+**Goal.** Establish the rule behaviourally before any fixture is touched: build
+a hostile signing configuration, prove it is genuinely hostile, prove the
+repository-local declaration defeats it, and leave the configuration behind as a
+committed generator every later step runs.
+
+**Entry.** Step 1's exit state: the spec copies committed, `tests/run_tests.py`
+present and writing a valid report, every command in step 1's exit at 0.
+
+**Exit.** The guard is committed and green, and it fails on a repository where
+the local declaration is removed. All of the following exit 0:
+
+```bash
+/Users/kethcode/.local/bin/python3.14 -m unittest discover -s tests
+/Users/kethcode/.local/bin/python3.14 tests/run_tests.py --elenchus-report .elenchus/fiat-621-step-2.json
+/Users/kethcode/.local/bin/python3.14 -m unittest tests.test_disposable_fixture_signing -v
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+```
+
+The committed generator produces a usable harness. All of these exit 0:
+
+```bash
+HOSTILE_DIR="$(mktemp -d)"
+/Users/kethcode/.local/bin/python3.14 tests/hostile_signing_harness.py --emit "$HOSTILE_DIR"
+export HOSTILE_SENTINEL="$HOSTILE_DIR/sentinel.log"
+```
+
+```bash
+test -s "$HOSTILE_DIR/hostile.gitconfig"
+test -x "$HOSTILE_DIR/hostile-signer"
+test ! -s "$HOSTILE_DIR/sentinel.log"
+```
+
+And this refusal check exits non-zero, proving the guard is not vacuous:
+
+```bash
+/Users/kethcode/.local/bin/python3.14 -m unittest tests.test_disposable_fixture_signing.NegativeControl.test_the_hostile_signer_is_reached_without_the_local_declaration \
+  && echo "GUARD IS VACUOUS" && exit 1
+```
+
+**Files.** Created: `tests/test_disposable_fixture_signing.py` and
+`tests/hostile_signing_harness.py`. No fixture under test is changed in this
+step; the guard exercises repositories it constructs itself, so both ends are
+green.
+
+`tests/hostile_signing_harness.py` holds the harness the guard uses in-process
+and a `--emit <dir>` entry point that writes `hostile.gitconfig` and the
+executable `hostile-signer` into the named directory and truncates
+`sentinel.log` beside them. The three filenames are fixed so a caller can name
+them without parsing output. The guard imports the module rather than
+duplicating the recipe, so the configuration every later step runs is the same
+one the guard proves hostile.
+
+**Tests.** `tests/test_disposable_fixture_signing.py`, in the order the study's
+section 11 fixes:
+
+1. The harness, imported from `tests/hostile_signing_harness.py`, writes a
+   hostile `GIT_CONFIG_GLOBAL` file and a signing program
+   that appends to a sentinel and exits non-zero, across three arms:
+   `gpg.format=openpgp` with `gpg.program`, `gpg.format=ssh` with
+   `gpg.ssh.program`, and an unsigned control. `GIT_CONFIG_SYSTEM=/dev/null`
+   accompanies each. Both variables are set on the child process only and never
+   on `os.environ`.
+2. Negative control: a disposable repository built without the local
+   declaration commits, and the test asserts the commit failed and the sentinel
+   recorded an invocation. This is the assertion that makes the rest mean
+   something, and its failure message says the hostile configuration failed to
+   be hostile rather than that the fix is broken.
+3. Positive case: the same construction with
+   `git config --local commit.gpgsign false` asserts the commit succeeded, the
+   sentinel is empty, and `git log -1 --format=%G?` reads exactly `N`. A commit
+   that succeeds but is signed fails this test.
+4. Enumeration: one representative test from each covered suite runs as a
+   bounded subprocess under the hostile configuration, asserting exit 0 and an
+   empty sentinel. This step registers no suite yet; steps 3 and 4 add their
+   entries. The list is a module-level constant so a reader can see the covered
+   set without reading the test bodies.
+
+The guard fails rather than skips when git is unavailable or the hostile
+configuration cannot be written, because a silent skip reports as a pass. Every
+subprocess uses fixed argv, no shell, `sys.executable` rather than a `PATH`
+lookup, and a timeout so a reintroduced pinentry stall fails the guard instead
+of hanging it. Expected new tests: 6 or more.
+
+```text
+test command: /Users/kethcode/.local/bin/python3.14 tests/run_tests.py --elenchus-report {report}
+report format: unittest-json-v1
+expected report schema: elenchus.unittest.v1
+report file: .elenchus/fiat-621-step-2.json
+```
+
+**Disciplines.** phylax: this step opens all three boundaries the study's
+section 9 names, writing and executing a signing program, redirecting git's
+global and system configuration through the environment, and spawning suites as
+subprocesses; the controls are the temporary directory, child-process-only
+variables, fixed argv and a bounded timeout. ephoros: the guard is the only test
+that fails when the cause is signing rather than the change under test, so it
+owns all four on-call questions in the study's section 8, and it reports the
+sentinel's contents on failure rather than only its emptiness. metron: none, the
+guard bounds its own runtime with a timeout but claims no budget; the
+measurement is step 5. elenchus: this step is the guard convention itself, and
+the negative control is what stops it passing for the wrong reason. hypomnema:
+none, the scope rule this guard enforces is recorded by ADR-045 in step 5, and a
+second record here would be edited before anyone read it.
+
+## Step 3: Declare the signing policy on the root and Horos construction sites
+
+**Goal.** Apply the rule to the five construction sites in the root and Horos
+suites, and extend the guard's enumeration to both.
+
+**Entry.** Step 2's exit state: the guard committed and green, its enumeration
+empty, `tests/hostile_signing_harness.py` committed, every command in step 2's
+exit at 0.
+
+**Exit.** Both suites pass under the hostile configuration, and the guard now
+covers them. All of the following exit 0:
+
+```bash
+/Users/kethcode/.local/bin/python3.14 -m unittest discover -s tests
+/Users/kethcode/.local/bin/python3.14 -m unittest discover -s plugins/horos/tests -t plugins/horos
+/Users/kethcode/.local/bin/python3.14 tests/run_tests.py --elenchus-report .elenchus/fiat-621-step-3.json
+/Users/kethcode/.local/bin/python3.14 plugins/horos/skills/horos/scripts/horos.py check .
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+```
+
+And, with this step's own hostile configuration generated by the committed
+harness from step 2:
+
+```bash
+HOSTILE_DIR="$(mktemp -d)"
+/Users/kethcode/.local/bin/python3.14 tests/hostile_signing_harness.py --emit "$HOSTILE_DIR"
+export HOSTILE_SENTINEL="$HOSTILE_DIR/sentinel.log"
+```
+
+```bash
+GIT_CONFIG_GLOBAL="$HOSTILE_DIR/hostile.gitconfig" GIT_CONFIG_SYSTEM=/dev/null \
+  /Users/kethcode/.local/bin/python3.14 -m unittest discover -s tests
+GIT_CONFIG_GLOBAL="$HOSTILE_DIR/hostile.gitconfig" GIT_CONFIG_SYSTEM=/dev/null \
+  /Users/kethcode/.local/bin/python3.14 -m unittest discover -s plugins/horos/tests -t plugins/horos
+test ! -s "$HOSTILE_SENTINEL"
+```
+
+**Files.** Changed: `tests/test_boundary_currency.py` (the `GuardMutationTests`
+setup at line 166), `plugins/horos/tests/test_scoped_entry.py` (line 64),
+`plugins/horos/tests/test_demonstration.py` (line 53),
+`plugins/horos/tests/test_universe.py` (lines 56, 134 and 195), and
+`tests/test_disposable_fixture_signing.py` (enumeration entries for both
+suites).
+
+Each edit is one call, `git config --local commit.gpgsign false`, against the
+fixture repository, placed immediately after the `git init` that created it and
+before any other configuration. The three Horos modules each carry their own
+byte-identical `git(root, *args)` helper; the line goes at each call site, not
+into a shared module, per the study's section 3 non-goal. One comment per suite,
+not per site, says why the line is there: fixture history is not signing
+evidence, so inherited signing must not decide whether the repository can be
+built. Do not touch `tests/test_boundary_currency.py:140` or
+`plugins/horos/tests/test_scoped_entry.py:140`; neither commits, and the study's
+section 2b records them as out of scope.
+
+**Tests.** No new test module. `tests/test_disposable_fixture_signing.py` gains
+one enumeration entry per suite, each naming a representative test that commits
+fixture history: for the root suite a `GuardMutationTests` method, for Horos a
+`UniverseTests` method. Both existing suites keep their counts; the root suite
+and the Horos suite must report the same number of tests as at step 2's exit,
+plus nothing.
+
+```text
+test command: /Users/kethcode/.local/bin/python3.14 tests/run_tests.py --elenchus-report {report}
+report format: unittest-json-v1
+expected report schema: elenchus.unittest.v1
+report file: .elenchus/fiat-621-step-3.json
+```
+
+Expected exact Elenchus result: `unguarded`. The fix and the guard are both test
+files, so applying the changed set to the parent carries the fix there too and
+the guard passes on the parent. Record that value; it is not a finding. The
+acceptance evidence for this step is the pair of hostile-configuration commands
+in the exit above.
+
+**Disciplines.** phylax: every edit is a filesystem-affecting `git config` write,
+and the register entry `config-scope-escape` is what Warden checks, that each
+call names its own fixture repository and cannot fall through to the outer
+checkout. ephoros: none, the step emits no new signal; the guard made the
+signing cause legible in step 2 and this step only extends its enumeration.
+metron: none, no performance claim is made here; both measurements are step 5.
+elenchus: the step extends the guard to the two suites it changes and declares
+`unguarded` in advance with the reason, so the audit round records rather than
+investigates it. hypomnema: none, no decision is taken here that ADR-045 does
+not already carry.
+
+## Step 4: Declare the signing policy on the Hexaemeron and Hermes construction sites
+
+**Goal.** Apply the rule to the remaining five construction sites, and extend
+the guard's enumeration to both suites.
+
+**Entry.** Step 3's exit state: the root and Horos sites declaring the policy,
+the guard enumerating both suites, the committed harness from step 2 available,
+every command in step 3's exit at 0.
+
+**Exit.** Both remaining suites pass under the hostile configuration. All of the
+following exit 0:
+
+```bash
+npx --yes --package=node@26.6.0 --call '/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/tests/run_tests.py'
+/Users/kethcode/.local/bin/python3.14 plugins/hermes/skills/hermes/scripts/test_hermes.py
+/Users/kethcode/.local/bin/python3.14 -m unittest discover -s tests
+/Users/kethcode/.local/bin/python3.14 tests/run_tests.py --elenchus-report .elenchus/fiat-621-step-4.json
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+```
+
+And, under a hostile configuration this step generates for itself:
+
+```bash
+HOSTILE_DIR="$(mktemp -d)"
+/Users/kethcode/.local/bin/python3.14 tests/hostile_signing_harness.py --emit "$HOSTILE_DIR"
+export HOSTILE_SENTINEL="$HOSTILE_DIR/sentinel.log"
+```
+
+```bash
+GIT_CONFIG_GLOBAL="$HOSTILE_DIR/hostile.gitconfig" GIT_CONFIG_SYSTEM=/dev/null \
+  npx --yes --package=node@26.6.0 --call '/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/tests/run_tests.py'
+GIT_CONFIG_GLOBAL="$HOSTILE_DIR/hostile.gitconfig" GIT_CONFIG_SYSTEM=/dev/null \
+  /Users/kethcode/.local/bin/python3.14 plugins/hermes/skills/hermes/scripts/test_hermes.py
+test ! -s "$HOSTILE_SENTINEL"
+```
+
+**Files.** Changed: `plugins/hexaemeron/tests/test_elenchus_checker.py` (the
+`Fixture` constructor at line 114),
+`plugins/hexaemeron/tests/test_kronos_scoreboard.py` (lines 664 and 759),
+`plugins/hermes/skills/hermes/scripts/test_hermes.py` (line 173),
+`plugins/hexaemeron/tests/test_hexctl.py` and
+`plugins/hexaemeron/tests/test_fiat_skill.py` for the scope hardening only, and
+`tests/test_disposable_fixture_signing.py` (enumeration entries for both
+suites).
+
+The Kronos site at line 759 is a `git clone`, not a `git init`; the declaration
+goes immediately after the clone, because the rule is stated at creation
+whichever verb created the repository. The hardening at
+`plugins/hexaemeron/tests/test_hexctl.py:55` and
+`plugins/hexaemeron/tests/test_fiat_skill.py:1458` adds the explicit `--local`
+scope and moves the call to immediately after `init`; both are already correct
+and neither is a defect, so this is uniformity, not repair. Do not change
+`plugins/hexaemeron/tests/test_hexctl.py:1366` or `:1388`: both re-initialise
+the repository `make_origin_checkout` already configured, and a re-init
+preserves local config. Do not change
+`plugins/hexaemeron/tests/test_issue_429_recovery.py` or the signature classes
+of `plugins/hexaemeron/tests/test_hexctl.py`; the study's section 2b lists them
+as excluded because signing is their subject.
+
+**Tests.** No new test module. `tests/test_disposable_fixture_signing.py` gains
+one enumeration entry per suite. The signature-verification legs must be shown
+untouched: the Hexaemeron suite reports the same test count as at step 3's exit
+plus nothing, and `git diff` over
+`plugins/hexaemeron/tests/test_issue_429_recovery.py` is empty.
+
+```text
+test command: /Users/kethcode/.local/bin/python3.14 tests/run_tests.py --elenchus-report {report}
+report format: unittest-json-v1
+expected report schema: elenchus.unittest.v1
+report file: .elenchus/fiat-621-step-4.json
+```
+
+Expected exact Elenchus result: `unguarded`, for the reason step 3 gives.
+
+**Disciplines.** phylax: the same `config-scope-escape` boundary as step 3, plus
+the register entry `signature-test-weakening`, because this is the step that
+touches the two files where signature-subject tests live and Warden must confirm
+their assertions and counts are unchanged. ephoros: none, no new signal; the
+enumeration entries reuse what step 2 established. metron: none, no performance
+claim; the measurement is step 5. elenchus: the guard is extended to the two
+remaining suites and `unguarded` is declared in advance with its reason.
+hypomnema: none, ADR-045 in step 5 carries the scope rule including the
+exclusions this step honours.
+
+## Step 5: Measure the construction path, demonstrate under inherited signing, and record ADR-045
+
+**Goal.** Run the problem statement's own demo path, record the before and after
+the acceptance requires, and write the decision record that governs the rule.
+
+**Entry.** Step 4's exit state: all ten construction sites declaring the policy,
+the guard enumerating all four suites, the committed harness from step 2
+available, every command in step 4's exit at 0.
+
+**Exit.** The demo path passes, both measurements are recorded, and the decision
+record is committed and lints clean.
+
+First generate the hostile configuration with the harness step 2 committed:
+
+```bash
+HOSTILE_DIR="$(mktemp -d)"
+/Users/kethcode/.local/bin/python3.14 tests/hostile_signing_harness.py --emit "$HOSTILE_DIR"
+export HOSTILE_SENTINEL="$HOSTILE_DIR/sentinel.log"
+```
+
+Then the demo path, which is the study's section 1 verbatim. All four exit 0:
+
+```bash
+GIT_CONFIG_GLOBAL="$HOSTILE_DIR/hostile.gitconfig" GIT_CONFIG_SYSTEM=/dev/null \
+  /Users/kethcode/.local/bin/python3.14 -m unittest discover -s tests
+GIT_CONFIG_GLOBAL="$HOSTILE_DIR/hostile.gitconfig" GIT_CONFIG_SYSTEM=/dev/null \
+  /Users/kethcode/.local/bin/python3.14 plugins/hermes/skills/hermes/scripts/test_hermes.py
+GIT_CONFIG_GLOBAL="$HOSTILE_DIR/hostile.gitconfig" GIT_CONFIG_SYSTEM=/dev/null \
+  npx --yes --package=node@26.6.0 --call '/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/tests/run_tests.py'
+GIT_CONFIG_GLOBAL="$HOSTILE_DIR/hostile.gitconfig" GIT_CONFIG_SYSTEM=/dev/null \
+  /Users/kethcode/.local/bin/python3.14 -m unittest discover -s plugins/horos/tests -t plugins/horos
+```
+
+And the sentinel is empty, which is the other half of the criterion:
+
+```bash
+test ! -s "$HOSTILE_SENTINEL"
+```
+
+Then the remaining exit commands, all 0:
+
+```bash
+/Users/kethcode/.local/bin/python3.14 tests/run_tests.py --elenchus-report .elenchus/fiat-621-step-5.json
+/Users/kethcode/.local/bin/python3.14 -m unittest tests.test_decision_records
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/decisions/ADR-045-declare-signing-policy-on-disposable-git-fixtures.md
+/Users/kethcode/.local/bin/python3.14 plugins/brevitas/skills/brevitas/scripts/brevitas.py docs/decisions/ADR-045-declare-signing-policy-on-disposable-git-fixtures.md
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents/skills/promise-machine/SKILL.md .agents/skills/promise-machine/PORTABLE.md plugins docs
+/Users/kethcode/.local/bin/python3.14 plugins/horos/skills/horos/scripts/horos.py check .
+```
+
+Acceptance item 2 is proved by comparison rather than assertion, and both
+commands must print nothing:
+
+```bash
+git config --global --list > /tmp/fiat-621-global-after.txt
+diff /tmp/fiat-621-global-before.txt /tmp/fiat-621-global-after.txt
+git -C . config --local --list | diff - /tmp/fiat-621-local-before.txt
+```
+
+The two `before` files are captured at this step's entry, before any suite runs.
+
+**Files.** Created:
+`docs/decisions/ADR-045-declare-signing-policy-on-disposable-git-fixtures.md`,
+`docs/disposable-fixture-signing/measurement.md`. Changed:
+`plugins/horos/docs/marker-self-exclusion/runbook.md` is deliberately not
+changed; it recorded a true host condition at its own ref and ADR-045 supersedes
+it rather than editing it.
+
+ADR-045 carries the scope rule, the three rejected options from the study's
+section 4 with the measured reason for rejecting the process-wide override, the
+`GIT_CONFIG_GLOBAL` constraint, and the retirement of the `<sign-off>` prefix.
+Confirm before writing it that 045 is still free: `tests/test_decision_records.py`
+refuses a number already on the default branch, and `main` moves during a run.
+If it is taken, take the next free number and change the filename and first
+heading together, since that test also requires the heading to state the number
+its filename claims.
+
+`docs/disposable-fixture-signing/measurement.md` records both measurements with
+the host and its `commit.gpgsign`, `gpg.format` and `user.signingkey` beside the
+numbers.
+
+**Tests.** No new test module and no changed test file. The measurement is the
+step's own work, recorded rather than asserted.
+
+M1, the construction path, is where acceptance item 4's claim lives. Three
+samples per arm, twenty commits each, wall time divided by twenty:
+
+```bash
+for mode in signed unsigned; do for run in 1 2 3; do
+  R=$(mktemp -d); cd "$R"; git init -q
+  git config user.name T; git config user.email t@example.invalid
+  [ "$mode" = unsigned ] && git config --local commit.gpgsign false
+  S=$(/Users/kethcode/.local/bin/python3.14 -c 'import time;print(time.time())')
+  for i in $(seq 1 20); do echo "$i" > f.txt; git add f.txt; git commit -q -m "c$i"; done
+  E=$(/Users/kethcode/.local/bin/python3.14 -c 'import time;print(time.time())')
+  /Users/kethcode/.local/bin/python3.14 -c "print(f'$mode run$run: {($E-$S)*1000/20:.1f} ms/commit')"
+done; done
+```
+
+The study's section 10 recorded this at the base ref: 25.6, 25.5 and 25.5
+ms/commit signed against 20.3, 20.5 and 20.1 unsigned, spread at most 0.4 ms and
+improvement 5.2 ms. The step re-runs it at the run head and records what it
+gets. The improvement must exceed the spread; if it does not, that is the
+recorded result and item 4 is reported as unmet rather than rounded into shape.
+
+M2, suite wall time, is three samples of each of the four suite commands before
+and after, under the contributor's real configuration. A delta inside variance
+is recorded as inside variance. No suite-level speedup is claimed on this host
+and item 4 is not satisfied from M2.
+
+```text
+test command: /Users/kethcode/.local/bin/python3.14 tests/run_tests.py --elenchus-report {report}
+report format: unittest-json-v1
+expected report schema: elenchus.unittest.v1
+report file: .elenchus/fiat-621-step-5.json
+```
+
+**Disciplines.** phylax: none, the step opens no boundary the earlier steps did
+not already open, and the hostile signer it writes is the one step 2 specified
+and controlled. ephoros: none, the step emits no new signal; it records the exit
+codes and sentinel contents that step 2 defined as the observable surface.
+metron: this step is the measurement, and both M1 and M2 exist because
+acceptance item 4 requires a recorded before and after with its spread. elenchus:
+the demo path is the acceptance proof for items 1 and 5, and it is a command and
+an empty file rather than a verdict; the guard itself is unchanged. hypomnema:
+ADR-045 is the expensive-to-reverse decision this delivery produces, because the
+scope rule governs every future test that creates a repository and getting it
+wrong in either direction is costly.
+
+### Amendment -- 2026-08-28
+
+**What changed.** Complete replacement Exit: The two documents are committed
+under `docs/disposable-fixture-signing/` byte-identical to the receipted
+artefacts, and `tests/run_tests.py` writes a valid report. All of the following
+exit 0:
+
+```bash
+cmp .hexaemeron/study.md docs/disposable-fixture-signing/study.md
+cmp .hexaemeron/runbook.md docs/disposable-fixture-signing/runbook.md
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/disposable-fixture-signing/study.md
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/disposable-fixture-signing/runbook.md
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/disposable-fixture-signing/study.md docs/disposable-fixture-signing/runbook.md
+/Users/kethcode/.local/bin/python3.14 plugins/brevitas/skills/brevitas/scripts/brevitas.py docs/disposable-fixture-signing/study.md
+/Users/kethcode/.local/bin/python3.14 plugins/brevitas/skills/brevitas/scripts/brevitas.py docs/disposable-fixture-signing/runbook.md
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents/skills/promise-machine/SKILL.md .agents/skills/promise-machine/PORTABLE.md plugins docs
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+/Users/kethcode/.local/bin/python3.14 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+/Users/kethcode/.local/bin/python3.14 -m unittest discover -s tests
+/Users/kethcode/.local/bin/python3.14 tests/run_tests.py
+/Users/kethcode/.local/bin/python3.14 tests/run_tests.py --elenchus-report .elenchus/fiat-621-step-1.json
+/Users/kethcode/.local/bin/python3.14 -c "import json,pathlib;d=json.loads(pathlib.Path('.elenchus/fiat-621-step-1.json').read_text());assert d['schema']=='elenchus.unittest.v1' and d['complete'] is True and d['failures']==0 and d['errors']==0, d"
+/Users/kethcode/.local/bin/python3.14 plugins/horos/skills/horos/scripts/horos.py check .
+```
+
+Every relative link in both committed documents resolves from
+`docs/disposable-fixture-signing/`, which the hypomnema command above proves:
+`H001` fires on a relative link that resolves to nothing.
+
+Complete replacement Files: Created:
+`docs/disposable-fixture-signing/study.md`,
+`docs/disposable-fixture-signing/runbook.md`, `tests/__init__.py`,
+`tests/run_tests.py`, `tests/test_root_elenchus_runner.py`. Changed:
+`.horos/boundary.json` only if the horos check above reports drift.
+
+`tests/__init__.py` makes the root suite a package. It is required by this
+step's own mandated divergence rather than chosen: `TestLoader.discover`
+refuses a start directory that is not importable whenever `start_dir` differs
+from `top_level_dir`, so passing the repository root is unreachable without it.
+Every plugin suite in this repository that passes a top-level directory already
+carries one. It is also load-bearing: `tests/test_marketplace_prose.py` imports
+`repo_contract` and `tests/test_run_observation_inoculation.py` imports
+`tests.test_run_observation`, and today both resolve only because another test
+module inserts the repository root as an import side effect and happens to sort
+before them.
+
+`tests/run_tests.py` is a faithful port of `plugins/hexaemeron/tests/run_tests.py`,
+which is 241 lines and roughly 20 of them are path containment. Port that
+containment rather than reimplementing it: reject a path containing `..`; refuse
+a target that is already a symlink or already exists; resolve against the
+worktree root and require `relative_to` to succeed; walk each parent component
+with `lstat` and refuse a non-directory; probe for `os.O_DIRECTORY`,
+`os.O_NOFOLLOW` and `dir_fd` support and refuse without them; open the root with
+`O_RDONLY | O_DIRECTORY | O_NOFOLLOW` and compare `st_dev` and `st_ino` against
+the pre-open stat to catch a worktree replaced during inspection; create report
+directories through `dir_fd` at mode `0o700` without following a symlink; and
+remove a failed write only while the target is still the inode that was created.
+The payload is the same `elenchus.unittest.v1` object with `schema`, `complete`,
+`testsRun`, `failures`, `errors`, `skipped`, `expectedFailures` and
+`unexpectedSuccesses`. The three intended divergences are the discovery root,
+which is `tests` rather than the Hexaemeron test directory; the top-level
+directory passed to `unittest`; and the module docstring, which names the
+repository suite rather than the controller suite because the parser prints it
+under `--help` and the reference wording would be false at the repository root.
+Any other divergence is a defect.
+
+**Why.** Two receipted criteria could not be met as written, and neither
+failure is in the delivery. The `brevitas` invocation named two documents in one
+call, but that checker declares a single optional positional draft, so the call
+exits 2 against any two paths, including the receipted originals; it is replaced
+by one invocation per document, each of which exits 0. The `Files` list named
+four created paths and forbade any divergence beyond two, but the step's own
+requirement to pass a top-level directory forces both a fifth file and a third
+divergence, so the field is restated to carry what the requirement actually
+implies. No exit criterion is weakened: every command still has to exit 0, and
+the two brevitas runs check the same bytes the single run intended to.
+
+**Steps touched.** Step 1's exit and files.
+
+**Still holding.** Step 1: entry holds; exit holds. Step 2: entry holds; exit
+holds. Step 3: entry holds; exit holds. Step 4: entry holds; exit holds. Step 5:
+entry holds; exit holds.

--- a/docs/disposable-fixture-signing/study.md
+++ b/docs/disposable-fixture-signing/study.md
@@ -1,0 +1,707 @@
+# Study: isolate disposable fixture signing
+
+Task issue: [wildcat-finance/skills#621](https://github.com/wildcat-finance/skills/issues/621),
+"framework-19: disposable Git fixtures inherit contributor signing and stall on
+pinentry". Base ref `main` at `f5d94a5f27168e6c0faecd43eee426f6ee892cdc`.
+
+Assuming, unless corrected:
+
+1. The interpreter is the exact patch in `.python-version`, 3.14.6, which
+   `pyproject.toml` pins as `==3.14.*`. On the operator machine bare `python3`
+   is 3.12.13 and the pinned interpreter is `/Users/kethcode/.local/bin/python3.14`.
+2. Git 2.54.0, the version on the operator machine. Config precedence and the
+   `GIT_CONFIG_GLOBAL` variable behave as measured in section 2.
+3. Stdlib `unittest`, no pytest. Every affected suite is discovered or run by
+   the commands AGENTS.md lists under "Suites".
+4. This run ships no Solidity, so the vendored security suite is waived and
+   recorded as waived. The waiver does not excuse the mechanical lints.
+5. The rule is applied to test fixtures only. No product code, contributor
+   configuration, key, or Fiat signing policy is touched.
+
+## 1. Problem statement
+
+Tests across four suites build throwaway Git repositories and commit into them.
+None of those repositories declares a signing policy, so each inherits the
+contributor's global `commit.gpgsign`. The fixture history is not evidence about
+signatures; it exists so a scanner, a checker or a controller has a tree to read.
+Letting the contributor's signing configuration decide whether that tree can be
+built makes a test's result depend on a setting the test has no opinion about.
+
+The fault has two forms, and which one a contributor sees depends on the signing
+format they use.
+
+On a contributor signing with GPG, the fixture commit invokes `gpg` and pinentry.
+A non-interactive run waits for a prompt nobody answers and fails before reaching
+the assertion. That is the form issue #621 recorded, measured at revision
+`e4d1f5677fa1`: the root suite took 188.38 seconds with three fixture commits
+failing after pinentry waits, against 6.91 seconds for the same 118 tests under a
+measurement-only override.
+
+On a contributor signing with SSH, there is no pinentry and no stall. The commit
+succeeds in about 20 milliseconds and is signed with the contributor's real key.
+That is the form on the machine this run executes on, and it is measured in
+section 2 rather than assumed. It is quieter and no less wrong: throwaway history
+in a temporary directory carries a real personal signature, and every fixture
+commit reaches for a key it has no reason to touch.
+
+**Who this is for.** A contributor running the suites locally, and any agent
+running them unattended. Today both must remember a per-invocation override; the
+repository's own #377 runbook makes that override mandatory on every suite command
+it lists.
+
+**What a working prototype means here.** Every disposable repository declares
+`commit.gpgsign=false` in its own local config before its first commit, so the
+result of a fixture commit is the same for a contributor who signs with GPG, signs
+with SSH, or does not sign at all. Repositories whose subject is signature
+verification keep their existing matrices untouched.
+
+**The demo path that proves it.** With a hostile global configuration supplied as
+a file, containing `commit.gpgsign=true` and a signing program that appends to a
+sentinel and exits non-zero:
+
+```bash
+GIT_CONFIG_GLOBAL=<hostile> GIT_CONFIG_SYSTEM=/dev/null \
+  python3 -m unittest discover -s tests
+GIT_CONFIG_GLOBAL=<hostile> GIT_CONFIG_SYSTEM=/dev/null \
+  python3 plugins/hermes/skills/hermes/scripts/test_hermes.py
+GIT_CONFIG_GLOBAL=<hostile> GIT_CONFIG_SYSTEM=/dev/null \
+  python3 plugins/hexaemeron/tests/run_tests.py
+GIT_CONFIG_GLOBAL=<hostile> GIT_CONFIG_SYSTEM=/dev/null \
+  python3 -m unittest discover -s plugins/horos/tests -t plugins/horos
+```
+
+All four exit 0 and the sentinel file stays empty. Before the change, the first
+three fail. That pairing is the success criterion: an exit code and an empty file,
+both checkable without judgement.
+
+## 2. Prior art
+
+### The same fix, built once already and left unmerged
+
+An earlier combined run for issue #622 produced commit
+`b1ce1c013a296196c267cd42cd1fa2403bdacab4`, carried by open PR #627 with a
+zero-finding audit in open PR #626. Neither is merged; both remain open against a
+run branch, and that branch is three days stale against a main that has moved
+roughly seventy merged pull requests since. This run rebuilds on current main
+rather than reviving it.
+
+That commit is worth reading for two things it got right and one it got wrong.
+
+Its **mechanism** is `git config --local commit.gpgsign false` against the fixture
+repository, immediately after `git init`. Judged on the merits below, that
+mechanism is correct and this study adopts it.
+
+Its **scope rule** is: a newly created disposable repository that commits
+non-signature fixture history is in scope; a repository that never commits is not;
+a test whose subject is signing or signature verification is excluded unless its
+matrix explicitly requires a neutral control. Re-derived against today's tree in
+section 3, that rule holds and is adopted.
+
+Its **inventory** no longer matches the tree, in both directions. It patched
+`plugins/hexaemeron/tests/test_hexctl.py:1366` and `:1388`, which do not need the
+change: both re-initialise a repository that `HexctlCase.setUp` already built
+through `make_origin_checkout`, and that helper has carried
+`["config", "commit.gpgsign", "false"]` at line 55 since before this run began. A
+re-init preserves local config, so those two edits were redundant. It also patched
+two `test_kronos_scoreboard.py` sites the issue never named, which is a real
+finding this study keeps.
+
+Its **rejected alternative** was a process-wide `GIT_CONFIG_*` or
+`git -c commit.gpgsign=false` override around all tests, refused because a broad
+override can invalidate signature tests and still leaves unmanaged fixtures to
+contributor behaviour. Section 4 re-derives that refusal and agrees, and section 2
+adds a measured reason the prior run did not record.
+
+Finally, that commit bundles `docs/affected-scope-test-runner/{study,runbook}.md`
+and an ADR selecting and scheduling repository checks from one graph. Those belong
+to issue #622, not to #621. See the non-goals in section 3.
+
+### What the last two merged pull requests on this subject left open
+
+Both belong to the issue #377 run, and both are merged.
+
+**PR #658**, "Commit the marker-self-exclusion study and runbook where the
+repository keeps them", commit `8942785d`. Its study records the host condition in
+`plugins/horos/docs/marker-self-exclusion/study.md:163-174`: this machine sets
+`commit.gpgsign=true` globally, the test helpers drop repository-pointing
+variables without neutralising signing, and every suite that commits in a
+temporary repository hangs on gpg in a non-interactive session. It then defers the
+real fix in as many words: "making the helpers self-sufficient is a repo-wide test
+change and stays an ask-first item for the maintainer."
+
+That deferred item is issue #621. This study carries it forward as its whole
+content rather than refusing it.
+
+**PR #663**, "Demonstrate the fixed boundary at the run head", commits `9f91455d`
+and `186a7193`. It applied the deferred workaround as a standing convention: the
+#377 runbook requires `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign
+GIT_CONFIG_VALUE_0=false` on every suite command, written `<sign-off>` for brevity,
+and the round record in `audit/rounds/fiat-377-stop-the-marker-rule-excluding-the-classifie.md`
+repeats that prefix through its demo transcript.
+
+Carried forward: once this change lands, that prefix stops being required. Retiring
+it is a named deliverable in section 12, not a side effect.
+
+### A measured correction to how the regression must be built
+
+The issue's required shape says a regression "supplies a temporary global Git
+config with signing enabled and a signing program that records or fails if
+invoked". How that hostile configuration is supplied decides whether the
+regression means anything. Measured on the operator machine, git 2.54.0, with one
+failing signer that appends to a sentinel on every invocation:
+
+| hostile config supplied via | fixture sets local `gpgsign=false` | commit rc | signer invocations |
+| --- | --- | --- | --- |
+| `GIT_CONFIG_COUNT` / `KEY_n` / `VALUE_n` | yes | 128 | 1 |
+| `GIT_CONFIG_GLOBAL` file | no | 128 | 1 |
+| `GIT_CONFIG_GLOBAL` file | yes | 0 | 0 |
+
+The environment triple carries the same precedence as `git -c`, which outranks
+repository-local config. Supplied that way, a fixture that correctly sets local
+`commit.gpgsign=false` still invokes the signer and still fails. The fix is fine;
+the injection is wrong, because the triple does not model what a contributor's
+`~/.gitconfig` actually is. Only the middle and bottom rows describe the real
+fault and the real fix.
+
+The same precedence fact explains why the repository's existing `<sign-off>`
+workaround works at all: it forces signing off from above local config. The
+property that makes it a usable workaround is exactly the property that makes it
+unusable as a hostile injection, and unsafe as a permanent mechanism.
+
+### Two forms of the fault, measured here
+
+On the operator machine `commit.gpgsign=true`, `gpg.format=ssh`, and
+`user.signingkey` is an SSH public key. A disposable repository built the way the
+fixtures build one produced a commit whose `%G?` is `G`, a good signature by the
+contributor's key. The same repository with local `commit.gpgsign=false` produced
+`%G?` of `N`. Per-commit cost over three samples of twenty commits each: 25.6,
+25.5 and 25.5 milliseconds signed, against 20.3, 20.5 and 20.1 unsigned.
+
+So on this host the defect does not stall. It attaches a real signing identity to
+throwaway history and spends about five milliseconds per fixture commit doing it.
+Section 10 takes that seriously rather than promising a stall this environment
+cannot produce.
+
+### The in-repository exemplar
+
+`plugins/hexaemeron/skills/kronos/scripts/kronos.py:574` already passes
+`-c commit.gpgsign=false` when the Kronos scoreboard commits into its own durable
+worktree, and `plugins/hexaemeron/tests/test_hexctl.py:55` and
+`plugins/hexaemeron/tests/test_fiat_skill.py:1458` already set the config on their
+fixtures. The rule is not new to the repository; it is applied in three places and
+missing from ten.
+
+### Audit records
+
+`python3 plugins/hexaemeron/skills/fiat/scripts/audit_synopsis.py --check .`
+exits 0 from the target root, with `committed=match` on every pair. A verified
+synopsis is therefore the normal reading view for the sources below.
+
+| In-scope source | Read | Evidence for the choice |
+| --- | --- | --- |
+| `audit/AUDIT.md` | `audit/AUDIT_SYNOPSIS.md` | whole-set check exit 0, `committed=match`, budget pass |
+| `plugins/hexaemeron/audit/AUDIT.md` | `plugins/hexaemeron/audit/AUDIT_SYNOPSIS.md` | whole-set check exit 0, `committed=match`, budget pass |
+| `audit/rounds/fiat-377-stop-the-marker-rule-excluding-the-classifie.md` | the source directly | its synopsis flattens the demo transcript to one line; the `<sign-off>` prefix convention this study retires is legible only in the source |
+
+No finding in either synopsis concerns disposable fixture signing. The #377 round
+record is the only audit source that touches the subject, and what it carries is
+the workaround, not a finding: its step-4 demo transcript runs every suite command
+under the `GIT_CONFIG` prefix and records the counts obtained that way.
+
+`plugins/horos` and `plugins/hermes` have no `audit/AUDIT.md`. Both suites are
+in scope for the fix and neither has an audit record to carry forward; that is an
+absence in the tree, not an unread source.
+
+No finding id, `Covered`, `Not checked`, `Elenchus verdict` or `Leads not pursued`
+entry from any source above is dropped by this study. The root synopsis carries
+`[missing legacy field: ...]` markers on pre-schema rounds; those remain unknown
+and are not reconstructed here.
+
+### Outside this repository
+
+`git-config(1)` for the `commit.gpgsign`, `gpg.format`, `gpg.program` and
+`gpg.ssh.program` keys and for the four configuration scopes; `git(1)` for
+`GIT_CONFIG_GLOBAL`, `GIT_CONFIG_SYSTEM` and the `GIT_CONFIG_COUNT` triple. No
+third-party package is added or needed.
+
+## 2b. Current-tree inventory
+
+Built by reading the tree at `f5d94a5f`, not from the issue's list. The issue was
+filed against revision `e4d1f5677fa1` and its line numbers have all moved; one of
+its seven named paths is already handled and two files it never named are in scope.
+
+**In scope: creates a disposable repository, commits into it, declares no signing
+policy.** Ten sites in six files.
+
+| # | Site | Construction | First commit |
+| --- | --- | --- | --- |
+| 1 | `tests/test_boundary_currency.py:166` | `GuardMutationTests.setUp` | `:170` |
+| 2 | `plugins/hermes/skills/hermes/scripts/test_hermes.py:173` | `HarnessFixture.setUp` | `:177` |
+| 3 | `plugins/hexaemeron/tests/test_elenchus_checker.py:114` | `Fixture.__init__` | `Fixture.commit`, `:133` |
+| 4 | `plugins/hexaemeron/tests/test_kronos_scoreboard.py:664` | `DurableHomeTest.make_scope` | `:668` |
+| 5 | `plugins/hexaemeron/tests/test_kronos_scoreboard.py:759` | `clone` in `test_extra_blobs_in_the_state_ref_are_ignored` | `:764` |
+| 6 | `plugins/horos/tests/test_scoped_entry.py:64` | `ScopedEntryTests.setUp` | `:73` |
+| 7 | `plugins/horos/tests/test_demonstration.py:53` | `DemonstrationTests.setUp` | `:55` |
+| 8 | `plugins/horos/tests/test_universe.py:56` | `UniverseTests.setUp` | `:61` |
+| 9 | `plugins/horos/tests/test_universe.py:134` | `BindingDirectoryTests.setUp` | `:144`, in test bodies |
+| 10 | `plugins/horos/tests/test_universe.py:195` | `CandidateBindingTests.setUp` | `:199` |
+
+Site 5 is a `git clone`, not a `git init`. The rule is therefore stated as
+"immediately after the disposable repository comes into existence", whichever verb
+created it.
+
+**Already carries the rule.** `plugins/hexaemeron/tests/test_hexctl.py:55` in
+`make_origin_checkout`, and `plugins/hexaemeron/tests/test_fiat_skill.py:1458`.
+Both write `["config", "commit.gpgsign", "false"]` without an explicit scope flag.
+`git config` writes to the repository-local file by default when run inside a
+repository, so both are correct today; both are candidates for the `--local`
+hardening in section 4, and neither is a defect.
+
+**Covered by inheritance, no change needed.** `test_hexctl.py:1366` and `:1388`
+re-initialise the repository `make_origin_checkout` already configured. Verified
+by reading `HexctlCase.setUp:134` and `OriginCheckoutMixin.target:82-84`. The prior
+run patched both; this run does not.
+
+**Out of scope: creates a repository but never commits into it.**
+`tests/test_boundary_currency.py:140` (index-isolation test, `add` only),
+`plugins/horos/tests/test_scoped_entry.py:140` (symlink refusal),
+`plugins/hexaemeron/tests/test_hexctl.py:5218` (worktree-path validator) and
+`:5468` (worktree add), and the three bare repositories at
+`test_kronos_scoreboard.py:642`, `:834` and `:910`, which receive pushes and take
+no local commit. `plugins/horos/tests/test_universe.py:247` adds a linked worktree,
+which shares the fixture repository's config file, so site 8's entry covers it.
+
+**Excluded: the subject is signing.** `plugins/hexaemeron/tests/test_issue_429_recovery.py`
+asserts a `gpgsig` header and runs `git verify-commit` against the real repository,
+and deliberately builds an unsigned commit with `-c commit.gpgsign=false` at
+`:490-491` to assert the refusal message. Its signed, unsigned and refusal legs
+stay exactly as they are. In `plugins/hexaemeron/tests/test_hexctl.py`, the
+signature classes are `TestCommitVerification`, `GitHubSignerDiagnosis`,
+`RewrittenStackRefusal` and the fake-git `verify-commit` handler at `:448-459`;
+they drive a fake git and build no repository. The exclusion is class-scoped, not
+file-scoped, because the same file also holds in-scope construction sites.
+
+**No shared helper exists.** There is no `conftest.py` in the tree and no shared
+git helper module. The three horos modules each carry a byte-identical
+`def git(root, *args)`; the root suite has a richer `git`/`git_env` pair at
+`tests/test_boundary_currency.py:76-101`; Kronos and the Elenchus checker have
+per-class methods; Hermes has six inline `subprocess.run` calls and no helper at
+all. Ten sites reduce to six edit points, one per chokepoint.
+
+## 3. Constraints and non-goals
+
+**Starting ref.** `main` at `f5d94a5f27168e6c0faecd43eee426f6ee892cdc`.
+
+**Toolchain.** Python 3.14.6, the exact patch in `.python-version`, resolved on
+the operator machine as `/Users/kethcode/.local/bin/python3.14`; bare `python3`
+there is 3.12.13 and must not be substituted. Git 2.54.0. The Hexaemeron suite
+needs Node 26 on this host: host `node` is v22.22.3 and
+`plugins/hexaemeron/tests/test_elenchus_checker.py` runs `node --version` and a
+`node:test` emitter, so that suite runs inside
+`npx --yes --package=node@26.6.0 --call '...'`.
+
+**Runner commands, verified against AGENTS.md lines 178, 183, 184 and 186 at this
+ref.** All four the prior run named are real and current:
+
+```bash
+python3 -m unittest discover -s tests
+python3 plugins/hermes/skills/hermes/scripts/test_hermes.py
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 -m unittest discover -s plugins/horos/tests -t plugins/horos
+```
+
+`.github/workflows/repo.yml:46` runs the first of those in CI. No workflow runs the
+Hermes, Hexaemeron or Horos suites, so those three are contributor-local today.
+
+**The hostile configuration must be supplied as a file through
+`GIT_CONFIG_GLOBAL`,** with `GIT_CONFIG_SYSTEM=/dev/null` alongside it. It must not
+be supplied through the `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_n` /
+`GIT_CONFIG_VALUE_n` triple. The measurement in section 2 shows the triple
+outranks repository-local config, so a regression built on it reports a correct fix
+as broken. This constraint is written here so that the runbook cannot get it wrong
+and a later reader does not simplify it back to the triple.
+
+**Ruled out by the user and by the issue's own boundary.** No signing gate anywhere
+is weakened. Contributor and Fiat signing policy is untouched. The repository's own
+commits keep their signing requirements. No test writes to global Git config, to
+the checked-out repository's local config, or to any contributor key. No preferred
+contributor identity is selected and no local key becomes a marketplace default.
+
+**Non-goals.**
+
+- The affected-scope test runner is issue #622's subject and is out of scope here.
+  The prior commit bundled `docs/affected-scope-test-runner/{study,runbook}.md` and
+  an ADR selecting and scheduling repository checks from one graph; none of that is
+  rebuilt by this run. The boundary is: #621 changes what a disposable repository
+  declares about signing, and nothing about which tests get selected or scheduled.
+- Deduplicating the three byte-identical horos `git()` helpers into one module is a
+  refactor with its own risk, and PR #732 moved the repository toward keeping
+  plugin suites detached rather than coupled. The rule is applied at each helper.
+- Issue #547, making the real-repository commit gate survive clones, stays separate.
+- No new dependency. No CI workflow is added for the three uncovered suites.
+
+**Boundaries for the build.**
+
+- **Always.** The four suite commands above before a commit, under the pinned
+  interpreter. The imprimatur and brevitas lints on every shipped document. The
+  phylax, ephoros and hypomnema tree lints. A recorded before and after for any
+  timing claim.
+- **Ask first.** Adding a repository-level test runner surface (see the open
+  question in section 12). Changing any assertion or count in a
+  signature-verification test. Touching CI. Editing `AGENTS.md`.
+- **Never.** Commit key material. Disable signing for product commits. Delete or
+  skip a failing test to make a suite pass. Supply the hostile configuration
+  through the `GIT_CONFIG_*` triple. Claim a suite ran when it did not.
+
+## 4. Design options
+
+**Option A: declare the policy on each disposable repository, at creation.**
+Immediately after `git init` or `git clone` brings the repository into existence,
+run `git config --local commit.gpgsign false` against it. Applied at the six
+chokepoints identified in section 2b, which covers all ten sites.
+
+The trade: the rule is written at six chokepoints, and a construction site added
+later can forget it. Closed by the guard in section 11 rather than by discipline.
+
+**Option B: one shared cross-plugin helper.** A module exporting
+`init_disposable(path)` that every suite imports.
+
+The trade: it creates an import edge from `plugins/hermes/skills/hermes/scripts/`
+and `plugins/horos/tests/` to a root module. Each plugin is packaged and
+distributed on its own, and `test_hermes.py` ships inside the Hermes skill
+directory, so a root import would break plugin independence. PR #732 moved the
+repository the other way. Rejected.
+
+**Option C: teach each module's existing `git()` wrapper to notice.** The wrapper
+detects an `init` argument and chains a second call.
+
+The trade: behaviour hidden inside a generic pass-through, where a reader of the
+call site sees `git(root, "init", "-q")` and nothing else. Three of the six
+chokepoints have no such wrapper, so coverage is partial anyway. Rejected, though
+its useful half survives in Option A: where a chokepoint is a helper, the line goes
+in the helper.
+
+**Option D: a process-wide or runner-wide override.** `GIT_CONFIG_*` in the
+environment, or `git -c commit.gpgsign=false` wrapped around every suite.
+
+This is what the repository does today as a manual workaround, and the trade is
+measured rather than argued. The override sits at `git -c` precedence, above
+repository-local config, so no test can opt back into signing for its own purpose.
+A signature-verification fixture that deliberately wants signing on would be
+silently defeated, and the failure would look like a signing bug rather than a
+configuration one. It also protects nothing the moment somebody runs a single test
+without the prefix, which is the common case. Rejected, and this run additionally
+retires the existing workaround rather than promoting it.
+
+**Chosen: Option A.**
+
+It is the cheapest to comprehend: the declaration sits next to the `git init` it
+protects, so a reader sees the whole rule in one place, with no import graph, no
+wrapper magic and no environment precedence to reason about. It is the only option
+that leaves a signature-verification test free to set its own policy, because
+repository-local config is the layer tests can still override. It matches the
+mechanism already used at three places in this repository, so it adds no new idea.
+
+What it trades away: a single point of control. Ten sites become six edit points
+and any eleventh site is a future omission. That is a real cost and section 11
+pays it with an enumerating behavioural guard rather than accepting it.
+
+**Hardening carried with the choice.** The two sites that already declare the
+policy write `["config", "commit.gpgsign", "false"]` with no scope flag. That is
+correct today because `git config` defaults to the local file inside a repository.
+Both become `--local` so the scope is stated rather than inferred, and both move to
+immediately after creation so the ordering rule is uniform across all twelve sites.
+
+## 5. Risk register seed
+
+The concern this register exists for is not that the one-line change is hard. It is
+that a regression which looks green can be green for the wrong reason: a hostile
+configuration that is not hostile, a signer that is never reached because the test
+never commits, or an injection whose precedence hides the very thing it claims to
+prove. Ids below are cited by round records.
+
+```risk-register
+injection-precedence | how the regression supplies the hostile global config | a GIT_CONFIG_GLOBAL file is used and the GIT_CONFIG_COUNT triple is absent from the regression
+vacuous-regression | the hostile-config harness | a negative control commits without the local policy and is observed to fail and to invoke the signer
+config-scope-escape | the cwd or -C target of each git config call | every call names its fixture repository explicitly and cannot fall through to the outer checkout
+contributor-config-mutation | the contributor's global config, keyring, and the checked-out repository's local config | no test writes outside its own temporary directory, checked before and after the suite
+signature-test-weakening | test_issue_429_recovery.py and the signing classes of test_hexctl.py | their assertions and case counts are unchanged, and the unsigned and invalid-signature legs still fail when the code under test stops refusing
+format-coverage | the gpg.format the hostile signer declares | the regression covers openpgp via gpg.program and ssh via gpg.ssh.program, plus an unsigned control
+missed-construction-site | a disposable repository added after this change | the guard fails when a covered suite commits under the hostile configuration, so a new unguarded site is caught by the suite rather than by a contributor
+clone-and-worktree-paths | repositories created by clone or worktree add rather than init | the rule is applied at creation whichever verb created it, and a linked worktree is shown to share the config it inherits
+skip-instead-of-fail | the regression's own preconditions | it fails rather than skips when git is unavailable or the hostile config cannot be written, because a silent skip reads as a pass
+sentinel-leak | the sentinel file and signer script the hostile harness writes | both live inside the test's own temporary directory and are removed with it
+subprocess-argv | the argv of the git and suite calls the regression adds | fixed argv, no shell, and a phylax pragma with a reason where the linter asks
+measurement-honesty | the recorded before and after in section 10 | the record names the host and signing configuration the samples came from, and reports a delta inside variance as inside variance
+```
+
+## 6. Glossary seeds
+
+- **Disposable repository.** A Git repository a test creates in a temporary
+  directory, commits fixture history into, and deletes when the test ends.
+- **Fixture history.** Commits made only so something has a tree to read. Their
+  signatures are never the subject of an assertion.
+- **Construction site.** The exact line where a disposable repository comes into
+  existence, by `git init`, `git clone` or `git worktree add`.
+- **Chokepoint.** A helper or setup method through which several construction sites
+  pass, so one edit covers all of them.
+- **Hostile configuration.** A temporary global Git config with signing on and a
+  signing program that records every invocation and exits non-zero.
+- **Sentinel.** The file the hostile signing program appends to. Empty means the
+  signer was never reached.
+- **Negative control.** A commit deliberately made without the local policy, to
+  show the hostile configuration is genuinely hostile.
+- **Signature-subject test.** A test whose assertions are about signatures. Excluded
+  from the rule.
+- **The `<sign-off>` prefix.** The `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign
+  GIT_CONFIG_VALUE_0=false` workaround the #377 runbook requires on every suite
+  command. Retired by this change.
+
+## 7. Sources
+
+- Issue #621, `gh issue view 621 --repo wildcat-finance/skills`. Original filing is
+  the specification; the `wave-atlas-review` block is routing guidance.
+- Commit `b1ce1c013a296196c267cd42cd1fa2403bdacab4`, the prior run's implementation.
+  Open PRs #627 and #626 carry it and its audit.
+- `plugins/horos/docs/marker-self-exclusion/study.md:163-174` and
+  `plugins/horos/docs/marker-self-exclusion/runbook.md:9-14`, the recorded host
+  condition and the deferral that became this issue. Merged as PR #658.
+- `audit/rounds/fiat-377-stop-the-marker-rule-excluding-the-classifie.md`, the demo
+  transcript carrying the `<sign-off>` prefix. Merged as PR #663.
+- `AGENTS.md:169-194`, the interpreter rule and the suite commands.
+- `.github/workflows/repo.yml:46`, the one suite CI runs.
+- `plugins/hexaemeron/skills/kronos/scripts/kronos.py:574`, the in-repository
+  exemplar.
+- `plugins/hexaemeron/skills/elenchus/SKILL.md:284-300`, the runner contract and the
+  three accepted report formats.
+- `plugins/hexaemeron/tests/run_tests.py:26,118`, the `elenchus.unittest.v1` emitter.
+- `git-config(1)` and `git(1)` for scope precedence and the `GIT_CONFIG_*` variables.
+- Measurements in section 2 were taken on this host on 2026-08-28 at base
+  `f5d94a5f`; the commands are reproduced in section 10.
+
+## 8. Signals, and the questions behind them
+
+This is a test-fixture change, not an unattended service, so there is no metrics or
+tracing surface and none is added. There is still an on-call reader: the
+contributor or agent staring at a red suite at three in the morning. The
+observable surface is exit codes and assertion messages, and the questions worth
+answering with them are these.
+
+1. **"Did my suite fail because of my change, or because of my signing setup?"**
+   Today that question is unanswerable from the output: a pinentry stall looks like
+   a hang and a signer failure looks like a git error. The guard added in section 11
+   answers it directly, because it is the only test that fails when the cause is
+   signing, and its failure message names `commit.gpgsign` and the sentinel path.
+
+2. **"Was the signer actually reached?"** The sentinel file is the answer, and it is
+   a file rather than a log line so it survives the process. The guard reports its
+   contents on failure rather than only its emptiness, so the reader sees which
+   invocation happened, not merely that one did.
+
+3. **"Is this test green for the right reason?"** The negative control answers it.
+   Its assertion message states that the hostile configuration failed to be hostile,
+   which is a different sentence from the fix being broken and points at a different
+   repair.
+
+4. **"Did a fixture commit get signed with my key?"** Answered by `%G?` on the
+   fixture head, which the guard asserts is `N` rather than only asserting the
+   commit succeeded. A commit that succeeds and is signed still fails the rule.
+
+Which steps emit these: the step that adds the guard emits all four; the steps that
+apply the rule extend the enumeration the first question relies on. No other step
+emits a signal, because no other step changes behaviour anyone observes at runtime.
+
+`plugins/hexaemeron/skills/ephoros/SKILL.md` owns what a signal must carry.
+
+## 9. Boundaries, per capability
+
+Three boundaries open here, all inside the test process, and all opened by the
+regression rather than by the fix.
+
+**Writing and executing a signing program.** The hostile harness writes an
+executable script to disk and git executes it. What is worth taking: the ability to
+observe whether signing was attempted, which no assertion on the commit alone can
+establish. The control: the script is written into the test's own temporary
+directory with a fixed body containing no interpolated caller input, it is invoked
+only by git through a config value the test wrote, and the directory is removed on
+teardown. It is never placed on `PATH`.
+
+**Supplying a global configuration through the environment.** `GIT_CONFIG_GLOBAL`
+and `GIT_CONFIG_SYSTEM` redirect git away from the contributor's real files. What is
+worth taking: it is the only way to model an inherited configuration without
+touching the contributor's own. The control: both variables are set on the child
+process only, never on `os.environ` of the test process, so a failure mid-test
+cannot leave the contributor's git pointed at a temporary file. The paths are
+absolute and inside the test's temporary directory.
+
+**Spawning suites as subprocesses.** The guard runs representative tests from other
+suites under the hostile configuration. What is worth taking: it proves the rule
+behaviourally without importing across plugin boundaries. The control: fixed argv
+built from repository-relative paths, no shell, a bounded timeout so a
+reintroduced pinentry stall fails the guard instead of hanging it, and the
+interpreter taken from `sys.executable` rather than resolved from `PATH`.
+
+Nothing here reads untrusted input, holds secret material, opens a network
+connection, or adds a dependency. The one filesystem write outside a temporary
+directory would be a scope escape, and `config-scope-escape` in section 5 is the
+register entry for it.
+
+`plugins/hexaemeron/skills/phylax/SKILL.md` owns the boundary list and the
+controls.
+
+## 10. The budget, or its absence
+
+There is a budget, and acceptance item 4 requires it: three same-command before and
+after samples recording wall time and spread, with the improvement exceeding the
+measured variance. It needs care, because the honest answer depends on which
+machine asks.
+
+On a GPG contributor the before does not finish at all, so a wall-clock comparison
+is not measuring a speedup, it is measuring the difference between failing and
+working. The issue's 188.38 seconds against 6.91 is that difference, recorded at
+revision `e4d1f5677fa1` on a machine this run does not have. This study does not
+re-claim those figures.
+
+On this host, signing with SSH, there is no stall to remove. Section 2 measured the
+whole effect: about 5.2 milliseconds per fixture commit. Across the handful of
+fixture commits in a suite that is tens of milliseconds against suite times measured
+in seconds and minutes, which is inside noise. Promising a suite-level speedup here
+would be a claim the environment cannot support.
+
+So the budget is recorded at two levels, and both are measurable here.
+
+**M1, the construction path, where the claim lives.** Twenty fixture commits in a
+disposable repository, three samples per arm, signed against locally overridden:
+
+```bash
+# per arm: git init; git config user.name/user.email; optionally
+# git config --local commit.gpgsign false; then twenty add-and-commit cycles,
+# wall time divided by twenty.
+```
+
+Recorded at base `f5d94a5f` on 2026-08-28: 25.6, 25.5, 25.5 ms/commit signed;
+20.3, 20.5, 20.1 ms/commit unsigned. Spread within an arm is at most 0.4 ms; the
+improvement is 5.2 ms. The improvement exceeds the variance by more than an order
+of magnitude, which is what item 4 asks for, and it is a real before and after taken
+on the machine that runs this delivery.
+
+**M2, the four suites, recorded for completeness and reported honestly.** Three
+samples of each suite command before and after, under the contributor's real
+configuration, with the host and its `commit.gpgsign`, `gpg.format` and
+`user.signingkey` recorded beside the numbers. The expected result on this host is a
+delta inside variance, and the record says so if that is what happens. A suite-level
+speedup is not claimed and item 4 is not satisfied from M2.
+
+**The correctness result that carries acceptance items 1 and 5** is not a timing
+result at all: under the hostile configuration the four suite commands exit 0 and
+the sentinel stays empty, where three of the four fail before the change. That is
+the demo path in section 1, and it is the same on every host regardless of signing
+format.
+
+`plugins/hexaemeron/skills/metron/SKILL.md` owns what a budget carries and how it
+is checked.
+
+## 11. The fail-closed posture
+
+**What stops the run.** Any of the four suite commands returning non-zero under the
+hostile configuration. A non-empty sentinel. A fixture head whose `%G?` is anything
+other than `N`. The negative control passing, which means the hostile configuration
+is not hostile and every other result in the run is uninformative. Any evidence that
+the contributor's global config, the checked-out repository's local config, or a key
+changed during a suite run.
+
+**What must not stop the run quietly.** A skip. The existing fixtures guard
+themselves with `unittest.skipIf(GIT is None, ...)`, which is right for a suite that
+cannot run without git; it is wrong for this guard, because a guard that skips when
+it cannot build its hostile configuration reports as a pass and reads as evidence.
+The guard fails in that case and says which precondition was missing.
+
+**The guard convention.** One guard test that fails without the fix, named for what
+it protects rather than for the issue number, living beside the tests it constrains.
+Its shape, in the order the assertions run:
+
+1. Build the hostile configuration as a `GIT_CONFIG_GLOBAL` file with signing on and
+   a recording, failing signer, across three arms: `gpg.format=openpgp` with
+   `gpg.program`, `gpg.format=ssh` with `gpg.ssh.program`, and an unsigned control.
+2. Negative control: construct a disposable repository without the local policy and
+   assert the commit fails and the sentinel records an invocation. This is what makes
+   the rest of the test mean something.
+3. Positive case: construct one the way the fixtures do, with the policy, and assert
+   the commit succeeds, the sentinel is empty, and `%G?` is `N`.
+4. Enumeration: run one representative test from each covered suite as a bounded
+   subprocess under the hostile configuration, and assert exit 0 and an empty
+   sentinel. This is the assertion that fails when a new construction site forgets
+   the rule, and the assertion that makes each apply-the-rule step fail on its own
+   parent commit.
+
+Step 4 is what ties the guard to Elenchus's mechanical rule: a step that applies the
+rule to a suite also extends the enumeration to that suite, so the changed test file
+applied to the parent fails there and passes on the fix.
+
+`plugins/hexaemeron/skills/elenchus/SKILL.md` owns the triage order and the guard
+rule.
+
+## 12. Decisions and their homes
+
+Three decisions here are expensive to reverse, in the sense that reversing them
+later means re-editing every construction site or re-reading every round record.
+
+**The scope rule.** Which disposable repositories get the policy, and which are
+excluded because their subject is signing. This governs every future test that
+creates a repository, and getting it wrong in either direction is costly: too narrow
+and the fault returns, too wide and a signature test is silently defeated. Home: a
+new decision record, `docs/decisions/ADR-045-declare-signing-policy-on-disposable-git-fixtures.md`.
+ADR-044 is the current highest at this ref. The record carries the rule, the three
+rejected options from section 4 with the measured reason for rejecting D, and the
+`GIT_CONFIG_GLOBAL` constraint from section 3.
+
+**The mechanism and its layer.** That the policy is repository-local rather than
+process-wide, so a test can still opt back in. This is the property that keeps the
+signature suites working, and it is not obvious from reading any single call site.
+Home: the same ADR, plus a comment at the chokepoints saying why the line is there
+rather than what it does. The prior run's comment at
+`tests/test_boundary_currency.py` is a good model: fixture history is not signing
+evidence, so inherited signing must not decide whether the repository can be built.
+
+**Retiring the `<sign-off>` prefix.** Once the rule holds, the workaround the #377
+runbook makes mandatory is no longer needed, and leaving it in place would teach
+every later runbook to keep using an override that outranks local config. Home: the
+study and runbook copies committed under `docs/disposable-fixture-signing/`,
+following the `docs/<topic>/{study,runbook}.md` pattern that
+`docs/elenchus-rpc-boundary-fixtures/` and `docs/ariadne-state-fixture-predicate/`
+already use. The #377 documents are not edited: they recorded a true host condition
+at their own ref, and the ADR is what supersedes them.
+
+Not earning a record: the individual line at each of the ten sites, and the `--local`
+hardening at the two that already declare the policy. Both are direct consequences
+of the ADR and a record per site would be noise.
+
+`plugins/hexaemeron/skills/hypomnema/SKILL.md` owns which decisions earn a record
+and where each one belongs.
+
+### One question the repository could not settle
+
+Where the guard lives changes the runbook's every `Tests` field, so it is a design
+question rather than a detail, and it is asked rather than guessed.
+
+The guard belongs in the repository-wide invariant suite, `tests/`, because the rule
+is repository-wide and because `.github/workflows/repo.yml` runs that suite on every
+pull request, which is the only way the rule gets enforced for contributors other
+than the one who wrote it. The guard is meaningful in CI even though CI configures no
+signing, because it supplies its own hostile configuration.
+
+The cost is that the root suite has no `elenchus.unittest.v1` emitter. The four
+`tests/emit_*_report.py` files are human-readable printers, not Elenchus runners, so
+a step whose changed test file is in `tests/` has no `{report}` command to declare.
+Adding `tests/run_tests.py`, modelled on `plugins/hexaemeron/tests/run_tests.py`,
+would close that and is roughly ninety lines. It is also a new repository runner
+surface, which section 3 puts under ask-first.
+
+**The question: may this run add `tests/run_tests.py` so the guard can live in the
+CI-covered root suite?** If yes, every step declares
+`python3 tests/run_tests.py --elenchus-report {report}` with format
+`unittest-json-v1`. If no, the guard goes to
+`plugins/hexaemeron/tests/test_disposable_fixture_signing.py`, every step declares
+the existing `python3 plugins/hexaemeron/tests/run_tests.py --elenchus-report {report}`,
+and the rule is not enforced in CI. Both are buildable; the first is better and costs
+one file.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Repository test package."""

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Run the repository suite and print a pass count."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+import unittest
+
+
+def report_target(argv):
+    """Parse one fresh report path and bind its worktree identity."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "report",
+        nargs="?",
+        metavar="PATH",
+        help="the source-bound Elenchus report path",
+    )
+    parser.add_argument(
+        "--elenchus-report",
+        action="append",
+        metavar="PATH",
+        help="write an elenchus.unittest.v1 result to a fresh worktree path",
+    )
+    arguments = parser.parse_args(argv)
+    values = list(arguments.elenchus_report or [])
+    if arguments.report is not None:
+        values.append(arguments.report)
+    if len(values) > 1:
+        parser.error("name one report path, either positionally or with --elenchus-report")
+    if not values:
+        return None
+
+    raw = values[0]
+    if not raw or "\x00" in raw:
+        parser.error("--elenchus-report requires a non-empty path")
+    supplied = Path(raw)
+    if ".." in supplied.parts:
+        parser.error("--elenchus-report must stay inside the current worktree")
+    try:
+        cwd = Path.cwd()
+        root = cwd.resolve(strict=True)
+        lexical_target = supplied if supplied.is_absolute() else cwd / supplied
+        if lexical_target.is_symlink():
+            parser.error("--elenchus-report target must not already exist")
+        target = (
+            supplied if supplied.is_absolute() else root / supplied
+        ).resolve(strict=False)
+        relative = target.relative_to(root)
+    except (OSError, RuntimeError, ValueError):
+        parser.error("--elenchus-report must stay inside the current worktree")
+
+    current = root
+    for part in relative.parts[:-1]:
+        current /= part
+        try:
+            current_stat = current.lstat()
+        except FileNotFoundError:
+            break
+        except OSError:
+            parser.error("--elenchus-report cannot be inspected")
+        if not stat.S_ISDIR(current_stat.st_mode):
+            parser.error("--elenchus-report parent is not a directory")
+    try:
+        existing = target.lstat()
+    except FileNotFoundError:
+        existing = None
+    except (OSError, ValueError):
+        parser.error("--elenchus-report cannot be inspected")
+    if existing is not None:
+        parser.error("--elenchus-report target must not already exist")
+
+    missing = []
+    for name in ("O_DIRECTORY", "O_NOFOLLOW"):
+        if not hasattr(os, name):
+            missing.append(f"os.{name}")
+    supports_dir_fd = getattr(os, "supports_dir_fd", ())
+    for operation, name in (
+        (os.open, "os.open(dir_fd)"),
+        (os.mkdir, "os.mkdir(dir_fd)"),
+        (os.stat, "os.stat(dir_fd)"),
+        (os.unlink, "os.unlink(dir_fd)"),
+    ):
+        if operation not in supports_dir_fd:
+            missing.append(name)
+    supports_follow_symlinks = getattr(os, "supports_follow_symlinks", ())
+    if os.stat not in supports_follow_symlinks:
+        missing.append("os.stat(follow_symlinks)")
+    if missing:
+        parser.error(
+            "--elenchus-report requires secure directory operations: "
+            + ", ".join(missing)
+        )
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    try:
+        root_stat = root.stat()
+        root_fd = os.open(root, directory_flags)
+        try:
+            opened_stat = os.fstat(root_fd)
+        finally:
+            os.close(root_fd)
+    except OSError:
+        parser.error("--elenchus-report worktree cannot be opened and inspected")
+    if (opened_stat.st_dev, opened_stat.st_ino) != (
+        root_stat.st_dev,
+        root_stat.st_ino,
+    ):
+        parser.error("--elenchus-report worktree changed during inspection")
+    return root, (opened_stat.st_dev, opened_stat.st_ino), relative.parts
+
+
+def result_payload(result):
+    """Return Elenchus's complete unittest counter schema."""
+    return {
+        "schema": "elenchus.unittest.v1",
+        "complete": True,
+        "testsRun": result.testsRun,
+        "failures": len(result.failures),
+        "errors": len(result.errors),
+        "skipped": len(result.skipped),
+        "expectedFailures": len(result.expectedFailures),
+        "unexpectedSuccesses": len(result.unexpectedSuccesses),
+    }
+
+
+def report_parent(root_fd, parts):
+    """Open or create report directories without following a symlink."""
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    current_fd = os.dup(root_fd)
+    try:
+        for part in parts:
+            try:
+                next_fd = os.open(part, flags, dir_fd=current_fd)
+            except FileNotFoundError:
+                try:
+                    os.mkdir(part, 0o700, dir_fd=current_fd)
+                except FileExistsError:
+                    pass
+                next_fd = os.open(part, flags, dir_fd=current_fd)
+            os.close(current_fd)
+            current_fd = next_fd
+        return current_fd
+    except OSError:
+        os.close(current_fd)
+        raise
+
+
+def report_root(root, identity):
+    """Reopen the bound worktree and refuse a replaced directory."""
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    descriptor = os.open(root, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if (opened.st_dev, opened.st_ino) != identity:
+            raise OSError("report worktree identity changed")
+        return descriptor
+    except OSError:
+        os.close(descriptor)
+        raise
+
+
+def remove_created_report(parent_fd, name, created):
+    """Remove a failed write only while the target is still our inode."""
+    try:
+        current = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError:
+        return
+    if (current.st_dev, current.st_ino) != (created.st_dev, created.st_ino):
+        return
+    try:
+        os.unlink(name, dir_fd=parent_fd)
+    except OSError:
+        pass
+
+
+def write_report(target, payload):
+    """Create the declared report through its bound worktree identity."""
+    root, identity, parts = target
+    if not parts:
+        raise OSError("report path has no filename")
+    root_fd = report_root(root, identity)
+    try:
+        parent_fd = report_parent(root_fd, parts[:-1])
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+        descriptor = None
+        created = None
+        try:
+            descriptor = os.open(parts[-1], flags, 0o600, dir_fd=parent_fd)
+            created = os.fstat(descriptor)
+            if not stat.S_ISREG(created.st_mode):
+                raise OSError("report target is not a regular file")
+            body = (json.dumps(payload, sort_keys=True) + "\n").encode("utf-8")
+            remaining = memoryview(body)
+            while remaining:
+                written = os.write(descriptor, remaining)
+                if written <= 0:
+                    raise OSError("report write made no progress")
+                remaining = remaining[written:]
+            os.close(descriptor)
+            descriptor = None
+        except OSError:
+            if descriptor is not None:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+            if created is not None:
+                remove_created_report(parent_fd, parts[-1], created)
+            raise
+        finally:
+            os.close(parent_fd)
+    finally:
+        os.close(root_fd)
+
+
+def main(argv=None):
+    """Run the suite, optionally emit its report, and preserve suite exits."""
+    target = report_target(sys.argv[1:] if argv is None else argv)
+    here = os.path.dirname(os.path.abspath(__file__))
+    repository = os.path.dirname(here)
+    suite = unittest.defaultTestLoader.discover(
+        here, pattern="test_*.py", top_level_dir=repository
+    )
+    runner = unittest.TextTestRunner(verbosity=1)
+    result = runner.run(suite)
+    total = result.testsRun
+    failed = len(result.failures) + len(result.errors)
+
+    if target is not None:
+        try:
+            write_report(target, result_payload(result))
+        except OSError:
+            print("run_tests.py: report write failed", file=sys.stderr)
+            return 2
+
+    print(f"{total - failed}/{total} tests passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_root_elenchus_runner.py
+++ b/tests/test_root_elenchus_runner.py
@@ -1,0 +1,128 @@
+"""The root Elenchus runner contains its report path and writes one schema.
+
+`tests/run_tests.py` accepts a filesystem write path from the command line,
+which is a boundary this repository did not previously open under `tests/`.
+The containment it ports from `plugins/hexaemeron/tests/run_tests.py` is the
+control that closes it, so the refusals are covered here rather than only the
+path that writes a file. Each case also reads the diagnostic, because a later
+audit round scores a missing or malformed report `inconclusive` and needs the
+message to name which precondition failed.
+"""
+
+from pathlib import Path
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "tests" / "run_tests.py"
+
+SCHEMA = "elenchus.unittest.v1"
+SCHEMA_KEYS = {
+    "schema",
+    "complete",
+    "testsRun",
+    "failures",
+    "errors",
+    "skipped",
+    "expectedFailures",
+    "unexpectedSuccesses",
+}
+
+
+def load_runner():
+    """Load the runner by path so every invocation reaches the same file."""
+    spec = importlib.util.spec_from_file_location("root_run_tests", RUNNER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+run_tests = load_runner()
+
+
+@contextlib.contextmanager
+def worktree():
+    """Bind one disposable directory as the worktree the runner resolves."""
+    previous = os.getcwd()
+    with tempfile.TemporaryDirectory() as directory:
+        os.chdir(directory)
+        try:
+            yield Path(os.getcwd())
+        finally:
+            os.chdir(previous)
+
+
+def refusal(*argv):
+    """Return the diagnostic printed while one report path is refused."""
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr):
+        try:
+            run_tests.report_target(list(argv))
+        except SystemExit:
+            return stderr.getvalue()
+    raise AssertionError(f"report path was accepted: {argv}")
+
+
+def written_payload(relative):
+    """Write one report through the runner and return what it left on disk."""
+    with worktree():
+        target = run_tests.report_target(["--elenchus-report", relative])
+        run_tests.write_report(target, run_tests.result_payload(unittest.TestResult()))
+        return json.loads(Path(relative).read_text(encoding="utf-8"))
+
+
+class ReportPathContainmentTests(unittest.TestCase):
+    def test_a_parent_traversal_component_is_refused(self):
+        with worktree():
+            message = refusal("--elenchus-report", "../escape.json")
+        self.assertIn("must stay inside the current worktree", message)
+
+    def test_an_absolute_path_outside_the_worktree_is_refused(self):
+        with worktree(), tempfile.TemporaryDirectory() as outside:
+            message = refusal(
+                "--elenchus-report", str(Path(outside) / "escape.json")
+            )
+        self.assertIn("must stay inside the current worktree", message)
+
+    def test_an_existing_regular_file_is_refused(self):
+        with worktree() as root:
+            (root / "report.json").write_text("{}\n", encoding="utf-8")
+            message = refusal("--elenchus-report", "report.json")
+        self.assertIn("target must not already exist", message)
+
+    def test_an_existing_symlink_is_refused(self):
+        with worktree() as root:
+            os.symlink("elsewhere.json", root / "report.json")
+            message = refusal("--elenchus-report", "report.json")
+        self.assertIn("target must not already exist", message)
+
+    def test_a_parent_component_that_is_a_regular_file_is_refused(self):
+        with worktree() as root:
+            (root / "elenchus").write_text("not a directory\n", encoding="utf-8")
+            message = refusal("--elenchus-report", "elenchus/report.json")
+        self.assertIn("parent is not a directory", message)
+
+    def test_two_report_paths_in_one_invocation_are_refused(self):
+        with worktree():
+            message = refusal(
+                "--elenchus-report", "first.json", "--elenchus-report", "second.json"
+            )
+        self.assertIn("name one report path", message)
+
+
+class ReportPayloadTests(unittest.TestCase):
+    def test_the_written_report_carries_every_schema_key(self):
+        self.assertEqual(set(written_payload(".elenchus/report.json")), SCHEMA_KEYS)
+
+    def test_the_written_report_declares_the_elenchus_schema(self):
+        self.assertEqual(written_payload(".elenchus/report.json")["schema"], SCHEMA)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

## What changed

`docs/disposable-fixture-signing/study.md` and `runbook.md` are the receipted study and runbook, committed byte-identical to the artefacts the run accepted.

`tests/run_tests.py` gives the repository-wide suite an Elenchus report writer. It runs the root suite, and when the caller names a path it writes an `elenchus.unittest.v1` report there. It's a port of `plugins/hexaemeron/tests/run_tests.py`, 244 lines against the reference's 241. The roughly 20 lines of path containment are carried across byte-for-byte rather than reimplemented.

The port diverges from the reference in exactly the three places the runbook permits:

- the discovery root, which follows from the file sitting under `tests/` rather than in the Hexaemeron test directory;
- the top-level directory passed to `unittest`, which is the repository root;
- the module docstring, which names the repository suite because the parser prints it under `--help` and the reference wording would be false here.

`diff -u` against the reference produces two hunks covering those three. Any other divergence is a defect.

`tests/__init__.py` was required, not chosen. `TestLoader.discover` refuses a start directory that isn't importable whenever `start_dir` differs from `top_level_dir`, so the second divergence above is unreachable without a package here. Every plugin suite in this repository that passes a top-level directory already carries one. The package also puts the repository root on `sys.path` before any test module is imported. Two root tests already depend on that by accident: `tests/test_marketplace_prose.py` imports `repo_contract`, and `tests/test_run_observation_inoculation.py` imports `tests.test_run_observation`. Today both resolve only because a third test module inserts the root as an import side effect and happens to sort before them. That dependency is now explicit.

`tests/test_root_elenchus_runner.py` adds eight tests. Six cover refusals: a `..` component, an absolute path outside the worktree, an existing regular file, an existing symlink, a parent component that is a regular file, and two report paths in one invocation. The other two check the written payload's schema keys and its schema id. The refusals are covered because the runner opens a filesystem write boundary this repository didn't previously have under `tests/`.

## Why

Later steps in this run change files under `tests/`, and each has to declare a runner contract for the file it changes. That needs a repository-wide runner that emits a report an audit round can read, and there wasn't one. This step builds it before any behaviour changes, and commits the spec copies into the tree while it's there.

No decision record is owed here. The runbook defers ADR-045 to step 5, which is where the scope rule is settled.

This targets the run branch `fiat/621-isolate-disposable-fixture-signing`. It's the first step, so nothing is stacked beneath it.

## Audit

Round 1 read the complete five-file diff and found nothing. Elenchus didn't run because the round made no fix, so the verdict is `null`. `phylax`, `ephoros` and `hypomnema` each print `clean` and exit 0.

The round probed the ported boundary thirteen ways beyond the eight shipped tests. Every hostile path is refused with a diagnostic naming the precondition that failed, and both time-of-check races fail closed: a symlink planted at the target after the check raises `FileExistsError`, and a parent replaced by a symlink pointing outside the worktree raises `NotADirectoryError`. Neither leaks a file outside the worktree. Nested report directories are created `0o700` and the report `0o600`.

The new top-level `tests` package regressed no sibling suite.

The record is `audit/rounds/fiat-621-isolate-disposable-fixture-signing.md`.

## Proof

From the repository root, under the interpreter pinned in [`.python-version`](./.python-version):

```bash
cmp .hexaemeron/study.md docs/disposable-fixture-signing/study.md
cmp .hexaemeron/runbook.md docs/disposable-fixture-signing/runbook.md
python3 -m unittest discover -s tests
python3 tests/run_tests.py --elenchus-report .elenchus/fiat-621-step-1.json
```

The root suite runs 470 tests, up from 462, and all of them pass. The report is 161 bytes and declares `elenchus.unittest.v1`, `complete: true`, 470 tests, and zero failures, errors and skips.

## Carried forward

- The audit probed two boundary behaviours that matter most for security: a parent symlink resolving outside the worktree, and the two races. Neither is covered by `tests/test_root_elenchus_runner.py`. The step's Tests field doesn't require them, so the audit records this as a coverage observation rather than a defect.
- The step commit message says two things diverge from the reference and then names two, while three are permitted and three are present. The one it omits is the docstring, which is permitted and correct. Rewriting the receipted commit to repair that sentence would cost more than the sentence is worth, so this note stands in its place.
- Imprimatur scores the runbook 98.8 with one high `structural_metaphor` hit. It falls inside the receipted amendment text, which can't be edited without breaking the byte identity the step's exit requires. The check still exits 0.

<!-- wildcat-origin: shoggoth -->
