### PR TITLE
Scaffold the report-only dead-code baseline

### DIFF
--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -1,0 +1,112 @@
+name: dead-code
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.horos/**'
+      - '.github/workflows/dead-code.yml'
+      - 'docs/dead-code/**'
+      - 'docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md'
+      - 'schemas/dead-code-report-v1.schema.json'
+      - 'scripts/dead_code.py'
+      - 'scripts/run_checks.py'
+      - 'tests/check-map-v1.json'
+      - 'tests/emit_dead_code_report.py'
+      - 'tests/test_dead_code.py'
+      - ".python-version"
+      - "pyproject.toml"
+  pull_request:
+    paths:
+      - '.horos/**'
+      - '.github/workflows/dead-code.yml'
+      - 'docs/dead-code/**'
+      - 'docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md'
+      - 'schemas/dead-code-report-v1.schema.json'
+      - 'scripts/dead_code.py'
+      - 'scripts/run_checks.py'
+      - 'tests/check-map-v1.json'
+      - 'tests/emit_dead_code_report.py'
+      - 'tests/test_dead_code.py'
+      - ".python-version"
+      - "pyproject.toml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Run the checked dead-code scope
+        run: python3 scripts/run_checks.py --scope dead-code
+
+      - name: Build the report
+        run: |
+          python3 scripts/dead_code.py report --json --output .dead-code/report.json
+          python3 scripts/dead_code.py report
+
+      - name: Check the report contract
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(
+              Path(".dead-code/report.json").read_text(encoding="utf-8")
+          )
+          if report["schema"] != "dead-code-report/v1":
+              raise SystemExit("dead-code report schema is wrong")
+          if report["universe"]["analysed_count"] < 1:
+              raise SystemExit("dead-code universe collapsed")
+          if report["status"]["state"] == "failed":
+              raise SystemExit("dead-code analyser failed")
+          PY
+
+      - name: Summarise the report
+        if: success()
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+
+          report = json.loads(
+              Path(".dead-code/report.json").read_text(encoding="utf-8")
+          )
+          universe = report["universe"]
+          print("## Dead-code report")
+          print()
+          print("Candidates are reported, not gated.")
+          print()
+          print(f"- commit: {report['tree']['commit']}")
+          print(f"- git_tree: {report['tree']['git_tree']}")
+          print(f"- universe: {universe['id']}")
+          print(
+              f"- paths: {universe['tracked_count']} tracked, "
+              f"{universe['analysed_count']} analysed, "
+              f"{universe['excluded_count']} excluded"
+          )
+          print(f"- status: {report['status']['state']}")
+          states = ", ".join(
+              f"{item['id']}={item['state']}" for item in report["analysers"]
+          )
+          print(f"- analysers: {states or 'none ran'}")
+          print(f"- findings: {len(report['findings'])} candidate(s)")
+          PY
+
+      - name: Record an inconclusive failure
+        if: failure()
+        run: |
+          echo '## Dead-code report' >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo 'The command or report contract failed. This run established no dead-code result.' >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,12 @@ plugins/*/harness/cache/
 .CONTRIBUTORS.md.*
 .README.md.*
 
+# Dead-code report temporaries and uncommitted workflow reports. Step 4 may
+# commit other files below .dead-code, so the directory itself stays visible.
+**/.dead-code-tmp-*
+/.dead-code/report.json
+/.dead-code/checks.json
+
 # Elenchus reports. ADR-038 keeps them inside the invocation checkout and
 # outside every Git control namespace, so they land here as ordinary untracked
 # files. They are generated evidence rather than source: without this rule

--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 2030
+    "files_walked": 2038
   },
   "entries": [
     {

--- a/docs/dead-code/runbook.md
+++ b/docs/dead-code/runbook.md
@@ -1,0 +1,276 @@
+# Runbook: establish a report-only dead-code baseline
+
+This run starts from `main` at
+`0698092d27871031b6d5521d77f6e8d8dc5dc937`. Every command below uses the
+repository's Python 3.14.6 interpreter. The four steps implement the chosen
+design from the receipted study; none may turn a candidate count into a merge
+gate or deletion authority.
+
+## Step 1: Commit the specification and scaffold the report contract
+
+**Goal.** Publish the accepted design and create the deterministic universe,
+report model, schema, root check, and report-only workflow without claiming any
+reachability result.
+
+**Entry.** `fiat/437-establish-a-report-only-dead-code-baseline` at
+`0698092d27871031b6d5521d77f6e8d8dc5dc937`, with the study receipt verified and
+no product changes in the worktree. Before editing, confirm ADR-051 is still the
+next free decision identity on `origin/main`; a collision stops the step for a
+receipted runbook amendment.
+
+**Exit.** `docs/dead-code/study.md` and `docs/dead-code/runbook.md` are
+byte-identical copies of the receipted artefacts. ADR-051 records the
+report-only authority, Horos and checked-runner ownership boundaries, and the
+rejected per-plugin and Horos-widening designs. `scripts/dead_code.py report`
+discovers a non-empty Git-tree universe, applies hard Horos file and directory
+classifications, emits equivalent text and schema-valid JSON from one ordered
+model, and reports that no analyser has run rather than calling the tree clean.
+The schema fixes finding, status, universe and tool identities. The `dead-code`
+scope and report-only workflow invoke the focused suite and fail only on command
+or report failure. `python3 tests/emit_dead_code_report.py
+.elenchus/fiat-437-step-1.json`, `python3 scripts/run_checks.py --scope
+dead-code`, both Protasis checks, Imprimatur over shipped prose, and `git diff
+--check` exit 0.
+
+**Files.** Create `docs/dead-code/study.md`, `docs/dead-code/runbook.md`,
+`docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md`,
+`schemas/dead-code-report-v1.schema.json`, `scripts/dead_code.py`,
+`tests/test_dead_code.py`, `tests/emit_dead_code_report.py`, and
+`.github/workflows/dead-code.yml`. Update `.gitignore` and
+`tests/check-map-v1.json`. Regenerate `.horos/boundary.json`,
+`.horos/candidates.json`, and `.horos/census.json` last if the Horos scan changes
+them.
+
+**Tests.** Add at least twenty focused cases for clean-tree binding, empty-walk
+refusal, malformed and duplicate-key Horos input, hard file and descendant tree
+exclusion, prefix siblings, evidence carriage, sorted output, text/JSON parity,
+schema shape, analyser-status wording, unsafe output paths, partial writes,
+workflow report-only semantics, and check-map ownership. The Elenchus runner
+contract is test command `python3 tests/emit_dead_code_report.py {report}`;
+report format `unittest-json-v1`; expected schema `elenchus.unittest.v1`;
+report file `.elenchus/fiat-437-step-1.json`. A missing, stale, empty, malformed
+or infrastructure-failed report is `inconclusive`.
+
+**Disciplines.** phylax: tracked Git bytes, Horos JSON and output paths cross
+input and filesystem boundaries, so reads are bounded and writes are confined
+and atomic. ephoros: report headers and workflow summaries must identify the
+tree, universe and analyser states. metron: none, this step makes no speed
+change. elenchus: the historical classified-directory bug is reproduced red on
+the entry construction and retained as a guard. hypomnema: ADR-051 owns the
+expensive authority and ownership decision; the schema owns the record shape.
+
+## Step 2: Add bounded Python reachability and execution signals
+
+**Goal.** Add Python static candidates and a Python 3.14 execution probe over
+the exact check plan without importing analysed modules or replacing the
+checked runner.
+
+**Entry.** Step 1's signed, audited and prose-checked branch tip. Its report
+model, universe and schema are the only output surface this step extends.
+
+**Exit.** The Python analyser parses bounded tracked source without importing
+it and reports unused imports and locals, unreachable statements and constant
+branches, import-graph reachability, dynamic-reference downgrades, and per-file
+parse status. The execution probe wraps only Python commands selected by
+`scripts/run_checks.py`, uses Python 3.14 `sys.monitoring`, records named lines
+and branches per process, restores callbacks and masks on exit, and marks a
+failed or incomplete check `degraded` without producing never-executed
+findings. A fixture demonstrates one observed and one unobserved branch while a
+dynamic registration, CLI entry point, decorator registration, `__all__`, and
+intentional test fixture survive as negative cases. `python3
+tests/emit_dead_code_report.py .elenchus/fiat-437-step-2.json`, `python3
+scripts/dead_code.py coverage --scope dead-code --output
+.dead-code/coverage.json`, `python3 scripts/dead_code.py report --json
+--coverage .dead-code/coverage.json --analyser python,coverage`, `python3
+scripts/run_checks.py --scope dead-code`, and `git diff --check` exit 0.
+
+**Files.** Extend `scripts/dead_code.py`,
+`schemas/dead-code-report-v1.schema.json`, `tests/test_dead_code.py`, and
+`tests/emit_dead_code_report.py`. Create only the minimum checked-in monitoring
+helper under `scripts/` if process isolation requires one. Update
+`.gitignore` for ignored coverage records. Regenerate the three `.horos/`
+records last if their deterministic scan changes them.
+
+**Tests.** Extend the focused suite by at least twenty-five cases covering
+scope-plan binding, wrapper recursion refusal, monitoring cleanup, line and
+branch identity, multiple processes, failed and skipped checks, syntax errors,
+unused imports and locals, unreachable statements, computed imports,
+decorators, `getattr`, `__all__`, CLI seeds, output bounds and deterministic
+aggregation. Each fixed failure is red against Step 1's tree. The Elenchus
+runner contract is test command `python3 tests/emit_dead_code_report.py
+{report}`; report format `unittest-json-v1`; expected schema
+`elenchus.unittest.v1`; report file `.elenchus/fiat-437-step-2.json`. A missing,
+stale, empty, malformed or infrastructure-failed report is `inconclusive`.
+
+**Disciplines.** phylax: Python source and check argv are untrusted; parsing
+never imports source, the existing runner owns selection and subprocess
+budgets, and instrumentation writes only bounded process records. ephoros:
+status records answer which checks ran, degraded, failed or were unavailable
+and which coverage bytes they produced. metron: the 60-second static-report
+budget is measured before and after any speed-motivated change; otherwise no
+optimisation is authorised. elenchus: each parser, graph or monitoring failure
+is reduced to a fixture, shown red, fixed at its cause and guarded.
+hypomnema: implementation comments record why dynamic references lower
+confidence and why failed coverage cannot imply absence.
+
+## Step 3: Add repository-graph and optional Solidity signals
+
+**Goal.** Report orphan candidates across repository declarations and bounded
+Slither/Forge evidence while preserving every unavailable or degraded state.
+
+**Entry.** Step 2's signed, audited and prose-checked branch tip with Python
+signals stable under the v1 schema.
+
+**Exit.** The repository analyser reports candidates for fixtures, schemas,
+documents, CLI declarations, generated copies, routers, manifests and check-map
+objects only when it can name the parsed edge set and nearest computed-reference
+boundary. Existing Promise Machine, Hypomnema, Horos and check-map checks are
+invoked or consumed rather than copied. Foundry projects are discovered from
+tracked configuration; Slither `dead-code` and `unused-state` JSON and Forge
+coverage are run through fixed argv with project attribution and version
+capture when available. Tool absence is `not-available`; build, timeout or
+parse failure is `degraded` or `failed`, never zero findings. `python3
+tests/emit_dead_code_report.py .elenchus/fiat-437-step-3.json`, `python3
+scripts/dead_code.py report --json --analyser repository,solidity`, `python3
+scripts/run_checks.py --scope dead-code`, all existing Promise Machine and
+check-map validation selected by the changed scope, and `git diff --check` exit
+0.
+
+**Files.** Extend `scripts/dead_code.py`,
+`schemas/dead-code-report-v1.schema.json`, `tests/test_dead_code.py`, and
+`tests/emit_dead_code_report.py`. Add bounded fixture files below
+`tests/fixtures/dead-code/` only when inline temporary repositories cannot
+prove a case. Regenerate the three `.horos/` records last if required.
+
+**Tests.** Extend the focused suite by at least twenty cases: one positive and
+one retained negative case for every repository object family; dynamic and
+computed references; malformed declarations; empty discovery; absent Slither
+or Forge; non-zero, timed-out, oversized and malformed tool output; multiple
+Foundry projects; fixed argv and cwd; detector mapping; and finding/report
+parity. The Elenchus runner contract is test command `python3
+tests/emit_dead_code_report.py {report}`; report format `unittest-json-v1`;
+expected schema `elenchus.unittest.v1`; report file
+`.elenchus/fiat-437-step-3.json`. A missing, stale, empty, malformed or
+infrastructure-failed report is `inconclusive`.
+
+**Disciplines.** phylax: repository declarations and external tool output are
+bounded hostile input, and Slither/Forge use fixed argv, no shell, declared cwd
+and time/output ceilings. ephoros: each project and object family reports its
+version, status, duration, evidence count and refusal reason. metron: no speed
+claim; subprocess deadlines are termination controls, not performance results.
+elenchus: every adapter failure is reproduced at the parser or process boundary
+and its guard stays in the focused suite. hypomnema: no new standing decision;
+the v1 schema and ADR-051 already own the adapter and authority boundaries.
+
+## Step 4: Pin the baseline, check suppressions and demonstrate the prototype
+
+**Goal.** Bind the current candidate inventory to exact evidence, publish the
+operator path, and prove the complete report-only prototype on a clean tree.
+
+**Entry.** Step 3's signed, audited and prose-checked branch tip with every
+analyser represented in the report model.
+
+**Exit.** `.dead-code/baseline.json` binds commit, Git tree, universe digest,
+analyser versions and statuses, stable finding identities, and suppression
+digest. `.dead-code/suppressions.json` uses a closed schema whose entries name
+one exact candidate, reason, owner and still-present target; broad, duplicate,
+unknown, stale and unused suppressions refuse. `baseline --write` uses a
+confined atomic replacement and `baseline --check` is read-only. Operator docs
+state that findings are candidates, counts do not gate development, and a diff
+gate needs a separate decision. The four study demo commands run from a clean
+tree; text and JSON identities agree; all positive and negative fixtures pass;
+the static Python plus repository report has three warm runs recorded and stays
+within the study's 60-second budget; the complete selected repository check
+plan, prose gates, audit-synopsis currency, Horos check and `git diff --check`
+exit 0. No source candidate is deleted or rewritten.
+
+**Files.** Extend `scripts/dead_code.py`,
+`schemas/dead-code-report-v1.schema.json`, `tests/test_dead_code.py`, and
+`tests/emit_dead_code_report.py`. Create
+`schemas/dead-code-suppressions-v1.schema.json`,
+`.dead-code/baseline.json`, `.dead-code/suppressions.json`,
+`docs/promise-machine/dead-code-v1.md`, and
+`docs/dead-code/measurement.md`. Update `.github/workflows/dead-code.yml` and
+`tests/check-map-v1.json` only if the demonstrated command differs from the
+Step 1 stub. Regenerate `.horos/boundary.json`, `.horos/candidates.json`, and
+`.horos/census.json` last.
+
+**Tests.** Extend the focused suite by at least twenty cases for canonical
+identity, commit/tree/universe/version/status/suppression drift, unknown and
+duplicate fields, broad or stale suppressions, symlink and interrupted writes,
+stable rereads, text/JSON/baseline parity, finding-count non-gating, dirty-tree
+refusal and the exact four-command demo. The Elenchus runner contract is test
+command `python3 tests/emit_dead_code_report.py {report}`; report format
+`unittest-json-v1`; expected schema `elenchus.unittest.v1`; report file
+`.elenchus/fiat-437-step-4.json`. A missing, stale, empty, malformed or
+infrastructure-failed report is `inconclusive`.
+
+**Disciplines.** phylax: baseline and suppression reads and writes use closed
+schemas, confined no-follow paths, stable rereads and atomic replacement.
+ephoros: the final report and workflow summary carry tree, analyser, change and
+non-gating status for operators. metron: three warm static-report runs record
+command, commit, interpreter, median and spread against the 60-second budget.
+elenchus: every final failure keeps its smallest red reproducer and guard;
+candidate count alone remains a green result. hypomnema: the operator guide is
+the durable home for commands and failure recovery, measurement owns the
+runtime observation, and ADR-051 remains the standing decision.
+
+### Amendment -- 2026-08-29
+
+**What changed.** Complete replacement Exit: `docs/dead-code/study.md` and
+`docs/dead-code/runbook.md` are byte-identical copies of the receipted
+artefacts, including this amendment in the runbook copy. ADR-051 records the
+report-only authority, Horos and checked-runner ownership boundaries, and the
+rejected per-plugin and Horos-widening designs. `scripts/dead_code.py report`
+discovers a non-empty Git-tree universe, applies hard Horos file and directory
+classifications, emits equivalent text and schema-valid JSON from one ordered
+model, and reports that no analyser has run rather than calling the tree clean.
+The schema fixes finding, status, universe and tool identities. The `dead-code`
+scope and report-only workflow invoke the focused suite and fail only on command
+or report failure. The workflow follows the repository Python contract, and
+`tests/test_python_contract.py` registers and checks it. `python3
+tests/emit_dead_code_report.py .elenchus/fiat-437-step-1.json`, `python3 -m
+unittest tests.test_dead_code tests.test_python_contract.PythonRuntimeContractTests
+-v`, both Protasis checks, Imprimatur over shipped prose, Phylax, Ephoros,
+Hypomnema, the Horos check, and `git diff --check` exit 0. `python3
+scripts/run_checks.py --scope dead-code` runs the complete changed-path closure;
+its only permitted failed checks are `hexaemeron-suite`, `lazarus-suite`,
+`root-suite`, and `synkrisis-suite`, each reproduced at entry commit
+`0698092d27871031b6d5521d77f6e8d8dc5dc937` and attributed respectively to the
+Darwin `/var` symlink, missing locked Lazarus dependencies, the same Darwin
+`MP407` path handling, and Darwin RSS units. Every other selected check exits 0.
+Complete replacement Files: Create `docs/dead-code/study.md`,
+`docs/dead-code/runbook.md`,
+`docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md`,
+`schemas/dead-code-report-v1.schema.json`, `scripts/dead_code.py`,
+`tests/test_dead_code.py`, `tests/emit_dead_code_report.py`, and
+`.github/workflows/dead-code.yml`. Update `.gitignore`,
+`tests/check-map-v1.json`, and `tests/test_python_contract.py`. Regenerate
+`.horos/boundary.json`, `.horos/candidates.json`, and `.horos/census.json` last
+if the Horos scan changes them. Complete replacement Tests: Add at least twenty
+focused cases for clean-tree binding, empty-walk refusal, malformed and
+duplicate-key Horos input, hard file and descendant tree exclusion, prefix
+siblings, evidence carriage, sorted output, text/JSON parity, schema shape,
+analyser-status wording, unsafe output paths, partial writes, workflow
+report-only semantics, check-map ownership, and the repository Python workflow
+contract. The Elenchus runner contract is test command `python3
+tests/emit_dead_code_report.py {report}`; report format `unittest-json-v1`;
+expected schema `elenchus.unittest.v1`; report file
+`.elenchus/fiat-437-step-1.json`. A missing, stale, empty, malformed or
+infrastructure-failed report is `inconclusive`. Run the focused suite and Python
+workflow contract directly. Run the complete checked-runner closure and compare
+any failure with the exact entry commit; only the four host or dependency
+failures named in the replacement Exit are admissible, and every other check
+must pass.
+**Why.** Editing the check-map authority correctly expands the requested
+`dead-code` scope to the complete changed-path closure. The entry commit already
+fails four selected suites on this macOS host, so requiring the aggregate runner
+to exit 0 confused inherited environment failures with Step 1 regressions. The
+first run also exposed two Step 1 integration defects: the workflow did not use
+the exact quoted Python pin form, and the closed workflow inventory did not know
+about it. This amendment keeps the full closure visible, adds the missing
+contract file to scope, and admits only failures reproduced at the exact entry
+commit.
+**Steps touched.** Step 1.
+**Still holding.** Step 1: entry holds; exit holds. Step 2: entry holds; exit
+holds. Step 3: entry holds; exit holds. Step 4: entry holds; exit holds.

--- a/docs/dead-code/study.md
+++ b/docs/dead-code/study.md
@@ -1,0 +1,367 @@
+# Study: establish a report-only dead-code baseline
+
+Issue [#437](https://github.com/wildcat-finance/skills/issues/437) asks for a
+repository-wide candidate inventory. The run starts from `main` at
+`0698092d27871031b6d5521d77f6e8d8dc5dc937`.
+
+Assuming, unless corrected:
+
+1. The analysed universe is the Git-tracked tree at one commit. Modified
+   tracked bytes refuse a baseline; ignored Fiat state and unrelated untracked
+   files are outside the universe.
+2. The exact repository interpreter is Python 3.14.6 from `.python-version` and
+   `pyproject.toml`. Ambient `/usr/bin/python3` is 3.9.6 and is not an allowed
+   substitute.
+3. `.horos/boundary.json` remains the authority for generated, vendored,
+   binary, lockfile and content-addressed exclusions. This command consumes
+   that evidence; it does not widen Horos into a reachability skill.
+4. `tests/check-map-v1.json` and `scripts/run_checks.py` remain the authority
+   for repository check ownership and execution. Coverage consumes their
+   discovered commands and results rather than creating another scheduler.
+5. Findings are candidates. No confidence level, static signal or coverage gap
+   proves semantic uselessness or authorises deletion.
+6. This is repository tooling, not a frontier advancement for Fiat, Horos,
+   Metron or another skill. No `EVOLUTION.md` row is owed.
+
+## 1. Problem statement
+
+Build one deterministic root command for contributors and maintainers that
+inventories what it analysed and reports bounded dead-code signals without
+editing source. A working prototype provides equivalent text and canonical JSON
+reports, a pinned baseline, checked suppressions and explicit analyser status.
+
+Current `main` was remeasured rather than inheriting the 21 August issue counts:
+
+- 3,015 tracked paths, including 667 Python files with 294,599 lines and 168
+  Solidity files;
+- 23 declared checks across 22 selected scopes in the checked impact map;
+- 494 root tests under Python 3.14.6: 493 pass and one inherited isolated-copy
+  test fails with `MP407` on this Darwin host;
+- the historical #437 universe probe, executed from its old branch against the
+  current commit, finds 1,909 analysed paths and 1,106 hard-classified
+  exclusions: 978 generated, 72 content-addressed, 50 binary, three lockfiles
+  and three vendored paths. It has no registered analyser and therefore
+  establishes zero reachability findings, not a clean tree.
+
+The proving demo path, from a clean checkout, is:
+
+```bash
+python3 scripts/dead_code.py report
+python3 scripts/dead_code.py report --json
+python3 scripts/dead_code.py baseline --check
+python3 scripts/run_checks.py --scope dead-code
+```
+
+The prototype is working when both report formats carry the same ordered
+findings and statuses; the universe is non-empty and commit-bound; every
+finding names its analyser, object, evidence, confidence and nearest
+false-positive boundary; positive fixtures exercise every signal family;
+negative fixtures retain dynamic registration, CLI entry points, intentional
+fixtures and Horos-classified content; malformed reports, collapsed discovery
+and analyser crashes fail; existing candidate count alone does not fail; and
+no command deletes or rewrites source.
+
+## 2. Prior art
+
+### Current repository and organisation
+
+The current execution authority is `scripts/run_checks.py` plus
+`tests/check-map-v1.json`. It already proves total path ownership, rejects
+unreachable checks and stale commands, closes dependencies, executes one
+immutable snapshot and emits bounded results. `scripts/dead_code.py` must be a
+declared check and a consumer of that graph, not a rival scheduler.
+
+Horos at `plugins/horos/skills/horos/scripts/horos.py` and
+`.horos/boundary.json` already classify token sinks with evidence. The
+Promise Machine checker, Hypomnema link checker, marketplace tests and
+check-map validation already expose narrower repository-graph failures. The
+new command normalises those signals and adds missing reachability analysis;
+it does not copy their rules.
+
+The last two merged pull requests that changed this subject were read in full:
+
+- [#745, Reconstruct, check and prove the affected-scope test runner](https://github.com/wildcat-finance/skills/pull/745),
+  merged 28 August 2026. It made the impact map and runner authoritative. Its
+  carried Darwin failures, portable-runtime link findings, scratch-guard
+  evasion forms and runner edge cases remain facts about execution, not
+  dead-code findings. This run carries them as analyser statuses and invokes
+  the checked runner rather than duplicating process control.
+- [#732, Detach plugin suites from unrelated changes](https://github.com/wildcat-finance/skills/pull/732),
+  merged 28 August 2026. It narrowed hosted workflow ownership and recorded the
+  same Lazarus and Synkrisis Darwin failures. This run preserves those trigger
+  boundaries. Any dead-code lane is report-only on finding count and must not
+  restore every plugin workflow on every unrelated change.
+
+The old unmerged #437 branch is evidence, not authority. Its two commits,
+`6779ca2fdd1211f3b145f03135c024ac10ef1388` and
+`a07436c0d4190bb2e03e29c5b121720724352f80`, are based on
+`8de7a4bc910e398107ff2f54a4cf92a82e764a76` and deliver only universe
+discovery, report rendering and 38 scaffold tests. The second commit correctly
+extends a hard Horos directory classification to descendants without capturing
+a sibling sharing the prefix; that construction carries forward. The branch's
+standalone workflow, 1,512-path measurement, Python 3.11 premise, Slither
+0.11.6 pin and branch-coverage deferral are stale. Its seven-step runbook never
+landed and cannot govern this run.
+
+### Audit record inventory
+
+`python3 plugins/hexaemeron/skills/fiat/scripts/audit_synopsis.py --check .`
+verified all 39 committed synopsis views against their authoritative sources.
+The in-scope records and reading modes are:
+
+- `audit/AUDIT.md` through fresh `audit/AUDIT_SYNOPSIS.md`, limited to root
+  command, atomic-write, degraded-result and repository-graph records. The
+  relevant `scripts/contributors.py` S3-R2-01 is fixed and retains one rule:
+  read-only checks do not sweep old writer litter.
+- `audit/rounds/fiat-377-stop-the-marker-rule-excluding-the-classifie.md`
+  through its fresh synopsis. Its findings are fixed. Its remaining CR-only
+  line handling, sampled-window gaps and census-currency ideas define Horos
+  recall limits; this report carries the classifier evidence without
+  strengthening it.
+- `audit/rounds/fiat-621-isolate-disposable-fixture-signing.md` through its
+  fresh synopsis. Its product findings are fixed; the current root rerun still
+  reproduces the separate Darwin `MP407` isolated-copy failure.
+- all four `audit/rounds/fiat-622-*.md` sources through their fresh synopses.
+  Their scheduler findings are fixed. Their unexercised high-capacity hosts,
+  retained-descriptor lifetime, unexpected-success accounting, multi-subtest
+  report-reader limit and scratch-guard evasion forms stay outside this
+  command's ownership and are surfaced as runner evidence or status.
+
+The remaining 32 verified sources are out of scope: they audit venue evidence,
+credit laws, hook semantics, controller transitions, prose or other domain
+behaviour inside the analysed tree; none defines Git universe discovery, Horos
+classification, checked-run scheduling or this report format. The legacy
+`plugins/hexaemeron/audit/AUDIT.md` synopsis was inspected and likewise
+excluded: its controller and hook-gate findings do not govern the root runner.
+No authoritative #437 audit source exists because its old branch did not land
+one. No audit evidence gap blocks the study.
+
+### Outside both repositories
+
+- Vulture provides confidence-ranked Python dead-code candidates, including a
+  high-confidence-only mode: <https://github.com/jendrikseipp/vulture>.
+- Ruff F401 and F841 specify unused-import and unused-local signals and their
+  suppression boundaries: <https://docs.astral.sh/ruff/rules/unused-import/>
+  and <https://docs.astral.sh/ruff/rules/unused-variable/>.
+- Python 3.14 `sys.monitoring` exposes line and left/right branch events without
+  adding a package: <https://docs.python.org/3.14/library/sys.monitoring.html>.
+- Slither names `unused-state` high-confidence and `dead-code`
+  medium-confidence detectors, and can emit JSON for selected detectors:
+  <https://github.com/crytic/slither/wiki/Detector-Documentation>.
+- Forge exposes coverage for Foundry projects:
+  <https://getfoundry.sh/forge/reference/coverage/>.
+
+These tools produce signals, not deletion authority. Current local probes find
+Forge 1.7.1 and Slither 0.11.4; absence or a different version is report data.
+
+## 3. Constraints and non-goals
+
+Constraints:
+
+- exact starting ref `0698092d27871031b6d5521d77f6e8d8dc5dc937` on
+  `main`;
+- Python 3.14.6, standard library for the root implementation, and fixed argv
+  with no shell for external tools;
+- a deterministic, schema-validated, report-only command over tracked Git
+  bytes, with stable analyser and suppression identities;
+- current Horos and checked-runner contracts are consumed by path and version;
+  generated portable runtime stays excluded under its recorded classification;
+- a baseline records commit, Git tree, universe digest, analyser versions,
+  statuses, finding identities and suppression digest.
+
+Non-goals are source deletion, automatic rewriting, semantic proof of
+uselessness, type checking, a dashboard, database or backup service, changing
+Horos's promise, replacing the affected-scope runner, repairing the inherited
+Darwin failures, and making finding count a merge gate. A future diff gate is a
+separate decision after the baseline is triaged.
+
+Boundaries in force:
+
+- **Always:** run both the root suite and every check selected by the changed
+  scope before a commit; run Imprimatur on shipped prose; record a before and
+  after measurement before any speed-motivated change; regenerate Horos last.
+- **Ask first:** add a dependency; change the report schema after a baseline is
+  published; widen CI triggers beyond the owning workflow; change a public CLI;
+  alter check ownership or a Promise Machine declaration.
+- **Never:** commit credentials or signing material; import or execute a Python
+  file merely to analyse it; edit vendored code; delete a failing test or source
+  candidate; describe unexecuted analysis as clean; claim a command ran when it
+  did not.
+
+## 4. Design options
+
+**A. One stdlib root command consuming Horos and the checked runner.** Git and
+AST analysis discover the static universe; `sys.monitoring` records Python
+line/function/branch execution through declared check commands; Slither and
+Forge supply optional Solidity signals; existing graph checks contribute
+machine-readable statuses. Trade: more local adapter code and lower Python
+recall than dedicated packages, in exchange for one pinned implementation and
+no second dependency or scheduler.
+
+**B. One root command built around Vulture, Ruff and coverage.py.** This has
+broader mature Python analysis. Trade: it adds the repository's first Python
+tool dependencies, requires a lock/update policy, and still needs custom graph,
+Horos, Solidity and report adapters.
+
+**C. Widen Horos into reachability analysis.** It reuses the walk directly.
+Trade: it collapses the explicit boundary between evidenced reading exclusion
+and claims about unused objects, and would require a skill promise and frontier
+change.
+
+**D. Put one analyser in every plugin suite.** It keeps ownership local. Trade:
+it cannot see cross-plugin imports, root manifests, generated-copy topology or
+orphaned docs and fixtures, which are the issue's core gap.
+
+**Chosen: A.** It is the lowest-comprehension construction that meets the issue
+on the current tree because #745 already centralised discovery and execution,
+and Python 3.14.6 now supplies branch events the old branch lacked. It trades
+away Vulture/Ruff recall and coverage.py's mature arc model. Each missing signal
+is named in analyser status, and the schema permits a later adapter without
+rewriting finding identity.
+
+## 5. Risk register seed
+
+```risk-register
+discovery-collapse | Git tree and Horos classification join | an empty or unexpectedly reduced universe refuses instead of producing zero findings
+tree-prefix-classification | hard Horos directory entries | descendants inherit the exact parent evidence while siblings sharing the textual prefix remain analysed
+analyser-absence-as-clean | every analyser status | absent, skipped, timed-out and crashed remain distinct from ran-with-zero-findings
+dynamic-reference-blindness | Python import and call graph | importlib, entry points, decorators, __all__, getattr and computed paths lower confidence or retain the object
+coverage-failure-as-dead | check execution under monitoring | a failing, incomplete or unselected check yields degraded coverage status and no never-executed finding
+monitoring-leak | Python 3.14 sys.monitoring callbacks | tool id, callbacks and event masks are restored after every command and isolated in fixtures
+untrusted-parse | tracked Python source | analysis parses bytes without import, eval or execution and reports syntax failures by path
+subprocess-argv | Git, Slither, Forge and checked-runner invocations | fixed argv, no shell, bounded output, declared cwd and inherited runner timeouts
+solidity-project-attribution | Foundry project discovery | each finding names one project, tool versions and build or coverage status rather than a repository-wide clean claim
+repository-edge-overclaim | docs, fixtures, schemas, routers and manifests | every edge names the parser or declaration that produced it and computed references prevent high confidence
+report-parity | text and JSON renderers | both formats derive from one ordered model and tests compare stable identities and counts
+baseline-staleness | committed baseline | commit, tree, universe, analyser versions, statuses and suppression digest all bind or check refuses
+suppression-abuse | suppression document | each narrow id has a reason, owner and still-present target; stale, broad or unused entries refuse
+path-confinement | report, baseline and temporary files | no-follow descendant checks and atomic replace keep writes inside owned paths
+partial-write | report and baseline publication | interrupted writes leave no accepted half-file and read-only checks never sweep unrelated litter
+finding-overclaim | candidate wording and confidence | no emitted record says proved dead, safe to delete or semantically unused
+```
+
+## 6. Glossary seeds
+
+- **Universe:** tracked paths at one commit, partitioned into analysed and
+  evidence-classified exclusions.
+- **Analyser:** one versioned signal source with a declared status and boundary.
+- **Finding:** a stable candidate identity plus object, evidence, confidence and
+  nearest false-positive boundary.
+- **Coverage signal:** an observed execution relation for named checks, never a
+  proof that unobserved code is unreachable.
+- **Repository edge:** a named reference between a manifest, router, command,
+  fixture, schema, document or generated copy and another tracked object.
+- **Suppression:** a narrow, reasoned decision to retain one candidate; not a
+  deletion waiver or hidden ignore pattern.
+- **Baseline:** the report identity bound to one Git tree, universe and analyser
+  set.
+- **Degraded:** an analyser began but its evidence did not establish the
+  requested signal.
+- **Not available:** the named optional tool was absent before execution.
+
+## 7. Sources
+
+- GitHub issue #437, including its 26 August keep-but-remeasure review.
+- Current `AGENTS.md`, `.python-version`, `pyproject.toml`,
+  `.horos/boundary.json`, `scripts/run_checks.py`, `tests/check-map-v1.json`,
+  `PROMISE_MACHINE.md` and `tests/promise_machine_coverage.json` at the starting
+  ref.
+- Pull requests #745 and #732, including their full bodies, files and carried
+  work.
+- Old branch commits `6779ca2` and `a07436c`, its committed study, runbook,
+  schema, script, tests and workflow.
+- The seven in-scope audit sources and verified synopsis modes listed in item 2;
+  the synopsis currency command's complete 39-source output.
+- The Vulture, Ruff, Python 3.14, Slither and Foundry primary documentation
+  linked in item 2.
+- Reproduction commands and outputs in item 1 for current counts, universe,
+  check inventory, versions and root-suite status.
+
+## 8. Signals, and the questions behind them
+
+This command runs in terminals and CI, so Ephoros applies to the report and job
+summary rather than a service dashboard.
+
+- *Did it analyse the intended tree?* The header emits commit, tree, universe
+  digest, analysed/excluded counts and each classification count.
+- *Which signals actually ran?* One status per analyser emits version, command
+  identity, selected check manifest, duration and one of `ran`, `not-available`,
+  `degraded` or `failed` with reason.
+- *What changed from the baseline?* Comparison emits added, resolved,
+  suppressed and stale-suppression identities by analyser and path.
+- *Did candidates block development?* The terminal status distinguishes a
+  green report with findings from a failed report contract; CI publishes the
+  count but gates only malformed, crashed or collapsed analysis.
+
+## 9. Boundaries, per capability
+
+Phylax governs the controls cited here.
+
+- **Tracked-source read:** contributor-controlled bytes can exhaust or confuse
+  parsers. Use bounded regular-file reads from the recorded tree, never import
+  analysed Python, reject unsafe paths and retain per-file parse errors.
+- **Check execution:** repository tests execute arbitrary project code. Delegate
+  selection, snapshotting, timeouts, process groups and result accounting to
+  `scripts/run_checks.py`; consume its bounded record.
+- **External Solidity tools:** Slither and Forge execute compilers and project
+  configuration. Use fixed argv, declared project cwd, version capture and
+  existing timeouts; absence is visible and a crash is not zero findings.
+- **Classification and manifests:** malformed JSON can erase the universe or
+  invent graph edges. Use duplicate-key rejection, closed shapes, exact schema
+  versions and a non-empty floor before analysis.
+- **Artefact writes:** symlink swaps and interruption can escape or corrupt a
+  baseline. Use confined no-follow paths, stable rereads, same-directory atomic
+  replacement and product-specific temporary prefixes.
+
+## 10. The budget, or its absence
+
+The static Python plus repository-graph report should finish within 60 seconds
+on a warm checkout at the starting ref. Record at least three runs before and
+after any speed-motivated change using the same interpreter and tree:
+
+```bash
+/usr/bin/time -p python3 scripts/dead_code.py report --analyser python,repository --json
+```
+
+This follows Metron; the recorded median and spread decide keep or revert.
+Coverage and Solidity have no aggregate speed budget because they execute the
+declared suites and optional toolchains. Their existing per-check timeouts and
+the report's measured durations are still required. No performance conclusion
+may be drawn across different manifests, commits or tool versions.
+
+## 11. The fail-closed posture
+
+Elenchus governs any failure worked during implementation. The report refuses
+on a dirty tracked tree, unsafe path, malformed or stale Horos boundary,
+duplicate-key or wrong-schema input, empty/collapsed universe, analyser crash,
+missing required status, report-schema failure, text/JSON identity mismatch or
+unsafe write. `baseline --check` additionally refuses changed commit, tree,
+universe, analyser version/status or suppression digest.
+
+An optional tool absent before execution is `not-available`, not a crash. A
+check failure or incomplete monitoring run is `degraded` and contributes no
+absence finding. Existing candidate count never changes the exit status by
+itself.
+
+Every implementation or audit fix follows the guard convention: preserve the
+smallest reproducer, show the focused test red on the exact parent bytes, fix
+the cause, then show the same test green and run the affected scope. If the
+failure cannot be reproduced, record `inconclusive`; do not guess at a fix.
+
+## 12. Decisions and their homes
+
+Hypomnema governs the records.
+
+- The expensive decision is a report-only root capability that consumes Horos
+  classification and the checked runner without changing either promise. Put
+  it in the next free `docs/decisions/ADR-*.md`, chosen when the step begins so
+  concurrent work cannot collide.
+- The finding, analyser-status, baseline and suppression shapes live in schemas
+  under `schemas/`; the schemas are the normative records and prose links to
+  them instead of restating fields.
+- Capability and operator documentation lives under
+  `docs/promise-machine/dead-code-v1.md`; the study and runbook receive durable
+  copies under `docs/dead-code/`.
+- Current baseline bytes live under `.dead-code/` and name their generating
+  command. A later diff gate requires a new ADR and issue; it is not smuggled
+  into a suppression or workflow threshold.

--- a/docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md
+++ b/docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md
@@ -1,0 +1,55 @@
+# ADR-051: Keep dead-code discovery report-only
+
+## Status
+
+Accepted, 2026-08-29.
+
+## Context
+
+Issue #437 needs one repository-wide inventory of possible dead code. The
+repository already has two narrower authorities that must not drift: Horos
+classifies generated, vendored, binary, lockfile and content-addressed reading
+exclusions, while tests/check-map-v1.json and scripts/run_checks.py select and
+execute checks.
+
+A reachability signal is incomplete around dynamic imports, registrations,
+entry points, fixtures and computed paths. Candidate counts therefore cannot
+establish semantic uselessness or authorise deletion.
+
+## Decision
+
+Provide one root report-only command whose universe is the clean tracked Git
+tree. It consumes hard Horos classifications without changing Horos and
+consumes the checked runner without becoming another scheduler. Findings remain
+candidates with explicit evidence and false-positive boundaries. Candidate
+count never fails the command, blocks a merge or authorises source deletion.
+
+The dead-code scope owns this command, schema, focused tests, workflow and
+documentation. Horos continues to own classification evidence. The checked
+runner continues to own scope selection, snapshots, process budgets and result
+accounting.
+
+## Alternatives
+
+Put one analyser in every plugin. Rejected because plugin-local views cannot
+resolve cross-plugin imports, root manifests, generated-copy topology or
+orphaned repository objects.
+
+Widen Horos into reachability analysis. Rejected because reading exclusion and
+semantic reachability make different promises. Combining them would strengthen
+Horos evidence beyond its contract and blur which component owns a refusal.
+
+Use candidate count as a workflow gate. Rejected because a static or execution
+signal does not prove that a candidate is unused. A future diff gate requires
+a separate decision after the baseline is reviewed.
+
+## Consequences
+
+Contributors get one deterministic text and JSON report bound to commit, Git
+tree and universe identity. CI fails on command, schema, discovery or analyser
+failure, not on findings. The root command must preserve unavailable and
+degraded analyser states and must not edit analysed source.
+
+The command depends on Horos and the checked runner, so their changes select
+the dead-code suite through the repository check graph. Later analysers extend
+the versioned schema; they do not acquire deletion authority.

--- a/schemas/dead-code-report-v1.schema.json
+++ b/schemas/dead-code-report-v1.schema.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wildcat.finance/schemas/dead-code-report-v1.schema.json",
+  "title": "dead-code-report/v1",
+  "description": "A report-only inventory over one clean Git tree. Findings are candidates, their count is not a gate, and this document never authorises deletion.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "tool",
+    "tree",
+    "universe",
+    "status",
+    "analysers",
+    "findings"
+  ],
+  "properties": {
+    "schema": {
+      "const": "dead-code-report/v1"
+    },
+    "tool": {
+      "$ref": "#/$defs/toolIdentity"
+    },
+    "tree": {
+      "$ref": "#/$defs/treeIdentity"
+    },
+    "universe": {
+      "$ref": "#/$defs/universeIdentity"
+    },
+    "status": {
+      "$ref": "#/$defs/analysisStatus"
+    },
+    "analysers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/analyserStatus"
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/finding"
+      }
+    }
+  },
+  "$defs": {
+    "sha256Identity": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "gitObjectIdentity": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "repositoryPath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096,
+      "pattern": "^[^/].*$"
+    },
+    "toolIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version"],
+      "properties": {
+        "id": {
+          "const": "dead-code"
+        },
+        "version": {
+          "const": "1"
+        }
+      }
+    },
+    "treeIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["commit", "git_tree"],
+      "properties": {
+        "commit": {
+          "$ref": "#/$defs/gitObjectIdentity"
+        },
+        "git_tree": {
+          "$ref": "#/$defs/gitObjectIdentity"
+        }
+      }
+    },
+    "classifiedPath": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "category", "evidence", "grade"],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/repositoryPath"
+        },
+        "category": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence": {
+          "type": "string",
+          "minLength": 1
+        },
+        "grade": {
+          "const": "hard"
+        }
+      }
+    },
+    "universeIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "tracked_count",
+        "analysed_count",
+        "analysed",
+        "excluded_count",
+        "excluded_by_category",
+        "excluded"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/sha256Identity"
+        },
+        "tracked_count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "analysed_count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "analysed": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/repositoryPath"
+          }
+        },
+        "excluded_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "excluded_by_category": {
+          "type": "object",
+          "propertyNames": {
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "excluded": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/classifiedPath"
+          }
+        }
+      }
+    },
+    "analysisStatus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "state", "detail"],
+      "properties": {
+        "id": {
+          "const": "analysis"
+        },
+        "state": {
+          "enum": ["not-run", "ran", "degraded", "failed"]
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "analyserStatus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "state", "version", "detail"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "state": {
+          "enum": ["ran", "not-available", "degraded", "failed"]
+        },
+        "version": {
+          "type": ["string", "null"]
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "analyser_id",
+        "path",
+        "symbol",
+        "evidence",
+        "confidence",
+        "false_positive_boundary"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/sha256Identity"
+        },
+        "analyser_id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "path": {
+          "$ref": "#/$defs/repositoryPath"
+        },
+        "symbol": {
+          "type": ["string", "null"]
+        },
+        "evidence": {
+          "type": "string",
+          "minLength": 1
+        },
+        "confidence": {
+          "enum": ["high", "medium", "low"]
+        },
+        "false_positive_boundary": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -236,20 +236,35 @@ def run_process(
     cwd: Path,
     timeout_seconds: int,
     output_limit: int,
+    cwd_fd: int | None = None,
 ) -> tuple[bytes, bytes, int]:
     """Run fixed argv while bounding time and combined captured output."""
+    process_cwd: Path | None = cwd
+    pass_fds: tuple[int, ...] = ()
+    preexec_fn: Callable[[], None] | None = None
+    if cwd_fd is not None:
+        process_cwd = None
+        pass_fds = (cwd_fd,)
+
+        def enter_opened_directory() -> None:
+            os.fchdir(cwd_fd)
+            os.close(cwd_fd)
+
+        preexec_fn = enter_opened_directory
     try:
         process = subprocess.Popen(
             argv,
-            cwd=cwd,
+            cwd=process_cwd,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             shell=False,
+            pass_fds=pass_fds,
+            preexec_fn=preexec_fn,
         )
     except FileNotFoundError as error:
         raise Refusal(f"{argv[0]} is not available on PATH") from error
-    except OSError as error:
+    except (OSError, subprocess.SubprocessError) as error:
         raise Refusal(f"{argv[0]} could not start: {error}") from error
 
     assert process.stdout is not None
@@ -301,12 +316,16 @@ def decode_output(payload: bytes, label: str) -> str:
         raise Refusal(f"{label} output is not UTF-8") from error
 
 
-def run_git(root: Path, *arguments: str) -> str:
+def run_git(root: Path, *arguments: str, root_fd: int | None = None) -> str:
+    argv = ["git", "-C", str(root), *arguments]
+    if root_fd is not None:
+        argv = ["git", *arguments]
     stdout, stderr, returncode = run_process(
-        ["git", "-C", str(root), *arguments],
+        argv,
         cwd=root,
         timeout_seconds=GIT_TIMEOUT_SECONDS,
         output_limit=MAX_GIT_OUTPUT_BYTES,
+        cwd_fd=root_fd,
     )
     if returncode != 0:
         detail = decode_output(stderr, "git stderr").strip()
@@ -332,24 +351,33 @@ def _require_oid(value: str, label: str) -> str:
     return value
 
 
-def resolve_commit(root: Path) -> str:
-    return _require_oid(run_git(root, "rev-parse", "HEAD").strip(), "HEAD")
-
-
-def resolve_tree(root: Path, commit: str) -> str:
+def resolve_commit(root: Path, *, root_fd: int | None = None) -> str:
     return _require_oid(
-        run_git(root, "rev-parse", f"{commit}^{{tree}}").strip(),
+        run_git(root, "rev-parse", "HEAD", root_fd=root_fd).strip(),
+        "HEAD",
+    )
+
+
+def resolve_tree(root: Path, commit: str, *, root_fd: int | None = None) -> str:
+    return _require_oid(
+        run_git(
+            root,
+            "rev-parse",
+            f"{commit}^{{tree}}",
+            root_fd=root_fd,
+        ).strip(),
         "HEAD tree",
     )
 
 
-def require_clean_tree(root: Path) -> None:
+def require_clean_tree(root: Path, *, root_fd: int | None = None) -> None:
     porcelain = run_git(
         root,
         "status",
         "--porcelain=v1",
         "-z",
         "--untracked-files=no",
+        root_fd=root_fd,
     )
     changed = [entry for entry in porcelain.split(chr(0)) if entry]
     if changed:
@@ -378,8 +406,21 @@ def validate_repository_path(value: str, label: str) -> str:
     return value
 
 
-def tracked_paths(root: Path, commit: str) -> tuple[str, ...]:
-    listing = run_git(root, "ls-tree", "-r", "--name-only", "-z", commit)
+def tracked_paths(
+    root: Path,
+    commit: str,
+    *,
+    root_fd: int | None = None,
+) -> tuple[str, ...]:
+    listing = run_git(
+        root,
+        "ls-tree",
+        "-r",
+        "--name-only",
+        "-z",
+        commit,
+        root_fd=root_fd,
+    )
     paths = tuple(
         sorted(
             validate_repository_path(entry, "tracked path")
@@ -443,6 +484,69 @@ def read_bounded_regular(path: Path, *, limit: int, label: str) -> str:
         raise Refusal(f"{label} is not UTF-8") from error
 
 
+def read_commit_regular(
+    root: Path,
+    commit: str,
+    repository_path: str,
+    *,
+    limit: int,
+    label: str,
+    root_fd: int | None = None,
+) -> str:
+    """Read one bounded regular blob from the recorded Git tree."""
+    listing = run_git(
+        root,
+        "ls-tree",
+        "-z",
+        commit,
+        "--",
+        repository_path,
+        root_fd=root_fd,
+    )
+    records = [record for record in listing.split(chr(0)) if record]
+    if not records:
+        raise Refusal(f"{label} is absent from commit {commit}")
+    if len(records) != 1 or chr(9) not in records[0]:
+        raise Refusal(f"{label} has an ambiguous Git tree record")
+    metadata, listed_path = records[0].split(chr(9), 1)
+    fields = metadata.split()
+    if len(fields) != 3 or listed_path != repository_path:
+        raise Refusal(f"{label} has a malformed Git tree record")
+    mode, object_type, object_id = fields
+    if mode not in {"100644", "100755"} or object_type != "blob":
+        raise Refusal(f"{label} is not a regular file in commit {commit}")
+    _require_oid(object_id, f"{label} blob")
+    size_text = run_git(
+        root,
+        "cat-file",
+        "-s",
+        object_id,
+        root_fd=root_fd,
+    ).strip()
+    if not size_text.isdecimal():
+        raise Refusal(f"{label} blob size is not an integer")
+    size = int(size_text)
+    if size > limit:
+        raise Refusal(f"{label} exceeds {limit} bytes")
+    stdout, stderr, returncode = run_process(
+        ["git", "cat-file", "blob", object_id]
+        if root_fd is not None
+        else ["git", "-C", str(root), "cat-file", "blob", object_id],
+        cwd=root,
+        timeout_seconds=GIT_TIMEOUT_SECONDS,
+        output_limit=limit,
+        cwd_fd=root_fd,
+    )
+    if returncode != 0:
+        detail = decode_output(stderr, "git stderr").strip()
+        if not detail:
+            detail = f"exit {returncode}"
+        raise Refusal(f"{label} blob cannot be read: {detail}")
+    if len(stdout) != size:
+        raise Refusal(f"{label} blob size changed while it was read")
+    return decode_output(stdout, label)
+
+
 def reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
     document: dict[str, object] = {}
     for key, value in pairs:
@@ -452,13 +556,31 @@ def reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
     return document
 
 
-def load_boundary(root: Path) -> Classification:
+def load_boundary(
+    root: Path,
+    *,
+    commit: str | None = None,
+    root_fd: int | None = None,
+) -> Classification:
     label = BOUNDARY_PATH.as_posix()
-    raw = read_bounded_regular(
-        root / BOUNDARY_PATH,
-        limit=MAX_BOUNDARY_BYTES,
-        label=label,
-    )
+    owns_root_fd = root_fd is None
+    if root_fd is None:
+        root_fd = open_repository_directory(root)
+    try:
+        recorded_commit = (
+            resolve_commit(root, root_fd=root_fd) if commit is None else commit
+        )
+        raw = read_commit_regular(
+            root,
+            recorded_commit,
+            label,
+            limit=MAX_BOUNDARY_BYTES,
+            label=label,
+            root_fd=root_fd,
+        )
+    finally:
+        if owns_root_fd:
+            os.close(root_fd)
     try:
         document = json.loads(raw, object_pairs_hook=reject_duplicate_keys)
     except DuplicateKey as error:
@@ -517,26 +639,35 @@ def universe_identity(
     )
 
 
-def discover(root: Path) -> Universe:
-    require_clean_tree(root)
-    commit = resolve_commit(root)
-    tree = resolve_tree(root, commit)
-    tracked = tracked_paths(root, commit)
-    classified = load_boundary(root)
+def discover(root: Path, *, root_fd: int | None = None) -> Universe:
+    owns_root_fd = root_fd is None
+    if root_fd is None:
+        root_fd = open_repository_directory(root)
+    try:
+        require_clean_tree(root, root_fd=root_fd)
+        commit = resolve_commit(root, root_fd=root_fd)
+        tree = resolve_tree(root, commit, root_fd=root_fd)
+        tracked = tracked_paths(root, commit, root_fd=root_fd)
+        classified = load_boundary(root, commit=commit, root_fd=root_fd)
 
-    analysed: list[str] = []
-    excluded: list[ClassifiedPath] = []
-    for path in tracked:
-        match = classified.match(path)
-        if match is None:
-            analysed.append(path)
-        else:
-            excluded.append(match)
-    if len(analysed) < UNIVERSE_FLOOR:
-        raise Refusal(
-            f"discovery returned {len(analysed)} analysable paths from "
-            f"{len(tracked)} tracked; this is a collapsed walk"
-        )
+        analysed: list[str] = []
+        excluded: list[ClassifiedPath] = []
+        for path in tracked:
+            match = classified.match(path)
+            if match is None:
+                analysed.append(path)
+            else:
+                excluded.append(match)
+        if len(analysed) < UNIVERSE_FLOOR:
+            raise Refusal(
+                f"discovery returned {len(analysed)} analysable paths from "
+                f"{len(tracked)} tracked; this is a collapsed walk"
+            )
+        require_clean_tree(root, root_fd=root_fd)
+    finally:
+        if owns_root_fd:
+            os.close(root_fd)
+
     analysed_tuple = tuple(analysed)
     excluded_tuple = tuple(excluded)
     return Universe(
@@ -647,8 +778,8 @@ def validate_report(report: Report) -> None:
         raise Refusal("findings are not sorted by stable report identity")
 
 
-def build_report(root: Path) -> Report:
-    universe = discover(root)
+def build_report(root: Path, *, root_fd: int | None = None) -> Report:
+    universe = discover(root, root_fd=root_fd)
     statuses, findings = collect(root, universe)
     report = Report(universe=universe, statuses=statuses, findings=findings)
     validate_report(report)
@@ -898,18 +1029,16 @@ def atomic_write(
 
 def command_report(arguments: argparse.Namespace) -> int:
     root = repository_root(Path(arguments.directory).resolve())
-    root_fd: int | None = None
+    root_fd = open_repository_directory(root)
     target: Path | None = None
     try:
         if arguments.output is not None:
-            root_fd = open_repository_directory(root)
             target = confine(root, arguments.output)
-        report = build_report(root)
+        report = build_report(root, root_fd=root_fd)
         rendered = render_json(report) if arguments.json else render_text(report)
         if arguments.output is None:
             sys.stdout.write(rendered)
             return 0
-        assert root_fd is not None
         assert target is not None
         atomic_write(root, target, rendered, root_fd=root_fd)
         return 0

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -733,8 +733,10 @@ def confine(root: Path, candidate: str) -> Path:
         raise Refusal(
             f"the output path must be beneath the owned {OWNED_OUTPUT_DIRECTORY}/ sink"
         )
-    target = root.resolve(strict=True).joinpath(*parts)
-    if target == root.resolve(strict=True):
+    if not root.is_absolute():
+        raise Refusal("the repository root is not absolute")
+    target = root.joinpath(*parts)
+    if target == root:
         raise Refusal("the repository root is not an output file")
     return target
 
@@ -765,18 +767,18 @@ def output_parts(root: Path, target: Path) -> tuple[str, ...]:
     return parts
 
 
-def open_repository_directory(root: Path) -> tuple[Path, int]:
+def open_repository_directory(root: Path) -> int:
     nofollow = getattr(os, "O_NOFOLLOW", None)
     directory_flag = getattr(os, "O_DIRECTORY", None)
     if nofollow is None or directory_flag is None:
         raise Refusal("this platform cannot open output directories without following links")
+    if not root.is_absolute():
+        raise Refusal("the repository root is not absolute")
     flags = os.O_RDONLY | nofollow | directory_flag | getattr(os, "O_CLOEXEC", 0)
     try:
-        resolved_root = root.resolve(strict=True)
-        root_fd = os.open(resolved_root, flags)
-    except (OSError, RuntimeError) as error:
+        return os.open(root, flags)
+    except OSError as error:
         raise Refusal(f"the repository root cannot be opened safely: {error}") from error
-    return resolved_root, root_fd
 
 
 def open_output_directory(root_fd: int, parts: tuple[str, ...]) -> int:
@@ -846,16 +848,25 @@ def create_temporary(directory_fd: int) -> tuple[int, str]:
     raise Refusal("report temporary name allocation was exhausted")
 
 
-def atomic_write(root: Path, target: Path, payload: str) -> None:
+def atomic_write(
+    root: Path,
+    target: Path,
+    payload: str,
+    *,
+    root_fd: int | None = None,
+) -> None:
     encoded = payload.encode("utf-8")
     if len(encoded) > MAX_REPORT_BYTES:
         raise Refusal(f"report exceeds {MAX_REPORT_BYTES} bytes")
-    resolved_root, root_fd = open_repository_directory(root)
+    owns_root_fd = root_fd is None
+    if root_fd is None:
+        root_fd = open_repository_directory(root)
     try:
-        parts = output_parts(resolved_root, target)
+        parts = output_parts(root, target)
         directory_fd = open_output_directory(root_fd, parts)
     finally:
-        os.close(root_fd)
+        if owns_root_fd:
+            os.close(root_fd)
     temporary_name: str | None = None
     try:
         require_regular_target(directory_fd, parts[-1])
@@ -887,14 +898,24 @@ def atomic_write(root: Path, target: Path, payload: str) -> None:
 
 def command_report(arguments: argparse.Namespace) -> int:
     root = repository_root(Path(arguments.directory).resolve())
-    report = build_report(root)
-    rendered = render_json(report) if arguments.json else render_text(report)
-    if arguments.output is None:
-        sys.stdout.write(rendered)
-    else:
-        target = confine(root, arguments.output)
-        atomic_write(root, target, rendered)
-    return 0
+    root_fd: int | None = None
+    target: Path | None = None
+    try:
+        if arguments.output is not None:
+            root_fd = open_repository_directory(root)
+            target = confine(root, arguments.output)
+        report = build_report(root)
+        rendered = render_json(report) if arguments.json else render_text(report)
+        if arguments.output is None:
+            sys.stdout.write(rendered)
+            return 0
+        assert root_fd is not None
+        assert target is not None
+        atomic_write(root, target, rendered, root_fd=root_fd)
+        return 0
+    finally:
+        if root_fd is not None:
+            os.close(root_fd)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -740,7 +740,8 @@ def confine(root: Path, candidate: str) -> Path:
 
 
 def output_parts(root: Path, target: Path) -> tuple[str, ...]:
-    root = root.resolve(strict=True)
+    if not root.is_absolute():
+        raise Refusal("the repository root is not absolute")
     try:
         relative = target.relative_to(root)
     except ValueError as error:
@@ -764,14 +765,28 @@ def output_parts(root: Path, target: Path) -> tuple[str, ...]:
     return parts
 
 
-def open_output_directory(root: Path, parts: tuple[str, ...]) -> int:
+def open_repository_directory(root: Path) -> tuple[Path, int]:
     nofollow = getattr(os, "O_NOFOLLOW", None)
     directory_flag = getattr(os, "O_DIRECTORY", None)
     if nofollow is None or directory_flag is None:
         raise Refusal("this platform cannot open output directories without following links")
     flags = os.O_RDONLY | nofollow | directory_flag | getattr(os, "O_CLOEXEC", 0)
     try:
-        current_fd = os.open(root.resolve(strict=True), flags)
+        resolved_root = root.resolve(strict=True)
+        root_fd = os.open(resolved_root, flags)
+    except (OSError, RuntimeError) as error:
+        raise Refusal(f"the repository root cannot be opened safely: {error}") from error
+    return resolved_root, root_fd
+
+
+def open_output_directory(root_fd: int, parts: tuple[str, ...]) -> int:
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    directory_flag = getattr(os, "O_DIRECTORY", None)
+    if nofollow is None or directory_flag is None:
+        raise Refusal("this platform cannot open output directories without following links")
+    flags = os.O_RDONLY | nofollow | directory_flag | getattr(os, "O_CLOEXEC", 0)
+    try:
+        current_fd = os.dup(root_fd)
     except OSError as error:
         raise Refusal(f"the repository root cannot be opened safely: {error}") from error
     try:
@@ -835,8 +850,12 @@ def atomic_write(root: Path, target: Path, payload: str) -> None:
     encoded = payload.encode("utf-8")
     if len(encoded) > MAX_REPORT_BYTES:
         raise Refusal(f"report exceeds {MAX_REPORT_BYTES} bytes")
-    parts = output_parts(root, target)
-    directory_fd = open_output_directory(root, parts)
+    resolved_root, root_fd = open_repository_directory(root)
+    try:
+        parts = output_parts(resolved_root, target)
+        directory_fd = open_output_directory(root_fd, parts)
+    finally:
+        os.close(root_fd)
     temporary_name: str | None = None
     try:
         require_regular_target(directory_fd, parts[-1])

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -1,0 +1,883 @@
+#!/usr/bin/env python3
+"""Build a report-only dead-code inventory for one clean Git tree.
+
+The command discovers tracked paths, applies hard Horos classifications and
+renders one deterministic model as text or JSON. Step 1 registers no analyser,
+so the report says that no reachability result was established. It never
+deletes source and a finding count is never an exit gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import selectors
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Callable
+
+SCHEMA_ID = "dead-code-report/v1"
+TOOL_ID = "dead-code"
+TOOL_VERSION = "1"
+STATUS_ID = "analysis"
+BOUNDARY_PATH = Path(".horos") / "boundary.json"
+BOUNDARY_SCHEMA = 2
+BOUNDARY_TOOL = "horos"
+EXCLUDING_GRADE = "hard"
+UNIVERSE_FLOOR = 1
+TEMP_PREFIX = ".dead-code-tmp-"
+GIT_TIMEOUT_SECONDS = 60
+MAX_GIT_OUTPUT_BYTES = 16 * 1024 * 1024
+MAX_BOUNDARY_BYTES = 4 * 1024 * 1024
+MAX_REPORT_BYTES = 32 * 1024 * 1024
+MAX_TRACKED_PATHS = 100_000
+MAX_PATH_BYTES = 4096
+ANALYSER_STATES = frozenset({"ran", "not-available", "degraded", "failed"})
+CONFIDENCE_LEVELS = frozenset({"high", "medium", "low"})
+
+Analyser = Callable[
+    [Path, "Universe"],
+    tuple["AnalyserStatus", tuple["Finding", ...]],
+]
+ANALYSERS: dict[str, Analyser] = {}
+
+
+class Refusal(Exception):
+    """A named condition that stops the command before it reports."""
+
+
+class DuplicateKey(ValueError):
+    """A duplicate JSON member that would otherwise overwrite evidence."""
+
+
+@dataclass(frozen=True)
+class ClassifiedPath:
+    path: str
+    category: str
+    evidence: str
+    grade: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "path": self.path,
+            "category": self.category,
+            "evidence": self.evidence,
+            "grade": self.grade,
+        }
+
+
+@dataclass(frozen=True)
+class Classification:
+    files: dict[str, ClassifiedPath]
+    directories: tuple[ClassifiedPath, ...]
+
+    def match(self, path: str) -> ClassifiedPath | None:
+        exact = self.files.get(path)
+        if exact is not None:
+            return exact
+        for tree in self.directories:
+            if path.startswith(tree.path):
+                return ClassifiedPath(
+                    path=path,
+                    category=tree.category,
+                    evidence=(
+                        f"{tree.evidence}, inherited from the classified tree "
+                        f"{tree.path}"
+                    ),
+                    grade=tree.grade,
+                )
+        return None
+
+
+@dataclass(frozen=True)
+class Universe:
+    commit: str
+    tree: str
+    identity: str
+    tracked_count: int
+    analysed: tuple[str, ...]
+    excluded: tuple[ClassifiedPath, ...]
+
+    def excluded_by_category(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for entry in self.excluded:
+            counts[entry.category] = counts.get(entry.category, 0) + 1
+        return {name: counts[name] for name in sorted(counts)}
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.identity,
+            "tracked_count": self.tracked_count,
+            "analysed_count": len(self.analysed),
+            "analysed": list(self.analysed),
+            "excluded_count": len(self.excluded),
+            "excluded_by_category": self.excluded_by_category(),
+            "excluded": [entry.as_dict() for entry in self.excluded],
+        }
+
+
+@dataclass(frozen=True)
+class AnalyserStatus:
+    analyser_id: str
+    state: str
+    version: str | None
+    detail: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.analyser_id,
+            "state": self.state,
+            "version": self.version,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class Finding:
+    analyser_id: str
+    path: str
+    symbol: str | None
+    evidence: str
+    confidence: str
+    false_positive_boundary: str
+
+    @property
+    def identity(self) -> str:
+        payload = {
+            "analyser_id": self.analyser_id,
+            "path": self.path,
+            "symbol": self.symbol,
+            "evidence": self.evidence,
+            "confidence": self.confidence,
+            "false_positive_boundary": self.false_positive_boundary,
+        }
+        return digest_json(payload)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.identity,
+            "analyser_id": self.analyser_id,
+            "path": self.path,
+            "symbol": self.symbol,
+            "evidence": self.evidence,
+            "confidence": self.confidence,
+            "false_positive_boundary": self.false_positive_boundary,
+        }
+
+
+@dataclass(frozen=True)
+class Report:
+    universe: Universe
+    statuses: tuple[AnalyserStatus, ...]
+    findings: tuple[Finding, ...]
+
+    def analysis_status(self) -> dict[str, str]:
+        if not self.statuses:
+            return {
+                "id": STATUS_ID,
+                "state": "not-run",
+                "detail": (
+                    "no analyser registered; this report establishes no "
+                    "reachability result"
+                ),
+            }
+        if any(item.state == "failed" for item in self.statuses):
+            state = "failed"
+            detail = "at least one analyser failed; no clean result is established"
+        elif any(item.state in {"degraded", "not-available"} for item in self.statuses):
+            state = "degraded"
+            detail = "one or more analyser signals are incomplete"
+        else:
+            state = "ran"
+            detail = "every registered analyser completed"
+        return {"id": STATUS_ID, "state": state, "detail": detail}
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "schema": SCHEMA_ID,
+            "tool": {"id": TOOL_ID, "version": TOOL_VERSION},
+            "tree": {
+                "commit": self.universe.commit,
+                "git_tree": self.universe.tree,
+            },
+            "universe": self.universe.as_dict(),
+            "status": self.analysis_status(),
+            "analysers": [status.as_dict() for status in self.statuses],
+            "findings": [finding.as_dict() for finding in self.findings],
+        }
+
+
+def digest_json(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _stop_process(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is None:
+        process.kill()
+    process.wait()
+
+
+def run_process(
+    argv: list[str],
+    *,
+    cwd: Path,
+    timeout_seconds: int,
+    output_limit: int,
+) -> tuple[bytes, bytes, int]:
+    """Run fixed argv while bounding time and combined captured output."""
+    try:
+        process = subprocess.Popen(
+            argv,
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=False,
+        )
+    except FileNotFoundError as error:
+        raise Refusal(f"{argv[0]} is not available on PATH") from error
+    except OSError as error:
+        raise Refusal(f"{argv[0]} could not start: {error}") from error
+
+    assert process.stdout is not None
+    assert process.stderr is not None
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+    selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+    buffers = {"stdout": bytearray(), "stderr": bytearray()}
+    total = 0
+    deadline = time.monotonic() + timeout_seconds
+    try:
+        while selector.get_map():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                _stop_process(process)
+                raise Refusal(f"{argv[0]} timed out after {timeout_seconds}s")
+            events = selector.select(min(remaining, 0.25))
+            if not events:
+                continue
+            for key, _ in events:
+                chunk = os.read(
+                    key.fileobj.fileno(),
+                    min(65_536, output_limit - total + 1),
+                )
+                if not chunk:
+                    selector.unregister(key.fileobj)
+                    continue
+                buffers[key.data].extend(chunk)
+                total += len(chunk)
+                if total > output_limit:
+                    _stop_process(process)
+                    raise Refusal(
+                        f"{argv[0]} output exceeded {output_limit} bytes"
+                    )
+        returncode = process.wait()
+    finally:
+        selector.close()
+        if process.poll() is None:
+            _stop_process(process)
+        process.stdout.close()
+        process.stderr.close()
+    return bytes(buffers["stdout"]), bytes(buffers["stderr"]), returncode
+
+
+def decode_output(payload: bytes, label: str) -> str:
+    try:
+        return payload.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise Refusal(f"{label} output is not UTF-8") from error
+
+
+def run_git(root: Path, *arguments: str) -> str:
+    stdout, stderr, returncode = run_process(
+        ["git", "-C", str(root), *arguments],
+        cwd=root,
+        timeout_seconds=GIT_TIMEOUT_SECONDS,
+        output_limit=MAX_GIT_OUTPUT_BYTES,
+    )
+    if returncode != 0:
+        detail = decode_output(stderr, "git stderr").strip()
+        if not detail:
+            detail = f"exit {returncode}"
+        raise Refusal(f"git {arguments[0]} failed: {detail}")
+    return decode_output(stdout, "git stdout")
+
+
+def repository_root(start: Path) -> Path:
+    output = run_git(start, "rev-parse", "--show-toplevel").strip()
+    if not output:
+        raise Refusal(f"{start} is not inside a Git worktree")
+    root = Path(output).resolve(strict=True)
+    if not root.is_dir():
+        raise Refusal("Git returned a root that is not a directory")
+    return root
+
+
+def _require_oid(value: str, label: str) -> str:
+    if len(value) != 40 or any(character not in "0123456789abcdef" for character in value):
+        raise Refusal(f"{label} is not a lowercase 40-byte Git object identity")
+    return value
+
+
+def resolve_commit(root: Path) -> str:
+    return _require_oid(run_git(root, "rev-parse", "HEAD").strip(), "HEAD")
+
+
+def resolve_tree(root: Path, commit: str) -> str:
+    return _require_oid(
+        run_git(root, "rev-parse", f"{commit}^{{tree}}").strip(),
+        "HEAD tree",
+    )
+
+
+def require_clean_tree(root: Path) -> None:
+    porcelain = run_git(
+        root,
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=no",
+    )
+    changed = [entry for entry in porcelain.split(chr(0)) if entry]
+    if changed:
+        names = sorted(entry[3:] if len(entry) > 3 else entry for entry in changed)
+        listed = ", ".join(names[:5])
+        more = "" if len(names) <= 5 else f" and {len(names) - 5} more"
+        raise Refusal(
+            f"the checkout has {len(names)} modified tracked file(s): "
+            f"{listed}{more}; commit or stash before analysing"
+        )
+
+
+def validate_repository_path(value: str, label: str) -> str:
+    if not value:
+        raise Refusal(f"{label} is empty")
+    if len(value.encode("utf-8")) > MAX_PATH_BYTES:
+        raise Refusal(f"{label} exceeds {MAX_PATH_BYTES} bytes")
+    if value.startswith("/") or chr(92) in value or chr(0) in value:
+        raise Refusal(f"{label} is not a safe repository-relative POSIX path")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise Refusal(f"{label} contains a control character")
+    without_tree_suffix = value[:-1] if value.endswith("/") else value
+    parts = PurePosixPath(without_tree_suffix).parts
+    if not parts or any(part in {"", ".", ".."} for part in parts):
+        raise Refusal(f"{label} is not a safe repository-relative POSIX path")
+    return value
+
+
+def tracked_paths(root: Path, commit: str) -> tuple[str, ...]:
+    listing = run_git(root, "ls-tree", "-r", "--name-only", "-z", commit)
+    paths = tuple(
+        sorted(
+            validate_repository_path(entry, "tracked path")
+            for entry in listing.split(chr(0))
+            if entry
+        )
+    )
+    if len(paths) > MAX_TRACKED_PATHS:
+        raise Refusal(f"tracked discovery exceeded {MAX_TRACKED_PATHS} paths")
+    if len(paths) != len(set(paths)):
+        raise Refusal("tracked discovery returned duplicate paths")
+    return paths
+
+
+def read_bounded_regular(path: Path, *, limit: int, label: str) -> str:
+    try:
+        before = path.lstat()
+    except FileNotFoundError as error:
+        raise Refusal(f"{label} is absent") from error
+    except OSError as error:
+        raise Refusal(f"{label} cannot be inspected: {error}") from error
+    if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
+        raise Refusal(f"{label} is not a regular file")
+    if before.st_size > limit:
+        raise Refusal(f"{label} exceeds {limit} bytes")
+    try:
+        with path.open("rb") as handle:
+            opened = os.fstat(handle.fileno())
+            if (opened.st_dev, opened.st_ino) != (before.st_dev, before.st_ino):
+                raise Refusal(f"{label} changed before it was opened")
+            payload = handle.read(limit + 1)
+            after_handle = os.fstat(handle.fileno())
+        after = path.lstat()
+    except OSError as error:
+        raise Refusal(f"{label} cannot be read: {error}") from error
+    if len(payload) > limit:
+        raise Refusal(f"{label} exceeds {limit} bytes")
+    before_identity = (
+        before.st_dev,
+        before.st_ino,
+        before.st_size,
+        before.st_mtime_ns,
+    )
+    after_identity = (
+        after.st_dev,
+        after.st_ino,
+        after.st_size,
+        after.st_mtime_ns,
+    )
+    handle_identity = (
+        after_handle.st_dev,
+        after_handle.st_ino,
+        after_handle.st_size,
+        after_handle.st_mtime_ns,
+    )
+    if before_identity != after_identity or before_identity != handle_identity:
+        raise Refusal(f"{label} changed while it was read")
+    try:
+        return payload.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise Refusal(f"{label} is not UTF-8") from error
+
+
+def reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    document: dict[str, object] = {}
+    for key, value in pairs:
+        if key in document:
+            raise DuplicateKey(key)
+        document[key] = value
+    return document
+
+
+def load_boundary(root: Path) -> Classification:
+    label = BOUNDARY_PATH.as_posix()
+    raw = read_bounded_regular(
+        root / BOUNDARY_PATH,
+        limit=MAX_BOUNDARY_BYTES,
+        label=label,
+    )
+    try:
+        document = json.loads(raw, object_pairs_hook=reject_duplicate_keys)
+    except DuplicateKey as error:
+        raise Refusal(f"{label} repeats JSON key {error.args[0]}") from error
+    except json.JSONDecodeError as error:
+        raise Refusal(f"{label} is not valid JSON: {error}") from error
+    if not isinstance(document, dict):
+        raise Refusal(f"{label} is not a JSON object")
+    if document.get("schema") != BOUNDARY_SCHEMA:
+        raise Refusal(f"{label} does not declare schema {BOUNDARY_SCHEMA}")
+    if document.get("tool") != BOUNDARY_TOOL:
+        raise Refusal(f"{label} does not declare tool {BOUNDARY_TOOL}")
+    entries = document.get("entries")
+    if not isinstance(entries, list):
+        raise Refusal(f"{label} has no entries list")
+
+    files: dict[str, ClassifiedPath] = {}
+    directories: list[ClassifiedPath] = []
+    seen_paths: set[str] = set()
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise Refusal(f"{label} entry {index} is not an object")
+        fields: dict[str, str] = {}
+        for name in ("path", "category", "evidence", "grade"):
+            value = entry.get(name)
+            if not isinstance(value, str) or not value:
+                raise Refusal(f"{label} entry {index} has no usable {name}")
+            fields[name] = value
+        path = validate_repository_path(fields["path"], f"{label} entry {index} path")
+        if path in seen_paths:
+            raise Refusal(f"{label} repeats classified path {path}")
+        seen_paths.add(path)
+        if fields["grade"] != EXCLUDING_GRADE:
+            continue
+        classified = ClassifiedPath(**fields)
+        if path.endswith("/"):
+            directories.append(classified)
+        else:
+            files[path] = classified
+
+    directories.sort(key=lambda item: (-len(item.path), item.path))
+    return Classification(files=files, directories=tuple(directories))
+
+
+def universe_identity(
+    tree: str,
+    analysed: tuple[str, ...],
+    excluded: tuple[ClassifiedPath, ...],
+) -> str:
+    return digest_json(
+        {
+            "git_tree": tree,
+            "analysed": list(analysed),
+            "excluded": [entry.as_dict() for entry in excluded],
+        }
+    )
+
+
+def discover(root: Path) -> Universe:
+    require_clean_tree(root)
+    commit = resolve_commit(root)
+    tree = resolve_tree(root, commit)
+    tracked = tracked_paths(root, commit)
+    classified = load_boundary(root)
+
+    analysed: list[str] = []
+    excluded: list[ClassifiedPath] = []
+    for path in tracked:
+        match = classified.match(path)
+        if match is None:
+            analysed.append(path)
+        else:
+            excluded.append(match)
+    if len(analysed) < UNIVERSE_FLOOR:
+        raise Refusal(
+            f"discovery returned {len(analysed)} analysable paths from "
+            f"{len(tracked)} tracked; this is a collapsed walk"
+        )
+    analysed_tuple = tuple(analysed)
+    excluded_tuple = tuple(excluded)
+    return Universe(
+        commit=commit,
+        tree=tree,
+        identity=universe_identity(tree, analysed_tuple, excluded_tuple),
+        tracked_count=len(tracked),
+        analysed=analysed_tuple,
+        excluded=excluded_tuple,
+    )
+
+
+def collect(
+    root: Path,
+    universe: Universe,
+) -> tuple[tuple[AnalyserStatus, ...], tuple[Finding, ...]]:
+    statuses: list[AnalyserStatus] = []
+    findings: list[Finding] = []
+    for analyser_id in sorted(ANALYSERS):
+        status, produced = ANALYSERS[analyser_id](root, universe)
+        if status.analyser_id != analyser_id:
+            raise Refusal(
+                f"analyser {analyser_id} returned status for {status.analyser_id}"
+            )
+        statuses.append(status)
+        findings.extend(produced)
+    statuses.sort(key=lambda item: item.analyser_id)
+    findings.sort(
+        key=lambda item: (
+            item.analyser_id,
+            item.path,
+            item.symbol or "",
+            item.evidence,
+        )
+    )
+    return tuple(statuses), tuple(findings)
+
+
+def validate_report(report: Report) -> None:
+    universe = report.universe
+    _require_oid(universe.commit, "report commit")
+    _require_oid(universe.tree, "report tree")
+    if not universe.analysed:
+        raise Refusal("report universe has no analysed paths")
+    if universe.analysed != tuple(sorted(set(universe.analysed))):
+        raise Refusal("report analysed paths are not sorted and unique")
+    excluded_paths = tuple(item.path for item in universe.excluded)
+    if excluded_paths != tuple(sorted(set(excluded_paths))):
+        raise Refusal("report excluded paths are not sorted and unique")
+    if any(item.grade != EXCLUDING_GRADE for item in universe.excluded):
+        raise Refusal("report carries a non-hard exclusion")
+    if universe.tracked_count != len(universe.analysed) + len(universe.excluded):
+        raise Refusal("report universe counts do not partition the tracked tree")
+    expected_universe_id = universe_identity(
+        universe.tree,
+        universe.analysed,
+        universe.excluded,
+    )
+    if universe.identity != expected_universe_id:
+        raise Refusal("report universe identity does not match its paths")
+
+    status_ids: set[str] = set()
+    for item in report.statuses:
+        if not item.analyser_id or item.analyser_id in status_ids:
+            raise Refusal("analyser status identities are empty or repeated")
+        if item.state not in ANALYSER_STATES:
+            raise Refusal(
+                f"analyser {item.analyser_id} has unknown state {item.state}"
+            )
+        if not item.detail:
+            raise Refusal(f"analyser {item.analyser_id} has no detail")
+        status_ids.add(item.analyser_id)
+    if tuple(item.analyser_id for item in report.statuses) != tuple(sorted(status_ids)):
+        raise Refusal("analyser statuses are not sorted by identity")
+
+    finding_ids: set[str] = set()
+    analysed = set(report.universe.analysed)
+    for finding in report.findings:
+        if finding.analyser_id not in status_ids:
+            raise Refusal(
+                f"finding {finding.identity} names unreported analyser "
+                f"{finding.analyser_id}"
+            )
+        if finding.path not in analysed:
+            raise Refusal(f"finding {finding.identity} names path outside the universe")
+        if finding.confidence not in CONFIDENCE_LEVELS:
+            raise Refusal(
+                f"finding {finding.identity} has unknown confidence "
+                f"{finding.confidence}"
+            )
+        if finding.identity in finding_ids:
+            raise Refusal(f"finding identity repeats: {finding.identity}")
+        finding_ids.add(finding.identity)
+    if not report.statuses and report.findings:
+        raise Refusal("findings exist although no analyser ran")
+    expected_finding_order = tuple(
+        sorted(
+            report.findings,
+            key=lambda item: (
+                item.analyser_id,
+                item.path,
+                item.symbol or "",
+                item.evidence,
+            ),
+        )
+    )
+    if report.findings != expected_finding_order:
+        raise Refusal("findings are not sorted by stable report identity")
+
+
+def build_report(root: Path) -> Report:
+    universe = discover(root)
+    statuses, findings = collect(root, universe)
+    report = Report(universe=universe, statuses=statuses, findings=findings)
+    validate_report(report)
+    return report
+
+
+def render_json(report: Report) -> str:
+    return json.dumps(
+        report.as_dict(),
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    ) + chr(10)
+
+
+def render_text(report: Report) -> str:
+    document = report.as_dict()
+    tree = document["tree"]
+    universe = document["universe"]
+    status = document["status"]
+    lines = [
+        f"{TOOL_ID} {TOOL_VERSION} report  schema {document['schema']}",
+        f"commit    {tree['commit']}",
+        f"tree      {tree['git_tree']}",
+        f"universe  {universe['id']}",
+        (
+            f"paths     {universe['tracked_count']} tracked, "
+            f"{universe['analysed_count']} analysed, "
+            f"{universe['excluded_count']} excluded"
+        ),
+        f"status    {status['state']}  {status['detail']}",
+    ]
+    by_category = universe["excluded_by_category"]
+    if by_category:
+        summary = ", ".join(
+            f"{name} {by_category[name]}" for name in sorted(by_category)
+        )
+        lines.append(f"excluded  {summary}")
+    lines.extend(["", "analysers"])
+    if not document["analysers"]:
+        lines.append("  none ran; no reachability result was established")
+    for analyser in document["analysers"]:
+        version = f" {analyser['version']}" if analyser["version"] else ""
+        lines.append(
+            f"  {analyser['id']}{version}  {analyser['state']}  "
+            f"{analyser['detail']}"
+        )
+
+    findings = document["findings"]
+    lines.extend(["", f"findings  {len(findings)} candidate(s); report-only"])
+    if not findings:
+        lines.append("  none reported")
+    for finding in findings:
+        symbol = f" {finding['symbol']}" if finding["symbol"] else ""
+        lines.append(
+            f"  [{finding['confidence']}] {finding['id']}  "
+            f"{finding['analyser_id']}  {finding['path']}{symbol}"
+        )
+        lines.append(f"      saw     {finding['evidence']}")
+        lines.append(f"      but     {finding['false_positive_boundary']}")
+    return chr(10).join(lines) + chr(10)
+
+
+def confine(root: Path, candidate: str) -> Path:
+    if not isinstance(candidate, str) or not candidate:
+        raise Refusal("the output path is empty")
+    if chr(0) in candidate:
+        raise Refusal("the output path contains a null byte")
+    supplied = Path(candidate)
+    if supplied.is_absolute():
+        raise Refusal("the output path must be repository-relative")
+    parts = supplied.parts
+    if not parts or any(part in {"", ".", ".."} for part in parts):
+        raise Refusal(f"the output path {candidate} escapes the repository root")
+    if len(candidate.encode("utf-8")) > MAX_PATH_BYTES:
+        raise Refusal(f"the output path exceeds {MAX_PATH_BYTES} bytes")
+    target = root.resolve(strict=True).joinpath(*parts)
+    if target == root.resolve(strict=True):
+        raise Refusal("the repository root is not an output file")
+    return target
+
+
+def ensure_safe_parent(root: Path, target: Path) -> Path:
+    root = root.resolve(strict=True)
+    try:
+        relative = target.relative_to(root)
+    except ValueError as error:
+        raise Refusal("the output path escapes the repository root") from error
+    current = root
+    for part in relative.parts[:-1]:
+        current = current / part
+        try:
+            current.mkdir()
+        except FileExistsError:
+            pass
+        except OSError as error:
+            raise Refusal(f"the output directory cannot be created: {error}") from error
+        try:
+            current_stat = current.lstat()
+        except OSError as error:
+            raise Refusal(f"the output directory cannot be inspected: {error}") from error
+        if stat.S_ISLNK(current_stat.st_mode) or not stat.S_ISDIR(current_stat.st_mode):
+            raise Refusal(f"the output ancestor {current} is not a real directory")
+    try:
+        target_stat = target.lstat()
+    except FileNotFoundError:
+        pass
+    except OSError as error:
+        raise Refusal(f"the output target cannot be inspected: {error}") from error
+    else:
+        if stat.S_ISLNK(target_stat.st_mode) or not stat.S_ISREG(target_stat.st_mode):
+            raise Refusal("the output target is not a regular file")
+    return current
+
+
+def sweep_orphans(directory: Path) -> None:
+    try:
+        candidates = list(directory.iterdir())
+    except OSError:
+        return
+    for candidate in candidates:
+        if not candidate.name.startswith(TEMP_PREFIX):
+            continue
+        try:
+            candidate_stat = candidate.lstat()
+            if stat.S_ISREG(candidate_stat.st_mode):
+                candidate.unlink()
+        except OSError:
+            continue
+
+
+def atomic_write(root: Path, target: Path, payload: str) -> None:
+    encoded = payload.encode("utf-8")
+    if len(encoded) > MAX_REPORT_BYTES:
+        raise Refusal(f"report exceeds {MAX_REPORT_BYTES} bytes")
+    directory = ensure_safe_parent(root, target)
+    before_directory = directory.lstat()
+    sweep_orphans(directory)
+    try:
+        handle = tempfile.NamedTemporaryFile(
+            "wb",
+            dir=directory,
+            prefix=TEMP_PREFIX,
+            delete=False,
+        )
+    except OSError as error:
+        raise Refusal(f"report temporary cannot be created: {error}") from error
+    temporary = Path(handle.name)
+    try:
+        with handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        after_directory = directory.lstat()
+        if (before_directory.st_dev, before_directory.st_ino) != (
+            after_directory.st_dev,
+            after_directory.st_ino,
+        ):
+            raise Refusal("the output directory changed during the write")
+        ensure_safe_parent(root, target)
+        os.replace(temporary, target)
+        directory_fd = os.open(directory, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except Refusal:
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
+        raise
+    except OSError as error:
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
+        raise Refusal(f"report write failed: {error}") from error
+
+
+def command_report(arguments: argparse.Namespace) -> int:
+    root = repository_root(Path(arguments.directory).resolve())
+    report = build_report(root)
+    rendered = render_json(report) if arguments.json else render_text(report)
+    if arguments.output is None:
+        sys.stdout.write(rendered)
+    else:
+        target = confine(root, arguments.output)
+        atomic_write(root, target, rendered)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="dead_code.py",
+        description=__doc__,
+    )
+    parser.add_argument(
+        "--directory",
+        default=".",
+        help="a path inside the repository to analyse",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    report = subparsers.add_parser(
+        "report",
+        help="report the universe and its candidates",
+    )
+    report.add_argument(
+        "--json",
+        action="store_true",
+        help="emit canonical JSON",
+    )
+    report.add_argument(
+        "--output",
+        help="write inside the repository instead of stdout",
+    )
+    report.set_defaults(handler=command_report)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    arguments = parser.parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        return arguments.handler(arguments)
+    except Refusal as refusal:
+        print(f"dead_code.py: {refusal}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -17,7 +17,6 @@ import selectors
 import stat
 import subprocess
 import sys
-import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
@@ -33,6 +32,7 @@ BOUNDARY_TOOL = "horos"
 EXCLUDING_GRADE = "hard"
 UNIVERSE_FLOOR = 1
 TEMP_PREFIX = ".dead-code-tmp-"
+OWNED_OUTPUT_DIRECTORY = ".dead-code"
 GIT_TIMEOUT_SECONDS = 60
 MAX_GIT_OUTPUT_BYTES = 16 * 1024 * 1024
 MAX_BOUNDARY_BYTES = 4 * 1024 * 1024
@@ -717,6 +717,10 @@ def confine(root: Path, candidate: str) -> Path:
         raise Refusal("the output path is empty")
     if chr(0) in candidate:
         raise Refusal("the output path contains a null byte")
+    if chr(92) in candidate or any(
+        ord(character) < 32 or ord(character) == 127 for character in candidate
+    ):
+        raise Refusal("the output path is not a safe repository-relative POSIX path")
     supplied = Path(candidate)
     if supplied.is_absolute():
         raise Refusal("the output path must be repository-relative")
@@ -725,108 +729,141 @@ def confine(root: Path, candidate: str) -> Path:
         raise Refusal(f"the output path {candidate} escapes the repository root")
     if len(candidate.encode("utf-8")) > MAX_PATH_BYTES:
         raise Refusal(f"the output path exceeds {MAX_PATH_BYTES} bytes")
+    if len(parts) < 2 or parts[0] != OWNED_OUTPUT_DIRECTORY:
+        raise Refusal(
+            f"the output path must be beneath the owned {OWNED_OUTPUT_DIRECTORY}/ sink"
+        )
     target = root.resolve(strict=True).joinpath(*parts)
     if target == root.resolve(strict=True):
         raise Refusal("the repository root is not an output file")
     return target
 
 
-def ensure_safe_parent(root: Path, target: Path) -> Path:
+def output_parts(root: Path, target: Path) -> tuple[str, ...]:
     root = root.resolve(strict=True)
     try:
         relative = target.relative_to(root)
     except ValueError as error:
         raise Refusal("the output path escapes the repository root") from error
-    current = root
-    for part in relative.parts[:-1]:
-        current = current / part
-        try:
-            current.mkdir()
-        except FileExistsError:
-            pass
-        except OSError as error:
-            raise Refusal(f"the output directory cannot be created: {error}") from error
-        try:
-            current_stat = current.lstat()
-        except OSError as error:
-            raise Refusal(f"the output directory cannot be inspected: {error}") from error
-        if stat.S_ISLNK(current_stat.st_mode) or not stat.S_ISDIR(current_stat.st_mode):
-            raise Refusal(f"the output ancestor {current} is not a real directory")
+    parts = relative.parts
+    if (
+        not parts
+        or any(part in {"", ".", ".."} for part in parts)
+        or chr(92) in relative.as_posix()
+        or any(
+            ord(character) < 32 or ord(character) == 127
+            for character in relative.as_posix()
+        )
+        or len(relative.as_posix().encode("utf-8")) > MAX_PATH_BYTES
+    ):
+        raise Refusal("the output path is not a safe repository-relative POSIX path")
+    if len(parts) < 2 or parts[0] != OWNED_OUTPUT_DIRECTORY:
+        raise Refusal(
+            f"the output path must be beneath the owned {OWNED_OUTPUT_DIRECTORY}/ sink"
+        )
+    return parts
+
+
+def open_output_directory(root: Path, parts: tuple[str, ...]) -> int:
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    directory_flag = getattr(os, "O_DIRECTORY", None)
+    if nofollow is None or directory_flag is None:
+        raise Refusal("this platform cannot open output directories without following links")
+    flags = os.O_RDONLY | nofollow | directory_flag | getattr(os, "O_CLOEXEC", 0)
     try:
-        target_stat = target.lstat()
+        current_fd = os.open(root.resolve(strict=True), flags)
+    except OSError as error:
+        raise Refusal(f"the repository root cannot be opened safely: {error}") from error
+    try:
+        for part in parts[:-1]:
+            try:
+                os.mkdir(part, mode=0o755, dir_fd=current_fd)
+            except FileExistsError:
+                pass
+            except OSError as error:
+                raise Refusal(
+                    f"the output directory {part} cannot be created: {error}"
+                ) from error
+            try:
+                next_fd = os.open(part, flags, dir_fd=current_fd)
+            except OSError as error:
+                raise Refusal(
+                    f"the output ancestor {part} is not a real directory: {error}"
+                ) from error
+            os.close(current_fd)
+            current_fd = next_fd
+        return current_fd
+    except BaseException:
+        os.close(current_fd)
+        raise
+
+
+def require_regular_target(directory_fd: int, name: str) -> None:
+    try:
+        target_stat = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
     except FileNotFoundError:
-        pass
+        return
     except OSError as error:
         raise Refusal(f"the output target cannot be inspected: {error}") from error
-    else:
-        if stat.S_ISLNK(target_stat.st_mode) or not stat.S_ISREG(target_stat.st_mode):
-            raise Refusal("the output target is not a regular file")
-    return current
+    if stat.S_ISLNK(target_stat.st_mode) or not stat.S_ISREG(target_stat.st_mode):
+        raise Refusal("the output target is not a regular file")
 
 
-def sweep_orphans(directory: Path) -> None:
-    try:
-        candidates = list(directory.iterdir())
-    except OSError:
-        return
-    for candidate in candidates:
-        if not candidate.name.startswith(TEMP_PREFIX):
-            continue
+def create_temporary(directory_fd: int) -> tuple[int, str]:
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    if nofollow is None:
+        raise Refusal("this platform cannot create output files without following links")
+    flags = (
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | nofollow
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    for _ in range(128):
+        name = TEMP_PREFIX + os.urandom(16).hex()
         try:
-            candidate_stat = candidate.lstat()
-            if stat.S_ISREG(candidate_stat.st_mode):
-                candidate.unlink()
-        except OSError:
+            return os.open(name, flags, 0o600, dir_fd=directory_fd), name
+        except FileExistsError:
             continue
+        except OSError as error:
+            raise Refusal(f"report temporary cannot be created: {error}") from error
+    raise Refusal("report temporary name allocation was exhausted")
 
 
 def atomic_write(root: Path, target: Path, payload: str) -> None:
     encoded = payload.encode("utf-8")
     if len(encoded) > MAX_REPORT_BYTES:
         raise Refusal(f"report exceeds {MAX_REPORT_BYTES} bytes")
-    directory = ensure_safe_parent(root, target)
-    before_directory = directory.lstat()
-    sweep_orphans(directory)
+    parts = output_parts(root, target)
+    directory_fd = open_output_directory(root, parts)
+    temporary_name: str | None = None
     try:
-        handle = tempfile.NamedTemporaryFile(
-            "wb",
-            dir=directory,
-            prefix=TEMP_PREFIX,
-            delete=False,
-        )
-    except OSError as error:
-        raise Refusal(f"report temporary cannot be created: {error}") from error
-    temporary = Path(handle.name)
-    try:
-        with handle:
+        require_regular_target(directory_fd, parts[-1])
+        temporary_fd, temporary_name = create_temporary(directory_fd)
+        with os.fdopen(temporary_fd, "wb") as handle:
             handle.write(encoded)
             handle.flush()
             os.fsync(handle.fileno())
-        after_directory = directory.lstat()
-        if (before_directory.st_dev, before_directory.st_ino) != (
-            after_directory.st_dev,
-            after_directory.st_ino,
-        ):
-            raise Refusal("the output directory changed during the write")
-        ensure_safe_parent(root, target)
-        os.replace(temporary, target)
-        directory_fd = os.open(directory, os.O_RDONLY)
-        try:
-            os.fsync(directory_fd)
-        finally:
-            os.close(directory_fd)
+        os.replace(
+            temporary_name,
+            parts[-1],
+            src_dir_fd=directory_fd,
+            dst_dir_fd=directory_fd,
+        )
+        temporary_name = None
+        os.fsync(directory_fd)
     except Refusal:
-        try:
-            temporary.unlink()
-        except OSError:
-            pass
         raise
     except OSError as error:
-        try:
-            temporary.unlink()
-        except OSError:
-            pass
         raise Refusal(f"report write failed: {error}") from error
+    finally:
+        if temporary_name is not None:
+            try:
+                os.unlink(temporary_name, dir_fd=directory_fd)
+            except OSError:
+                pass
+        os.close(directory_fd)
 
 
 def command_report(arguments: argparse.Namespace) -> int:

--- a/tests/check-map-v1.json
+++ b/tests/check-map-v1.json
@@ -10,6 +10,13 @@
       "kind": "suite",
       "script": "tests"
     },
+    "dead-code-suite": {
+      "title": "Report-only dead-code suite",
+      "argv": ["python3", "-m", "unittest", "tests.test_dead_code", "-v"],
+      "cwd": ".",
+      "kind": "suite",
+      "script": "tests/test_dead_code.py"
+    },
     "alexandria-suite": {
       "title": "Alexandria suite",
       "argv": ["python3", "-m", "unittest", "discover", "-s", "plugins/alexandria/tests", "-t", "plugins/alexandria"],
@@ -181,6 +188,10 @@
       "title": "Root contract, shared scripts and root suite",
       "checks": ["root-suite"]
     },
+    "dead-code": {
+      "title": "Report-only dead-code discovery",
+      "checks": ["dead-code-suite"]
+    },
     "repo-lints": {
       "title": "Repository-wide tree lints",
       "checks": ["lint-phylax", "lint-ephoros", "lint-hypomnema"]
@@ -222,7 +233,8 @@
     "tabularium": {"title": "Tabularium plugin", "checks": ["tabularium-suite"]}
   },
   "dependencies": {
-    "root": ["repo-lints"],
+    "root": ["repo-lints", "dead-code"],
+    "dead-code": ["repo-lints"],
     "docs": ["root", "repo-lints"],
     "schemas": ["root"],
     "promise-machine": ["root", "hexaemeron"],
@@ -234,7 +246,7 @@
     "brevitas": ["repo-lints", "root"],
     "hermes": ["repo-lints"],
     "hexaemeron": ["repo-lints", "root"],
-    "horos": ["repo-lints", "root"],
+    "horos": ["repo-lints", "root", "dead-code"],
     "janus": ["repo-lints"],
     "lazarus": ["repo-lints"],
     "lemma": ["repo-lints"],
@@ -249,6 +261,7 @@
     {"path": ".claude", "scope": "marketplace"},
     {"path": ".claude-plugin", "scope": "marketplace"},
     {"path": ".github", "scope": "ci"},
+    {"path": ".github/workflows/dead-code.yml", "scope": "dead-code"},
     {"path": ".gitattributes", "scope": "root"},
     {"path": ".gitignore", "scope": "root"},
     {"path": ".python-version", "scope": "root"},
@@ -266,11 +279,17 @@
     {"path": "assets", "scope": "root"},
     {"path": "audit", "scope": "root"},
     {"path": "docs", "scope": "docs"},
+    {"path": "docs/dead-code", "scope": "dead-code"},
+    {"path": "docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md", "scope": "dead-code"},
     {"path": "repo_contract.py", "scope": "root"},
     {"path": "schemas", "scope": "schemas"},
+    {"path": "schemas/dead-code-report-v1.schema.json", "scope": "dead-code"},
     {"path": "scripts", "scope": "root"},
+    {"path": "scripts/dead_code.py", "scope": "dead-code"},
     {"path": "scripts/promise_machine.py", "scope": "promise-machine"},
     {"path": "tests", "scope": "root"},
+    {"path": "tests/emit_dead_code_report.py", "scope": "dead-code"},
+    {"path": "tests/test_dead_code.py", "scope": "dead-code"},
     {"path": "tests/check-map-v1.json", "scope": "root"},
     {"path": "tests/promise_machine_coverage.json", "scope": "promise-machine"},
     {"path": "plugins/alexandria", "scope": "alexandria"},

--- a/tests/emit_dead_code_report.py
+++ b/tests/emit_dead_code_report.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Run the dead-code surface and emit one fresh Elenchus report.
+
+The confined report writer lives in `tests/emit_run_observation_report.py` and
+is imported rather than copied. That writer is the product of the issue #434
+audit rounds, including the C5 round 5 finding about absolute report targets; a
+second copy of three hundred hardened lines would drift away from it silently
+and would be exactly the duplication this command exists to surface.
+"""
+
+import sys
+from pathlib import Path
+import unittest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from tests.emit_run_observation_report import (  # noqa: E402
+    report_target,
+    result_payload,
+    write_report,
+)
+
+REQUIRED_SURFACE = (
+    Path("schemas/dead-code-report-v1.schema.json"),
+    Path("scripts/dead_code.py"),
+    Path("tests/test_dead_code.py"),
+)
+MODULES = ("tests.test_dead_code",)
+
+
+def missing_surface_suite(root):
+    """A suite that fails by name when the surface under test is not there."""
+    missing = [path.as_posix() for path in REQUIRED_SURFACE if not (root / path).is_file()]
+    if not missing:
+        return None
+
+    def required_surface_is_present():
+        raise AssertionError("required dead-code test surface absent: " + ", ".join(missing))
+
+    return unittest.TestSuite([unittest.FunctionTestCase(required_surface_is_present)])
+
+
+def main(argv=None):
+    target = report_target(sys.argv[1:] if argv is None else argv)
+    root = Path.cwd().resolve(strict=True)
+    suite = missing_surface_suite(root)
+    if suite is None:
+        suite = unittest.defaultTestLoader.loadTestsFromNames(MODULES)
+    result = unittest.TextTestRunner(verbosity=1).run(suite)
+    try:
+        write_report(target, result_payload(result))
+    except OSError:
+        print("emit_dead_code_report.py: report write failed", file=sys.stderr)
+        return 2
+    failed = len(result.failures) + len(result.errors)
+    print(f"{result.testsRun - failed}/{result.testsRun} tests passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -724,6 +724,51 @@ class WriteBoundaryTests(TemporaryRepositoryTestCase):
             "payload" + NL,
         )
 
+    def test_repository_substitution_cannot_redirect_directory_traversal(self):
+        target = dead_code.confine(self.root, ".dead-code/report.json")
+        outside = self.root.parent / (self.root.name + "-outside-directory")
+        held = self.root.parent / (self.root.name + "-opened-repository")
+        outside.mkdir()
+
+        def restore_repository():
+            outside_report = outside / ".dead-code" / "report.json"
+            outside_report.unlink(missing_ok=True)
+            try:
+                outside_report.parent.rmdir()
+            except FileNotFoundError:
+                pass
+            if self.root.is_symlink():
+                self.root.unlink()
+            if held.exists():
+                held.rename(self.root)
+            outside.rmdir()
+
+        self.addCleanup(restore_repository)
+        real_output_parts = dead_code.output_parts
+
+        def substitute_repository(root, output):
+            parts = real_output_parts(root, output)
+            self.root.rename(held)
+            self.root.symlink_to(outside, target_is_directory=True)
+            return parts
+
+        refusal = None
+        try:
+            with mock.patch.object(
+                dead_code,
+                "output_parts",
+                side_effect=substitute_repository,
+            ):
+                dead_code.atomic_write(self.root, target, "payload" + NL)
+        except dead_code.Refusal as error:
+            refusal = str(error)
+        self.assertIsNone(refusal, refusal)
+        self.assertFalse((outside / ".dead-code" / "report.json").exists())
+        self.assertEqual(
+            (held / ".dead-code" / "report.json").read_text(encoding="utf-8"),
+            "payload" + NL,
+        )
+
     def test_atomic_write_does_not_sweep_an_unrelated_owned_temporary(self):
         directory = self.root / ".dead-code"
         directory.mkdir()

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -135,6 +135,51 @@ class UniverseDiscoveryTests(TemporaryRepositoryTestCase):
         self.assertEqual(len(universe.commit), 40)
         self.assertEqual(len(universe.tree), 40)
 
+    def test_transient_boundary_edit_cannot_change_the_commit_universe(self):
+        build_repository(
+            self.root,
+            files={
+                "a.py": "a = 1" + NL,
+                "generated.txt": "generated" + NL,
+            },
+            entries=[horos_entry("generated.txt")],
+        )
+        boundary = self.root / ".horos" / "boundary.json"
+        committed = boundary.read_text(encoding="utf-8")
+        replacement = json.dumps(
+            boundary_document([horos_entry("a.py")]),
+            sort_keys=True,
+        ) + NL
+        real_require_clean_tree = dead_code.require_clean_tree
+        real_load_boundary = dead_code.load_boundary
+
+        def edit_after_clean_check(root, *args, **kwargs):
+            real_require_clean_tree(root, *args, **kwargs)
+            boundary.write_text(replacement, encoding="utf-8")
+
+        def load_then_restore(*args, **kwargs):
+            try:
+                return real_load_boundary(*args, **kwargs)
+            finally:
+                boundary.write_text(committed, encoding="utf-8")
+
+        with (
+            mock.patch.object(
+                dead_code,
+                "require_clean_tree",
+                side_effect=edit_after_clean_check,
+            ),
+            mock.patch.object(
+                dead_code,
+                "load_boundary",
+                side_effect=load_then_restore,
+            ),
+        ):
+            universe = dead_code.discover(self.root)
+
+        self.assertIn("a.py", universe.analysed)
+        self.assertNotIn("generated.txt", universe.analysed)
+
     def test_universe_paths_are_sorted_and_identity_is_recomputed(self):
         build_repository(
             self.root,
@@ -342,6 +387,8 @@ class BoundaryRefusalTests(TemporaryRepositoryTestCase):
         target = self.root / ".horos" / "boundary.json"
         target.unlink()
         target.symlink_to(outside)
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "--quiet", "-m", "symlink boundary")
         with self.assertRaisesRegex(dead_code.Refusal, "not a regular file"):
             dead_code.load_boundary(self.root)
 
@@ -894,6 +941,53 @@ class CommandLineTests(TemporaryRepositoryTestCase):
             json.loads(report_path.read_text(encoding="utf-8"))["schema"],
             "dead-code-report/v1",
         )
+
+    def test_repository_substitution_before_discovery_keeps_the_opened_tree(self):
+        original_commit = git(self.root, "rev-parse", "HEAD").strip()
+        outside_temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(outside_temporary.cleanup)
+        outside = Path(outside_temporary.name).resolve()
+        build_repository(
+            outside,
+            files={"outside.py": "outside = True" + NL},
+        )
+        self.assertNotEqual(
+            original_commit,
+            git(outside, "rev-parse", "HEAD").strip(),
+        )
+        held = self.root.parent / (self.root.name + "-opened-repository")
+        real_build_report = dead_code.build_report
+
+        def substitute_repository(root, *args, **kwargs):
+            self.root.rename(held)
+            self.root.symlink_to(outside, target_is_directory=True)
+            return real_build_report(root, *args, **kwargs)
+
+        arguments = dead_code.argparse.Namespace(
+            directory=str(self.root),
+            json=True,
+            output=".dead-code/report.json",
+        )
+        try:
+            with mock.patch.object(
+                dead_code,
+                "build_report",
+                side_effect=substitute_repository,
+            ):
+                result = dead_code.command_report(arguments)
+            report = json.loads(
+                (held / ".dead-code" / "report.json").read_text(encoding="utf-8")
+            )
+        finally:
+            if self.root.is_symlink():
+                self.root.unlink()
+            if held.exists():
+                held.rename(self.root)
+
+        self.assertEqual(result, 0)
+        self.assertEqual(report["tree"]["commit"], original_commit)
+        self.assertIn("a.py", report["universe"]["analysed"])
+        self.assertNotIn("outside.py", report["universe"]["analysed"])
 
     def test_unsafe_output_path_exits_two(self):
         completed = self._run("report", "--output", "../escape.json")

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -637,15 +637,19 @@ class WriteBoundaryTests(TemporaryRepositoryTestCase):
             dead_code.confine(self.root, "out" + chr(0) + ".json")
 
     def test_descendant_output_is_confined_to_the_repository(self):
-        target = dead_code.confine(self.root, "reports/out.json")
-        self.assertEqual(target, self.root / "reports" / "out.json")
+        target = dead_code.confine(self.root, ".dead-code/report.json")
+        self.assertEqual(target, self.root / ".dead-code" / "report.json")
+
+    def test_output_outside_the_owned_dead_code_sink_is_refused(self):
+        with self.assertRaisesRegex(dead_code.Refusal, "owned .dead-code"):
+            dead_code.confine(self.root, "a.py")
 
     def test_symlinked_output_ancestor_is_refused(self):
         outside = self.root.parent / (self.root.name + "-outside")
         outside.mkdir()
         self.addCleanup(outside.rmdir)
-        (self.root / "reports").symlink_to(outside, target_is_directory=True)
-        target = dead_code.confine(self.root, "reports/out.json")
+        (self.root / ".dead-code").symlink_to(outside, target_is_directory=True)
+        target = dead_code.confine(self.root, ".dead-code/out.json")
         with self.assertRaisesRegex(dead_code.Refusal, "not a real directory"):
             dead_code.atomic_write(self.root, target, "{}" + NL)
 
@@ -653,14 +657,15 @@ class WriteBoundaryTests(TemporaryRepositoryTestCase):
         outside = self.root.parent / (self.root.name + "-outside.json")
         outside.write_text("old", encoding="utf-8")
         self.addCleanup(outside.unlink, missing_ok=True)
-        target = self.root / "out.json"
+        (self.root / ".dead-code").mkdir()
+        target = self.root / ".dead-code" / "out.json"
         target.symlink_to(outside)
         with self.assertRaisesRegex(dead_code.Refusal, "not a regular file"):
             dead_code.atomic_write(self.root, target, "new" + NL)
         self.assertEqual(outside.read_text(encoding="utf-8"), "old")
 
     def test_atomic_write_publishes_complete_bytes_and_no_temporary(self):
-        target = dead_code.confine(self.root, "reports/out.json")
+        target = dead_code.confine(self.root, ".dead-code/report.json")
         dead_code.atomic_write(self.root, target, "payload" + NL)
         self.assertEqual(target.read_text(encoding="utf-8"), "payload" + NL)
         leftovers = [
@@ -671,7 +676,7 @@ class WriteBoundaryTests(TemporaryRepositoryTestCase):
         self.assertEqual(leftovers, [])
 
     def test_failed_replace_leaves_the_previous_report_intact(self):
-        target = dead_code.confine(self.root, "reports/out.json")
+        target = dead_code.confine(self.root, ".dead-code/report.json")
         target.parent.mkdir()
         target.write_text("previous" + NL, encoding="utf-8")
         with mock.patch.object(
@@ -689,22 +694,46 @@ class WriteBoundaryTests(TemporaryRepositoryTestCase):
         ]
         self.assertEqual(leftovers, [])
 
-    def test_orphan_sweep_removes_only_regular_files_with_the_owned_prefix(self):
-        directory = self.root / "reports"
+    def test_ancestor_substitution_cannot_redirect_the_atomic_replace(self):
+        target = dead_code.confine(self.root, ".dead-code/report.json")
+        outside = self.root.parent / (self.root.name + "-outside-directory")
+        held = self.root / ".dead-code-opened"
+        outside.mkdir()
+        self.addCleanup(outside.rmdir)
+        real_replace = os.replace
+
+        def substitute_ancestor(source, destination, **kwargs):
+            target.parent.rename(held)
+            target.parent.symlink_to(outside, target_is_directory=True)
+            real_replace(source, destination, **kwargs)
+
+        refusal = None
+        try:
+            with mock.patch.object(
+                dead_code.os,
+                "replace",
+                side_effect=substitute_ancestor,
+            ):
+                dead_code.atomic_write(self.root, target, "payload" + NL)
+        except dead_code.Refusal as error:
+            refusal = str(error)
+        self.assertIsNone(refusal, refusal)
+        self.assertFalse((outside / "report.json").exists())
+        self.assertEqual(
+            (held / "report.json").read_text(encoding="utf-8"),
+            "payload" + NL,
+        )
+
+    def test_atomic_write_does_not_sweep_an_unrelated_owned_temporary(self):
+        directory = self.root / ".dead-code"
         directory.mkdir()
         orphan = directory / (dead_code.TEMP_PREFIX + "old")
         bystander = directory / "keep.json"
-        symlink = directory / (dead_code.TEMP_PREFIX + "link")
-        outside = self.root / "outside.txt"
         orphan.write_text("half", encoding="utf-8")
         bystander.write_text("keep", encoding="utf-8")
-        outside.write_text("outside", encoding="utf-8")
-        symlink.symlink_to(outside)
-        dead_code.sweep_orphans(directory)
-        self.assertFalse(orphan.exists())
+        dead_code.atomic_write(self.root, directory / "report.json", "payload" + NL)
+        self.assertTrue(orphan.exists())
         self.assertTrue(bystander.exists())
-        self.assertTrue(symlink.is_symlink())
-        self.assertEqual(outside.read_text(encoding="utf-8"), "outside")
 
 
 class CommandLineTests(TemporaryRepositoryTestCase):
@@ -761,11 +790,11 @@ class CommandLineTests(TemporaryRepositoryTestCase):
             "report",
             "--json",
             "--output",
-            "reports/out.json",
+            ".dead-code/report.json",
         )
         self.assertEqual(completed.returncode, 0, completed.stderr)
         document = json.loads(
-            (self.root / "reports" / "out.json").read_text(encoding="utf-8")
+            (self.root / ".dead-code" / "report.json").read_text(encoding="utf-8")
         )
         schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
         self.assertEqual(set(document), set(schema["required"]))
@@ -779,6 +808,15 @@ class CommandLineTests(TemporaryRepositoryTestCase):
         completed = self._run("report", "--output", "../escape.json")
         self.assertEqual(completed.returncode, 2)
         self.assertIn("escapes", completed.stderr)
+
+    def test_output_flag_cannot_overwrite_a_tracked_source_file(self):
+        target = self.root / "a.py"
+        before = target.read_bytes()
+        completed = self._run("report", "--output", "a.py")
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("owned .dead-code", completed.stderr)
+        self.assertEqual(target.read_bytes(), before)
+        self.assertEqual(git(self.root, "status", "--porcelain"), "")
 
 
 class ShippedSurfaceTests(unittest.TestCase):

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -849,6 +849,52 @@ class CommandLineTests(TemporaryRepositoryTestCase):
             + document["universe"]["excluded_count"],
         )
 
+    def test_repository_substitution_after_render_cannot_redirect_output(self):
+        outside = self.root.parent / (self.root.name + "-outside-directory")
+        held = self.root.parent / (self.root.name + "-opened-repository")
+        outside.mkdir()
+
+        def restore_repository():
+            outside_report = outside / ".dead-code" / "report.json"
+            outside_report.unlink(missing_ok=True)
+            try:
+                outside_report.parent.rmdir()
+            except FileNotFoundError:
+                pass
+            if self.root.is_symlink():
+                self.root.unlink()
+            if held.exists():
+                held.rename(self.root)
+            outside.rmdir()
+
+        self.addCleanup(restore_repository)
+        real_render_json = dead_code.render_json
+
+        def substitute_repository(report):
+            rendered = real_render_json(report)
+            self.root.rename(held)
+            self.root.symlink_to(outside, target_is_directory=True)
+            return rendered
+
+        arguments = dead_code.argparse.Namespace(
+            directory=str(self.root),
+            json=True,
+            output=".dead-code/report.json",
+        )
+        with mock.patch.object(
+            dead_code,
+            "render_json",
+            side_effect=substitute_repository,
+        ):
+            result = dead_code.command_report(arguments)
+        self.assertEqual(result, 0)
+        self.assertFalse((outside / ".dead-code" / "report.json").exists())
+        report_path = held / ".dead-code" / "report.json"
+        self.assertEqual(
+            json.loads(report_path.read_text(encoding="utf-8"))["schema"],
+            "dead-code-report/v1",
+        )
+
     def test_unsafe_output_path_exits_two(self):
         completed = self._run("report", "--output", "../escape.json")
         self.assertEqual(completed.returncode, 2)

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -1,0 +1,879 @@
+"""Focused tests for the report-only dead-code scaffold."""
+
+import gc
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+import warnings
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "dead_code.py"
+SCHEMA_PATH = ROOT / "schemas" / "dead-code-report-v1.schema.json"
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "dead-code.yml"
+CHECK_MAP_PATH = ROOT / "tests" / "check-map-v1.json"
+STUDY_PATH = ROOT / "docs" / "dead-code" / "study.md"
+RUNBOOK_PATH = ROOT / "docs" / "dead-code" / "runbook.md"
+ADR_PATH = (
+    ROOT
+    / "docs"
+    / "decisions"
+    / "ADR-051-keep-dead-code-discovery-report-only.md"
+)
+EXPECTED_STUDY_SHA256 = "da8ceed7ee91168e4ab60b1d3ba27c4e59df40be3a9dadd87d0dba17af8059e6"
+EXPECTED_RUNBOOK_SHA256 = "e5ea55c688615d9d1d0322e8c82bba335acfd6745cac99f49b471a564f860857"
+NL = chr(10)
+
+SPEC = importlib.util.spec_from_file_location("dead_code", SCRIPT)
+dead_code = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = dead_code
+SPEC.loader.exec_module(dead_code)
+
+
+def git(directory, *arguments):
+    return subprocess.run(
+        ["git", "-C", str(directory), *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def horos_entry(
+    path,
+    *,
+    category="generated",
+    evidence="classified by the fixture",
+    grade="hard",
+):
+    return {
+        "path": path,
+        "category": category,
+        "evidence": evidence,
+        "grade": grade,
+        "bytes": 1,
+    }
+
+
+def boundary_document(entries):
+    return {
+        "schema": 2,
+        "tool": "horos",
+        "universe": "tracked",
+        "counts": {},
+        "entries": entries,
+    }
+
+
+def build_repository(
+    directory,
+    *,
+    files=None,
+    entries=None,
+    boundary_text=None,
+    commit=True,
+):
+    files = {"a.py": "x = 1" + NL} if files is None else files
+    entries = [] if entries is None else entries
+    git(directory, "init", "--quiet", "--initial-branch=main")
+    git(directory, "config", "user.email", "test@example.invalid")
+    git(directory, "config", "user.name", "Test")
+    git(directory, "config", "commit.gpgsign", "false")
+    for relative, content in files.items():
+        target = directory / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    target = directory / ".horos" / "boundary.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if boundary_text is None:
+        boundary_text = json.dumps(boundary_document(entries), sort_keys=True) + NL
+    target.write_text(boundary_text, encoding="utf-8")
+    git(directory, "add", "-A")
+    if commit:
+        git(directory, "commit", "--quiet", "-m", "fixture")
+    return directory
+
+
+class TemporaryRepositoryTestCase(unittest.TestCase):
+    def setUp(self):
+        self._temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self._temporary.cleanup)
+        self.root = Path(self._temporary.name).resolve()
+
+
+class UniverseDiscoveryTests(TemporaryRepositoryTestCase):
+    def test_bounded_process_closes_both_capture_pipes(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", ResourceWarning)
+            dead_code.run_process(
+                ["git", "--version"],
+                cwd=self.root,
+                timeout_seconds=5,
+                output_limit=4096,
+            )
+            gc.collect()
+        leaked = [item for item in caught if item.category is ResourceWarning]
+        self.assertEqual(leaked, [])
+
+    def test_universe_binds_the_exact_commit_and_git_tree(self):
+        build_repository(
+            self.root,
+            files={"b.py": "b = 2" + NL, "a.py": "a = 1" + NL},
+        )
+        universe = dead_code.discover(self.root)
+        self.assertEqual(universe.commit, git(self.root, "rev-parse", "HEAD").strip())
+        self.assertEqual(
+            universe.tree,
+            git(self.root, "rev-parse", "HEAD^{tree}").strip(),
+        )
+        self.assertEqual(len(universe.commit), 40)
+        self.assertEqual(len(universe.tree), 40)
+
+    def test_universe_paths_are_sorted_and_identity_is_recomputed(self):
+        build_repository(
+            self.root,
+            files={"z.py": "z = 1" + NL, "a.py": "a = 1" + NL},
+        )
+        universe = dead_code.discover(self.root)
+        self.assertEqual(universe.analysed, tuple(sorted(universe.analysed)))
+        self.assertEqual(
+            universe.identity,
+            dead_code.universe_identity(
+                universe.tree,
+                universe.analysed,
+                universe.excluded,
+            ),
+        )
+
+    def test_untracked_files_do_not_enter_the_committed_universe(self):
+        build_repository(self.root)
+        (self.root / "scratch.txt").write_text("scratch", encoding="utf-8")
+        universe = dead_code.discover(self.root)
+        self.assertNotIn("scratch.txt", universe.analysed)
+
+    def test_modified_tracked_bytes_refuse_before_discovery(self):
+        build_repository(self.root)
+        (self.root / "a.py").write_text("x = 2" + NL, encoding="utf-8")
+        with self.assertRaisesRegex(dead_code.Refusal, "modified tracked"):
+            dead_code.discover(self.root)
+
+    def test_staged_tracked_bytes_refuse_before_discovery(self):
+        build_repository(self.root)
+        (self.root / "a.py").write_text("x = 2" + NL, encoding="utf-8")
+        git(self.root, "add", "a.py")
+        with self.assertRaisesRegex(dead_code.Refusal, "modified tracked"):
+            dead_code.discover(self.root)
+
+    def test_empty_analysed_walk_refuses_instead_of_reporting_clean(self):
+        build_repository(
+            self.root,
+            files={"generated.txt": "generated" + NL},
+            entries=[
+                horos_entry("generated.txt"),
+                horos_entry(".horos/boundary.json"),
+            ],
+        )
+        with self.assertRaisesRegex(dead_code.Refusal, "collapsed walk"):
+            dead_code.discover(self.root)
+
+    def test_discovery_outside_a_git_worktree_refuses(self):
+        with self.assertRaises(dead_code.Refusal):
+            dead_code.repository_root(self.root)
+
+
+class ClassificationJoinTests(TemporaryRepositoryTestCase):
+    def test_hard_file_classification_excludes_and_carries_evidence(self):
+        build_repository(
+            self.root,
+            files={
+                "a.py": "x = 1" + NL,
+                "CONTRIBUTORS.md": "generated" + NL,
+            },
+            entries=[
+                horos_entry(
+                    "CONTRIBUTORS.md",
+                    evidence="generation marker in the first 4096 bytes",
+                )
+            ],
+        )
+        universe = dead_code.discover(self.root)
+        excluded = {entry.path: entry for entry in universe.excluded}
+        self.assertNotIn("CONTRIBUTORS.md", universe.analysed)
+        self.assertIn("generation marker", excluded["CONTRIBUTORS.md"].evidence)
+        self.assertEqual(excluded["CONTRIBUTORS.md"].grade, "hard")
+
+    def test_candidate_grade_remains_in_the_fail_open_universe(self):
+        build_repository(
+            self.root,
+            files={"a.py": "x = 1" + NL, "maybe.txt": "maybe" + NL},
+            entries=[horos_entry("maybe.txt", grade="candidate")],
+        )
+        universe = dead_code.discover(self.root)
+        self.assertIn("maybe.txt", universe.analysed)
+
+    def test_boundary_entry_for_an_absent_path_excludes_nothing(self):
+        build_repository(self.root, entries=[horos_entry("gone.txt")])
+        self.assertEqual(dead_code.discover(self.root).excluded, ())
+
+    def test_hard_directory_classification_excludes_every_descendant(self):
+        build_repository(
+            self.root,
+            files={
+                "a.py": "x = 1" + NL,
+                "vendor/pkg/a.py": "a = 1" + NL,
+                "vendor/pkg/b.py": "b = 1" + NL,
+            },
+            entries=[
+                horos_entry(
+                    "vendor/",
+                    category="vendored",
+                    evidence="directory name vendor",
+                )
+            ],
+        )
+        universe = dead_code.discover(self.root)
+        self.assertIn("a.py", universe.analysed)
+        self.assertNotIn("vendor/pkg/a.py", universe.analysed)
+        self.assertNotIn("vendor/pkg/b.py", universe.analysed)
+        self.assertEqual(universe.excluded_by_category(), {"vendored": 2})
+
+    def test_inherited_exclusion_names_the_classified_tree(self):
+        build_repository(
+            self.root,
+            files={"a.py": "x = 1" + NL, "build/out.json": "{}" + NL},
+            entries=[
+                horos_entry(
+                    "build/",
+                    evidence="directory name build",
+                )
+            ],
+        )
+        excluded = {
+            entry.path: entry for entry in dead_code.discover(self.root).excluded
+        }
+        self.assertIn("directory name build", excluded["build/out.json"].evidence)
+        self.assertIn("classified tree build/", excluded["build/out.json"].evidence)
+
+    def test_directory_prefix_does_not_capture_a_sibling_with_the_same_stem(self):
+        build_repository(
+            self.root,
+            files={
+                "lib/vendored.py": "x = 1" + NL,
+                "libexec/kept.py": "y = 2" + NL,
+            },
+            entries=[
+                horos_entry(
+                    "lib/",
+                    category="vendored",
+                    evidence="directory name lib",
+                )
+            ],
+        )
+        universe = dead_code.discover(self.root)
+        self.assertNotIn("lib/vendored.py", universe.analysed)
+        self.assertIn("libexec/kept.py", universe.analysed)
+
+    def test_longest_classified_directory_supplies_descendant_evidence(self):
+        build_repository(
+            self.root,
+            files={
+                "a.py": "x = 1" + NL,
+                "tree/nested/item.txt": "item" + NL,
+            },
+            entries=[
+                horos_entry("tree/", evidence="outer tree"),
+                horos_entry("tree/nested/", evidence="inner tree"),
+            ],
+        )
+        excluded = {
+            entry.path: entry for entry in dead_code.discover(self.root).excluded
+        }
+        self.assertIn("inner tree", excluded["tree/nested/item.txt"].evidence)
+        self.assertNotIn("outer tree", excluded["tree/nested/item.txt"].evidence)
+
+    def test_exclusion_counts_are_sorted_by_category(self):
+        build_repository(
+            self.root,
+            files={
+                "a.py": "x" + NL,
+                "z.txt": "z" + NL,
+                "a.txt": "a" + NL,
+            },
+            entries=[
+                horos_entry("z.txt", category="vendored"),
+                horos_entry("a.txt", category="binary"),
+            ],
+        )
+        counts = dead_code.discover(self.root).excluded_by_category()
+        self.assertEqual(list(counts), ["binary", "vendored"])
+
+
+class BoundaryRefusalTests(TemporaryRepositoryTestCase):
+    def _replace_boundary(self, text):
+        build_repository(self.root)
+        target = self.root / ".horos" / "boundary.json"
+        target.write_text(text, encoding="utf-8")
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "--quiet", "-m", "boundary")
+
+    def test_absent_boundary_refuses_by_name(self):
+        build_repository(self.root)
+        target = self.root / ".horos" / "boundary.json"
+        target.unlink()
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "--quiet", "-m", "drop boundary")
+        with self.assertRaisesRegex(dead_code.Refusal, ".horos/boundary.json"):
+            dead_code.load_boundary(self.root)
+
+    def test_boundary_symlink_refuses_as_non_regular(self):
+        outside = self.root.parent / (self.root.name + "-outside.json")
+        self.addCleanup(outside.unlink, missing_ok=True)
+        outside.write_text(
+            json.dumps(boundary_document([])),
+            encoding="utf-8",
+        )
+        build_repository(self.root)
+        target = self.root / ".horos" / "boundary.json"
+        target.unlink()
+        target.symlink_to(outside)
+        with self.assertRaisesRegex(dead_code.Refusal, "not a regular file"):
+            dead_code.load_boundary(self.root)
+
+    def test_oversized_boundary_refuses_before_json_parse(self):
+        build_repository(self.root)
+        with mock.patch.object(dead_code, "MAX_BOUNDARY_BYTES", 8):
+            with self.assertRaisesRegex(dead_code.Refusal, "exceeds 8 bytes"):
+                dead_code.load_boundary(self.root)
+
+    def test_malformed_boundary_json_refuses(self):
+        self._replace_boundary("{not json")
+        with self.assertRaisesRegex(dead_code.Refusal, "not valid JSON"):
+            dead_code.load_boundary(self.root)
+
+    def test_duplicate_json_key_refuses_instead_of_overwriting(self):
+        self._replace_boundary(
+            '{"schema":2,"tool":"horos","tool":"other","entries":[]}'
+        )
+        with self.assertRaisesRegex(dead_code.Refusal, "repeats JSON key tool"):
+            dead_code.load_boundary(self.root)
+
+    def test_wrong_boundary_schema_refuses_as_stale(self):
+        self._replace_boundary(
+            json.dumps({"schema": 1, "tool": "horos", "entries": []})
+        )
+        with self.assertRaisesRegex(dead_code.Refusal, "schema 2"):
+            dead_code.load_boundary(self.root)
+
+    def test_wrong_boundary_tool_refuses(self):
+        self._replace_boundary(
+            json.dumps({"schema": 2, "tool": "other", "entries": []})
+        )
+        with self.assertRaisesRegex(dead_code.Refusal, "tool horos"):
+            dead_code.load_boundary(self.root)
+
+    def test_missing_entries_list_refuses(self):
+        self._replace_boundary(json.dumps({"schema": 2, "tool": "horos"}))
+        with self.assertRaisesRegex(dead_code.Refusal, "no entries list"):
+            dead_code.load_boundary(self.root)
+
+    def test_entry_missing_evidence_refuses(self):
+        broken = {
+            "path": "a.py",
+            "category": "generated",
+            "grade": "hard",
+        }
+        self._replace_boundary(
+            json.dumps(
+                {
+                    "schema": 2,
+                    "tool": "horos",
+                    "entries": [broken],
+                }
+            )
+        )
+        with self.assertRaisesRegex(dead_code.Refusal, "evidence"):
+            dead_code.load_boundary(self.root)
+
+    def test_duplicate_classified_path_refuses(self):
+        duplicate = horos_entry("a.py")
+        self._replace_boundary(
+            json.dumps(
+                {
+                    "schema": 2,
+                    "tool": "horos",
+                    "entries": [duplicate, duplicate],
+                }
+            )
+        )
+        with self.assertRaisesRegex(dead_code.Refusal, "repeats classified path"):
+            dead_code.load_boundary(self.root)
+
+    def test_unsafe_classified_path_refuses(self):
+        self._replace_boundary(
+            json.dumps(
+                {
+                    "schema": 2,
+                    "tool": "horos",
+                    "entries": [horos_entry("../outside")],
+                }
+            )
+        )
+        with self.assertRaisesRegex(dead_code.Refusal, "safe repository-relative"):
+            dead_code.load_boundary(self.root)
+
+
+class RenderingTests(TemporaryRepositoryTestCase):
+    def _report(self):
+        build_repository(
+            self.root,
+            files={
+                "b.py": "b = 2" + NL,
+                "a.py": "a = 1" + NL,
+                "generated.txt": "g" + NL,
+            },
+            entries=[horos_entry("generated.txt")],
+        )
+        return dead_code.build_report(self.root)
+
+    def test_json_has_the_schema_fixed_top_level_shape(self):
+        document = json.loads(dead_code.render_json(self._report()))
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(set(document), set(schema["required"]))
+        self.assertEqual(document["schema"], "dead-code-report/v1")
+        self.assertEqual(document["tool"], {"id": "dead-code", "version": "1"})
+
+    def test_schema_fixes_tool_universe_status_and_finding_identities(self):
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        definitions = schema["$defs"]
+        self.assertEqual(
+            definitions["toolIdentity"]["properties"]["id"]["const"],
+            "dead-code",
+        )
+        self.assertEqual(
+            definitions["analysisStatus"]["properties"]["id"]["const"],
+            "analysis",
+        )
+        self.assertEqual(
+            definitions["universeIdentity"]["properties"]["id"]["$ref"],
+            "#/$defs/sha256Identity",
+        )
+        self.assertEqual(
+            definitions["finding"]["properties"]["id"]["$ref"],
+            "#/$defs/sha256Identity",
+        )
+
+    def test_text_and_json_carry_the_same_tree_universe_status_and_counts(self):
+        report = self._report()
+        document = json.loads(dead_code.render_json(report))
+        text = dead_code.render_text(report)
+        for value in (
+            document["tree"]["commit"],
+            document["tree"]["git_tree"],
+            document["universe"]["id"],
+            document["status"]["state"],
+        ):
+            self.assertIn(value, text)
+        self.assertIn(
+            f"{document['universe']['analysed_count']} analysed",
+            text,
+        )
+        self.assertIn(
+            f"{document['universe']['excluded_count']} excluded",
+            text,
+        )
+
+    def test_report_explicitly_says_that_no_analyser_ran(self):
+        report = self._report()
+        document = json.loads(dead_code.render_json(report))
+        text = dead_code.render_text(report)
+        self.assertEqual(document["status"]["state"], "not-run")
+        self.assertEqual(document["analysers"], [])
+        self.assertIn("none ran", text)
+        self.assertIn("no reachability result", text)
+
+    def test_finding_identity_and_evidence_match_in_both_renderings(self):
+        base = self._report()
+        status = dead_code.AnalyserStatus(
+            analyser_id="python",
+            state="ran",
+            version="1",
+            detail="fixture analyser completed",
+        )
+        finding = dead_code.Finding(
+            analyser_id="python",
+            path=base.universe.analysed[0],
+            symbol="candidate",
+            evidence="no static reference in the fixture graph",
+            confidence="medium",
+            false_positive_boundary="a computed import could reach the symbol",
+        )
+        report = dead_code.Report(
+            universe=base.universe,
+            statuses=(status,),
+            findings=(finding,),
+        )
+        dead_code.validate_report(report)
+        document = json.loads(dead_code.render_json(report))
+        text = dead_code.render_text(report)
+        self.assertEqual(document["findings"][0]["id"], finding.identity)
+        for value in (
+            finding.identity,
+            finding.path,
+            finding.symbol,
+            finding.evidence,
+            finding.false_positive_boundary,
+        ):
+            self.assertIn(value, text)
+
+    def test_collect_sorts_statuses_and_findings_from_one_model(self):
+        build_repository(
+            self.root,
+            files={"b.py": "b = 1" + NL, "a.py": "a = 1" + NL},
+        )
+        universe = dead_code.discover(self.root)
+
+        def analyser(name, path):
+            def run(root, supplied_universe):
+                self.assertEqual(supplied_universe, universe)
+                return (
+                    dead_code.AnalyserStatus(name, "ran", "1", "done"),
+                    (
+                        dead_code.Finding(
+                            name,
+                            path,
+                            None,
+                            "fixture evidence",
+                            "low",
+                            "fixture boundary",
+                        ),
+                    ),
+                )
+            return run
+
+        with mock.patch.dict(
+            dead_code.ANALYSERS,
+            {
+                "zeta": analyser("zeta", "b.py"),
+                "alpha": analyser("alpha", "a.py"),
+            },
+            clear=True,
+        ):
+            statuses, findings = dead_code.collect(self.root, universe)
+        self.assertEqual(
+            [item.analyser_id for item in statuses],
+            ["alpha", "zeta"],
+        )
+        self.assertEqual(
+            [(item.analyser_id, item.path) for item in findings],
+            [("alpha", "a.py"), ("zeta", "b.py")],
+        )
+
+    def test_unreported_analyser_cannot_supply_a_finding(self):
+        base = self._report()
+        finding = dead_code.Finding(
+            "missing",
+            base.universe.analysed[0],
+            None,
+            "evidence",
+            "low",
+            "boundary",
+        )
+        report = dead_code.Report(base.universe, (), (finding,))
+        with self.assertRaisesRegex(dead_code.Refusal, "unreported analyser"):
+            dead_code.validate_report(report)
+
+    def test_candidate_count_does_not_change_the_report_exit_contract(self):
+        base = self._report()
+        status = dead_code.AnalyserStatus("python", "ran", "1", "done")
+        finding = dead_code.Finding(
+            "python",
+            base.universe.analysed[0],
+            None,
+            "evidence",
+            "low",
+            "boundary",
+        )
+        report = dead_code.Report(base.universe, (status,), (finding,))
+        dead_code.validate_report(report)
+        self.assertIn("1 candidate(s); report-only", dead_code.render_text(report))
+
+    def test_rendering_never_strengthens_candidates_into_deletion_authority(self):
+        report = self._report()
+        rendered = (dead_code.render_text(report) + dead_code.render_json(report)).lower()
+        for forbidden in (
+            "is dead",
+            "safe to delete",
+            "can be removed",
+            "proves unused",
+        ):
+            self.assertNotIn(forbidden, rendered)
+
+
+class WriteBoundaryTests(TemporaryRepositoryTestCase):
+    def setUp(self):
+        super().setUp()
+        build_repository(self.root)
+
+    def test_parent_escape_is_refused(self):
+        with self.assertRaisesRegex(dead_code.Refusal, "escapes"):
+            dead_code.confine(self.root, "../escape.json")
+
+    def test_absolute_output_is_refused(self):
+        with self.assertRaisesRegex(dead_code.Refusal, "repository-relative"):
+            dead_code.confine(self.root, str(self.root / "out.json"))
+
+    def test_repository_root_is_not_an_output_file(self):
+        with self.assertRaises(dead_code.Refusal):
+            dead_code.confine(self.root, ".")
+
+    def test_null_byte_output_is_refused(self):
+        with self.assertRaisesRegex(dead_code.Refusal, "null byte"):
+            dead_code.confine(self.root, "out" + chr(0) + ".json")
+
+    def test_descendant_output_is_confined_to_the_repository(self):
+        target = dead_code.confine(self.root, "reports/out.json")
+        self.assertEqual(target, self.root / "reports" / "out.json")
+
+    def test_symlinked_output_ancestor_is_refused(self):
+        outside = self.root.parent / (self.root.name + "-outside")
+        outside.mkdir()
+        self.addCleanup(outside.rmdir)
+        (self.root / "reports").symlink_to(outside, target_is_directory=True)
+        target = dead_code.confine(self.root, "reports/out.json")
+        with self.assertRaisesRegex(dead_code.Refusal, "not a real directory"):
+            dead_code.atomic_write(self.root, target, "{}" + NL)
+
+    def test_symlinked_output_target_is_refused(self):
+        outside = self.root.parent / (self.root.name + "-outside.json")
+        outside.write_text("old", encoding="utf-8")
+        self.addCleanup(outside.unlink, missing_ok=True)
+        target = self.root / "out.json"
+        target.symlink_to(outside)
+        with self.assertRaisesRegex(dead_code.Refusal, "not a regular file"):
+            dead_code.atomic_write(self.root, target, "new" + NL)
+        self.assertEqual(outside.read_text(encoding="utf-8"), "old")
+
+    def test_atomic_write_publishes_complete_bytes_and_no_temporary(self):
+        target = dead_code.confine(self.root, "reports/out.json")
+        dead_code.atomic_write(self.root, target, "payload" + NL)
+        self.assertEqual(target.read_text(encoding="utf-8"), "payload" + NL)
+        leftovers = [
+            item
+            for item in target.parent.iterdir()
+            if item.name.startswith(dead_code.TEMP_PREFIX)
+        ]
+        self.assertEqual(leftovers, [])
+
+    def test_failed_replace_leaves_the_previous_report_intact(self):
+        target = dead_code.confine(self.root, "reports/out.json")
+        target.parent.mkdir()
+        target.write_text("previous" + NL, encoding="utf-8")
+        with mock.patch.object(
+            dead_code.os,
+            "replace",
+            side_effect=OSError("fixture interruption"),
+        ):
+            with self.assertRaisesRegex(dead_code.Refusal, "report write failed"):
+                dead_code.atomic_write(self.root, target, "replacement" + NL)
+        self.assertEqual(target.read_text(encoding="utf-8"), "previous" + NL)
+        leftovers = [
+            item
+            for item in target.parent.iterdir()
+            if item.name.startswith(dead_code.TEMP_PREFIX)
+        ]
+        self.assertEqual(leftovers, [])
+
+    def test_orphan_sweep_removes_only_regular_files_with_the_owned_prefix(self):
+        directory = self.root / "reports"
+        directory.mkdir()
+        orphan = directory / (dead_code.TEMP_PREFIX + "old")
+        bystander = directory / "keep.json"
+        symlink = directory / (dead_code.TEMP_PREFIX + "link")
+        outside = self.root / "outside.txt"
+        orphan.write_text("half", encoding="utf-8")
+        bystander.write_text("keep", encoding="utf-8")
+        outside.write_text("outside", encoding="utf-8")
+        symlink.symlink_to(outside)
+        dead_code.sweep_orphans(directory)
+        self.assertFalse(orphan.exists())
+        self.assertTrue(bystander.exists())
+        self.assertTrue(symlink.is_symlink())
+        self.assertEqual(outside.read_text(encoding="utf-8"), "outside")
+
+
+class CommandLineTests(TemporaryRepositoryTestCase):
+    def setUp(self):
+        super().setUp()
+        build_repository(
+            self.root,
+            files={
+                "a.py": "a = 1" + NL,
+                "b.py": "b = 1" + NL,
+                "generated.txt": "generated" + NL,
+            },
+            entries=[horos_entry("generated.txt")],
+        )
+
+    def _run(self, *arguments):
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--directory",
+                str(self.root),
+                *arguments,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_text_report_exits_zero_with_tree_and_not_run_status(self):
+        completed = self._run("report")
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("dead-code 1 report", completed.stdout)
+        self.assertIn("tree      ", completed.stdout)
+        self.assertIn("status    not-run", completed.stdout)
+
+    def test_json_report_exits_zero_and_parses(self):
+        completed = self._run("report", "--json")
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        document = json.loads(completed.stdout)
+        self.assertEqual(document["schema"], "dead-code-report/v1")
+        self.assertEqual(document["universe"]["analysed_count"], 3)
+        self.assertEqual(document["status"]["state"], "not-run")
+
+    def test_dirty_tree_refusal_exits_two_without_stdout(self):
+        (self.root / "a.py").write_text("changed" + NL, encoding="utf-8")
+        completed = self._run("report")
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("modified tracked", completed.stderr)
+        self.assertEqual(completed.stdout, "")
+
+    def test_output_flag_writes_schema_valid_shape_inside_repository(self):
+        completed = self._run(
+            "report",
+            "--json",
+            "--output",
+            "reports/out.json",
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        document = json.loads(
+            (self.root / "reports" / "out.json").read_text(encoding="utf-8")
+        )
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(set(document), set(schema["required"]))
+        self.assertEqual(
+            document["universe"]["tracked_count"],
+            document["universe"]["analysed_count"]
+            + document["universe"]["excluded_count"],
+        )
+
+    def test_unsafe_output_path_exits_two(self):
+        completed = self._run("report", "--output", "../escape.json")
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("escapes", completed.stderr)
+
+
+class ShippedSurfaceTests(unittest.TestCase):
+    def test_receipted_study_and_runbook_digests_are_preserved(self):
+        self.assertEqual(
+            hashlib.sha256(STUDY_PATH.read_bytes()).hexdigest(),
+            EXPECTED_STUDY_SHA256,
+        )
+        self.assertEqual(
+            hashlib.sha256(RUNBOOK_PATH.read_bytes()).hexdigest(),
+            EXPECTED_RUNBOOK_SHA256,
+        )
+
+    def test_adr_has_the_repository_shape_and_records_both_ownership_boundaries(self):
+        text = ADR_PATH.read_text(encoding="utf-8")
+        for heading in (
+            "## Status",
+            "## Context",
+            "## Decision",
+            "## Alternatives",
+            "## Consequences",
+        ):
+            self.assertIn(heading, text)
+        self.assertIn("report-only", text)
+        self.assertIn("Horos", text)
+        self.assertIn("checked runner", text)
+        self.assertIn("one analyser in every plugin", text)
+
+    def test_schema_is_closed_at_every_named_record_identity(self):
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        self.assertFalse(schema["additionalProperties"])
+        for name in (
+            "toolIdentity",
+            "treeIdentity",
+            "universeIdentity",
+            "analysisStatus",
+            "analyserStatus",
+            "finding",
+        ):
+            self.assertFalse(schema["$defs"][name]["additionalProperties"])
+
+    def test_check_map_declares_the_focused_dead_code_scope(self):
+        check_map = json.loads(CHECK_MAP_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(
+            check_map["scopes"]["dead-code"]["checks"],
+            ["dead-code-suite"],
+        )
+        self.assertEqual(
+            check_map["checks"]["dead-code-suite"]["argv"],
+            ["python3", "-m", "unittest", "tests.test_dead_code", "-v"],
+        )
+
+    def test_check_map_assigns_every_dead_code_surface_to_the_scope(self):
+        check_map = json.loads(CHECK_MAP_PATH.read_text(encoding="utf-8"))
+        owners = {
+            entry["path"]: entry["scope"]
+            for entry in check_map["owners"]
+        }
+        expected = (
+            ".github/workflows/dead-code.yml",
+            "docs/dead-code",
+            "docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md",
+            "schemas/dead-code-report-v1.schema.json",
+            "scripts/dead_code.py",
+            "tests/emit_dead_code_report.py",
+            "tests/test_dead_code.py",
+        )
+        for path in expected:
+            self.assertEqual(owners.get(path), "dead-code", path)
+
+    def test_workflow_is_read_only_and_runs_the_checked_scope(self):
+        text = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn("contents: read", text)
+        self.assertNotIn("contents: write", text)
+        self.assertIn("scripts/run_checks.py --scope dead-code", text)
+        self.assertIn('python-version-file: ".python-version"', text)
+
+    def test_workflow_summary_names_tree_universe_analyser_and_non_gating_state(self):
+        text = WORKFLOW_PATH.read_text(encoding="utf-8")
+        for field in ("commit", "git_tree", "universe", "status", "analysers"):
+            self.assertIn(field, text)
+        self.assertIn("Candidates are reported, not gated", text)
+        self.assertNotIn("findings']) > 0", text)
+
+    def test_source_contains_no_source_removal_or_shell_execution(self):
+        source = SCRIPT.read_text(encoding="utf-8")
+        for forbidden in ("shutil.rmtree", "os.remove(", "shell=True"):
+            self.assertNotIn(forbidden, source)
+
+    def test_owned_temporary_and_report_paths_are_ignored(self):
+        text = (ROOT / ".gitignore").read_text(encoding="utf-8")
+        self.assertIn(dead_code.TEMP_PREFIX, text)
+        self.assertIn("/.dead-code/report.json", text)
+        self.assertIn("/.dead-code/checks.json", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_python_contract.py
+++ b/tests/test_python_contract.py
@@ -31,6 +31,7 @@ REQUIRED_MINOR = "==3.14.*"
 EXACT_VERSION = "3.14.6"
 PYTHON_WORKFLOWS = {
     "contributors.yml",
+    "dead-code.yml",
     "janus.yml",
     "lazarus.yml",
     "pandects.yml",


### PR DESCRIPTION
## What changed

Add the deterministic Git-tree universe, v1 report schema, text and JSON
renderers, root check, and report-only workflow for issue #437. The command
consumes hard Horos classifications, keeps each analyser state explicit, and
refuses dirty or substituted repository state instead of publishing a report
under the wrong commit identity.

This step establishes the output contract and reports that no reachability
analyser has run. It does not classify a candidate as semantically dead, delete
source, or make finding count a merge gate. ADR-051 records that authority
boundary and leaves check selection with `scripts/run_checks.py`.

## Audit

- Record: `audit/rounds/fiat-437-establish-a-report-only-dead-code-baseline.md`
- Stacked audit PR URL: https://github.com/wildcat-finance/skills/pull/849
- Task issue: https://github.com/wildcat-finance/skills/issues/437

Five rounds fixed four filesystem-integrity findings. The fifth round found no
new issue. The four inherited macOS or dependency failures allowed by the
runbook amendment reproduce at the entry commit; every other check in the
changed-path closure passes.

## Proof

```bash
python3 tests/emit_dead_code_report.py .elenchus/fiat-437-step-1.json
python3 -m unittest tests.test_dead_code tests.test_python_contract.PythonRuntimeContractTests -v
python3 scripts/dead_code.py report
python3 scripts/dead_code.py report --json
python3 scripts/run_checks.py --scope dead-code
```

<!-- wildcat-origin: shoggoth -->