### PR TITLE
Add bounded Python dead-code signals

### DIFF
--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -1,0 +1,112 @@
+name: dead-code
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.horos/**'
+      - '.github/workflows/dead-code.yml'
+      - 'docs/dead-code/**'
+      - 'docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md'
+      - 'schemas/dead-code-report-v1.schema.json'
+      - 'scripts/dead_code.py'
+      - 'scripts/run_checks.py'
+      - 'tests/check-map-v1.json'
+      - 'tests/emit_dead_code_report.py'
+      - 'tests/test_dead_code.py'
+      - ".python-version"
+      - "pyproject.toml"
+  pull_request:
+    paths:
+      - '.horos/**'
+      - '.github/workflows/dead-code.yml'
+      - 'docs/dead-code/**'
+      - 'docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md'
+      - 'schemas/dead-code-report-v1.schema.json'
+      - 'scripts/dead_code.py'
+      - 'scripts/run_checks.py'
+      - 'tests/check-map-v1.json'
+      - 'tests/emit_dead_code_report.py'
+      - 'tests/test_dead_code.py'
+      - ".python-version"
+      - "pyproject.toml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Run the checked dead-code scope
+        run: python3 scripts/run_checks.py --scope dead-code
+
+      - name: Build the report
+        run: |
+          python3 scripts/dead_code.py report --json --output .dead-code/report.json
+          python3 scripts/dead_code.py report
+
+      - name: Check the report contract
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(
+              Path(".dead-code/report.json").read_text(encoding="utf-8")
+          )
+          if report["schema"] != "dead-code-report/v1":
+              raise SystemExit("dead-code report schema is wrong")
+          if report["universe"]["analysed_count"] < 1:
+              raise SystemExit("dead-code universe collapsed")
+          if report["status"]["state"] == "failed":
+              raise SystemExit("dead-code analyser failed")
+          PY
+
+      - name: Summarise the report
+        if: success()
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+
+          report = json.loads(
+              Path(".dead-code/report.json").read_text(encoding="utf-8")
+          )
+          universe = report["universe"]
+          print("## Dead-code report")
+          print()
+          print("Candidates are reported, not gated.")
+          print()
+          print(f"- commit: {report['tree']['commit']}")
+          print(f"- git_tree: {report['tree']['git_tree']}")
+          print(f"- universe: {universe['id']}")
+          print(
+              f"- paths: {universe['tracked_count']} tracked, "
+              f"{universe['analysed_count']} analysed, "
+              f"{universe['excluded_count']} excluded"
+          )
+          print(f"- status: {report['status']['state']}")
+          states = ", ".join(
+              f"{item['id']}={item['state']}" for item in report["analysers"]
+          )
+          print(f"- analysers: {states or 'none ran'}")
+          print(f"- findings: {len(report['findings'])} candidate(s)")
+          PY
+
+      - name: Record an inconclusive failure
+        if: failure()
+        run: |
+          echo '## Dead-code report' >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo 'The command or report contract failed. This run established no dead-code result.' >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,12 @@ plugins/*/harness/cache/
 .CONTRIBUTORS.md.*
 .README.md.*
 
+# Dead-code report temporaries and uncommitted workflow reports. Step 4 may
+# commit other files below .dead-code, so the directory itself stays visible.
+**/.dead-code-tmp-*
+/.dead-code/report.json
+/.dead-code/checks.json
+
 # Elenchus reports. ADR-038 keeps them inside the invocation checkout and
 # outside every Git control namespace, so they land here as ordinary untracked
 # files. They are generated evidence rather than source: without this rule

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ plugins/*/harness/cache/
 **/.dead-code-tmp-*
 /.dead-code/report.json
 /.dead-code/checks.json
+/.dead-code/coverage.json
+/.dead-code/coverage-processes-*/
 
 # Elenchus reports. ADR-038 keeps them inside the invocation checkout and
 # outside every Git control namespace, so they land here as ordinary untracked

--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 2030
+    "files_walked": 2038
   },
   "entries": [
     {

--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 2038
+    "files_walked": 2039
   },
   "entries": [
     {

--- a/docs/dead-code/runbook.md
+++ b/docs/dead-code/runbook.md
@@ -1,0 +1,276 @@
+# Runbook: establish a report-only dead-code baseline
+
+This run starts from `main` at
+`0698092d27871031b6d5521d77f6e8d8dc5dc937`. Every command below uses the
+repository's Python 3.14.6 interpreter. The four steps implement the chosen
+design from the receipted study; none may turn a candidate count into a merge
+gate or deletion authority.
+
+## Step 1: Commit the specification and scaffold the report contract
+
+**Goal.** Publish the accepted design and create the deterministic universe,
+report model, schema, root check, and report-only workflow without claiming any
+reachability result.
+
+**Entry.** `fiat/437-establish-a-report-only-dead-code-baseline` at
+`0698092d27871031b6d5521d77f6e8d8dc5dc937`, with the study receipt verified and
+no product changes in the worktree. Before editing, confirm ADR-051 is still the
+next free decision identity on `origin/main`; a collision stops the step for a
+receipted runbook amendment.
+
+**Exit.** `docs/dead-code/study.md` and `docs/dead-code/runbook.md` are
+byte-identical copies of the receipted artefacts. ADR-051 records the
+report-only authority, Horos and checked-runner ownership boundaries, and the
+rejected per-plugin and Horos-widening designs. `scripts/dead_code.py report`
+discovers a non-empty Git-tree universe, applies hard Horos file and directory
+classifications, emits equivalent text and schema-valid JSON from one ordered
+model, and reports that no analyser has run rather than calling the tree clean.
+The schema fixes finding, status, universe and tool identities. The `dead-code`
+scope and report-only workflow invoke the focused suite and fail only on command
+or report failure. `python3 tests/emit_dead_code_report.py
+.elenchus/fiat-437-step-1.json`, `python3 scripts/run_checks.py --scope
+dead-code`, both Protasis checks, Imprimatur over shipped prose, and `git diff
+--check` exit 0.
+
+**Files.** Create `docs/dead-code/study.md`, `docs/dead-code/runbook.md`,
+`docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md`,
+`schemas/dead-code-report-v1.schema.json`, `scripts/dead_code.py`,
+`tests/test_dead_code.py`, `tests/emit_dead_code_report.py`, and
+`.github/workflows/dead-code.yml`. Update `.gitignore` and
+`tests/check-map-v1.json`. Regenerate `.horos/boundary.json`,
+`.horos/candidates.json`, and `.horos/census.json` last if the Horos scan changes
+them.
+
+**Tests.** Add at least twenty focused cases for clean-tree binding, empty-walk
+refusal, malformed and duplicate-key Horos input, hard file and descendant tree
+exclusion, prefix siblings, evidence carriage, sorted output, text/JSON parity,
+schema shape, analyser-status wording, unsafe output paths, partial writes,
+workflow report-only semantics, and check-map ownership. The Elenchus runner
+contract is test command `python3 tests/emit_dead_code_report.py {report}`;
+report format `unittest-json-v1`; expected schema `elenchus.unittest.v1`;
+report file `.elenchus/fiat-437-step-1.json`. A missing, stale, empty, malformed
+or infrastructure-failed report is `inconclusive`.
+
+**Disciplines.** phylax: tracked Git bytes, Horos JSON and output paths cross
+input and filesystem boundaries, so reads are bounded and writes are confined
+and atomic. ephoros: report headers and workflow summaries must identify the
+tree, universe and analyser states. metron: none, this step makes no speed
+change. elenchus: the historical classified-directory bug is reproduced red on
+the entry construction and retained as a guard. hypomnema: ADR-051 owns the
+expensive authority and ownership decision; the schema owns the record shape.
+
+## Step 2: Add bounded Python reachability and execution signals
+
+**Goal.** Add Python static candidates and a Python 3.14 execution probe over
+the exact check plan without importing analysed modules or replacing the
+checked runner.
+
+**Entry.** Step 1's signed, audited and prose-checked branch tip. Its report
+model, universe and schema are the only output surface this step extends.
+
+**Exit.** The Python analyser parses bounded tracked source without importing
+it and reports unused imports and locals, unreachable statements and constant
+branches, import-graph reachability, dynamic-reference downgrades, and per-file
+parse status. The execution probe wraps only Python commands selected by
+`scripts/run_checks.py`, uses Python 3.14 `sys.monitoring`, records named lines
+and branches per process, restores callbacks and masks on exit, and marks a
+failed or incomplete check `degraded` without producing never-executed
+findings. A fixture demonstrates one observed and one unobserved branch while a
+dynamic registration, CLI entry point, decorator registration, `__all__`, and
+intentional test fixture survive as negative cases. `python3
+tests/emit_dead_code_report.py .elenchus/fiat-437-step-2.json`, `python3
+scripts/dead_code.py coverage --scope dead-code --output
+.dead-code/coverage.json`, `python3 scripts/dead_code.py report --json
+--coverage .dead-code/coverage.json --analyser python,coverage`, `python3
+scripts/run_checks.py --scope dead-code`, and `git diff --check` exit 0.
+
+**Files.** Extend `scripts/dead_code.py`,
+`schemas/dead-code-report-v1.schema.json`, `tests/test_dead_code.py`, and
+`tests/emit_dead_code_report.py`. Create only the minimum checked-in monitoring
+helper under `scripts/` if process isolation requires one. Update
+`.gitignore` for ignored coverage records. Regenerate the three `.horos/`
+records last if their deterministic scan changes them.
+
+**Tests.** Extend the focused suite by at least twenty-five cases covering
+scope-plan binding, wrapper recursion refusal, monitoring cleanup, line and
+branch identity, multiple processes, failed and skipped checks, syntax errors,
+unused imports and locals, unreachable statements, computed imports,
+decorators, `getattr`, `__all__`, CLI seeds, output bounds and deterministic
+aggregation. Each fixed failure is red against Step 1's tree. The Elenchus
+runner contract is test command `python3 tests/emit_dead_code_report.py
+{report}`; report format `unittest-json-v1`; expected schema
+`elenchus.unittest.v1`; report file `.elenchus/fiat-437-step-2.json`. A missing,
+stale, empty, malformed or infrastructure-failed report is `inconclusive`.
+
+**Disciplines.** phylax: Python source and check argv are untrusted; parsing
+never imports source, the existing runner owns selection and subprocess
+budgets, and instrumentation writes only bounded process records. ephoros:
+status records answer which checks ran, degraded, failed or were unavailable
+and which coverage bytes they produced. metron: the 60-second static-report
+budget is measured before and after any speed-motivated change; otherwise no
+optimisation is authorised. elenchus: each parser, graph or monitoring failure
+is reduced to a fixture, shown red, fixed at its cause and guarded.
+hypomnema: implementation comments record why dynamic references lower
+confidence and why failed coverage cannot imply absence.
+
+## Step 3: Add repository-graph and optional Solidity signals
+
+**Goal.** Report orphan candidates across repository declarations and bounded
+Slither/Forge evidence while preserving every unavailable or degraded state.
+
+**Entry.** Step 2's signed, audited and prose-checked branch tip with Python
+signals stable under the v1 schema.
+
+**Exit.** The repository analyser reports candidates for fixtures, schemas,
+documents, CLI declarations, generated copies, routers, manifests and check-map
+objects only when it can name the parsed edge set and nearest computed-reference
+boundary. Existing Promise Machine, Hypomnema, Horos and check-map checks are
+invoked or consumed rather than copied. Foundry projects are discovered from
+tracked configuration; Slither `dead-code` and `unused-state` JSON and Forge
+coverage are run through fixed argv with project attribution and version
+capture when available. Tool absence is `not-available`; build, timeout or
+parse failure is `degraded` or `failed`, never zero findings. `python3
+tests/emit_dead_code_report.py .elenchus/fiat-437-step-3.json`, `python3
+scripts/dead_code.py report --json --analyser repository,solidity`, `python3
+scripts/run_checks.py --scope dead-code`, all existing Promise Machine and
+check-map validation selected by the changed scope, and `git diff --check` exit
+0.
+
+**Files.** Extend `scripts/dead_code.py`,
+`schemas/dead-code-report-v1.schema.json`, `tests/test_dead_code.py`, and
+`tests/emit_dead_code_report.py`. Add bounded fixture files below
+`tests/fixtures/dead-code/` only when inline temporary repositories cannot
+prove a case. Regenerate the three `.horos/` records last if required.
+
+**Tests.** Extend the focused suite by at least twenty cases: one positive and
+one retained negative case for every repository object family; dynamic and
+computed references; malformed declarations; empty discovery; absent Slither
+or Forge; non-zero, timed-out, oversized and malformed tool output; multiple
+Foundry projects; fixed argv and cwd; detector mapping; and finding/report
+parity. The Elenchus runner contract is test command `python3
+tests/emit_dead_code_report.py {report}`; report format `unittest-json-v1`;
+expected schema `elenchus.unittest.v1`; report file
+`.elenchus/fiat-437-step-3.json`. A missing, stale, empty, malformed or
+infrastructure-failed report is `inconclusive`.
+
+**Disciplines.** phylax: repository declarations and external tool output are
+bounded hostile input, and Slither/Forge use fixed argv, no shell, declared cwd
+and time/output ceilings. ephoros: each project and object family reports its
+version, status, duration, evidence count and refusal reason. metron: no speed
+claim; subprocess deadlines are termination controls, not performance results.
+elenchus: every adapter failure is reproduced at the parser or process boundary
+and its guard stays in the focused suite. hypomnema: no new standing decision;
+the v1 schema and ADR-051 already own the adapter and authority boundaries.
+
+## Step 4: Pin the baseline, check suppressions and demonstrate the prototype
+
+**Goal.** Bind the current candidate inventory to exact evidence, publish the
+operator path, and prove the complete report-only prototype on a clean tree.
+
+**Entry.** Step 3's signed, audited and prose-checked branch tip with every
+analyser represented in the report model.
+
+**Exit.** `.dead-code/baseline.json` binds commit, Git tree, universe digest,
+analyser versions and statuses, stable finding identities, and suppression
+digest. `.dead-code/suppressions.json` uses a closed schema whose entries name
+one exact candidate, reason, owner and still-present target; broad, duplicate,
+unknown, stale and unused suppressions refuse. `baseline --write` uses a
+confined atomic replacement and `baseline --check` is read-only. Operator docs
+state that findings are candidates, counts do not gate development, and a diff
+gate needs a separate decision. The four study demo commands run from a clean
+tree; text and JSON identities agree; all positive and negative fixtures pass;
+the static Python plus repository report has three warm runs recorded and stays
+within the study's 60-second budget; the complete selected repository check
+plan, prose gates, audit-synopsis currency, Horos check and `git diff --check`
+exit 0. No source candidate is deleted or rewritten.
+
+**Files.** Extend `scripts/dead_code.py`,
+`schemas/dead-code-report-v1.schema.json`, `tests/test_dead_code.py`, and
+`tests/emit_dead_code_report.py`. Create
+`schemas/dead-code-suppressions-v1.schema.json`,
+`.dead-code/baseline.json`, `.dead-code/suppressions.json`,
+`docs/promise-machine/dead-code-v1.md`, and
+`docs/dead-code/measurement.md`. Update `.github/workflows/dead-code.yml` and
+`tests/check-map-v1.json` only if the demonstrated command differs from the
+Step 1 stub. Regenerate `.horos/boundary.json`, `.horos/candidates.json`, and
+`.horos/census.json` last.
+
+**Tests.** Extend the focused suite by at least twenty cases for canonical
+identity, commit/tree/universe/version/status/suppression drift, unknown and
+duplicate fields, broad or stale suppressions, symlink and interrupted writes,
+stable rereads, text/JSON/baseline parity, finding-count non-gating, dirty-tree
+refusal and the exact four-command demo. The Elenchus runner contract is test
+command `python3 tests/emit_dead_code_report.py {report}`; report format
+`unittest-json-v1`; expected schema `elenchus.unittest.v1`; report file
+`.elenchus/fiat-437-step-4.json`. A missing, stale, empty, malformed or
+infrastructure-failed report is `inconclusive`.
+
+**Disciplines.** phylax: baseline and suppression reads and writes use closed
+schemas, confined no-follow paths, stable rereads and atomic replacement.
+ephoros: the final report and workflow summary carry tree, analyser, change and
+non-gating status for operators. metron: three warm static-report runs record
+command, commit, interpreter, median and spread against the 60-second budget.
+elenchus: every final failure keeps its smallest red reproducer and guard;
+candidate count alone remains a green result. hypomnema: the operator guide is
+the durable home for commands and failure recovery, measurement owns the
+runtime observation, and ADR-051 remains the standing decision.
+
+### Amendment -- 2026-08-29
+
+**What changed.** Complete replacement Exit: `docs/dead-code/study.md` and
+`docs/dead-code/runbook.md` are byte-identical copies of the receipted
+artefacts, including this amendment in the runbook copy. ADR-051 records the
+report-only authority, Horos and checked-runner ownership boundaries, and the
+rejected per-plugin and Horos-widening designs. `scripts/dead_code.py report`
+discovers a non-empty Git-tree universe, applies hard Horos file and directory
+classifications, emits equivalent text and schema-valid JSON from one ordered
+model, and reports that no analyser has run rather than calling the tree clean.
+The schema fixes finding, status, universe and tool identities. The `dead-code`
+scope and report-only workflow invoke the focused suite and fail only on command
+or report failure. The workflow follows the repository Python contract, and
+`tests/test_python_contract.py` registers and checks it. `python3
+tests/emit_dead_code_report.py .elenchus/fiat-437-step-1.json`, `python3 -m
+unittest tests.test_dead_code tests.test_python_contract.PythonRuntimeContractTests
+-v`, both Protasis checks, Imprimatur over shipped prose, Phylax, Ephoros,
+Hypomnema, the Horos check, and `git diff --check` exit 0. `python3
+scripts/run_checks.py --scope dead-code` runs the complete changed-path closure;
+its only permitted failed checks are `hexaemeron-suite`, `lazarus-suite`,
+`root-suite`, and `synkrisis-suite`, each reproduced at entry commit
+`0698092d27871031b6d5521d77f6e8d8dc5dc937` and attributed respectively to the
+Darwin `/var` symlink, missing locked Lazarus dependencies, the same Darwin
+`MP407` path handling, and Darwin RSS units. Every other selected check exits 0.
+Complete replacement Files: Create `docs/dead-code/study.md`,
+`docs/dead-code/runbook.md`,
+`docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md`,
+`schemas/dead-code-report-v1.schema.json`, `scripts/dead_code.py`,
+`tests/test_dead_code.py`, `tests/emit_dead_code_report.py`, and
+`.github/workflows/dead-code.yml`. Update `.gitignore`,
+`tests/check-map-v1.json`, and `tests/test_python_contract.py`. Regenerate
+`.horos/boundary.json`, `.horos/candidates.json`, and `.horos/census.json` last
+if the Horos scan changes them. Complete replacement Tests: Add at least twenty
+focused cases for clean-tree binding, empty-walk refusal, malformed and
+duplicate-key Horos input, hard file and descendant tree exclusion, prefix
+siblings, evidence carriage, sorted output, text/JSON parity, schema shape,
+analyser-status wording, unsafe output paths, partial writes, workflow
+report-only semantics, check-map ownership, and the repository Python workflow
+contract. The Elenchus runner contract is test command `python3
+tests/emit_dead_code_report.py {report}`; report format `unittest-json-v1`;
+expected schema `elenchus.unittest.v1`; report file
+`.elenchus/fiat-437-step-1.json`. A missing, stale, empty, malformed or
+infrastructure-failed report is `inconclusive`. Run the focused suite and Python
+workflow contract directly. Run the complete checked-runner closure and compare
+any failure with the exact entry commit; only the four host or dependency
+failures named in the replacement Exit are admissible, and every other check
+must pass.
+**Why.** Editing the check-map authority correctly expands the requested
+`dead-code` scope to the complete changed-path closure. The entry commit already
+fails four selected suites on this macOS host, so requiring the aggregate runner
+to exit 0 confused inherited environment failures with Step 1 regressions. The
+first run also exposed two Step 1 integration defects: the workflow did not use
+the exact quoted Python pin form, and the closed workflow inventory did not know
+about it. This amendment keeps the full closure visible, adds the missing
+contract file to scope, and admits only failures reproduced at the exact entry
+commit.
+**Steps touched.** Step 1.
+**Still holding.** Step 1: entry holds; exit holds. Step 2: entry holds; exit
+holds. Step 3: entry holds; exit holds. Step 4: entry holds; exit holds.

--- a/docs/dead-code/study.md
+++ b/docs/dead-code/study.md
@@ -1,0 +1,367 @@
+# Study: establish a report-only dead-code baseline
+
+Issue [#437](https://github.com/wildcat-finance/skills/issues/437) asks for a
+repository-wide candidate inventory. The run starts from `main` at
+`0698092d27871031b6d5521d77f6e8d8dc5dc937`.
+
+Assuming, unless corrected:
+
+1. The analysed universe is the Git-tracked tree at one commit. Modified
+   tracked bytes refuse a baseline; ignored Fiat state and unrelated untracked
+   files are outside the universe.
+2. The exact repository interpreter is Python 3.14.6 from `.python-version` and
+   `pyproject.toml`. Ambient `/usr/bin/python3` is 3.9.6 and is not an allowed
+   substitute.
+3. `.horos/boundary.json` remains the authority for generated, vendored,
+   binary, lockfile and content-addressed exclusions. This command consumes
+   that evidence; it does not widen Horos into a reachability skill.
+4. `tests/check-map-v1.json` and `scripts/run_checks.py` remain the authority
+   for repository check ownership and execution. Coverage consumes their
+   discovered commands and results rather than creating another scheduler.
+5. Findings are candidates. No confidence level, static signal or coverage gap
+   proves semantic uselessness or authorises deletion.
+6. This is repository tooling, not a frontier advancement for Fiat, Horos,
+   Metron or another skill. No `EVOLUTION.md` row is owed.
+
+## 1. Problem statement
+
+Build one deterministic root command for contributors and maintainers that
+inventories what it analysed and reports bounded dead-code signals without
+editing source. A working prototype provides equivalent text and canonical JSON
+reports, a pinned baseline, checked suppressions and explicit analyser status.
+
+Current `main` was remeasured rather than inheriting the 21 August issue counts:
+
+- 3,015 tracked paths, including 667 Python files with 294,599 lines and 168
+  Solidity files;
+- 23 declared checks across 22 selected scopes in the checked impact map;
+- 494 root tests under Python 3.14.6: 493 pass and one inherited isolated-copy
+  test fails with `MP407` on this Darwin host;
+- the historical #437 universe probe, executed from its old branch against the
+  current commit, finds 1,909 analysed paths and 1,106 hard-classified
+  exclusions: 978 generated, 72 content-addressed, 50 binary, three lockfiles
+  and three vendored paths. It has no registered analyser and therefore
+  establishes zero reachability findings, not a clean tree.
+
+The proving demo path, from a clean checkout, is:
+
+```bash
+python3 scripts/dead_code.py report
+python3 scripts/dead_code.py report --json
+python3 scripts/dead_code.py baseline --check
+python3 scripts/run_checks.py --scope dead-code
+```
+
+The prototype is working when both report formats carry the same ordered
+findings and statuses; the universe is non-empty and commit-bound; every
+finding names its analyser, object, evidence, confidence and nearest
+false-positive boundary; positive fixtures exercise every signal family;
+negative fixtures retain dynamic registration, CLI entry points, intentional
+fixtures and Horos-classified content; malformed reports, collapsed discovery
+and analyser crashes fail; existing candidate count alone does not fail; and
+no command deletes or rewrites source.
+
+## 2. Prior art
+
+### Current repository and organisation
+
+The current execution authority is `scripts/run_checks.py` plus
+`tests/check-map-v1.json`. It already proves total path ownership, rejects
+unreachable checks and stale commands, closes dependencies, executes one
+immutable snapshot and emits bounded results. `scripts/dead_code.py` must be a
+declared check and a consumer of that graph, not a rival scheduler.
+
+Horos at `plugins/horos/skills/horos/scripts/horos.py` and
+`.horos/boundary.json` already classify token sinks with evidence. The
+Promise Machine checker, Hypomnema link checker, marketplace tests and
+check-map validation already expose narrower repository-graph failures. The
+new command normalises those signals and adds missing reachability analysis;
+it does not copy their rules.
+
+The last two merged pull requests that changed this subject were read in full:
+
+- [#745, Reconstruct, check and prove the affected-scope test runner](https://github.com/wildcat-finance/skills/pull/745),
+  merged 28 August 2026. It made the impact map and runner authoritative. Its
+  carried Darwin failures, portable-runtime link findings, scratch-guard
+  evasion forms and runner edge cases remain facts about execution, not
+  dead-code findings. This run carries them as analyser statuses and invokes
+  the checked runner rather than duplicating process control.
+- [#732, Detach plugin suites from unrelated changes](https://github.com/wildcat-finance/skills/pull/732),
+  merged 28 August 2026. It narrowed hosted workflow ownership and recorded the
+  same Lazarus and Synkrisis Darwin failures. This run preserves those trigger
+  boundaries. Any dead-code lane is report-only on finding count and must not
+  restore every plugin workflow on every unrelated change.
+
+The old unmerged #437 branch is evidence, not authority. Its two commits,
+`6779ca2fdd1211f3b145f03135c024ac10ef1388` and
+`a07436c0d4190bb2e03e29c5b121720724352f80`, are based on
+`8de7a4bc910e398107ff2f54a4cf92a82e764a76` and deliver only universe
+discovery, report rendering and 38 scaffold tests. The second commit correctly
+extends a hard Horos directory classification to descendants without capturing
+a sibling sharing the prefix; that construction carries forward. The branch's
+standalone workflow, 1,512-path measurement, Python 3.11 premise, Slither
+0.11.6 pin and branch-coverage deferral are stale. Its seven-step runbook never
+landed and cannot govern this run.
+
+### Audit record inventory
+
+`python3 plugins/hexaemeron/skills/fiat/scripts/audit_synopsis.py --check .`
+verified all 39 committed synopsis views against their authoritative sources.
+The in-scope records and reading modes are:
+
+- `audit/AUDIT.md` through fresh `audit/AUDIT_SYNOPSIS.md`, limited to root
+  command, atomic-write, degraded-result and repository-graph records. The
+  relevant `scripts/contributors.py` S3-R2-01 is fixed and retains one rule:
+  read-only checks do not sweep old writer litter.
+- `audit/rounds/fiat-377-stop-the-marker-rule-excluding-the-classifie.md`
+  through its fresh synopsis. Its findings are fixed. Its remaining CR-only
+  line handling, sampled-window gaps and census-currency ideas define Horos
+  recall limits; this report carries the classifier evidence without
+  strengthening it.
+- `audit/rounds/fiat-621-isolate-disposable-fixture-signing.md` through its
+  fresh synopsis. Its product findings are fixed; the current root rerun still
+  reproduces the separate Darwin `MP407` isolated-copy failure.
+- all four `audit/rounds/fiat-622-*.md` sources through their fresh synopses.
+  Their scheduler findings are fixed. Their unexercised high-capacity hosts,
+  retained-descriptor lifetime, unexpected-success accounting, multi-subtest
+  report-reader limit and scratch-guard evasion forms stay outside this
+  command's ownership and are surfaced as runner evidence or status.
+
+The remaining 32 verified sources are out of scope: they audit venue evidence,
+credit laws, hook semantics, controller transitions, prose or other domain
+behaviour inside the analysed tree; none defines Git universe discovery, Horos
+classification, checked-run scheduling or this report format. The legacy
+`plugins/hexaemeron/audit/AUDIT.md` synopsis was inspected and likewise
+excluded: its controller and hook-gate findings do not govern the root runner.
+No authoritative #437 audit source exists because its old branch did not land
+one. No audit evidence gap blocks the study.
+
+### Outside both repositories
+
+- Vulture provides confidence-ranked Python dead-code candidates, including a
+  high-confidence-only mode: <https://github.com/jendrikseipp/vulture>.
+- Ruff F401 and F841 specify unused-import and unused-local signals and their
+  suppression boundaries: <https://docs.astral.sh/ruff/rules/unused-import/>
+  and <https://docs.astral.sh/ruff/rules/unused-variable/>.
+- Python 3.14 `sys.monitoring` exposes line and left/right branch events without
+  adding a package: <https://docs.python.org/3.14/library/sys.monitoring.html>.
+- Slither names `unused-state` high-confidence and `dead-code`
+  medium-confidence detectors, and can emit JSON for selected detectors:
+  <https://github.com/crytic/slither/wiki/Detector-Documentation>.
+- Forge exposes coverage for Foundry projects:
+  <https://getfoundry.sh/forge/reference/coverage/>.
+
+These tools produce signals, not deletion authority. Current local probes find
+Forge 1.7.1 and Slither 0.11.4; absence or a different version is report data.
+
+## 3. Constraints and non-goals
+
+Constraints:
+
+- exact starting ref `0698092d27871031b6d5521d77f6e8d8dc5dc937` on
+  `main`;
+- Python 3.14.6, standard library for the root implementation, and fixed argv
+  with no shell for external tools;
+- a deterministic, schema-validated, report-only command over tracked Git
+  bytes, with stable analyser and suppression identities;
+- current Horos and checked-runner contracts are consumed by path and version;
+  generated portable runtime stays excluded under its recorded classification;
+- a baseline records commit, Git tree, universe digest, analyser versions,
+  statuses, finding identities and suppression digest.
+
+Non-goals are source deletion, automatic rewriting, semantic proof of
+uselessness, type checking, a dashboard, database or backup service, changing
+Horos's promise, replacing the affected-scope runner, repairing the inherited
+Darwin failures, and making finding count a merge gate. A future diff gate is a
+separate decision after the baseline is triaged.
+
+Boundaries in force:
+
+- **Always:** run both the root suite and every check selected by the changed
+  scope before a commit; run Imprimatur on shipped prose; record a before and
+  after measurement before any speed-motivated change; regenerate Horos last.
+- **Ask first:** add a dependency; change the report schema after a baseline is
+  published; widen CI triggers beyond the owning workflow; change a public CLI;
+  alter check ownership or a Promise Machine declaration.
+- **Never:** commit credentials or signing material; import or execute a Python
+  file merely to analyse it; edit vendored code; delete a failing test or source
+  candidate; describe unexecuted analysis as clean; claim a command ran when it
+  did not.
+
+## 4. Design options
+
+**A. One stdlib root command consuming Horos and the checked runner.** Git and
+AST analysis discover the static universe; `sys.monitoring` records Python
+line/function/branch execution through declared check commands; Slither and
+Forge supply optional Solidity signals; existing graph checks contribute
+machine-readable statuses. Trade: more local adapter code and lower Python
+recall than dedicated packages, in exchange for one pinned implementation and
+no second dependency or scheduler.
+
+**B. One root command built around Vulture, Ruff and coverage.py.** This has
+broader mature Python analysis. Trade: it adds the repository's first Python
+tool dependencies, requires a lock/update policy, and still needs custom graph,
+Horos, Solidity and report adapters.
+
+**C. Widen Horos into reachability analysis.** It reuses the walk directly.
+Trade: it collapses the explicit boundary between evidenced reading exclusion
+and claims about unused objects, and would require a skill promise and frontier
+change.
+
+**D. Put one analyser in every plugin suite.** It keeps ownership local. Trade:
+it cannot see cross-plugin imports, root manifests, generated-copy topology or
+orphaned docs and fixtures, which are the issue's core gap.
+
+**Chosen: A.** It is the lowest-comprehension construction that meets the issue
+on the current tree because #745 already centralised discovery and execution,
+and Python 3.14.6 now supplies branch events the old branch lacked. It trades
+away Vulture/Ruff recall and coverage.py's mature arc model. Each missing signal
+is named in analyser status, and the schema permits a later adapter without
+rewriting finding identity.
+
+## 5. Risk register seed
+
+```risk-register
+discovery-collapse | Git tree and Horos classification join | an empty or unexpectedly reduced universe refuses instead of producing zero findings
+tree-prefix-classification | hard Horos directory entries | descendants inherit the exact parent evidence while siblings sharing the textual prefix remain analysed
+analyser-absence-as-clean | every analyser status | absent, skipped, timed-out and crashed remain distinct from ran-with-zero-findings
+dynamic-reference-blindness | Python import and call graph | importlib, entry points, decorators, __all__, getattr and computed paths lower confidence or retain the object
+coverage-failure-as-dead | check execution under monitoring | a failing, incomplete or unselected check yields degraded coverage status and no never-executed finding
+monitoring-leak | Python 3.14 sys.monitoring callbacks | tool id, callbacks and event masks are restored after every command and isolated in fixtures
+untrusted-parse | tracked Python source | analysis parses bytes without import, eval or execution and reports syntax failures by path
+subprocess-argv | Git, Slither, Forge and checked-runner invocations | fixed argv, no shell, bounded output, declared cwd and inherited runner timeouts
+solidity-project-attribution | Foundry project discovery | each finding names one project, tool versions and build or coverage status rather than a repository-wide clean claim
+repository-edge-overclaim | docs, fixtures, schemas, routers and manifests | every edge names the parser or declaration that produced it and computed references prevent high confidence
+report-parity | text and JSON renderers | both formats derive from one ordered model and tests compare stable identities and counts
+baseline-staleness | committed baseline | commit, tree, universe, analyser versions, statuses and suppression digest all bind or check refuses
+suppression-abuse | suppression document | each narrow id has a reason, owner and still-present target; stale, broad or unused entries refuse
+path-confinement | report, baseline and temporary files | no-follow descendant checks and atomic replace keep writes inside owned paths
+partial-write | report and baseline publication | interrupted writes leave no accepted half-file and read-only checks never sweep unrelated litter
+finding-overclaim | candidate wording and confidence | no emitted record says proved dead, safe to delete or semantically unused
+```
+
+## 6. Glossary seeds
+
+- **Universe:** tracked paths at one commit, partitioned into analysed and
+  evidence-classified exclusions.
+- **Analyser:** one versioned signal source with a declared status and boundary.
+- **Finding:** a stable candidate identity plus object, evidence, confidence and
+  nearest false-positive boundary.
+- **Coverage signal:** an observed execution relation for named checks, never a
+  proof that unobserved code is unreachable.
+- **Repository edge:** a named reference between a manifest, router, command,
+  fixture, schema, document or generated copy and another tracked object.
+- **Suppression:** a narrow, reasoned decision to retain one candidate; not a
+  deletion waiver or hidden ignore pattern.
+- **Baseline:** the report identity bound to one Git tree, universe and analyser
+  set.
+- **Degraded:** an analyser began but its evidence did not establish the
+  requested signal.
+- **Not available:** the named optional tool was absent before execution.
+
+## 7. Sources
+
+- GitHub issue #437, including its 26 August keep-but-remeasure review.
+- Current `AGENTS.md`, `.python-version`, `pyproject.toml`,
+  `.horos/boundary.json`, `scripts/run_checks.py`, `tests/check-map-v1.json`,
+  `PROMISE_MACHINE.md` and `tests/promise_machine_coverage.json` at the starting
+  ref.
+- Pull requests #745 and #732, including their full bodies, files and carried
+  work.
+- Old branch commits `6779ca2` and `a07436c`, its committed study, runbook,
+  schema, script, tests and workflow.
+- The seven in-scope audit sources and verified synopsis modes listed in item 2;
+  the synopsis currency command's complete 39-source output.
+- The Vulture, Ruff, Python 3.14, Slither and Foundry primary documentation
+  linked in item 2.
+- Reproduction commands and outputs in item 1 for current counts, universe,
+  check inventory, versions and root-suite status.
+
+## 8. Signals, and the questions behind them
+
+This command runs in terminals and CI, so Ephoros applies to the report and job
+summary rather than a service dashboard.
+
+- *Did it analyse the intended tree?* The header emits commit, tree, universe
+  digest, analysed/excluded counts and each classification count.
+- *Which signals actually ran?* One status per analyser emits version, command
+  identity, selected check manifest, duration and one of `ran`, `not-available`,
+  `degraded` or `failed` with reason.
+- *What changed from the baseline?* Comparison emits added, resolved,
+  suppressed and stale-suppression identities by analyser and path.
+- *Did candidates block development?* The terminal status distinguishes a
+  green report with findings from a failed report contract; CI publishes the
+  count but gates only malformed, crashed or collapsed analysis.
+
+## 9. Boundaries, per capability
+
+Phylax governs the controls cited here.
+
+- **Tracked-source read:** contributor-controlled bytes can exhaust or confuse
+  parsers. Use bounded regular-file reads from the recorded tree, never import
+  analysed Python, reject unsafe paths and retain per-file parse errors.
+- **Check execution:** repository tests execute arbitrary project code. Delegate
+  selection, snapshotting, timeouts, process groups and result accounting to
+  `scripts/run_checks.py`; consume its bounded record.
+- **External Solidity tools:** Slither and Forge execute compilers and project
+  configuration. Use fixed argv, declared project cwd, version capture and
+  existing timeouts; absence is visible and a crash is not zero findings.
+- **Classification and manifests:** malformed JSON can erase the universe or
+  invent graph edges. Use duplicate-key rejection, closed shapes, exact schema
+  versions and a non-empty floor before analysis.
+- **Artefact writes:** symlink swaps and interruption can escape or corrupt a
+  baseline. Use confined no-follow paths, stable rereads, same-directory atomic
+  replacement and product-specific temporary prefixes.
+
+## 10. The budget, or its absence
+
+The static Python plus repository-graph report should finish within 60 seconds
+on a warm checkout at the starting ref. Record at least three runs before and
+after any speed-motivated change using the same interpreter and tree:
+
+```bash
+/usr/bin/time -p python3 scripts/dead_code.py report --analyser python,repository --json
+```
+
+This follows Metron; the recorded median and spread decide keep or revert.
+Coverage and Solidity have no aggregate speed budget because they execute the
+declared suites and optional toolchains. Their existing per-check timeouts and
+the report's measured durations are still required. No performance conclusion
+may be drawn across different manifests, commits or tool versions.
+
+## 11. The fail-closed posture
+
+Elenchus governs any failure worked during implementation. The report refuses
+on a dirty tracked tree, unsafe path, malformed or stale Horos boundary,
+duplicate-key or wrong-schema input, empty/collapsed universe, analyser crash,
+missing required status, report-schema failure, text/JSON identity mismatch or
+unsafe write. `baseline --check` additionally refuses changed commit, tree,
+universe, analyser version/status or suppression digest.
+
+An optional tool absent before execution is `not-available`, not a crash. A
+check failure or incomplete monitoring run is `degraded` and contributes no
+absence finding. Existing candidate count never changes the exit status by
+itself.
+
+Every implementation or audit fix follows the guard convention: preserve the
+smallest reproducer, show the focused test red on the exact parent bytes, fix
+the cause, then show the same test green and run the affected scope. If the
+failure cannot be reproduced, record `inconclusive`; do not guess at a fix.
+
+## 12. Decisions and their homes
+
+Hypomnema governs the records.
+
+- The expensive decision is a report-only root capability that consumes Horos
+  classification and the checked runner without changing either promise. Put
+  it in the next free `docs/decisions/ADR-*.md`, chosen when the step begins so
+  concurrent work cannot collide.
+- The finding, analyser-status, baseline and suppression shapes live in schemas
+  under `schemas/`; the schemas are the normative records and prose links to
+  them instead of restating fields.
+- Capability and operator documentation lives under
+  `docs/promise-machine/dead-code-v1.md`; the study and runbook receive durable
+  copies under `docs/dead-code/`.
+- Current baseline bytes live under `.dead-code/` and name their generating
+  command. A later diff gate requires a new ADR and issue; it is not smuggled
+  into a suppression or workflow threshold.

--- a/docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md
+++ b/docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md
@@ -1,0 +1,55 @@
+# ADR-051: Keep dead-code discovery report-only
+
+## Status
+
+Accepted, 2026-08-29.
+
+## Context
+
+Issue #437 needs one repository-wide inventory of possible dead code. The
+repository already has two narrower authorities that must not drift: Horos
+classifies generated, vendored, binary, lockfile and content-addressed reading
+exclusions, while tests/check-map-v1.json and scripts/run_checks.py select and
+execute checks.
+
+A reachability signal is incomplete around dynamic imports, registrations,
+entry points, fixtures and computed paths. Candidate counts therefore cannot
+establish semantic uselessness or authorise deletion.
+
+## Decision
+
+Provide one root report-only command whose universe is the clean tracked Git
+tree. It consumes hard Horos classifications without changing Horos and
+consumes the checked runner without becoming another scheduler. Findings remain
+candidates with explicit evidence and false-positive boundaries. Candidate
+count never fails the command, blocks a merge or authorises source deletion.
+
+The dead-code scope owns this command, schema, focused tests, workflow and
+documentation. Horos continues to own classification evidence. The checked
+runner continues to own scope selection, snapshots, process budgets and result
+accounting.
+
+## Alternatives
+
+Put one analyser in every plugin. Rejected because plugin-local views cannot
+resolve cross-plugin imports, root manifests, generated-copy topology or
+orphaned repository objects.
+
+Widen Horos into reachability analysis. Rejected because reading exclusion and
+semantic reachability make different promises. Combining them would strengthen
+Horos evidence beyond its contract and blur which component owns a refusal.
+
+Use candidate count as a workflow gate. Rejected because a static or execution
+signal does not prove that a candidate is unused. A future diff gate requires
+a separate decision after the baseline is reviewed.
+
+## Consequences
+
+Contributors get one deterministic text and JSON report bound to commit, Git
+tree and universe identity. CI fails on command, schema, discovery or analyser
+failure, not on findings. The root command must preserve unavailable and
+degraded analyser states and must not edit analysed source.
+
+The command depends on Horos and the checked runner, so their changes select
+the dead-code suite through the repository check graph. Later analysers extend
+the versioned schema; they do not acquire deletion authority.

--- a/schemas/dead-code-report-v1.schema.json
+++ b/schemas/dead-code-report-v1.schema.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wildcat.finance/schemas/dead-code-report-v1.schema.json",
+  "title": "dead-code-report/v1",
+  "description": "A report-only inventory over one clean Git tree. Findings are candidates, their count is not a gate, and this document never authorises deletion.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "tool",
+    "tree",
+    "universe",
+    "status",
+    "analysers",
+    "findings"
+  ],
+  "properties": {
+    "schema": {
+      "const": "dead-code-report/v1"
+    },
+    "tool": {
+      "$ref": "#/$defs/toolIdentity"
+    },
+    "tree": {
+      "$ref": "#/$defs/treeIdentity"
+    },
+    "universe": {
+      "$ref": "#/$defs/universeIdentity"
+    },
+    "status": {
+      "$ref": "#/$defs/analysisStatus"
+    },
+    "analysers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/analyserStatus"
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/finding"
+      }
+    }
+  },
+  "$defs": {
+    "sha256Identity": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "gitObjectIdentity": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "repositoryPath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096,
+      "pattern": "^[^/].*$"
+    },
+    "toolIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version"],
+      "properties": {
+        "id": {
+          "const": "dead-code"
+        },
+        "version": {
+          "const": "1"
+        }
+      }
+    },
+    "treeIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["commit", "git_tree"],
+      "properties": {
+        "commit": {
+          "$ref": "#/$defs/gitObjectIdentity"
+        },
+        "git_tree": {
+          "$ref": "#/$defs/gitObjectIdentity"
+        }
+      }
+    },
+    "classifiedPath": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "category", "evidence", "grade"],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/repositoryPath"
+        },
+        "category": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence": {
+          "type": "string",
+          "minLength": 1
+        },
+        "grade": {
+          "const": "hard"
+        }
+      }
+    },
+    "universeIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "tracked_count",
+        "analysed_count",
+        "analysed",
+        "excluded_count",
+        "excluded_by_category",
+        "excluded"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/sha256Identity"
+        },
+        "tracked_count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "analysed_count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "analysed": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/repositoryPath"
+          }
+        },
+        "excluded_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "excluded_by_category": {
+          "type": "object",
+          "propertyNames": {
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "excluded": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/classifiedPath"
+          }
+        }
+      }
+    },
+    "analysisStatus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "state", "detail"],
+      "properties": {
+        "id": {
+          "const": "analysis"
+        },
+        "state": {
+          "enum": ["not-run", "ran", "degraded", "failed"]
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "analyserStatus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "state", "version", "detail"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "state": {
+          "enum": ["ran", "not-available", "degraded", "failed"]
+        },
+        "version": {
+          "type": ["string", "null"]
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "analyser_id",
+        "path",
+        "symbol",
+        "evidence",
+        "confidence",
+        "false_positive_boundary"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/sha256Identity"
+        },
+        "analyser_id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "path": {
+          "$ref": "#/$defs/repositoryPath"
+        },
+        "symbol": {
+          "type": ["string", "null"]
+        },
+        "evidence": {
+          "type": "string",
+          "minLength": 1
+        },
+        "confidence": {
+          "enum": ["high", "medium", "low"]
+        },
+        "false_positive_boundary": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/schemas/dead-code-report-v1.schema.json
+++ b/schemas/dead-code-report-v1.schema.json
@@ -180,7 +180,7 @@
     "analyserStatus": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "state", "version", "detail"],
+      "required": ["id", "state", "version", "detail", "records"],
       "properties": {
         "id": {
           "type": "string",
@@ -196,6 +196,37 @@
         "detail": {
           "type": "string",
           "minLength": 1
+        },
+        "records": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/analyserRecord"
+          }
+        }
+      }
+    },
+    "analyserRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "state", "detail", "bytes"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "enum": ["file", "check"]
+        },
+        "state": {
+          "enum": ["parsed", "parse-error", "skipped", "passed", "failed", "unavailable"]
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1
+        },
+        "bytes": {
+          "type": "integer",
+          "minimum": 0
         }
       }
     },

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -236,20 +236,35 @@ def run_process(
     cwd: Path,
     timeout_seconds: int,
     output_limit: int,
+    cwd_fd: int | None = None,
 ) -> tuple[bytes, bytes, int]:
     """Run fixed argv while bounding time and combined captured output."""
+    process_cwd: Path | None = cwd
+    pass_fds: tuple[int, ...] = ()
+    preexec_fn: Callable[[], None] | None = None
+    if cwd_fd is not None:
+        process_cwd = None
+        pass_fds = (cwd_fd,)
+
+        def enter_opened_directory() -> None:
+            os.fchdir(cwd_fd)
+            os.close(cwd_fd)
+
+        preexec_fn = enter_opened_directory
     try:
         process = subprocess.Popen(
             argv,
-            cwd=cwd,
+            cwd=process_cwd,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             shell=False,
+            pass_fds=pass_fds,
+            preexec_fn=preexec_fn,
         )
     except FileNotFoundError as error:
         raise Refusal(f"{argv[0]} is not available on PATH") from error
-    except OSError as error:
+    except (OSError, subprocess.SubprocessError) as error:
         raise Refusal(f"{argv[0]} could not start: {error}") from error
 
     assert process.stdout is not None
@@ -301,12 +316,16 @@ def decode_output(payload: bytes, label: str) -> str:
         raise Refusal(f"{label} output is not UTF-8") from error
 
 
-def run_git(root: Path, *arguments: str) -> str:
+def run_git(root: Path, *arguments: str, root_fd: int | None = None) -> str:
+    argv = ["git", "-C", str(root), *arguments]
+    if root_fd is not None:
+        argv = ["git", *arguments]
     stdout, stderr, returncode = run_process(
-        ["git", "-C", str(root), *arguments],
+        argv,
         cwd=root,
         timeout_seconds=GIT_TIMEOUT_SECONDS,
         output_limit=MAX_GIT_OUTPUT_BYTES,
+        cwd_fd=root_fd,
     )
     if returncode != 0:
         detail = decode_output(stderr, "git stderr").strip()
@@ -332,24 +351,33 @@ def _require_oid(value: str, label: str) -> str:
     return value
 
 
-def resolve_commit(root: Path) -> str:
-    return _require_oid(run_git(root, "rev-parse", "HEAD").strip(), "HEAD")
-
-
-def resolve_tree(root: Path, commit: str) -> str:
+def resolve_commit(root: Path, *, root_fd: int | None = None) -> str:
     return _require_oid(
-        run_git(root, "rev-parse", f"{commit}^{{tree}}").strip(),
+        run_git(root, "rev-parse", "HEAD", root_fd=root_fd).strip(),
+        "HEAD",
+    )
+
+
+def resolve_tree(root: Path, commit: str, *, root_fd: int | None = None) -> str:
+    return _require_oid(
+        run_git(
+            root,
+            "rev-parse",
+            f"{commit}^{{tree}}",
+            root_fd=root_fd,
+        ).strip(),
         "HEAD tree",
     )
 
 
-def require_clean_tree(root: Path) -> None:
+def require_clean_tree(root: Path, *, root_fd: int | None = None) -> None:
     porcelain = run_git(
         root,
         "status",
         "--porcelain=v1",
         "-z",
         "--untracked-files=no",
+        root_fd=root_fd,
     )
     changed = [entry for entry in porcelain.split(chr(0)) if entry]
     if changed:
@@ -378,8 +406,21 @@ def validate_repository_path(value: str, label: str) -> str:
     return value
 
 
-def tracked_paths(root: Path, commit: str) -> tuple[str, ...]:
-    listing = run_git(root, "ls-tree", "-r", "--name-only", "-z", commit)
+def tracked_paths(
+    root: Path,
+    commit: str,
+    *,
+    root_fd: int | None = None,
+) -> tuple[str, ...]:
+    listing = run_git(
+        root,
+        "ls-tree",
+        "-r",
+        "--name-only",
+        "-z",
+        commit,
+        root_fd=root_fd,
+    )
     paths = tuple(
         sorted(
             validate_repository_path(entry, "tracked path")
@@ -443,6 +484,69 @@ def read_bounded_regular(path: Path, *, limit: int, label: str) -> str:
         raise Refusal(f"{label} is not UTF-8") from error
 
 
+def read_commit_regular(
+    root: Path,
+    commit: str,
+    repository_path: str,
+    *,
+    limit: int,
+    label: str,
+    root_fd: int | None = None,
+) -> str:
+    """Read one bounded regular blob from the recorded Git tree."""
+    listing = run_git(
+        root,
+        "ls-tree",
+        "-z",
+        commit,
+        "--",
+        repository_path,
+        root_fd=root_fd,
+    )
+    records = [record for record in listing.split(chr(0)) if record]
+    if not records:
+        raise Refusal(f"{label} is absent from commit {commit}")
+    if len(records) != 1 or chr(9) not in records[0]:
+        raise Refusal(f"{label} has an ambiguous Git tree record")
+    metadata, listed_path = records[0].split(chr(9), 1)
+    fields = metadata.split()
+    if len(fields) != 3 or listed_path != repository_path:
+        raise Refusal(f"{label} has a malformed Git tree record")
+    mode, object_type, object_id = fields
+    if mode not in {"100644", "100755"} or object_type != "blob":
+        raise Refusal(f"{label} is not a regular file in commit {commit}")
+    _require_oid(object_id, f"{label} blob")
+    size_text = run_git(
+        root,
+        "cat-file",
+        "-s",
+        object_id,
+        root_fd=root_fd,
+    ).strip()
+    if not size_text.isdecimal():
+        raise Refusal(f"{label} blob size is not an integer")
+    size = int(size_text)
+    if size > limit:
+        raise Refusal(f"{label} exceeds {limit} bytes")
+    stdout, stderr, returncode = run_process(
+        ["git", "cat-file", "blob", object_id]
+        if root_fd is not None
+        else ["git", "-C", str(root), "cat-file", "blob", object_id],
+        cwd=root,
+        timeout_seconds=GIT_TIMEOUT_SECONDS,
+        output_limit=limit,
+        cwd_fd=root_fd,
+    )
+    if returncode != 0:
+        detail = decode_output(stderr, "git stderr").strip()
+        if not detail:
+            detail = f"exit {returncode}"
+        raise Refusal(f"{label} blob cannot be read: {detail}")
+    if len(stdout) != size:
+        raise Refusal(f"{label} blob size changed while it was read")
+    return decode_output(stdout, label)
+
+
 def reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
     document: dict[str, object] = {}
     for key, value in pairs:
@@ -452,13 +556,31 @@ def reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
     return document
 
 
-def load_boundary(root: Path) -> Classification:
+def load_boundary(
+    root: Path,
+    *,
+    commit: str | None = None,
+    root_fd: int | None = None,
+) -> Classification:
     label = BOUNDARY_PATH.as_posix()
-    raw = read_bounded_regular(
-        root / BOUNDARY_PATH,
-        limit=MAX_BOUNDARY_BYTES,
-        label=label,
-    )
+    owns_root_fd = root_fd is None
+    if root_fd is None:
+        root_fd = open_repository_directory(root)
+    try:
+        recorded_commit = (
+            resolve_commit(root, root_fd=root_fd) if commit is None else commit
+        )
+        raw = read_commit_regular(
+            root,
+            recorded_commit,
+            label,
+            limit=MAX_BOUNDARY_BYTES,
+            label=label,
+            root_fd=root_fd,
+        )
+    finally:
+        if owns_root_fd:
+            os.close(root_fd)
     try:
         document = json.loads(raw, object_pairs_hook=reject_duplicate_keys)
     except DuplicateKey as error:
@@ -517,26 +639,35 @@ def universe_identity(
     )
 
 
-def discover(root: Path) -> Universe:
-    require_clean_tree(root)
-    commit = resolve_commit(root)
-    tree = resolve_tree(root, commit)
-    tracked = tracked_paths(root, commit)
-    classified = load_boundary(root)
+def discover(root: Path, *, root_fd: int | None = None) -> Universe:
+    owns_root_fd = root_fd is None
+    if root_fd is None:
+        root_fd = open_repository_directory(root)
+    try:
+        require_clean_tree(root, root_fd=root_fd)
+        commit = resolve_commit(root, root_fd=root_fd)
+        tree = resolve_tree(root, commit, root_fd=root_fd)
+        tracked = tracked_paths(root, commit, root_fd=root_fd)
+        classified = load_boundary(root, commit=commit, root_fd=root_fd)
 
-    analysed: list[str] = []
-    excluded: list[ClassifiedPath] = []
-    for path in tracked:
-        match = classified.match(path)
-        if match is None:
-            analysed.append(path)
-        else:
-            excluded.append(match)
-    if len(analysed) < UNIVERSE_FLOOR:
-        raise Refusal(
-            f"discovery returned {len(analysed)} analysable paths from "
-            f"{len(tracked)} tracked; this is a collapsed walk"
-        )
+        analysed: list[str] = []
+        excluded: list[ClassifiedPath] = []
+        for path in tracked:
+            match = classified.match(path)
+            if match is None:
+                analysed.append(path)
+            else:
+                excluded.append(match)
+        if len(analysed) < UNIVERSE_FLOOR:
+            raise Refusal(
+                f"discovery returned {len(analysed)} analysable paths from "
+                f"{len(tracked)} tracked; this is a collapsed walk"
+            )
+        require_clean_tree(root, root_fd=root_fd)
+    finally:
+        if owns_root_fd:
+            os.close(root_fd)
+
     analysed_tuple = tuple(analysed)
     excluded_tuple = tuple(excluded)
     return Universe(
@@ -647,8 +778,8 @@ def validate_report(report: Report) -> None:
         raise Refusal("findings are not sorted by stable report identity")
 
 
-def build_report(root: Path) -> Report:
-    universe = discover(root)
+def build_report(root: Path, *, root_fd: int | None = None) -> Report:
+    universe = discover(root, root_fd=root_fd)
     statuses, findings = collect(root, universe)
     report = Report(universe=universe, statuses=statuses, findings=findings)
     validate_report(report)
@@ -898,18 +1029,16 @@ def atomic_write(
 
 def command_report(arguments: argparse.Namespace) -> int:
     root = repository_root(Path(arguments.directory).resolve())
-    root_fd: int | None = None
+    root_fd = open_repository_directory(root)
     target: Path | None = None
     try:
         if arguments.output is not None:
-            root_fd = open_repository_directory(root)
             target = confine(root, arguments.output)
-        report = build_report(root)
+        report = build_report(root, root_fd=root_fd)
         rendered = render_json(report) if arguments.json else render_text(report)
         if arguments.output is None:
             sys.stdout.write(rendered)
             return 0
-        assert root_fd is not None
         assert target is not None
         atomic_write(root, target, rendered, root_fd=root_fd)
         return 0

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -733,8 +733,10 @@ def confine(root: Path, candidate: str) -> Path:
         raise Refusal(
             f"the output path must be beneath the owned {OWNED_OUTPUT_DIRECTORY}/ sink"
         )
-    target = root.resolve(strict=True).joinpath(*parts)
-    if target == root.resolve(strict=True):
+    if not root.is_absolute():
+        raise Refusal("the repository root is not absolute")
+    target = root.joinpath(*parts)
+    if target == root:
         raise Refusal("the repository root is not an output file")
     return target
 
@@ -765,18 +767,18 @@ def output_parts(root: Path, target: Path) -> tuple[str, ...]:
     return parts
 
 
-def open_repository_directory(root: Path) -> tuple[Path, int]:
+def open_repository_directory(root: Path) -> int:
     nofollow = getattr(os, "O_NOFOLLOW", None)
     directory_flag = getattr(os, "O_DIRECTORY", None)
     if nofollow is None or directory_flag is None:
         raise Refusal("this platform cannot open output directories without following links")
+    if not root.is_absolute():
+        raise Refusal("the repository root is not absolute")
     flags = os.O_RDONLY | nofollow | directory_flag | getattr(os, "O_CLOEXEC", 0)
     try:
-        resolved_root = root.resolve(strict=True)
-        root_fd = os.open(resolved_root, flags)
-    except (OSError, RuntimeError) as error:
+        return os.open(root, flags)
+    except OSError as error:
         raise Refusal(f"the repository root cannot be opened safely: {error}") from error
-    return resolved_root, root_fd
 
 
 def open_output_directory(root_fd: int, parts: tuple[str, ...]) -> int:
@@ -846,16 +848,25 @@ def create_temporary(directory_fd: int) -> tuple[int, str]:
     raise Refusal("report temporary name allocation was exhausted")
 
 
-def atomic_write(root: Path, target: Path, payload: str) -> None:
+def atomic_write(
+    root: Path,
+    target: Path,
+    payload: str,
+    *,
+    root_fd: int | None = None,
+) -> None:
     encoded = payload.encode("utf-8")
     if len(encoded) > MAX_REPORT_BYTES:
         raise Refusal(f"report exceeds {MAX_REPORT_BYTES} bytes")
-    resolved_root, root_fd = open_repository_directory(root)
+    owns_root_fd = root_fd is None
+    if root_fd is None:
+        root_fd = open_repository_directory(root)
     try:
-        parts = output_parts(resolved_root, target)
+        parts = output_parts(root, target)
         directory_fd = open_output_directory(root_fd, parts)
     finally:
-        os.close(root_fd)
+        if owns_root_fd:
+            os.close(root_fd)
     temporary_name: str | None = None
     try:
         require_regular_target(directory_fd, parts[-1])
@@ -887,14 +898,24 @@ def atomic_write(root: Path, target: Path, payload: str) -> None:
 
 def command_report(arguments: argparse.Namespace) -> int:
     root = repository_root(Path(arguments.directory).resolve())
-    report = build_report(root)
-    rendered = render_json(report) if arguments.json else render_text(report)
-    if arguments.output is None:
-        sys.stdout.write(rendered)
-    else:
-        target = confine(root, arguments.output)
-        atomic_write(root, target, rendered)
-    return 0
+    root_fd: int | None = None
+    target: Path | None = None
+    try:
+        if arguments.output is not None:
+            root_fd = open_repository_directory(root)
+            target = confine(root, arguments.output)
+        report = build_report(root)
+        rendered = render_json(report) if arguments.json else render_text(report)
+        if arguments.output is None:
+            sys.stdout.write(rendered)
+            return 0
+        assert root_fd is not None
+        assert target is not None
+        atomic_write(root, target, rendered, root_fd=root_fd)
+        return 0
+    finally:
+        if root_fd is not None:
+            os.close(root_fd)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -740,7 +740,8 @@ def confine(root: Path, candidate: str) -> Path:
 
 
 def output_parts(root: Path, target: Path) -> tuple[str, ...]:
-    root = root.resolve(strict=True)
+    if not root.is_absolute():
+        raise Refusal("the repository root is not absolute")
     try:
         relative = target.relative_to(root)
     except ValueError as error:
@@ -764,14 +765,28 @@ def output_parts(root: Path, target: Path) -> tuple[str, ...]:
     return parts
 
 
-def open_output_directory(root: Path, parts: tuple[str, ...]) -> int:
+def open_repository_directory(root: Path) -> tuple[Path, int]:
     nofollow = getattr(os, "O_NOFOLLOW", None)
     directory_flag = getattr(os, "O_DIRECTORY", None)
     if nofollow is None or directory_flag is None:
         raise Refusal("this platform cannot open output directories without following links")
     flags = os.O_RDONLY | nofollow | directory_flag | getattr(os, "O_CLOEXEC", 0)
     try:
-        current_fd = os.open(root.resolve(strict=True), flags)
+        resolved_root = root.resolve(strict=True)
+        root_fd = os.open(resolved_root, flags)
+    except (OSError, RuntimeError) as error:
+        raise Refusal(f"the repository root cannot be opened safely: {error}") from error
+    return resolved_root, root_fd
+
+
+def open_output_directory(root_fd: int, parts: tuple[str, ...]) -> int:
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    directory_flag = getattr(os, "O_DIRECTORY", None)
+    if nofollow is None or directory_flag is None:
+        raise Refusal("this platform cannot open output directories without following links")
+    flags = os.O_RDONLY | nofollow | directory_flag | getattr(os, "O_CLOEXEC", 0)
+    try:
+        current_fd = os.dup(root_fd)
     except OSError as error:
         raise Refusal(f"the repository root cannot be opened safely: {error}") from error
     try:
@@ -835,8 +850,12 @@ def atomic_write(root: Path, target: Path, payload: str) -> None:
     encoded = payload.encode("utf-8")
     if len(encoded) > MAX_REPORT_BYTES:
         raise Refusal(f"report exceeds {MAX_REPORT_BYTES} bytes")
-    parts = output_parts(root, target)
-    directory_fd = open_output_directory(root, parts)
+    resolved_root, root_fd = open_repository_directory(root)
+    try:
+        parts = output_parts(resolved_root, target)
+        directory_fd = open_output_directory(root_fd, parts)
+    finally:
+        os.close(root_fd)
     temporary_name: str | None = None
     try:
         require_regular_target(directory_fd, parts[-1])

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -16,6 +16,7 @@ import json
 import os
 import re
 import selectors
+import signal
 import stat
 import subprocess
 import sys
@@ -49,6 +50,7 @@ MAX_COVERAGE_PROCESS_BYTES = 16 * 1024 * 1024
 MAX_COVERAGE_PROCESSES = 4096
 MAX_RUNNER_OUTPUT_BYTES = 32 * 1024 * 1024
 RUNNER_TIMEOUT_SECONDS = 3600
+COVERAGE_DRAIN_SECONDS = 5.0
 CHECK_RUNNER = Path("scripts") / "run_checks.py"
 MONITOR_DIRECTORY = Path("scripts") / "dead_code_monitoring"
 COVERAGE_SCHEMA_ID = "dead-code-coverage/v1"
@@ -1064,6 +1066,29 @@ def _candidate(
     return Finding(analyser_id, path, symbol, evidence, confidence, boundary)
 
 
+def _function_scope_nodes(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> Iterable[ast.AST]:
+    """Walk stores in one function scope without entering child scopes."""
+    boundaries = (
+        ast.FunctionDef,
+        ast.AsyncFunctionDef,
+        ast.Lambda,
+        ast.ClassDef,
+        ast.ListComp,
+        ast.SetComp,
+        ast.DictComp,
+        ast.GeneratorExp,
+    )
+    pending = list(reversed(function.body))
+    while pending:
+        node = pending.pop()
+        yield node
+        if isinstance(node, boundaries):
+            continue
+        pending.extend(reversed(list(ast.iter_child_nodes(node))))
+
+
 def _unused_bindings(item: ParsedPython) -> Iterable[Finding]:
     loads = {
         node.id
@@ -1110,12 +1135,19 @@ def _unused_bindings(item: ParsedPython) -> Iterable[Finding]:
             for node in ast.walk(function)
             if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
         }
+        scope_nodes = tuple(_function_scope_nodes(function))
         assignments: dict[str, int] = {}
-        for node in ast.walk(function):
+        external_bindings = {
+            name
+            for declaration in scope_nodes
+            if isinstance(declaration, (ast.Global, ast.Nonlocal))
+            for name in declaration.names
+        }
+        for node in scope_nodes:
             if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
                 assignments.setdefault(node.id, node.lineno)
         for name, line in sorted(assignments.items()):
-            if name in function_loads or name.startswith("_"):
+            if name in function_loads or name in external_bindings or name.startswith("_"):
                 continue
             yield _candidate(
                 item.path,
@@ -1366,7 +1398,13 @@ def _normalise_coverage_events(
         path = item.get("path")
         function = item.get("function")
         line = item.get("line")
-        if not isinstance(path, str) or not isinstance(function, str) or not isinstance(line, int) or line < 1:
+        if (
+            not isinstance(path, str)
+            or not isinstance(function, str)
+            or not isinstance(line, int)
+            or isinstance(line, bool)
+            or line < 1
+        ):
             raise Refusal("coverage line event has an invalid identity")
         validate_repository_path(path, "coverage line path")
         if path in analysed:
@@ -1383,9 +1421,12 @@ def _normalise_coverage_events(
             not isinstance(path, str)
             or not isinstance(function, str)
             or not isinstance(source, int)
+            or isinstance(source, bool)
             or source < 1
             or not isinstance(target, int)
+            or isinstance(target, bool)
             or target < 1
+            or not isinstance(direction, str)
             or direction not in {"left", "right"}
         ):
             raise Refusal("coverage branch event has an invalid identity")
@@ -1410,12 +1451,34 @@ def _normalise_coverage_events(
     )
 
 
+def _coverage_process_complete(status: object) -> bool:
+    if not isinstance(status, dict):
+        raise Refusal("coverage process status is not an object")
+    state = status.get("state")
+    truncated = status.get("truncated")
+    errors = status.get("errors")
+    if (
+        not isinstance(state, str)
+        or state not in {"ran", "degraded"}
+        or not isinstance(truncated, bool)
+        or not isinstance(errors, list)
+        or not all(isinstance(error, str) and error for error in errors)
+    ):
+        raise Refusal("coverage process status is malformed")
+    return state == "ran" and not truncated and not errors
+
+
 def aggregate_coverage(
     plan: dict[str, object],
     run: dict[str, object],
     process_documents: list[tuple[dict[str, object], int]],
     universe: Universe,
 ) -> dict[str, object]:
+    for field in ("map_digest", "requested_scopes", "selected_checks"):
+        if run.get(field) != plan.get(field):
+            raise Refusal(
+                f"checked runner result does not match the preflight plan field {field}"
+            )
     selected = plan.get("selected_checks")
     results = run.get("checks")
     if not isinstance(selected, list) or not isinstance(results, list):
@@ -1424,12 +1487,18 @@ def aggregate_coverage(
     for item in selected:
         if not isinstance(item, dict) or not isinstance(item.get("id"), str):
             raise Refusal("checked runner selected-check record is malformed")
-        planned[item["id"]] = item
+        identifier = item["id"]
+        if not identifier or identifier in planned:
+            raise Refusal("checked runner plan has an empty or repeated check identity")
+        planned[identifier] = item
     terminal: dict[str, dict[str, object]] = {}
     for item in results:
         if not isinstance(item, dict) or not isinstance(item.get("check"), str):
             raise Refusal("checked runner terminal record is malformed")
-        terminal[item["check"]] = item
+        identifier = item["check"]
+        if not identifier or identifier in terminal:
+            raise Refusal("checked runner terminal record has an empty or repeated check identity")
+        terminal[identifier] = item
     if set(terminal) != set(planned):
         raise Refusal("checked runner terminal records do not match its plan")
 
@@ -1476,7 +1545,7 @@ def aggregate_coverage(
             branches,
             set(universe.analysed),
         )
-        if status.get("state") != "ran":
+        if not _coverage_process_complete(status):
             degraded_reasons.add(f"check {check_id} emitted a degraded process record")
         bytes_by_check[check_id] += size
         process_count_by_check[check_id] += 1
@@ -1486,7 +1555,6 @@ def aggregate_coverage(
                 "group": group_id,
                 "pid": process.get("pid"),
                 "parent_pid": process.get("parent_pid"),
-                "argv": process.get("argv"),
                 "lines": lines,
                 "branches": branches,
             }
@@ -1498,7 +1566,6 @@ def aggregate_coverage(
                 "check": check_id,
                 "pid": process.get("pid"),
                 "parent_pid": process.get("parent_pid"),
-                "argv": process.get("argv"),
                 "status": status,
                 "bytes": size,
                 "lines": lines,
@@ -1567,6 +1634,55 @@ def _coverage_environment(root: Path, process_directory: Path, run_id: str) -> d
     return environment
 
 
+def _coverage_survivor_pids(run_id: str) -> list[int]:
+    if len(run_id) != 32 or any(character not in "0123456789abcdef" for character in run_id):
+        raise Refusal("coverage run identity is malformed")
+    try:
+        listing = subprocess.run(
+            ["ps", "axeww", "-o", "pid=,command="],
+            capture_output=True,
+            shell=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise Refusal(f"coverage process sweep is unavailable: {error}") from error
+    if listing.returncode != 0 or len(listing.stdout) > MAX_GIT_OUTPUT_BYTES:
+        raise Refusal("coverage process sweep failed or exceeded its output bound")
+    token = f"{COVERAGE_ACTIVE_ENV}={run_id}"
+    pids: list[int] = []
+    for line in listing.stdout.decode("utf-8", "replace").splitlines():
+        stripped = line.strip()
+        if token not in stripped:
+            continue
+        pid_text = stripped.split(None, 1)[0]
+        if pid_text.isdigit() and int(pid_text) != os.getpid():
+            pids.append(int(pid_text))
+    return sorted(set(pids))
+
+
+def _terminate_coverage_processes(run_id: str) -> None:
+    survivors = _coverage_survivor_pids(run_id)
+    for requested_signal in (signal.SIGTERM, signal.SIGKILL):
+        if not survivors:
+            return
+        for pid in survivors:
+            try:
+                os.kill(pid, requested_signal)
+            except OSError:
+                continue
+        deadline = time.monotonic() + COVERAGE_DRAIN_SECONDS
+        while time.monotonic() < deadline:
+            survivors = _coverage_survivor_pids(run_id)
+            if not survivors:
+                return
+            time.sleep(0.05)
+    if survivors:
+        raise Refusal(
+            "coverage process recovery could not drain pid(s): "
+            + ", ".join(str(pid) for pid in survivors)
+        )
+
+
 def command_coverage(arguments: argparse.Namespace) -> int:
     if os.environ.get(COVERAGE_ACTIVE_ENV):
         raise Refusal("coverage wrapper recursion is active in this process")
@@ -1592,19 +1708,37 @@ def command_coverage(arguments: argparse.Namespace) -> int:
         for scope in scopes:
             argv.extend(["--scope", scope])
         argv.extend(["--report", runner_report])
-        _stdout, _stderr, _returncode = run_process(
-            argv,
-            cwd=root,
-            timeout_seconds=RUNNER_TIMEOUT_SECONDS,
-            output_limit=MAX_RUNNER_OUTPUT_BYTES,
-            env=environment,
-        )
+        try:
+            _stdout, _stderr, _returncode = run_process(
+                argv,
+                cwd=root,
+                timeout_seconds=RUNNER_TIMEOUT_SECONDS,
+                output_limit=MAX_RUNNER_OUTPUT_BYTES,
+                env=environment,
+            )
+        except BaseException as error:
+            try:
+                _terminate_coverage_processes(run_id)
+            except Refusal as cleanup_error:
+                if isinstance(error, Refusal):
+                    raise Refusal(f"{error}; {cleanup_error}") from error
+            raise
+        unexpected_survivors = _coverage_survivor_pids(run_id)
+        if unexpected_survivors:
+            _terminate_coverage_processes(run_id)
+            raise Refusal("checked runner returned with monitored processes still active")
         run_raw = read_bounded_regular(
             root / runner_report,
             limit=MAX_COVERAGE_BYTES,
             label=runner_report,
         )
         run = _json_document(run_raw, runner_report)
+        outcome = run.get("outcome")
+        expected_returncode = 0 if outcome == "green" else 1 if outcome == "red" else None
+        if expected_returncode is None or _returncode != expected_returncode:
+            raise Refusal(
+                f"checked runner exit {_returncode} does not match {outcome} outcome"
+            )
         documents = _read_process_documents(process_directory, process_fd, run_id)
         coverage = aggregate_coverage(plan, run, documents, universe)
         atomic_write(root, target, json.dumps(coverage, indent=2, sort_keys=True) + chr(10), root_fd=root_fd)
@@ -1627,6 +1761,28 @@ def _coverage_file(
     document = _json_document(raw, coverage_path)
     if document.get("schema") != COVERAGE_SCHEMA_ID:
         raise Refusal(f"{coverage_path} does not declare {COVERAGE_SCHEMA_ID}")
+    tool = document.get("tool")
+    if (
+        not isinstance(tool, dict)
+        or tool.get("id") != "sys.monitoring"
+        or not isinstance(tool.get("python"), str)
+        or re.fullmatch(r"3\.14\.\d+", tool["python"]) is None
+    ):
+        raise Refusal(f"{coverage_path} does not declare Python 3.14 sys.monitoring")
+    plan = document.get("plan")
+    if not isinstance(plan, dict) or plan.get("schema") != "wildcat.check-plan.v1":
+        raise Refusal(f"{coverage_path} does not declare wildcat.check-plan.v1")
+    map_digest = plan.get("map_digest")
+    requested_scopes = plan.get("requested_scopes")
+    if (
+        not isinstance(map_digest, str)
+        or re.fullmatch(r"[0-9a-f]{64}", map_digest) is None
+        or not isinstance(requested_scopes, list)
+        or not requested_scopes
+        or not all(isinstance(scope, str) and scope for scope in requested_scopes)
+        or len(requested_scopes) != len(set(requested_scopes))
+    ):
+        raise Refusal(f"{coverage_path} carries malformed checked-runner plan identity")
     tree = document.get("tree")
     if not isinstance(tree, dict):
         raise Refusal(f"{coverage_path} omits tree identity")
@@ -1651,7 +1807,15 @@ def _function_targets(item: ParsedPython) -> Iterable[tuple[str, int]]:
             continue
         if node.name in item.retained_names:
             continue
-        yield node.name, node.body[0].lineno
+        body = node.body
+        if (
+            isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)
+        ):
+            body = body[1:]
+        if body:
+            yield node.name, body[0].lineno
 
 
 def _branch_targets(item: ParsedPython) -> Iterable[tuple[int, int, str]]:
@@ -1676,22 +1840,100 @@ def analyse_coverage(
     if not isinstance(status, dict) or not isinstance(checks, list) or not isinstance(processes, list):
         raise Refusal("coverage record omits status, checks or processes")
     records: list[AnalyserRecord] = []
+    check_claims: dict[str, tuple[int, int]] = {}
     for item in checks:
         if not isinstance(item, dict) or not isinstance(item.get("id"), str):
             raise Refusal("coverage check record is malformed")
+        identifier = item["id"]
+        process_count = item.get("processes")
+        byte_count = item.get("bytes")
+        if (
+            not identifier
+            or identifier in check_claims
+            or not isinstance(process_count, int)
+            or isinstance(process_count, bool)
+            or process_count < 0
+            or not isinstance(byte_count, int)
+            or isinstance(byte_count, bool)
+            or byte_count < 0
+        ):
+            raise Refusal("coverage check record has an invalid identity or count")
+        check_claims[identifier] = (process_count, byte_count)
         state = item.get("state")
         mapped = "passed" if state == "passed" else "unavailable" if state == "unavailable" else "failed"
-        size = item.get("bytes")
         records.append(
             AnalyserRecord(
-                item["id"],
+                identifier,
                 "check",
                 mapped,
-                f"runner state {state}; {item.get('processes')} process record(s)",
-                size if isinstance(size, int) and size >= 0 else 0,
+                f"runner state {state}; {process_count} process record(s)",
+                byte_count,
             )
         )
     records.sort(key=lambda item: item.record_id)
+    plan = document.get("plan")
+    selected_checks = plan.get("selected_checks") if isinstance(plan, dict) else None
+    if (
+        not isinstance(selected_checks, list)
+        or not all(isinstance(item, str) and item for item in selected_checks)
+        or len(selected_checks) != len(set(selected_checks))
+        or set(selected_checks) != set(check_claims)
+    ):
+        raise Refusal("coverage plan and check records do not name the same checks")
+
+    observed_lines: set[tuple[str, int]] = set()
+    observed_branches: set[tuple[str, int, int]] = set()
+    actual_counts = {identifier: [0, 0] for identifier in check_claims}
+    incomplete: set[str] = set()
+    analysed_paths = set(universe.analysed)
+    for process in processes:
+        if not isinstance(process, dict):
+            raise Refusal("coverage process aggregate is malformed")
+        check_id = process.get("check")
+        size = process.get("bytes")
+        lines = process.get("lines")
+        branches = process.get("branches")
+        process_status = process.get("status")
+        if (
+            not isinstance(check_id, str)
+            or check_id not in check_claims
+            or not isinstance(size, int)
+            or isinstance(size, bool)
+            or size < 0
+            or not isinstance(lines, list)
+            or not isinstance(branches, list)
+            or not isinstance(process_status, dict)
+        ):
+            raise Refusal("coverage process aggregate omits a valid check, size, status or event list")
+        normal_lines, normal_branches = _normalise_coverage_events(
+            lines,
+            branches,
+            analysed_paths,
+        )
+        if normal_lines != lines or normal_branches != branches:
+            raise Refusal("coverage process events are not canonical for the report universe")
+        actual_counts[check_id][0] += 1
+        actual_counts[check_id][1] += size
+        if not _coverage_process_complete(process_status):
+            incomplete.add(f"process for {check_id} was degraded")
+        observed_lines.update(
+            (line["path"], line["line"])
+            for line in normal_lines
+        )
+        observed_branches.update(
+            (branch["path"], branch["from_line"], branch["to_line"])
+            for branch in normal_branches
+        )
+    for check_id, claimed in check_claims.items():
+        actual = tuple(actual_counts[check_id])
+        if actual != claimed:
+            incomplete.add(
+                f"check {check_id} claimed {claimed[0]} process record(s) and {claimed[1]} bytes; "
+                f"the aggregate carries {actual[0]} and {actual[1]}"
+            )
+        if claimed[0] == 0:
+            incomplete.add(f"check {check_id} carries no process record")
+
     if status.get("state") != "ran":
         return (
             AnalyserStatus(
@@ -1699,6 +1941,17 @@ def analyse_coverage(
                 "degraded",
                 COVERAGE_ANALYSER_VERSION,
                 str(status.get("detail") or "coverage did not complete"),
+                tuple(records),
+            ),
+            (),
+        )
+    if incomplete:
+        return (
+            AnalyserStatus(
+                "coverage",
+                "degraded",
+                COVERAGE_ANALYSER_VERSION,
+                "; ".join(sorted(incomplete)),
                 tuple(records),
             ),
             (),
@@ -1714,39 +1967,6 @@ def analyse_coverage(
             ),
             (),
         )
-
-    observed_lines: set[tuple[str, int]] = set()
-    observed_branches: set[tuple[str, int, int]] = set()
-    for process in processes:
-        if not isinstance(process, dict):
-            raise Refusal("coverage process aggregate is malformed")
-        lines = process.get("lines")
-        branches = process.get("branches")
-        if not isinstance(lines, list) or not isinstance(branches, list):
-            raise Refusal("coverage process aggregate omits lines or branches")
-        process_status = process.get("status")
-        if not isinstance(process_status, dict) or process_status.get("state") != "ran":
-            return (
-                AnalyserStatus(
-                    "coverage",
-                    "degraded",
-                    COVERAGE_ANALYSER_VERSION,
-                    "coverage claimed completion but one process record was degraded",
-                    tuple(records),
-                ),
-                (),
-            )
-        for line in lines:
-            if isinstance(line, dict) and isinstance(line.get("path"), str) and isinstance(line.get("line"), int):
-                observed_lines.add((line["path"], line["line"]))
-        for branch in branches:
-            if (
-                isinstance(branch, dict)
-                and isinstance(branch.get("path"), str)
-                and isinstance(branch.get("from_line"), int)
-                and isinstance(branch.get("to_line"), int)
-            ):
-                observed_branches.add((branch["path"], branch["from_line"], branch["to_line"]))
 
     snapshot = parse_python_snapshot(root, universe)
     if snapshot.degraded:

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -1,0 +1,883 @@
+#!/usr/bin/env python3
+"""Build a report-only dead-code inventory for one clean Git tree.
+
+The command discovers tracked paths, applies hard Horos classifications and
+renders one deterministic model as text or JSON. Step 1 registers no analyser,
+so the report says that no reachability result was established. It never
+deletes source and a finding count is never an exit gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import selectors
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Callable
+
+SCHEMA_ID = "dead-code-report/v1"
+TOOL_ID = "dead-code"
+TOOL_VERSION = "1"
+STATUS_ID = "analysis"
+BOUNDARY_PATH = Path(".horos") / "boundary.json"
+BOUNDARY_SCHEMA = 2
+BOUNDARY_TOOL = "horos"
+EXCLUDING_GRADE = "hard"
+UNIVERSE_FLOOR = 1
+TEMP_PREFIX = ".dead-code-tmp-"
+GIT_TIMEOUT_SECONDS = 60
+MAX_GIT_OUTPUT_BYTES = 16 * 1024 * 1024
+MAX_BOUNDARY_BYTES = 4 * 1024 * 1024
+MAX_REPORT_BYTES = 32 * 1024 * 1024
+MAX_TRACKED_PATHS = 100_000
+MAX_PATH_BYTES = 4096
+ANALYSER_STATES = frozenset({"ran", "not-available", "degraded", "failed"})
+CONFIDENCE_LEVELS = frozenset({"high", "medium", "low"})
+
+Analyser = Callable[
+    [Path, "Universe"],
+    tuple["AnalyserStatus", tuple["Finding", ...]],
+]
+ANALYSERS: dict[str, Analyser] = {}
+
+
+class Refusal(Exception):
+    """A named condition that stops the command before it reports."""
+
+
+class DuplicateKey(ValueError):
+    """A duplicate JSON member that would otherwise overwrite evidence."""
+
+
+@dataclass(frozen=True)
+class ClassifiedPath:
+    path: str
+    category: str
+    evidence: str
+    grade: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "path": self.path,
+            "category": self.category,
+            "evidence": self.evidence,
+            "grade": self.grade,
+        }
+
+
+@dataclass(frozen=True)
+class Classification:
+    files: dict[str, ClassifiedPath]
+    directories: tuple[ClassifiedPath, ...]
+
+    def match(self, path: str) -> ClassifiedPath | None:
+        exact = self.files.get(path)
+        if exact is not None:
+            return exact
+        for tree in self.directories:
+            if path.startswith(tree.path):
+                return ClassifiedPath(
+                    path=path,
+                    category=tree.category,
+                    evidence=(
+                        f"{tree.evidence}, inherited from the classified tree "
+                        f"{tree.path}"
+                    ),
+                    grade=tree.grade,
+                )
+        return None
+
+
+@dataclass(frozen=True)
+class Universe:
+    commit: str
+    tree: str
+    identity: str
+    tracked_count: int
+    analysed: tuple[str, ...]
+    excluded: tuple[ClassifiedPath, ...]
+
+    def excluded_by_category(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for entry in self.excluded:
+            counts[entry.category] = counts.get(entry.category, 0) + 1
+        return {name: counts[name] for name in sorted(counts)}
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.identity,
+            "tracked_count": self.tracked_count,
+            "analysed_count": len(self.analysed),
+            "analysed": list(self.analysed),
+            "excluded_count": len(self.excluded),
+            "excluded_by_category": self.excluded_by_category(),
+            "excluded": [entry.as_dict() for entry in self.excluded],
+        }
+
+
+@dataclass(frozen=True)
+class AnalyserStatus:
+    analyser_id: str
+    state: str
+    version: str | None
+    detail: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.analyser_id,
+            "state": self.state,
+            "version": self.version,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class Finding:
+    analyser_id: str
+    path: str
+    symbol: str | None
+    evidence: str
+    confidence: str
+    false_positive_boundary: str
+
+    @property
+    def identity(self) -> str:
+        payload = {
+            "analyser_id": self.analyser_id,
+            "path": self.path,
+            "symbol": self.symbol,
+            "evidence": self.evidence,
+            "confidence": self.confidence,
+            "false_positive_boundary": self.false_positive_boundary,
+        }
+        return digest_json(payload)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.identity,
+            "analyser_id": self.analyser_id,
+            "path": self.path,
+            "symbol": self.symbol,
+            "evidence": self.evidence,
+            "confidence": self.confidence,
+            "false_positive_boundary": self.false_positive_boundary,
+        }
+
+
+@dataclass(frozen=True)
+class Report:
+    universe: Universe
+    statuses: tuple[AnalyserStatus, ...]
+    findings: tuple[Finding, ...]
+
+    def analysis_status(self) -> dict[str, str]:
+        if not self.statuses:
+            return {
+                "id": STATUS_ID,
+                "state": "not-run",
+                "detail": (
+                    "no analyser registered; this report establishes no "
+                    "reachability result"
+                ),
+            }
+        if any(item.state == "failed" for item in self.statuses):
+            state = "failed"
+            detail = "at least one analyser failed; no clean result is established"
+        elif any(item.state in {"degraded", "not-available"} for item in self.statuses):
+            state = "degraded"
+            detail = "one or more analyser signals are incomplete"
+        else:
+            state = "ran"
+            detail = "every registered analyser completed"
+        return {"id": STATUS_ID, "state": state, "detail": detail}
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "schema": SCHEMA_ID,
+            "tool": {"id": TOOL_ID, "version": TOOL_VERSION},
+            "tree": {
+                "commit": self.universe.commit,
+                "git_tree": self.universe.tree,
+            },
+            "universe": self.universe.as_dict(),
+            "status": self.analysis_status(),
+            "analysers": [status.as_dict() for status in self.statuses],
+            "findings": [finding.as_dict() for finding in self.findings],
+        }
+
+
+def digest_json(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _stop_process(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is None:
+        process.kill()
+    process.wait()
+
+
+def run_process(
+    argv: list[str],
+    *,
+    cwd: Path,
+    timeout_seconds: int,
+    output_limit: int,
+) -> tuple[bytes, bytes, int]:
+    """Run fixed argv while bounding time and combined captured output."""
+    try:
+        process = subprocess.Popen(
+            argv,
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=False,
+        )
+    except FileNotFoundError as error:
+        raise Refusal(f"{argv[0]} is not available on PATH") from error
+    except OSError as error:
+        raise Refusal(f"{argv[0]} could not start: {error}") from error
+
+    assert process.stdout is not None
+    assert process.stderr is not None
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+    selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+    buffers = {"stdout": bytearray(), "stderr": bytearray()}
+    total = 0
+    deadline = time.monotonic() + timeout_seconds
+    try:
+        while selector.get_map():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                _stop_process(process)
+                raise Refusal(f"{argv[0]} timed out after {timeout_seconds}s")
+            events = selector.select(min(remaining, 0.25))
+            if not events:
+                continue
+            for key, _ in events:
+                chunk = os.read(
+                    key.fileobj.fileno(),
+                    min(65_536, output_limit - total + 1),
+                )
+                if not chunk:
+                    selector.unregister(key.fileobj)
+                    continue
+                buffers[key.data].extend(chunk)
+                total += len(chunk)
+                if total > output_limit:
+                    _stop_process(process)
+                    raise Refusal(
+                        f"{argv[0]} output exceeded {output_limit} bytes"
+                    )
+        returncode = process.wait()
+    finally:
+        selector.close()
+        if process.poll() is None:
+            _stop_process(process)
+        process.stdout.close()
+        process.stderr.close()
+    return bytes(buffers["stdout"]), bytes(buffers["stderr"]), returncode
+
+
+def decode_output(payload: bytes, label: str) -> str:
+    try:
+        return payload.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise Refusal(f"{label} output is not UTF-8") from error
+
+
+def run_git(root: Path, *arguments: str) -> str:
+    stdout, stderr, returncode = run_process(
+        ["git", "-C", str(root), *arguments],
+        cwd=root,
+        timeout_seconds=GIT_TIMEOUT_SECONDS,
+        output_limit=MAX_GIT_OUTPUT_BYTES,
+    )
+    if returncode != 0:
+        detail = decode_output(stderr, "git stderr").strip()
+        if not detail:
+            detail = f"exit {returncode}"
+        raise Refusal(f"git {arguments[0]} failed: {detail}")
+    return decode_output(stdout, "git stdout")
+
+
+def repository_root(start: Path) -> Path:
+    output = run_git(start, "rev-parse", "--show-toplevel").strip()
+    if not output:
+        raise Refusal(f"{start} is not inside a Git worktree")
+    root = Path(output).resolve(strict=True)
+    if not root.is_dir():
+        raise Refusal("Git returned a root that is not a directory")
+    return root
+
+
+def _require_oid(value: str, label: str) -> str:
+    if len(value) != 40 or any(character not in "0123456789abcdef" for character in value):
+        raise Refusal(f"{label} is not a lowercase 40-byte Git object identity")
+    return value
+
+
+def resolve_commit(root: Path) -> str:
+    return _require_oid(run_git(root, "rev-parse", "HEAD").strip(), "HEAD")
+
+
+def resolve_tree(root: Path, commit: str) -> str:
+    return _require_oid(
+        run_git(root, "rev-parse", f"{commit}^{{tree}}").strip(),
+        "HEAD tree",
+    )
+
+
+def require_clean_tree(root: Path) -> None:
+    porcelain = run_git(
+        root,
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=no",
+    )
+    changed = [entry for entry in porcelain.split(chr(0)) if entry]
+    if changed:
+        names = sorted(entry[3:] if len(entry) > 3 else entry for entry in changed)
+        listed = ", ".join(names[:5])
+        more = "" if len(names) <= 5 else f" and {len(names) - 5} more"
+        raise Refusal(
+            f"the checkout has {len(names)} modified tracked file(s): "
+            f"{listed}{more}; commit or stash before analysing"
+        )
+
+
+def validate_repository_path(value: str, label: str) -> str:
+    if not value:
+        raise Refusal(f"{label} is empty")
+    if len(value.encode("utf-8")) > MAX_PATH_BYTES:
+        raise Refusal(f"{label} exceeds {MAX_PATH_BYTES} bytes")
+    if value.startswith("/") or chr(92) in value or chr(0) in value:
+        raise Refusal(f"{label} is not a safe repository-relative POSIX path")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise Refusal(f"{label} contains a control character")
+    without_tree_suffix = value[:-1] if value.endswith("/") else value
+    parts = PurePosixPath(without_tree_suffix).parts
+    if not parts or any(part in {"", ".", ".."} for part in parts):
+        raise Refusal(f"{label} is not a safe repository-relative POSIX path")
+    return value
+
+
+def tracked_paths(root: Path, commit: str) -> tuple[str, ...]:
+    listing = run_git(root, "ls-tree", "-r", "--name-only", "-z", commit)
+    paths = tuple(
+        sorted(
+            validate_repository_path(entry, "tracked path")
+            for entry in listing.split(chr(0))
+            if entry
+        )
+    )
+    if len(paths) > MAX_TRACKED_PATHS:
+        raise Refusal(f"tracked discovery exceeded {MAX_TRACKED_PATHS} paths")
+    if len(paths) != len(set(paths)):
+        raise Refusal("tracked discovery returned duplicate paths")
+    return paths
+
+
+def read_bounded_regular(path: Path, *, limit: int, label: str) -> str:
+    try:
+        before = path.lstat()
+    except FileNotFoundError as error:
+        raise Refusal(f"{label} is absent") from error
+    except OSError as error:
+        raise Refusal(f"{label} cannot be inspected: {error}") from error
+    if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
+        raise Refusal(f"{label} is not a regular file")
+    if before.st_size > limit:
+        raise Refusal(f"{label} exceeds {limit} bytes")
+    try:
+        with path.open("rb") as handle:
+            opened = os.fstat(handle.fileno())
+            if (opened.st_dev, opened.st_ino) != (before.st_dev, before.st_ino):
+                raise Refusal(f"{label} changed before it was opened")
+            payload = handle.read(limit + 1)
+            after_handle = os.fstat(handle.fileno())
+        after = path.lstat()
+    except OSError as error:
+        raise Refusal(f"{label} cannot be read: {error}") from error
+    if len(payload) > limit:
+        raise Refusal(f"{label} exceeds {limit} bytes")
+    before_identity = (
+        before.st_dev,
+        before.st_ino,
+        before.st_size,
+        before.st_mtime_ns,
+    )
+    after_identity = (
+        after.st_dev,
+        after.st_ino,
+        after.st_size,
+        after.st_mtime_ns,
+    )
+    handle_identity = (
+        after_handle.st_dev,
+        after_handle.st_ino,
+        after_handle.st_size,
+        after_handle.st_mtime_ns,
+    )
+    if before_identity != after_identity or before_identity != handle_identity:
+        raise Refusal(f"{label} changed while it was read")
+    try:
+        return payload.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise Refusal(f"{label} is not UTF-8") from error
+
+
+def reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    document: dict[str, object] = {}
+    for key, value in pairs:
+        if key in document:
+            raise DuplicateKey(key)
+        document[key] = value
+    return document
+
+
+def load_boundary(root: Path) -> Classification:
+    label = BOUNDARY_PATH.as_posix()
+    raw = read_bounded_regular(
+        root / BOUNDARY_PATH,
+        limit=MAX_BOUNDARY_BYTES,
+        label=label,
+    )
+    try:
+        document = json.loads(raw, object_pairs_hook=reject_duplicate_keys)
+    except DuplicateKey as error:
+        raise Refusal(f"{label} repeats JSON key {error.args[0]}") from error
+    except json.JSONDecodeError as error:
+        raise Refusal(f"{label} is not valid JSON: {error}") from error
+    if not isinstance(document, dict):
+        raise Refusal(f"{label} is not a JSON object")
+    if document.get("schema") != BOUNDARY_SCHEMA:
+        raise Refusal(f"{label} does not declare schema {BOUNDARY_SCHEMA}")
+    if document.get("tool") != BOUNDARY_TOOL:
+        raise Refusal(f"{label} does not declare tool {BOUNDARY_TOOL}")
+    entries = document.get("entries")
+    if not isinstance(entries, list):
+        raise Refusal(f"{label} has no entries list")
+
+    files: dict[str, ClassifiedPath] = {}
+    directories: list[ClassifiedPath] = []
+    seen_paths: set[str] = set()
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise Refusal(f"{label} entry {index} is not an object")
+        fields: dict[str, str] = {}
+        for name in ("path", "category", "evidence", "grade"):
+            value = entry.get(name)
+            if not isinstance(value, str) or not value:
+                raise Refusal(f"{label} entry {index} has no usable {name}")
+            fields[name] = value
+        path = validate_repository_path(fields["path"], f"{label} entry {index} path")
+        if path in seen_paths:
+            raise Refusal(f"{label} repeats classified path {path}")
+        seen_paths.add(path)
+        if fields["grade"] != EXCLUDING_GRADE:
+            continue
+        classified = ClassifiedPath(**fields)
+        if path.endswith("/"):
+            directories.append(classified)
+        else:
+            files[path] = classified
+
+    directories.sort(key=lambda item: (-len(item.path), item.path))
+    return Classification(files=files, directories=tuple(directories))
+
+
+def universe_identity(
+    tree: str,
+    analysed: tuple[str, ...],
+    excluded: tuple[ClassifiedPath, ...],
+) -> str:
+    return digest_json(
+        {
+            "git_tree": tree,
+            "analysed": list(analysed),
+            "excluded": [entry.as_dict() for entry in excluded],
+        }
+    )
+
+
+def discover(root: Path) -> Universe:
+    require_clean_tree(root)
+    commit = resolve_commit(root)
+    tree = resolve_tree(root, commit)
+    tracked = tracked_paths(root, commit)
+    classified = load_boundary(root)
+
+    analysed: list[str] = []
+    excluded: list[ClassifiedPath] = []
+    for path in tracked:
+        match = classified.match(path)
+        if match is None:
+            analysed.append(path)
+        else:
+            excluded.append(match)
+    if len(analysed) < UNIVERSE_FLOOR:
+        raise Refusal(
+            f"discovery returned {len(analysed)} analysable paths from "
+            f"{len(tracked)} tracked; this is a collapsed walk"
+        )
+    analysed_tuple = tuple(analysed)
+    excluded_tuple = tuple(excluded)
+    return Universe(
+        commit=commit,
+        tree=tree,
+        identity=universe_identity(tree, analysed_tuple, excluded_tuple),
+        tracked_count=len(tracked),
+        analysed=analysed_tuple,
+        excluded=excluded_tuple,
+    )
+
+
+def collect(
+    root: Path,
+    universe: Universe,
+) -> tuple[tuple[AnalyserStatus, ...], tuple[Finding, ...]]:
+    statuses: list[AnalyserStatus] = []
+    findings: list[Finding] = []
+    for analyser_id in sorted(ANALYSERS):
+        status, produced = ANALYSERS[analyser_id](root, universe)
+        if status.analyser_id != analyser_id:
+            raise Refusal(
+                f"analyser {analyser_id} returned status for {status.analyser_id}"
+            )
+        statuses.append(status)
+        findings.extend(produced)
+    statuses.sort(key=lambda item: item.analyser_id)
+    findings.sort(
+        key=lambda item: (
+            item.analyser_id,
+            item.path,
+            item.symbol or "",
+            item.evidence,
+        )
+    )
+    return tuple(statuses), tuple(findings)
+
+
+def validate_report(report: Report) -> None:
+    universe = report.universe
+    _require_oid(universe.commit, "report commit")
+    _require_oid(universe.tree, "report tree")
+    if not universe.analysed:
+        raise Refusal("report universe has no analysed paths")
+    if universe.analysed != tuple(sorted(set(universe.analysed))):
+        raise Refusal("report analysed paths are not sorted and unique")
+    excluded_paths = tuple(item.path for item in universe.excluded)
+    if excluded_paths != tuple(sorted(set(excluded_paths))):
+        raise Refusal("report excluded paths are not sorted and unique")
+    if any(item.grade != EXCLUDING_GRADE for item in universe.excluded):
+        raise Refusal("report carries a non-hard exclusion")
+    if universe.tracked_count != len(universe.analysed) + len(universe.excluded):
+        raise Refusal("report universe counts do not partition the tracked tree")
+    expected_universe_id = universe_identity(
+        universe.tree,
+        universe.analysed,
+        universe.excluded,
+    )
+    if universe.identity != expected_universe_id:
+        raise Refusal("report universe identity does not match its paths")
+
+    status_ids: set[str] = set()
+    for item in report.statuses:
+        if not item.analyser_id or item.analyser_id in status_ids:
+            raise Refusal("analyser status identities are empty or repeated")
+        if item.state not in ANALYSER_STATES:
+            raise Refusal(
+                f"analyser {item.analyser_id} has unknown state {item.state}"
+            )
+        if not item.detail:
+            raise Refusal(f"analyser {item.analyser_id} has no detail")
+        status_ids.add(item.analyser_id)
+    if tuple(item.analyser_id for item in report.statuses) != tuple(sorted(status_ids)):
+        raise Refusal("analyser statuses are not sorted by identity")
+
+    finding_ids: set[str] = set()
+    analysed = set(report.universe.analysed)
+    for finding in report.findings:
+        if finding.analyser_id not in status_ids:
+            raise Refusal(
+                f"finding {finding.identity} names unreported analyser "
+                f"{finding.analyser_id}"
+            )
+        if finding.path not in analysed:
+            raise Refusal(f"finding {finding.identity} names path outside the universe")
+        if finding.confidence not in CONFIDENCE_LEVELS:
+            raise Refusal(
+                f"finding {finding.identity} has unknown confidence "
+                f"{finding.confidence}"
+            )
+        if finding.identity in finding_ids:
+            raise Refusal(f"finding identity repeats: {finding.identity}")
+        finding_ids.add(finding.identity)
+    if not report.statuses and report.findings:
+        raise Refusal("findings exist although no analyser ran")
+    expected_finding_order = tuple(
+        sorted(
+            report.findings,
+            key=lambda item: (
+                item.analyser_id,
+                item.path,
+                item.symbol or "",
+                item.evidence,
+            ),
+        )
+    )
+    if report.findings != expected_finding_order:
+        raise Refusal("findings are not sorted by stable report identity")
+
+
+def build_report(root: Path) -> Report:
+    universe = discover(root)
+    statuses, findings = collect(root, universe)
+    report = Report(universe=universe, statuses=statuses, findings=findings)
+    validate_report(report)
+    return report
+
+
+def render_json(report: Report) -> str:
+    return json.dumps(
+        report.as_dict(),
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    ) + chr(10)
+
+
+def render_text(report: Report) -> str:
+    document = report.as_dict()
+    tree = document["tree"]
+    universe = document["universe"]
+    status = document["status"]
+    lines = [
+        f"{TOOL_ID} {TOOL_VERSION} report  schema {document['schema']}",
+        f"commit    {tree['commit']}",
+        f"tree      {tree['git_tree']}",
+        f"universe  {universe['id']}",
+        (
+            f"paths     {universe['tracked_count']} tracked, "
+            f"{universe['analysed_count']} analysed, "
+            f"{universe['excluded_count']} excluded"
+        ),
+        f"status    {status['state']}  {status['detail']}",
+    ]
+    by_category = universe["excluded_by_category"]
+    if by_category:
+        summary = ", ".join(
+            f"{name} {by_category[name]}" for name in sorted(by_category)
+        )
+        lines.append(f"excluded  {summary}")
+    lines.extend(["", "analysers"])
+    if not document["analysers"]:
+        lines.append("  none ran; no reachability result was established")
+    for analyser in document["analysers"]:
+        version = f" {analyser['version']}" if analyser["version"] else ""
+        lines.append(
+            f"  {analyser['id']}{version}  {analyser['state']}  "
+            f"{analyser['detail']}"
+        )
+
+    findings = document["findings"]
+    lines.extend(["", f"findings  {len(findings)} candidate(s); report-only"])
+    if not findings:
+        lines.append("  none reported")
+    for finding in findings:
+        symbol = f" {finding['symbol']}" if finding["symbol"] else ""
+        lines.append(
+            f"  [{finding['confidence']}] {finding['id']}  "
+            f"{finding['analyser_id']}  {finding['path']}{symbol}"
+        )
+        lines.append(f"      saw     {finding['evidence']}")
+        lines.append(f"      but     {finding['false_positive_boundary']}")
+    return chr(10).join(lines) + chr(10)
+
+
+def confine(root: Path, candidate: str) -> Path:
+    if not isinstance(candidate, str) or not candidate:
+        raise Refusal("the output path is empty")
+    if chr(0) in candidate:
+        raise Refusal("the output path contains a null byte")
+    supplied = Path(candidate)
+    if supplied.is_absolute():
+        raise Refusal("the output path must be repository-relative")
+    parts = supplied.parts
+    if not parts or any(part in {"", ".", ".."} for part in parts):
+        raise Refusal(f"the output path {candidate} escapes the repository root")
+    if len(candidate.encode("utf-8")) > MAX_PATH_BYTES:
+        raise Refusal(f"the output path exceeds {MAX_PATH_BYTES} bytes")
+    target = root.resolve(strict=True).joinpath(*parts)
+    if target == root.resolve(strict=True):
+        raise Refusal("the repository root is not an output file")
+    return target
+
+
+def ensure_safe_parent(root: Path, target: Path) -> Path:
+    root = root.resolve(strict=True)
+    try:
+        relative = target.relative_to(root)
+    except ValueError as error:
+        raise Refusal("the output path escapes the repository root") from error
+    current = root
+    for part in relative.parts[:-1]:
+        current = current / part
+        try:
+            current.mkdir()
+        except FileExistsError:
+            pass
+        except OSError as error:
+            raise Refusal(f"the output directory cannot be created: {error}") from error
+        try:
+            current_stat = current.lstat()
+        except OSError as error:
+            raise Refusal(f"the output directory cannot be inspected: {error}") from error
+        if stat.S_ISLNK(current_stat.st_mode) or not stat.S_ISDIR(current_stat.st_mode):
+            raise Refusal(f"the output ancestor {current} is not a real directory")
+    try:
+        target_stat = target.lstat()
+    except FileNotFoundError:
+        pass
+    except OSError as error:
+        raise Refusal(f"the output target cannot be inspected: {error}") from error
+    else:
+        if stat.S_ISLNK(target_stat.st_mode) or not stat.S_ISREG(target_stat.st_mode):
+            raise Refusal("the output target is not a regular file")
+    return current
+
+
+def sweep_orphans(directory: Path) -> None:
+    try:
+        candidates = list(directory.iterdir())
+    except OSError:
+        return
+    for candidate in candidates:
+        if not candidate.name.startswith(TEMP_PREFIX):
+            continue
+        try:
+            candidate_stat = candidate.lstat()
+            if stat.S_ISREG(candidate_stat.st_mode):
+                candidate.unlink()
+        except OSError:
+            continue
+
+
+def atomic_write(root: Path, target: Path, payload: str) -> None:
+    encoded = payload.encode("utf-8")
+    if len(encoded) > MAX_REPORT_BYTES:
+        raise Refusal(f"report exceeds {MAX_REPORT_BYTES} bytes")
+    directory = ensure_safe_parent(root, target)
+    before_directory = directory.lstat()
+    sweep_orphans(directory)
+    try:
+        handle = tempfile.NamedTemporaryFile(
+            "wb",
+            dir=directory,
+            prefix=TEMP_PREFIX,
+            delete=False,
+        )
+    except OSError as error:
+        raise Refusal(f"report temporary cannot be created: {error}") from error
+    temporary = Path(handle.name)
+    try:
+        with handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        after_directory = directory.lstat()
+        if (before_directory.st_dev, before_directory.st_ino) != (
+            after_directory.st_dev,
+            after_directory.st_ino,
+        ):
+            raise Refusal("the output directory changed during the write")
+        ensure_safe_parent(root, target)
+        os.replace(temporary, target)
+        directory_fd = os.open(directory, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except Refusal:
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
+        raise
+    except OSError as error:
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
+        raise Refusal(f"report write failed: {error}") from error
+
+
+def command_report(arguments: argparse.Namespace) -> int:
+    root = repository_root(Path(arguments.directory).resolve())
+    report = build_report(root)
+    rendered = render_json(report) if arguments.json else render_text(report)
+    if arguments.output is None:
+        sys.stdout.write(rendered)
+    else:
+        target = confine(root, arguments.output)
+        atomic_write(root, target, rendered)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="dead_code.py",
+        description=__doc__,
+    )
+    parser.add_argument(
+        "--directory",
+        default=".",
+        help="a path inside the repository to analyse",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    report = subparsers.add_parser(
+        "report",
+        help="report the universe and its candidates",
+    )
+    report.add_argument(
+        "--json",
+        action="store_true",
+        help="emit canonical JSON",
+    )
+    report.add_argument(
+        "--output",
+        help="write inside the repository instead of stdout",
+    )
+    report.set_defaults(handler=command_report)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    arguments = parser.parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        return arguments.handler(arguments)
+    except Refusal as refusal:
+        print(f"dead_code.py: {refusal}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -17,7 +17,6 @@ import selectors
 import stat
 import subprocess
 import sys
-import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
@@ -33,6 +32,7 @@ BOUNDARY_TOOL = "horos"
 EXCLUDING_GRADE = "hard"
 UNIVERSE_FLOOR = 1
 TEMP_PREFIX = ".dead-code-tmp-"
+OWNED_OUTPUT_DIRECTORY = ".dead-code"
 GIT_TIMEOUT_SECONDS = 60
 MAX_GIT_OUTPUT_BYTES = 16 * 1024 * 1024
 MAX_BOUNDARY_BYTES = 4 * 1024 * 1024
@@ -717,6 +717,10 @@ def confine(root: Path, candidate: str) -> Path:
         raise Refusal("the output path is empty")
     if chr(0) in candidate:
         raise Refusal("the output path contains a null byte")
+    if chr(92) in candidate or any(
+        ord(character) < 32 or ord(character) == 127 for character in candidate
+    ):
+        raise Refusal("the output path is not a safe repository-relative POSIX path")
     supplied = Path(candidate)
     if supplied.is_absolute():
         raise Refusal("the output path must be repository-relative")
@@ -725,108 +729,141 @@ def confine(root: Path, candidate: str) -> Path:
         raise Refusal(f"the output path {candidate} escapes the repository root")
     if len(candidate.encode("utf-8")) > MAX_PATH_BYTES:
         raise Refusal(f"the output path exceeds {MAX_PATH_BYTES} bytes")
+    if len(parts) < 2 or parts[0] != OWNED_OUTPUT_DIRECTORY:
+        raise Refusal(
+            f"the output path must be beneath the owned {OWNED_OUTPUT_DIRECTORY}/ sink"
+        )
     target = root.resolve(strict=True).joinpath(*parts)
     if target == root.resolve(strict=True):
         raise Refusal("the repository root is not an output file")
     return target
 
 
-def ensure_safe_parent(root: Path, target: Path) -> Path:
+def output_parts(root: Path, target: Path) -> tuple[str, ...]:
     root = root.resolve(strict=True)
     try:
         relative = target.relative_to(root)
     except ValueError as error:
         raise Refusal("the output path escapes the repository root") from error
-    current = root
-    for part in relative.parts[:-1]:
-        current = current / part
-        try:
-            current.mkdir()
-        except FileExistsError:
-            pass
-        except OSError as error:
-            raise Refusal(f"the output directory cannot be created: {error}") from error
-        try:
-            current_stat = current.lstat()
-        except OSError as error:
-            raise Refusal(f"the output directory cannot be inspected: {error}") from error
-        if stat.S_ISLNK(current_stat.st_mode) or not stat.S_ISDIR(current_stat.st_mode):
-            raise Refusal(f"the output ancestor {current} is not a real directory")
+    parts = relative.parts
+    if (
+        not parts
+        or any(part in {"", ".", ".."} for part in parts)
+        or chr(92) in relative.as_posix()
+        or any(
+            ord(character) < 32 or ord(character) == 127
+            for character in relative.as_posix()
+        )
+        or len(relative.as_posix().encode("utf-8")) > MAX_PATH_BYTES
+    ):
+        raise Refusal("the output path is not a safe repository-relative POSIX path")
+    if len(parts) < 2 or parts[0] != OWNED_OUTPUT_DIRECTORY:
+        raise Refusal(
+            f"the output path must be beneath the owned {OWNED_OUTPUT_DIRECTORY}/ sink"
+        )
+    return parts
+
+
+def open_output_directory(root: Path, parts: tuple[str, ...]) -> int:
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    directory_flag = getattr(os, "O_DIRECTORY", None)
+    if nofollow is None or directory_flag is None:
+        raise Refusal("this platform cannot open output directories without following links")
+    flags = os.O_RDONLY | nofollow | directory_flag | getattr(os, "O_CLOEXEC", 0)
     try:
-        target_stat = target.lstat()
+        current_fd = os.open(root.resolve(strict=True), flags)
+    except OSError as error:
+        raise Refusal(f"the repository root cannot be opened safely: {error}") from error
+    try:
+        for part in parts[:-1]:
+            try:
+                os.mkdir(part, mode=0o755, dir_fd=current_fd)
+            except FileExistsError:
+                pass
+            except OSError as error:
+                raise Refusal(
+                    f"the output directory {part} cannot be created: {error}"
+                ) from error
+            try:
+                next_fd = os.open(part, flags, dir_fd=current_fd)
+            except OSError as error:
+                raise Refusal(
+                    f"the output ancestor {part} is not a real directory: {error}"
+                ) from error
+            os.close(current_fd)
+            current_fd = next_fd
+        return current_fd
+    except BaseException:
+        os.close(current_fd)
+        raise
+
+
+def require_regular_target(directory_fd: int, name: str) -> None:
+    try:
+        target_stat = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
     except FileNotFoundError:
-        pass
+        return
     except OSError as error:
         raise Refusal(f"the output target cannot be inspected: {error}") from error
-    else:
-        if stat.S_ISLNK(target_stat.st_mode) or not stat.S_ISREG(target_stat.st_mode):
-            raise Refusal("the output target is not a regular file")
-    return current
+    if stat.S_ISLNK(target_stat.st_mode) or not stat.S_ISREG(target_stat.st_mode):
+        raise Refusal("the output target is not a regular file")
 
 
-def sweep_orphans(directory: Path) -> None:
-    try:
-        candidates = list(directory.iterdir())
-    except OSError:
-        return
-    for candidate in candidates:
-        if not candidate.name.startswith(TEMP_PREFIX):
-            continue
+def create_temporary(directory_fd: int) -> tuple[int, str]:
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    if nofollow is None:
+        raise Refusal("this platform cannot create output files without following links")
+    flags = (
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | nofollow
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    for _ in range(128):
+        name = TEMP_PREFIX + os.urandom(16).hex()
         try:
-            candidate_stat = candidate.lstat()
-            if stat.S_ISREG(candidate_stat.st_mode):
-                candidate.unlink()
-        except OSError:
+            return os.open(name, flags, 0o600, dir_fd=directory_fd), name
+        except FileExistsError:
             continue
+        except OSError as error:
+            raise Refusal(f"report temporary cannot be created: {error}") from error
+    raise Refusal("report temporary name allocation was exhausted")
 
 
 def atomic_write(root: Path, target: Path, payload: str) -> None:
     encoded = payload.encode("utf-8")
     if len(encoded) > MAX_REPORT_BYTES:
         raise Refusal(f"report exceeds {MAX_REPORT_BYTES} bytes")
-    directory = ensure_safe_parent(root, target)
-    before_directory = directory.lstat()
-    sweep_orphans(directory)
+    parts = output_parts(root, target)
+    directory_fd = open_output_directory(root, parts)
+    temporary_name: str | None = None
     try:
-        handle = tempfile.NamedTemporaryFile(
-            "wb",
-            dir=directory,
-            prefix=TEMP_PREFIX,
-            delete=False,
-        )
-    except OSError as error:
-        raise Refusal(f"report temporary cannot be created: {error}") from error
-    temporary = Path(handle.name)
-    try:
-        with handle:
+        require_regular_target(directory_fd, parts[-1])
+        temporary_fd, temporary_name = create_temporary(directory_fd)
+        with os.fdopen(temporary_fd, "wb") as handle:
             handle.write(encoded)
             handle.flush()
             os.fsync(handle.fileno())
-        after_directory = directory.lstat()
-        if (before_directory.st_dev, before_directory.st_ino) != (
-            after_directory.st_dev,
-            after_directory.st_ino,
-        ):
-            raise Refusal("the output directory changed during the write")
-        ensure_safe_parent(root, target)
-        os.replace(temporary, target)
-        directory_fd = os.open(directory, os.O_RDONLY)
-        try:
-            os.fsync(directory_fd)
-        finally:
-            os.close(directory_fd)
+        os.replace(
+            temporary_name,
+            parts[-1],
+            src_dir_fd=directory_fd,
+            dst_dir_fd=directory_fd,
+        )
+        temporary_name = None
+        os.fsync(directory_fd)
     except Refusal:
-        try:
-            temporary.unlink()
-        except OSError:
-            pass
         raise
     except OSError as error:
-        try:
-            temporary.unlink()
-        except OSError:
-            pass
         raise Refusal(f"report write failed: {error}") from error
+    finally:
+        if temporary_name is not None:
+            try:
+                os.unlink(temporary_name, dir_fd=directory_fd)
+            except OSError:
+                pass
+        os.close(directory_fd)
 
 
 def command_report(arguments: argparse.Namespace) -> int:

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -10,17 +10,20 @@ deletes source and a finding count is never an exit gate.
 from __future__ import annotations
 
 import argparse
+import ast
 import hashlib
 import json
 import os
+import re
 import selectors
 import stat
 import subprocess
 import sys
 import time
+import uuid
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Callable
+from typing import Callable, Iterable
 
 SCHEMA_ID = "dead-code-report/v1"
 TOOL_ID = "dead-code"
@@ -39,8 +42,27 @@ MAX_BOUNDARY_BYTES = 4 * 1024 * 1024
 MAX_REPORT_BYTES = 32 * 1024 * 1024
 MAX_TRACKED_PATHS = 100_000
 MAX_PATH_BYTES = 4096
+MAX_PYTHON_FILE_BYTES = 4 * 1024 * 1024
+MAX_PYTHON_TOTAL_BYTES = 96 * 1024 * 1024
+MAX_COVERAGE_BYTES = 32 * 1024 * 1024
+MAX_COVERAGE_PROCESS_BYTES = 16 * 1024 * 1024
+MAX_COVERAGE_PROCESSES = 4096
+MAX_RUNNER_OUTPUT_BYTES = 32 * 1024 * 1024
+RUNNER_TIMEOUT_SECONDS = 3600
+CHECK_RUNNER = Path("scripts") / "run_checks.py"
+MONITOR_DIRECTORY = Path("scripts") / "dead_code_monitoring"
+COVERAGE_SCHEMA_ID = "dead-code-coverage/v1"
+COVERAGE_ACTIVE_ENV = "WILDCAT_DEAD_CODE_COVERAGE_ACTIVE"
+COVERAGE_OUTPUT_ENV = "WILDCAT_DEAD_CODE_COVERAGE_OUTPUT"
+CHECK_CONTAINMENT_ENV = "WILDCAT_CHECK_CONTAINMENT"
+PYTHON_ANALYSER_VERSION = "1"
+COVERAGE_ANALYSER_VERSION = "sys.monitoring/3.14"
 ANALYSER_STATES = frozenset({"ran", "not-available", "degraded", "failed"})
 CONFIDENCE_LEVELS = frozenset({"high", "medium", "low"})
+ANALYSER_RECORD_KINDS = frozenset({"file", "check"})
+ANALYSER_RECORD_STATES = frozenset(
+    {"parsed", "parse-error", "skipped", "passed", "failed", "unavailable"}
+)
 
 Analyser = Callable[
     [Path, "Universe"],
@@ -124,11 +146,30 @@ class Universe:
 
 
 @dataclass(frozen=True)
+class AnalyserRecord:
+    record_id: str
+    kind: str
+    state: str
+    detail: str
+    bytes_count: int
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.record_id,
+            "kind": self.kind,
+            "state": self.state,
+            "detail": self.detail,
+            "bytes": self.bytes_count,
+        }
+
+
+@dataclass(frozen=True)
 class AnalyserStatus:
     analyser_id: str
     state: str
     version: str | None
     detail: str
+    records: tuple[AnalyserRecord, ...] = ()
 
     def as_dict(self) -> dict[str, object]:
         return {
@@ -136,6 +177,7 @@ class AnalyserStatus:
             "state": self.state,
             "version": self.version,
             "detail": self.detail,
+            "records": [record.as_dict() for record in self.records],
         }
 
 
@@ -237,6 +279,7 @@ def run_process(
     timeout_seconds: int,
     output_limit: int,
     cwd_fd: int | None = None,
+    env: dict[str, str] | None = None,
 ) -> tuple[bytes, bytes, int]:
     """Run fixed argv while bounding time and combined captured output."""
     process_cwd: Path | None = cwd
@@ -261,6 +304,7 @@ def run_process(
             shell=False,
             pass_fds=pass_fds,
             preexec_fn=preexec_fn,
+            env=env,
         )
     except FileNotFoundError as error:
         raise Refusal(f"{argv[0]} is not available on PATH") from error
@@ -680,14 +724,1100 @@ def discover(root: Path, *, root_fd: int | None = None) -> Universe:
     )
 
 
+@dataclass(frozen=True)
+class ParsedPython:
+    path: str
+    module: str | None
+    tree: ast.Module
+    bytes_count: int
+    dynamic_boundaries: tuple[str, ...]
+    retained_names: frozenset[str]
+    imports: tuple[tuple[str, int], ...]
+
+
+@dataclass(frozen=True)
+class PythonSnapshot:
+    files: tuple[ParsedPython, ...]
+    records: tuple[AnalyserRecord, ...]
+    module_paths: dict[str, str]
+    reachable_paths: frozenset[str]
+    entry_paths: frozenset[str]
+    degraded: bool
+
+
+def python_module_name(path: str) -> str | None:
+    if not path.endswith(".py"):
+        return None
+    parts = list(PurePosixPath(path).parts)
+    if parts[-1] == "__init__.py":
+        parts.pop()
+    else:
+        parts[-1] = parts[-1][:-3]
+    if not parts or any(not part.isidentifier() for part in parts):
+        return None
+    return ".".join(parts)
+
+
+def _main_guard(node: ast.AST) -> bool:
+    if not isinstance(node, ast.If):
+        return False
+    test = node.test
+    if not isinstance(test, ast.Compare) or len(test.ops) != 1:
+        return False
+    if not isinstance(test.ops[0], (ast.Eq, ast.NotEq)) or len(test.comparators) != 1:
+        return False
+    sides = (test.left, test.comparators[0])
+    return any(
+        isinstance(left, ast.Name)
+        and left.id == "__name__"
+        and isinstance(right, ast.Constant)
+        and right.value == "__main__"
+        for left, right in (sides, tuple(reversed(sides)))
+    )
+
+
+def _call_name(node: ast.Call) -> str:
+    target = node.func
+    if isinstance(target, ast.Name):
+        return target.id
+    if isinstance(target, ast.Attribute):
+        return target.attr
+    return ""
+
+
+def _literal_exports(tree: ast.Module) -> set[str]:
+    exports: set[str] = set()
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if not any(isinstance(target, ast.Name) and target.id == "__all__" for target in targets):
+            continue
+        value = node.value
+        if not isinstance(value, (ast.List, ast.Tuple, ast.Set)):
+            continue
+        exports.update(
+            item.value
+            for item in value.elts
+            if isinstance(item, ast.Constant) and isinstance(item.value, str)
+        )
+    return exports
+
+
+def _python_dynamic_boundaries(tree: ast.Module) -> tuple[str, ...]:
+    boundaries: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.decorator_list:
+                boundaries.add("decorator-registration")
+        if not isinstance(node, ast.Call):
+            continue
+        name = _call_name(node)
+        lowered = name.lower()
+        if any(token in lowered for token in ("register", "callback", "fixture", "route")):
+            boundaries.add("dynamic-registration")
+        if name in {"__import__", "import_module"}:
+            if not node.args or not (
+                isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                boundaries.add("computed-import")
+        if name == "getattr" and (
+            len(node.args) < 2
+            or not (
+                isinstance(node.args[1], ast.Constant)
+                and isinstance(node.args[1].value, str)
+            )
+        ):
+            boundaries.add("computed-getattr")
+    if _literal_exports(tree):
+        boundaries.add("literal-__all__")
+    return tuple(sorted(boundaries))
+
+
+def _retained_names(path: str, tree: ast.Module) -> frozenset[str]:
+    retained = _literal_exports(tree)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.decorator_list or node.name.startswith("test_"):
+                retained.add(node.name)
+        if isinstance(node, ast.Call):
+            lowered = _call_name(node).lower()
+            if any(token in lowered for token in ("register", "callback", "fixture", "route")):
+                retained.update(
+                    argument.id for argument in node.args if isinstance(argument, ast.Name)
+                )
+        if _main_guard(node):
+            retained.update(
+                child.id
+                for child in ast.walk(node)
+                if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Load)
+            )
+    if path.startswith("tests/") or "/fixtures/" in f"/{path}":
+        retained.update(
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+        )
+    return frozenset(retained)
+
+
+def _import_targets(
+    module: str | None,
+    tree: ast.Module,
+    *,
+    package_module: bool,
+) -> tuple[tuple[str, int], ...]:
+    targets: set[tuple[str, int]] = set()
+    package = [] if module is None else module.split(".")
+    if not package_module:
+        package = package[:-1]
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            targets.update((alias.name, node.lineno) for alias in node.names)
+            continue
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if node.level:
+            remove = node.level - 1
+            base = package[: max(0, len(package) - remove)]
+        else:
+            base = []
+        if node.module:
+            base.extend(node.module.split("."))
+        if base:
+            targets.add((".".join(base), node.lineno))
+        for alias in node.names:
+            if alias.name != "*" and base:
+                targets.add((".".join([*base, alias.name]), node.lineno))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or _call_name(node) not in {"__import__", "import_module"}:
+            continue
+        if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+            targets.add((node.args[0].value, node.lineno))
+    return tuple(sorted(targets))
+
+
+def _check_map_entry_paths(
+    root: Path,
+    universe: Universe,
+    module_paths: dict[str, str],
+    *,
+    root_fd: int,
+) -> set[str]:
+    path = "tests/check-map-v1.json"
+    if path not in universe.analysed:
+        return set()
+    try:
+        raw = read_commit_regular(
+            root,
+            universe.commit,
+            path,
+            limit=MAX_BOUNDARY_BYTES,
+            label=path,
+            root_fd=root_fd,
+        )
+        document = json.loads(raw, object_pairs_hook=reject_duplicate_keys)
+    except (Refusal, DuplicateKey, json.JSONDecodeError):
+        return set()
+    checks = document.get("checks") if isinstance(document, dict) else None
+    if not isinstance(checks, dict):
+        return set()
+    seeds: set[str] = set()
+    for body in checks.values():
+        if not isinstance(body, dict):
+            continue
+        script = body.get("script")
+        if isinstance(script, str) and script.endswith(".py"):
+            seeds.add(script)
+        argv = body.get("argv")
+        if not isinstance(argv, list) or not argv or not all(isinstance(item, str) for item in argv):
+            continue
+        for item in argv[1:]:
+            if item.endswith(".py"):
+                seeds.add(item)
+            elif item in module_paths:
+                seeds.add(module_paths[item])
+    return seeds
+
+
+def parse_python_snapshot(root: Path, universe: Universe) -> PythonSnapshot:
+    parsed: list[ParsedPython] = []
+    records: list[AnalyserRecord] = []
+    total = 0
+    degraded = False
+    root_fd = open_repository_directory(root)
+    try:
+        for path in (item for item in universe.analysed if item.endswith(".py")):
+            if total >= MAX_PYTHON_TOTAL_BYTES:
+                degraded = True
+                records.append(
+                    AnalyserRecord(path, "file", "skipped", "aggregate Python byte limit reached", 0)
+                )
+                continue
+            try:
+                source = read_commit_regular(
+                    root,
+                    universe.commit,
+                    path,
+                    limit=MAX_PYTHON_FILE_BYTES,
+                    label=path,
+                    root_fd=root_fd,
+                )
+            except Refusal as error:
+                degraded = True
+                records.append(AnalyserRecord(path, "file", "parse-error", str(error), 0))
+                continue
+            size = len(source.encode("utf-8"))
+            total += size
+            if total > MAX_PYTHON_TOTAL_BYTES:
+                degraded = True
+                records.append(
+                    AnalyserRecord(path, "file", "skipped", "aggregate Python byte limit exceeded", size)
+                )
+                continue
+            try:
+                tree = ast.parse(source, filename=path, type_comments=True)
+            except (SyntaxError, ValueError, MemoryError) as error:
+                degraded = True
+                line = getattr(error, "lineno", None)
+                suffix = f" at line {line}" if isinstance(line, int) else ""
+                records.append(
+                    AnalyserRecord(path, "file", "parse-error", f"{type(error).__name__}{suffix}", size)
+                )
+                continue
+            dynamic = _python_dynamic_boundaries(tree)
+            detail = "parsed"
+            if dynamic:
+                detail += "; dynamic boundaries: " + ", ".join(dynamic)
+            records.append(AnalyserRecord(path, "file", "parsed", detail, size))
+            module = python_module_name(path)
+            parsed.append(
+                ParsedPython(
+                    path=path,
+                    module=module,
+                    tree=tree,
+                    bytes_count=size,
+                    dynamic_boundaries=dynamic,
+                    retained_names=_retained_names(path, tree),
+                    imports=_import_targets(
+                        module,
+                        tree,
+                        package_module=path.endswith("/__init__.py") or path == "__init__.py",
+                    ),
+                )
+            )
+
+        module_paths = {
+            item.module: item.path
+            for item in parsed
+            if item.module is not None
+        }
+        seeds = {
+            item.path
+            for item in parsed
+            if item.path.startswith("tests/")
+            or item.path.endswith("/__main__.py")
+            or any(_main_guard(node) for node in item.tree.body)
+        }
+        seeds.update(_check_map_entry_paths(root, universe, module_paths, root_fd=root_fd))
+    finally:
+        os.close(root_fd)
+
+    edges: dict[str, set[str]] = {item.path: set() for item in parsed}
+    for item in parsed:
+        for target, _line in item.imports:
+            probe = target
+            while probe:
+                destination = module_paths.get(probe)
+                if destination is not None:
+                    edges[item.path].add(destination)
+                    break
+                probe = probe.rpartition(".")[0]
+    reachable = set(path for path in seeds if path in edges)
+    pending = list(reachable)
+    while pending:
+        source = pending.pop()
+        for destination in edges[source]:
+            if destination not in reachable:
+                reachable.add(destination)
+                pending.append(destination)
+    return PythonSnapshot(
+        files=tuple(parsed),
+        records=tuple(sorted(records, key=lambda item: item.record_id)),
+        module_paths=module_paths,
+        reachable_paths=frozenset(reachable),
+        entry_paths=frozenset(path for path in seeds if path in edges),
+        degraded=degraded,
+    )
+
+
+def _candidate(
+    path: str,
+    symbol: str,
+    evidence: str,
+    confidence: str,
+    boundary: str,
+    *,
+    analyser_id: str = "python",
+) -> Finding:
+    return Finding(analyser_id, path, symbol, evidence, confidence, boundary)
+
+
+def _unused_bindings(item: ParsedPython) -> Iterable[Finding]:
+    loads = {
+        node.id
+        for node in ast.walk(item.tree)
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
+    } | set(_literal_exports(item.tree))
+    confidence = "low" if item.dynamic_boundaries else "high"
+    boundary = (
+        "computed references or registration may consume this binding"
+        if item.dynamic_boundaries
+        else "scope-insensitive name loading can retain a shadowed binding"
+    )
+    seen_imports: set[tuple[str, int]] = set()
+    for node in ast.walk(item.tree):
+        if isinstance(node, ast.Import):
+            aliases = node.names
+        elif isinstance(node, ast.ImportFrom):
+            aliases = node.names
+        else:
+            continue
+        for alias in aliases:
+            if alias.name == "*":
+                continue
+            binding = alias.asname or alias.name.split(".")[0]
+            identity = (binding, node.lineno)
+            if binding in loads or binding.startswith("_") or identity in seen_imports:
+                continue
+            seen_imports.add(identity)
+            yield _candidate(
+                item.path,
+                f"{binding}@{node.lineno}",
+                f"import binding {binding} has no Name load in the parsed file",
+                confidence,
+                boundary,
+            )
+
+    for function in (
+        node
+        for node in ast.walk(item.tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ):
+        function_loads = {
+            node.id
+            for node in ast.walk(function)
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
+        }
+        assignments: dict[str, int] = {}
+        for node in ast.walk(function):
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+                assignments.setdefault(node.id, node.lineno)
+        for name, line in sorted(assignments.items()):
+            if name in function_loads or name.startswith("_"):
+                continue
+            yield _candidate(
+                item.path,
+                f"{function.name}.{name}@{line}",
+                f"local binding {name} is stored but has no Name load in {function.name}",
+                confidence,
+                "a nested dynamic lookup or scope-insensitive shadow may consume the binding",
+            )
+
+
+def _block_findings(item: ParsedPython) -> Iterable[Finding]:
+    confidence = "low" if item.dynamic_boundaries else "high"
+
+    def inspect(block: list[ast.stmt]) -> Iterable[Finding]:
+        terminator_line: int | None = None
+        for statement in block:
+            if terminator_line is not None:
+                yield _candidate(
+                    item.path,
+                    f"line:{statement.lineno}:unreachable",
+                    f"statement follows an unconditional terminator at line {terminator_line}",
+                    confidence,
+                    "exception handling, generated bytecode or parser limitations may alter control flow",
+                )
+            for field in ("body", "orelse", "finalbody"):
+                child = getattr(statement, field, None)
+                if isinstance(child, list):
+                    yield from inspect(child)
+            if isinstance(statement, ast.Try):
+                for handler in statement.handlers:
+                    yield from inspect(handler.body)
+            if isinstance(statement, (ast.Return, ast.Raise, ast.Break, ast.Continue)):
+                terminator_line = statement.lineno
+
+    yield from inspect(item.tree.body)
+    for node in ast.walk(item.tree):
+        if not isinstance(node, (ast.If, ast.While)):
+            continue
+        truth: bool | None = None
+        if isinstance(node.test, ast.Constant) and isinstance(node.test.value, (bool, type(None))):
+            truth = bool(node.test.value)
+        if truth is None:
+            continue
+        direction = "true" if truth else "false"
+        yield _candidate(
+            item.path,
+            f"line:{node.lineno}:constant-{direction}",
+            f"branch condition is the literal constant {node.test.value!r}",
+            confidence,
+            "the syntax may be an intentional feature flag or type-checking guard",
+        )
+
+
+def analyse_python(root: Path, universe: Universe) -> tuple[AnalyserStatus, tuple[Finding, ...]]:
+    snapshot = parse_python_snapshot(root, universe)
+    findings: list[Finding] = []
+    for item in snapshot.files:
+        findings.extend(_unused_bindings(item))
+        findings.extend(_block_findings(item))
+        if (
+            item.module is not None
+            and snapshot.entry_paths
+            and item.path not in snapshot.reachable_paths
+            and not item.path.endswith("/__init__.py")
+        ):
+            findings.append(
+                _candidate(
+                    item.path,
+                    "<module>",
+                    "no path from a declared check, test or __main__ seed reaches this module over static imports",
+                    "low",
+                    "computed imports, plugin manifests and prose entry points are outside the static import graph",
+                )
+            )
+    state = "degraded" if snapshot.degraded else "ran"
+    parsed_count = sum(record.state == "parsed" for record in snapshot.records)
+    detail = (
+        f"parsed {parsed_count}/{len(snapshot.records)} bounded Python files; "
+        f"{len(snapshot.entry_paths)} entry seed(s)"
+    )
+    if snapshot.degraded:
+        detail += "; one or more files did not parse"
+    return (
+        AnalyserStatus("python", state, PYTHON_ANALYSER_VERSION, detail, snapshot.records),
+        tuple(findings),
+    )
+
+
+def _json_document(payload: bytes | str, label: str) -> dict[str, object]:
+    try:
+        document = json.loads(payload, object_pairs_hook=reject_duplicate_keys)
+    except DuplicateKey as error:
+        raise Refusal(f"{label} repeats JSON key {error.args[0]}") from error
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise Refusal(f"{label} is not valid UTF-8 JSON: {error}") from error
+    if not isinstance(document, dict):
+        raise Refusal(f"{label} is not a JSON object")
+    return document
+
+
+def _python_argv(argv: object) -> bool:
+    if not isinstance(argv, list) or not argv or not all(isinstance(item, str) and item for item in argv):
+        return False
+    executable = PurePosixPath(argv[0]).name
+    return re.fullmatch(r"python(?:3(?:\.14)?)?", executable) is not None
+
+
+def _coverage_recurses(argv: list[str]) -> bool:
+    normalised = [item.replace(chr(92), "/") for item in argv]
+    return any(item.endswith("scripts/dead_code.py") for item in normalised) and "coverage" in argv
+
+
+def _runner_plan(root: Path, scopes: tuple[str, ...]) -> dict[str, object]:
+    argv = [sys.executable, CHECK_RUNNER.as_posix()]
+    for scope in scopes:
+        argv.extend(["--scope", scope])
+    argv.extend(["--plan", "--format", "json"])
+    stdout, stderr, returncode = run_process(
+        argv,
+        cwd=root,
+        timeout_seconds=GIT_TIMEOUT_SECONDS,
+        output_limit=MAX_RUNNER_OUTPUT_BYTES,
+    )
+    if returncode != 0:
+        detail = decode_output(stderr, "check-plan stderr").strip() or f"exit {returncode}"
+        raise Refusal(f"checked runner plan failed: {detail}")
+    plan = _json_document(stdout, "checked runner plan")
+    if plan.get("schema") != "wildcat.check-plan.v1":
+        raise Refusal("checked runner returned an unknown plan schema")
+    if plan.get("requested_scopes") != list(scopes):
+        raise Refusal("checked runner plan is not bound to the requested scopes")
+    selected = plan.get("selected_checks")
+    if not isinstance(selected, list) or not selected:
+        raise Refusal("checked runner selected no checks for coverage")
+    identifiers: set[str] = set()
+    for index, check in enumerate(selected):
+        if not isinstance(check, dict):
+            raise Refusal(f"checked runner plan check {index} is not an object")
+        identifier = check.get("id")
+        argv_value = check.get("argv")
+        if not isinstance(identifier, str) or not identifier or identifier in identifiers:
+            raise Refusal("checked runner plan has empty or repeated check identities")
+        identifiers.add(identifier)
+        if not _python_argv(argv_value):
+            raise Refusal(
+                f"coverage scope includes non-Python check {identifier}; select a Python-only scope"
+            )
+        assert isinstance(argv_value, list)
+        if _coverage_recurses(argv_value):
+            raise Refusal(f"coverage check {identifier} recursively invokes dead_code.py coverage")
+    return plan
+
+
+def _create_process_directory(root: Path, root_fd: int, run_id: str) -> tuple[Path, int]:
+    relative = f"{OWNED_OUTPUT_DIRECTORY}/coverage-processes-{run_id}/record.json"
+    target = confine(root, relative)
+    parts = output_parts(root, target)
+    directory_fd = open_output_directory(root_fd, parts)
+    return target.parent, directory_fd
+
+
+def _read_process_documents(
+    directory: Path,
+    directory_fd: int,
+    run_id: str,
+) -> list[tuple[dict[str, object], int]]:
+    try:
+        names = sorted(os.listdir(directory_fd))
+    except OSError as error:
+        raise Refusal(f"coverage process directory cannot be listed: {error}") from error
+    if len(names) > MAX_COVERAGE_PROCESSES:
+        raise Refusal(f"coverage emitted more than {MAX_COVERAGE_PROCESSES} process records")
+    documents: list[tuple[dict[str, object], int]] = []
+    total_bytes = 0
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    for name in names:
+        if re.fullmatch(r"process-[0-9]+-[0-9a-f]{32}\.json", name) is None:
+            raise Refusal(f"coverage process directory contains foreign entry {name}")
+        try:
+            fd = os.open(name, flags, dir_fd=directory_fd)
+            info = os.fstat(fd)
+            if not stat.S_ISREG(info.st_mode):
+                raise Refusal(f"coverage process record {name} is not regular")
+            if info.st_size > MAX_COVERAGE_PROCESS_BYTES:
+                raise Refusal(f"coverage process record {name} exceeds its byte limit")
+            with os.fdopen(fd, "rb") as handle:
+                payload = handle.read(MAX_COVERAGE_PROCESS_BYTES + 1)
+        except Refusal:
+            raise
+        except OSError as error:
+            raise Refusal(f"coverage process record {name} cannot be read: {error}") from error
+        if len(payload) > MAX_COVERAGE_PROCESS_BYTES or len(payload) != info.st_size:
+            raise Refusal(f"coverage process record {name} changed or exceeded its byte limit")
+        total_bytes += len(payload)
+        if total_bytes > MAX_COVERAGE_BYTES:
+            raise Refusal(f"coverage process records exceed {MAX_COVERAGE_BYTES} aggregate bytes")
+        document = _json_document(payload, f"coverage process record {name}")
+        if document.get("schema") != "dead-code-process-coverage/v1" or document.get("run") != run_id:
+            raise Refusal(f"coverage process record {name} has the wrong identity")
+        documents.append((document, len(payload)))
+    return documents
+
+
+def _remove_process_directory(directory_fd: int, root_fd: int, name: str) -> None:
+    try:
+        for entry in os.listdir(directory_fd):
+            if re.fullmatch(r"process-[0-9]+-[0-9a-f]{32}\.json", entry):
+                try:
+                    os.unlink(entry, dir_fd=directory_fd)
+                except OSError:
+                    pass
+    finally:
+        os.close(directory_fd)
+    try:
+        dead_code_fd = os.open(
+            OWNED_OUTPUT_DIRECTORY,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=root_fd,
+        )
+    except OSError:
+        return
+    try:
+        os.rmdir(name, dir_fd=dead_code_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(dead_code_fd)
+
+
+def _argv_matches(process_argv: object, planned_argv: object) -> bool:
+    if not _python_argv(process_argv) or not _python_argv(planned_argv):
+        return False
+    assert isinstance(process_argv, list)
+    assert isinstance(planned_argv, list)
+    return process_argv[1:] == planned_argv[1:]
+
+
+def _normalise_coverage_events(
+    lines: list[object],
+    branches: list[object],
+    analysed: set[str],
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    normal_lines: set[tuple[str, str, int]] = set()
+    normal_branches: set[tuple[str, str, int, int, str]] = set()
+    for item in lines:
+        if not isinstance(item, dict):
+            raise Refusal("coverage line event is not an object")
+        path = item.get("path")
+        function = item.get("function")
+        line = item.get("line")
+        if not isinstance(path, str) or not isinstance(function, str) or not isinstance(line, int) or line < 1:
+            raise Refusal("coverage line event has an invalid identity")
+        validate_repository_path(path, "coverage line path")
+        if path in analysed:
+            normal_lines.add((path, function, line))
+    for item in branches:
+        if not isinstance(item, dict):
+            raise Refusal("coverage branch event is not an object")
+        path = item.get("path")
+        function = item.get("function")
+        source = item.get("from_line")
+        target = item.get("to_line")
+        direction = item.get("direction")
+        if (
+            not isinstance(path, str)
+            or not isinstance(function, str)
+            or not isinstance(source, int)
+            or source < 1
+            or not isinstance(target, int)
+            or target < 1
+            or direction not in {"left", "right"}
+        ):
+            raise Refusal("coverage branch event has an invalid identity")
+        validate_repository_path(path, "coverage branch path")
+        if path in analysed:
+            normal_branches.add((path, function, source, target, direction))
+    return (
+        [
+            {"path": path, "function": function, "line": line}
+            for path, function, line in sorted(normal_lines)
+        ],
+        [
+            {
+                "path": path,
+                "function": function,
+                "from_line": source,
+                "to_line": target,
+                "direction": direction,
+            }
+            for path, function, source, target, direction in sorted(normal_branches)
+        ],
+    )
+
+
+def aggregate_coverage(
+    plan: dict[str, object],
+    run: dict[str, object],
+    process_documents: list[tuple[dict[str, object], int]],
+    universe: Universe,
+) -> dict[str, object]:
+    selected = plan.get("selected_checks")
+    results = run.get("checks")
+    if not isinstance(selected, list) or not isinstance(results, list):
+        raise Refusal("checked runner record omits selected checks or results")
+    planned: dict[str, dict[str, object]] = {}
+    for item in selected:
+        if not isinstance(item, dict) or not isinstance(item.get("id"), str):
+            raise Refusal("checked runner selected-check record is malformed")
+        planned[item["id"]] = item
+    terminal: dict[str, dict[str, object]] = {}
+    for item in results:
+        if not isinstance(item, dict) or not isinstance(item.get("check"), str):
+            raise Refusal("checked runner terminal record is malformed")
+        terminal[item["check"]] = item
+    if set(terminal) != set(planned):
+        raise Refusal("checked runner terminal records do not match its plan")
+
+    marker_to_check: dict[str, str] = {}
+    degraded_reasons: set[str] = set()
+    for document, _size in process_documents:
+        process = document.get("process")
+        if not isinstance(process, dict):
+            raise Refusal("coverage process record omits process identity")
+        marker = process.get("containment")
+        argv = process.get("argv")
+        if not isinstance(marker, str) or not marker:
+            raise Refusal("coverage process record omits containment identity")
+        matches = [
+            check_id
+            for check_id, check in planned.items()
+            if _argv_matches(argv, check.get("argv"))
+        ]
+        if len(matches) == 1:
+            prior = marker_to_check.get(marker)
+            if prior is not None and prior != matches[0]:
+                degraded_reasons.add("one process group matched multiple checks")
+            marker_to_check[marker] = matches[0]
+
+    public_processes: list[dict[str, object]] = []
+    bytes_by_check = {check_id: 0 for check_id in planned}
+    process_count_by_check = {check_id: 0 for check_id in planned}
+    for document, size in process_documents:
+        process = document["process"]
+        assert isinstance(process, dict)
+        marker = process["containment"]
+        assert isinstance(marker, str)
+        check_id = marker_to_check.get(marker)
+        if check_id is None:
+            degraded_reasons.add("one monitored process group could not be attributed")
+            continue
+        status = document.get("status")
+        lines = document.get("lines")
+        branches = document.get("branches")
+        if not isinstance(status, dict) or not isinstance(lines, list) or not isinstance(branches, list):
+            raise Refusal("coverage process record omits status, lines or branches")
+        lines, branches = _normalise_coverage_events(
+            lines,
+            branches,
+            set(universe.analysed),
+        )
+        if status.get("state") != "ran":
+            degraded_reasons.add(f"check {check_id} emitted a degraded process record")
+        bytes_by_check[check_id] += size
+        process_count_by_check[check_id] += 1
+        group_id = digest_json({"run": document.get("run"), "containment": marker})
+        process_id = digest_json(
+            {
+                "group": group_id,
+                "pid": process.get("pid"),
+                "parent_pid": process.get("parent_pid"),
+                "argv": process.get("argv"),
+                "lines": lines,
+                "branches": branches,
+            }
+        )
+        public_processes.append(
+            {
+                "id": process_id,
+                "group": group_id,
+                "check": check_id,
+                "pid": process.get("pid"),
+                "parent_pid": process.get("parent_pid"),
+                "argv": process.get("argv"),
+                "status": status,
+                "bytes": size,
+                "lines": lines,
+                "branches": branches,
+            }
+        )
+
+    check_records: list[dict[str, object]] = []
+    for check_id in sorted(planned):
+        result = terminal[check_id]
+        state = result.get("status")
+        if state != "passed":
+            degraded_reasons.add(f"check {check_id} ended {state}")
+        if process_count_by_check[check_id] == 0:
+            degraded_reasons.add(f"check {check_id} emitted no process record")
+        check_records.append(
+            {
+                "id": check_id,
+                "state": state,
+                "duration_seconds": result.get("duration_seconds"),
+                "processes": process_count_by_check[check_id],
+                "bytes": bytes_by_check[check_id],
+            }
+        )
+    if run.get("schema") != "wildcat.check-run.v1" or run.get("outcome") != "green":
+        degraded_reasons.add(f"checked runner outcome was {run.get('outcome')}")
+    public_processes.sort(key=lambda item: (str(item["check"]), str(item["id"])))
+    state = "degraded" if degraded_reasons else "ran"
+    return {
+        "schema": COVERAGE_SCHEMA_ID,
+        "tool": {"id": "sys.monitoring", "python": sys.version.split()[0]},
+        "tree": {"commit": universe.commit, "git_tree": universe.tree, "universe": universe.identity},
+        "plan": {
+            "schema": plan.get("schema"),
+            "map_digest": plan.get("map_digest"),
+            "requested_scopes": plan.get("requested_scopes"),
+            "selected_checks": sorted(planned),
+        },
+        "status": {
+            "state": state,
+            "detail": (
+                "every selected Python check completed with process coverage"
+                if not degraded_reasons
+                else "; ".join(sorted(degraded_reasons))
+            ),
+        },
+        "checks": check_records,
+        "processes": public_processes,
+    }
+
+
+def _coverage_environment(root: Path, process_directory: Path, run_id: str) -> dict[str, str]:
+    environment = dict(os.environ)
+    monitoring_path = str(root / MONITOR_DIRECTORY)
+    inherited_python_path = environment.get("PYTHONPATH")
+    environment["PYTHONPATH"] = monitoring_path + (
+        os.pathsep + inherited_python_path if inherited_python_path else ""
+    )
+    runtime_directory = str(Path(sys.executable).parent)
+    inherited_path = environment.get("PATH")
+    environment["PATH"] = runtime_directory + (
+        os.pathsep + inherited_path if inherited_path else ""
+    )
+    environment[COVERAGE_ACTIVE_ENV] = run_id
+    environment[COVERAGE_OUTPUT_ENV] = str(process_directory)
+    return environment
+
+
+def command_coverage(arguments: argparse.Namespace) -> int:
+    if os.environ.get(COVERAGE_ACTIVE_ENV):
+        raise Refusal("coverage wrapper recursion is active in this process")
+    if sys.version_info[:2] != (3, 14) or not hasattr(sys, "monitoring"):
+        raise Refusal("coverage requires the repository Python 3.14 sys.monitoring runtime")
+    scopes = tuple(arguments.scope)
+    if not scopes or len(scopes) != len(set(scopes)):
+        raise Refusal("coverage requires one or more unique --scope values")
+    root = repository_root(Path(arguments.directory).resolve())
+    root_fd = open_repository_directory(root)
+    process_fd: int | None = None
+    process_name = ""
+    try:
+        target = confine(root, arguments.output)
+        universe = discover(root, root_fd=root_fd)
+        plan = _runner_plan(root, scopes)
+        run_id = uuid.uuid4().hex
+        process_directory, process_fd = _create_process_directory(root, root_fd, run_id)
+        process_name = process_directory.name
+        environment = _coverage_environment(root, process_directory, run_id)
+        runner_report = f"{OWNED_OUTPUT_DIRECTORY}/checks.json"
+        argv = [sys.executable, CHECK_RUNNER.as_posix()]
+        for scope in scopes:
+            argv.extend(["--scope", scope])
+        argv.extend(["--report", runner_report])
+        _stdout, _stderr, _returncode = run_process(
+            argv,
+            cwd=root,
+            timeout_seconds=RUNNER_TIMEOUT_SECONDS,
+            output_limit=MAX_RUNNER_OUTPUT_BYTES,
+            env=environment,
+        )
+        run_raw = read_bounded_regular(
+            root / runner_report,
+            limit=MAX_COVERAGE_BYTES,
+            label=runner_report,
+        )
+        run = _json_document(run_raw, runner_report)
+        documents = _read_process_documents(process_directory, process_fd, run_id)
+        coverage = aggregate_coverage(plan, run, documents, universe)
+        atomic_write(root, target, json.dumps(coverage, indent=2, sort_keys=True) + chr(10), root_fd=root_fd)
+        return 0
+    finally:
+        if process_fd is not None:
+            _remove_process_directory(process_fd, root_fd, process_name)
+        os.close(root_fd)
+
+
+def _coverage_file(
+    root: Path,
+    universe: Universe,
+    coverage_path: str | None,
+) -> dict[str, object]:
+    if coverage_path is None:
+        raise Refusal("coverage analyser requires --coverage")
+    target = confine(root, coverage_path)
+    raw = read_bounded_regular(target, limit=MAX_COVERAGE_BYTES, label=coverage_path)
+    document = _json_document(raw, coverage_path)
+    if document.get("schema") != COVERAGE_SCHEMA_ID:
+        raise Refusal(f"{coverage_path} does not declare {COVERAGE_SCHEMA_ID}")
+    tree = document.get("tree")
+    if not isinstance(tree, dict):
+        raise Refusal(f"{coverage_path} omits tree identity")
+    if (
+        tree.get("commit") != universe.commit
+        or tree.get("git_tree") != universe.tree
+        or tree.get("universe") != universe.identity
+    ):
+        return {
+            **document,
+            "status": {
+                "state": "degraded",
+                "detail": "coverage identity does not match the report universe",
+            },
+        }
+    return document
+
+
+def _function_targets(item: ParsedPython) -> Iterable[tuple[str, int]]:
+    for node in ast.walk(item.tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or not node.body:
+            continue
+        if node.name in item.retained_names:
+            continue
+        yield node.name, node.body[0].lineno
+
+
+def _branch_targets(item: ParsedPython) -> Iterable[tuple[int, int, str]]:
+    for node in ast.walk(item.tree):
+        if not isinstance(node, ast.If) or not node.body or not node.orelse:
+            continue
+        if isinstance(node.test, ast.Constant):
+            continue
+        yield node.lineno, node.body[0].lineno, "body"
+        yield node.lineno, node.orelse[0].lineno, "else"
+
+
+def analyse_coverage(
+    root: Path,
+    universe: Universe,
+    coverage_path: str | None,
+) -> tuple[AnalyserStatus, tuple[Finding, ...]]:
+    document = _coverage_file(root, universe, coverage_path)
+    status = document.get("status")
+    checks = document.get("checks")
+    processes = document.get("processes")
+    if not isinstance(status, dict) or not isinstance(checks, list) or not isinstance(processes, list):
+        raise Refusal("coverage record omits status, checks or processes")
+    records: list[AnalyserRecord] = []
+    for item in checks:
+        if not isinstance(item, dict) or not isinstance(item.get("id"), str):
+            raise Refusal("coverage check record is malformed")
+        state = item.get("state")
+        mapped = "passed" if state == "passed" else "unavailable" if state == "unavailable" else "failed"
+        size = item.get("bytes")
+        records.append(
+            AnalyserRecord(
+                item["id"],
+                "check",
+                mapped,
+                f"runner state {state}; {item.get('processes')} process record(s)",
+                size if isinstance(size, int) and size >= 0 else 0,
+            )
+        )
+    records.sort(key=lambda item: item.record_id)
+    if status.get("state") != "ran":
+        return (
+            AnalyserStatus(
+                "coverage",
+                "degraded",
+                COVERAGE_ANALYSER_VERSION,
+                str(status.get("detail") or "coverage did not complete"),
+                tuple(records),
+            ),
+            (),
+        )
+    if not records or any(record.state != "passed" for record in records):
+        return (
+            AnalyserStatus(
+                "coverage",
+                "degraded",
+                COVERAGE_ANALYSER_VERSION,
+                "coverage claimed completion but one or more check records were not passed",
+                tuple(records),
+            ),
+            (),
+        )
+
+    observed_lines: set[tuple[str, int]] = set()
+    observed_branches: set[tuple[str, int, int]] = set()
+    for process in processes:
+        if not isinstance(process, dict):
+            raise Refusal("coverage process aggregate is malformed")
+        lines = process.get("lines")
+        branches = process.get("branches")
+        if not isinstance(lines, list) or not isinstance(branches, list):
+            raise Refusal("coverage process aggregate omits lines or branches")
+        process_status = process.get("status")
+        if not isinstance(process_status, dict) or process_status.get("state") != "ran":
+            return (
+                AnalyserStatus(
+                    "coverage",
+                    "degraded",
+                    COVERAGE_ANALYSER_VERSION,
+                    "coverage claimed completion but one process record was degraded",
+                    tuple(records),
+                ),
+                (),
+            )
+        for line in lines:
+            if isinstance(line, dict) and isinstance(line.get("path"), str) and isinstance(line.get("line"), int):
+                observed_lines.add((line["path"], line["line"]))
+        for branch in branches:
+            if (
+                isinstance(branch, dict)
+                and isinstance(branch.get("path"), str)
+                and isinstance(branch.get("from_line"), int)
+                and isinstance(branch.get("to_line"), int)
+            ):
+                observed_branches.add((branch["path"], branch["from_line"], branch["to_line"]))
+
+    snapshot = parse_python_snapshot(root, universe)
+    if snapshot.degraded:
+        return (
+            AnalyserStatus(
+                "coverage",
+                "degraded",
+                COVERAGE_ANALYSER_VERSION,
+                "coverage completed but the bounded Python source inventory was incomplete",
+                tuple(records),
+            ),
+            (),
+        )
+    findings: list[Finding] = []
+    for item in snapshot.files:
+        for name, line in _function_targets(item):
+            if (item.path, line) not in observed_lines:
+                findings.append(
+                    _candidate(
+                        item.path,
+                        f"{name}@{line}",
+                        f"no body line for {name} was observed in the completed named checks",
+                        "low",
+                        "coverage names only the selected checks and cannot prove other entry points absent",
+                        analyser_id="coverage",
+                    )
+                )
+        for source, target, direction in _branch_targets(item):
+            if (item.path, source, target) not in observed_branches:
+                findings.append(
+                    _candidate(
+                        item.path,
+                        f"branch:{source}->{target}:{direction}",
+                        f"the {direction} branch from line {source} to line {target} was not observed",
+                        "low",
+                        "sys.monitoring observed only the completed named checks",
+                        analyser_id="coverage",
+                    )
+                )
+    return (
+        AnalyserStatus(
+            "coverage",
+            "ran",
+            COVERAGE_ANALYSER_VERSION,
+            f"consumed {len(processes)} process record(s) from {len(checks)} completed check(s)",
+            tuple(records),
+        ),
+        tuple(findings),
+    )
+
+
+ANALYSERS["python"] = analyse_python
+
+
 def collect(
     root: Path,
     universe: Universe,
+    analyser_ids: tuple[str, ...] | None = None,
+    coverage_path: str | None = None,
 ) -> tuple[tuple[AnalyserStatus, ...], tuple[Finding, ...]]:
     statuses: list[AnalyserStatus] = []
     findings: list[Finding] = []
-    for analyser_id in sorted(ANALYSERS):
-        status, produced = ANALYSERS[analyser_id](root, universe)
+    selected = tuple(sorted(ANALYSERS)) if analyser_ids is None else tuple(sorted(analyser_ids))
+    for analyser_id in selected:
+        if analyser_id == "coverage":
+            status, produced = analyse_coverage(root, universe, coverage_path)
+        else:
+            analyser = ANALYSERS.get(analyser_id)
+            if analyser is None:
+                raise Refusal(f"unknown analyser {analyser_id}")
+            status, produced = analyser(root, universe)
         if status.analyser_id != analyser_id:
             raise Refusal(
                 f"analyser {analyser_id} returned status for {status.analyser_id}"
@@ -739,6 +1869,20 @@ def validate_report(report: Report) -> None:
             )
         if not item.detail:
             raise Refusal(f"analyser {item.analyser_id} has no detail")
+        record_ids: set[tuple[str, str]] = set()
+        for record in item.records:
+            identity = (record.kind, record.record_id)
+            if not record.record_id or identity in record_ids:
+                raise Refusal(f"analyser {item.analyser_id} has empty or repeated records")
+            if record.kind not in ANALYSER_RECORD_KINDS:
+                raise Refusal(f"analyser {item.analyser_id} has unknown record kind {record.kind}")
+            if record.state not in ANALYSER_RECORD_STATES:
+                raise Refusal(f"analyser {item.analyser_id} has unknown record state {record.state}")
+            if not record.detail or record.bytes_count < 0:
+                raise Refusal(f"analyser {item.analyser_id} has an invalid record")
+            record_ids.add(identity)
+        if item.records != tuple(sorted(item.records, key=lambda record: (record.kind, record.record_id))):
+            raise Refusal(f"analyser {item.analyser_id} records are not sorted")
         status_ids.add(item.analyser_id)
     if tuple(item.analyser_id for item in report.statuses) != tuple(sorted(status_ids)):
         raise Refusal("analyser statuses are not sorted by identity")
@@ -778,9 +1922,15 @@ def validate_report(report: Report) -> None:
         raise Refusal("findings are not sorted by stable report identity")
 
 
-def build_report(root: Path, *, root_fd: int | None = None) -> Report:
+def build_report(
+    root: Path,
+    *,
+    root_fd: int | None = None,
+    analyser_ids: tuple[str, ...] = (),
+    coverage_path: str | None = None,
+) -> Report:
     universe = discover(root, root_fd=root_fd)
-    statuses, findings = collect(root, universe)
+    statuses, findings = collect(root, universe, analyser_ids, coverage_path)
     report = Report(universe=universe, statuses=statuses, findings=findings)
     validate_report(report)
     return report
@@ -827,6 +1977,11 @@ def render_text(report: Report) -> str:
             f"  {analyser['id']}{version}  {analyser['state']}  "
             f"{analyser['detail']}"
         )
+        for record in analyser["records"]:
+            lines.append(
+                f"    {record['kind']} {record['id']}  {record['state']}  "
+                f"{record['bytes']} byte(s)  {record['detail']}"
+            )
 
     findings = document["findings"]
     lines.extend(["", f"findings  {len(findings)} candidate(s); report-only"])
@@ -1032,9 +2187,16 @@ def command_report(arguments: argparse.Namespace) -> int:
     root_fd = open_repository_directory(root)
     target: Path | None = None
     try:
+        analyser_ids = parse_analyser_ids(getattr(arguments, "analyser", None))
+        coverage_path = getattr(arguments, "coverage", None)
         if arguments.output is not None:
             target = confine(root, arguments.output)
-        report = build_report(root, root_fd=root_fd)
+        report = build_report(
+            root,
+            root_fd=root_fd,
+            analyser_ids=analyser_ids,
+            coverage_path=coverage_path,
+        )
         rendered = render_json(report) if arguments.json else render_text(report)
         if arguments.output is None:
             sys.stdout.write(rendered)
@@ -1045,6 +2207,21 @@ def command_report(arguments: argparse.Namespace) -> int:
     finally:
         if root_fd is not None:
             os.close(root_fd)
+
+
+def parse_analyser_ids(value: str | None) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    identifiers = tuple(value.split(","))
+    if not identifiers or any(not item for item in identifiers):
+        raise Refusal("--analyser must be a comma-separated list of identities")
+    if len(identifiers) != len(set(identifiers)):
+        raise Refusal("--analyser repeats an identity")
+    supported = {*ANALYSERS, "coverage"}
+    unknown = sorted(set(identifiers) - supported)
+    if unknown:
+        raise Refusal("unknown analyser(s): " + ", ".join(unknown))
+    return identifiers
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -1058,6 +2235,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="a path inside the repository to analyse",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
+    coverage = subparsers.add_parser(
+        "coverage",
+        help="run a Python-only checked scope under sys.monitoring",
+    )
+    coverage.add_argument(
+        "--scope",
+        action="append",
+        default=[],
+        help="a checked-runner scope; repeatable",
+    )
+    coverage.add_argument(
+        "--output",
+        required=True,
+        help="write the coverage record inside the owned .dead-code sink",
+    )
+    coverage.set_defaults(handler=command_coverage)
     report = subparsers.add_parser(
         "report",
         help="report the universe and its candidates",
@@ -1070,6 +2263,14 @@ def build_parser() -> argparse.ArgumentParser:
     report.add_argument(
         "--output",
         help="write inside the repository instead of stdout",
+    )
+    report.add_argument(
+        "--analyser",
+        help="comma-separated analyser identities to run",
+    )
+    report.add_argument(
+        "--coverage",
+        help="coverage record below the owned .dead-code sink",
     )
     report.set_defaults(handler=command_report)
     return parser

--- a/scripts/dead_code_monitoring/sitecustomize.py
+++ b/scripts/dead_code_monitoring/sitecustomize.py
@@ -1,0 +1,285 @@
+"""Process-local Python 3.14 execution probe for ``dead_code.py coverage``.
+
+This module is loaded only when the coverage command prepends this directory to
+``PYTHONPATH``.  A checked-runner containment marker is also required, so the
+orchestrating runner is never monitored and recursive direct use is inert.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+import uuid
+
+ACTIVE_ENV = "WILDCAT_DEAD_CODE_COVERAGE_ACTIVE"
+OUTPUT_ENV = "WILDCAT_DEAD_CODE_COVERAGE_OUTPUT"
+CONTAINMENT_ENV = "WILDCAT_CHECK_CONTAINMENT"
+SOURCE_ROOT_ENV = "WILDCAT_DEAD_CODE_COVERAGE_SOURCE_ROOT"
+SCHEMA = "dead-code-process-coverage/v1"
+MAX_EVENTS = 50_000
+MAX_RECORD_BYTES = 16 * 1024 * 1024
+MAX_ARG_BYTES = 16 * 1024
+
+
+def _repository_root(start: Path) -> Path | None:
+    for candidate in (start, *start.parents):
+        try:
+            marker = candidate / ".git"
+            info = marker.lstat()
+        except OSError:
+            continue
+        if stat.S_ISDIR(info.st_mode) or stat.S_ISREG(info.st_mode):
+            return candidate
+    return None
+
+
+def _safe_argv() -> list[str]:
+    retained: list[str] = []
+    consumed = 0
+    for item in getattr(sys, "orig_argv", sys.argv):
+        encoded = os.fsencode(item)
+        if consumed + len(encoded) > MAX_ARG_BYTES:
+            retained.append("<truncated>")
+            break
+        retained.append(item)
+        consumed += len(encoded)
+    return retained
+
+
+class MonitoringProbe:
+    """Own one free monitoring id and put it back exactly as it was."""
+
+    def __init__(self, output_directory: Path, repository_root: Path, run_id: str):
+        self.output_directory = output_directory
+        self.repository_root = repository_root.resolve()
+        self.initial_cwd = Path.cwd()
+        self.run_id = run_id
+        self.tool_id = sys.monitoring.COVERAGE_ID
+        self.started = False
+        self.owns_tool = False
+        self.closed = False
+        self.truncated = False
+        self.errors: list[str] = []
+        self.lines: set[tuple[str, str, int]] = set()
+        self.branches: set[tuple[str, str, int, int, str]] = set()
+        self._line_cache: dict[object, dict[int, int]] = {}
+        self._location_cache: dict[object, tuple[str, str] | None] = {}
+
+    def _location(self, code: object) -> tuple[str, str] | None:
+        if code in self._location_cache:
+            return self._location_cache[code]
+        filename = getattr(code, "co_filename", None)
+        if not isinstance(filename, str) or not filename or filename.startswith("<"):
+            self._location_cache[code] = None
+            return None
+        candidate = Path(filename)
+        if not candidate.is_absolute():
+            candidate = self.initial_cwd / candidate
+        try:
+            relative = Path(os.path.normpath(candidate)).relative_to(self.repository_root)
+        except ValueError:
+            self._location_cache[code] = None
+            return None
+        path = relative.as_posix()
+        if not path.endswith(".py") or path.startswith("tmp/check-runner/"):
+            self._location_cache[code] = None
+            return None
+        qualname = getattr(code, "co_qualname", getattr(code, "co_name", "<module>"))
+        location = (path, str(qualname))
+        self._location_cache[code] = location
+        return location
+
+    def _remember_line(self, code: object, line: int) -> object:
+        if len(self.lines) >= MAX_EVENTS:
+            self.truncated = True
+            return sys.monitoring.DISABLE
+        location = self._location(code)
+        if location is None or line < 1:
+            return sys.monitoring.DISABLE
+        self.lines.add((*location, line))
+        return sys.monitoring.DISABLE
+
+    def _offset_line(self, code: object, offset: int) -> int | None:
+        mapping = self._line_cache.get(code)
+        if mapping is None:
+            mapping = {}
+            try:
+                for start, end, line in code.co_lines():
+                    if line is not None:
+                        for instruction in range(start, end, 2):
+                            mapping[instruction] = line
+            except (AttributeError, TypeError, ValueError) as error:
+                self.errors.append(f"line-map:{type(error).__name__}")
+            self._line_cache[code] = mapping
+        return mapping.get(offset)
+
+    def _remember_branch(
+        self,
+        direction: str,
+        code: object,
+        source: int,
+        target: int,
+    ) -> object:
+        if len(self.branches) >= MAX_EVENTS:
+            self.truncated = True
+            return sys.monitoring.DISABLE
+        location = self._location(code)
+        if location is None:
+            return sys.monitoring.DISABLE
+        source_line = self._offset_line(code, source)
+        target_line = self._offset_line(code, target)
+        if source_line is None or target_line is None:
+            return sys.monitoring.DISABLE
+        self.branches.add((*location, source_line, target_line, direction))
+        return sys.monitoring.DISABLE
+
+    def _left(self, code: object, source: int, target: int) -> object:
+        return self._remember_branch("left", code, source, target)
+
+    def _right(self, code: object, source: int, target: int) -> object:
+        return self._remember_branch("right", code, source, target)
+
+    def start(self) -> bool:
+        monitoring = sys.monitoring
+        if monitoring.get_tool(self.tool_id) is not None:
+            self.errors.append("coverage-tool-id-in-use")
+            return False
+        monitoring.use_tool_id(self.tool_id, "wildcat-dead-code-coverage")
+        self.owns_tool = True
+        try:
+            monitoring.register_callback(self.tool_id, monitoring.events.LINE, self._remember_line)
+            monitoring.register_callback(self.tool_id, monitoring.events.BRANCH_LEFT, self._left)
+            monitoring.register_callback(self.tool_id, monitoring.events.BRANCH_RIGHT, self._right)
+            monitoring.set_events(
+                self.tool_id,
+                monitoring.events.LINE
+                | monitoring.events.BRANCH_LEFT
+                | monitoring.events.BRANCH_RIGHT,
+            )
+        except BaseException:
+            self._restore()
+            raise
+        self.started = True
+        return True
+
+    def _restore(self) -> None:
+        monitoring = sys.monitoring
+        try:
+            if not self.owns_tool or monitoring.get_tool(self.tool_id) is None:
+                return
+            monitoring.set_events(self.tool_id, 0)
+            for event in (
+                monitoring.events.LINE,
+                monitoring.events.BRANCH_LEFT,
+                monitoring.events.BRANCH_RIGHT,
+            ):
+                monitoring.register_callback(self.tool_id, event, None)
+            monitoring.free_tool_id(self.tool_id)
+            self.owns_tool = False
+        except (RuntimeError, ValueError) as error:
+            self.errors.append(f"restore:{type(error).__name__}")
+
+    def _document(self) -> dict[str, object]:
+        containment = os.environ.get(CONTAINMENT_ENV, "")
+        return {
+            "schema": SCHEMA,
+            "run": self.run_id,
+            "process": {
+                "pid": os.getpid(),
+                "parent_pid": os.getppid(),
+                "containment": containment,
+                "argv": _safe_argv(),
+                "cwd": Path.cwd().as_posix(),
+            },
+            "status": {
+                "state": "degraded" if self.truncated or self.errors or not self.started else "ran",
+                "truncated": self.truncated,
+                "errors": sorted(set(self.errors)),
+            },
+            "lines": [
+                {"path": path, "function": function, "line": line}
+                for path, function, line in sorted(self.lines)
+            ],
+            "branches": [
+                {
+                    "path": path,
+                    "function": function,
+                    "from_line": source,
+                    "to_line": target,
+                    "direction": direction,
+                }
+                for path, function, source, target, direction in sorted(self.branches)
+            ],
+        }
+
+    def _write(self) -> None:
+        document = self._document()
+        payload = (json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n").encode()
+        if len(payload) > MAX_RECORD_BYTES:
+            document["lines"] = []
+            document["branches"] = []
+            document["status"] = {
+                "state": "degraded",
+                "truncated": True,
+                "errors": sorted(set([*self.errors, "record-byte-limit"])),
+            }
+            payload = (json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n").encode()
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        directory_fd = os.open(
+            self.output_directory,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+        try:
+            name = f"process-{os.getpid()}-{uuid.uuid4().hex}.json"
+            fd = os.open(name, flags, 0o600, dir_fd=directory_fd)
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        self._restore()
+        try:
+            self._write()
+        except OSError:
+            pass
+
+
+def _activate() -> MonitoringProbe | None:
+    run_id = os.environ.get(ACTIVE_ENV, "")
+    output = os.environ.get(OUTPUT_ENV, "")
+    if not run_id or not output or not os.environ.get(CONTAINMENT_ENV):
+        return None
+    if not hasattr(sys, "monitoring"):
+        return None
+    if len(run_id) != 32 or any(character not in "0123456789abcdef" for character in run_id):
+        return None
+    inherited_root = os.environ.get(SOURCE_ROOT_ENV)
+    root = Path(inherited_root) if inherited_root else _repository_root(Path.cwd().resolve())
+    if root is None:
+        return None
+    try:
+        root = root.resolve(strict=True)
+    except OSError:
+        return None
+    os.environ[SOURCE_ROOT_ENV] = str(root)
+    probe = MonitoringProbe(Path(output), root, run_id)
+    try:
+        probe.start()
+    except (RuntimeError, ValueError):
+        probe.errors.append("monitoring-start-failed")
+    atexit.register(probe.close)
+    return probe
+
+
+PROBE = _activate() if __name__ == "sitecustomize" else None

--- a/scripts/dead_code_monitoring/sitecustomize.py
+++ b/scripts/dead_code_monitoring/sitecustomize.py
@@ -23,6 +23,7 @@ SCHEMA = "dead-code-process-coverage/v1"
 MAX_EVENTS = 50_000
 MAX_RECORD_BYTES = 16 * 1024 * 1024
 MAX_ARG_BYTES = 16 * 1024
+TOOL_NAME = "wildcat-dead-code-coverage"
 
 
 def _repository_root(start: Path) -> Path | None:
@@ -148,7 +149,7 @@ class MonitoringProbe:
         if monitoring.get_tool(self.tool_id) is not None:
             self.errors.append("coverage-tool-id-in-use")
             return False
-        monitoring.use_tool_id(self.tool_id, "wildcat-dead-code-coverage")
+        monitoring.use_tool_id(self.tool_id, TOOL_NAME)
         self.owns_tool = True
         try:
             monitoring.register_callback(self.tool_id, monitoring.events.LINE, self._remember_line)
@@ -168,9 +169,15 @@ class MonitoringProbe:
 
     def _restore(self) -> None:
         monitoring = sys.monitoring
+        if not self.owns_tool:
+            return
+        owner = monitoring.get_tool(self.tool_id)
+        if owner != TOOL_NAME:
+            reason = "ownership-lost" if owner is None else "ownership-changed"
+            self.errors.append(f"restore:{reason}")
+            self.owns_tool = False
+            return
         try:
-            if not self.owns_tool or monitoring.get_tool(self.tool_id) is None:
-                return
             monitoring.set_events(self.tool_id, 0)
             for event in (
                 monitoring.events.LINE,
@@ -179,9 +186,10 @@ class MonitoringProbe:
             ):
                 monitoring.register_callback(self.tool_id, event, None)
             monitoring.free_tool_id(self.tool_id)
-            self.owns_tool = False
         except (RuntimeError, ValueError) as error:
             self.errors.append(f"restore:{type(error).__name__}")
+        finally:
+            self.owns_tool = False
 
     def _document(self) -> dict[str, object]:
         containment = os.environ.get(CONTAINMENT_ENV, "")

--- a/tests/check-map-v1.json
+++ b/tests/check-map-v1.json
@@ -286,6 +286,7 @@
     {"path": "schemas/dead-code-report-v1.schema.json", "scope": "dead-code"},
     {"path": "scripts", "scope": "root"},
     {"path": "scripts/dead_code.py", "scope": "dead-code"},
+    {"path": "scripts/dead_code_monitoring", "scope": "dead-code"},
     {"path": "scripts/promise_machine.py", "scope": "promise-machine"},
     {"path": "tests", "scope": "root"},
     {"path": "tests/emit_dead_code_report.py", "scope": "dead-code"},

--- a/tests/check-map-v1.json
+++ b/tests/check-map-v1.json
@@ -10,6 +10,13 @@
       "kind": "suite",
       "script": "tests"
     },
+    "dead-code-suite": {
+      "title": "Report-only dead-code suite",
+      "argv": ["python3", "-m", "unittest", "tests.test_dead_code", "-v"],
+      "cwd": ".",
+      "kind": "suite",
+      "script": "tests/test_dead_code.py"
+    },
     "alexandria-suite": {
       "title": "Alexandria suite",
       "argv": ["python3", "-m", "unittest", "discover", "-s", "plugins/alexandria/tests", "-t", "plugins/alexandria"],
@@ -181,6 +188,10 @@
       "title": "Root contract, shared scripts and root suite",
       "checks": ["root-suite"]
     },
+    "dead-code": {
+      "title": "Report-only dead-code discovery",
+      "checks": ["dead-code-suite"]
+    },
     "repo-lints": {
       "title": "Repository-wide tree lints",
       "checks": ["lint-phylax", "lint-ephoros", "lint-hypomnema"]
@@ -222,7 +233,8 @@
     "tabularium": {"title": "Tabularium plugin", "checks": ["tabularium-suite"]}
   },
   "dependencies": {
-    "root": ["repo-lints"],
+    "root": ["repo-lints", "dead-code"],
+    "dead-code": ["repo-lints"],
     "docs": ["root", "repo-lints"],
     "schemas": ["root"],
     "promise-machine": ["root", "hexaemeron"],
@@ -234,7 +246,7 @@
     "brevitas": ["repo-lints", "root"],
     "hermes": ["repo-lints"],
     "hexaemeron": ["repo-lints", "root"],
-    "horos": ["repo-lints", "root"],
+    "horos": ["repo-lints", "root", "dead-code"],
     "janus": ["repo-lints"],
     "lazarus": ["repo-lints"],
     "lemma": ["repo-lints"],
@@ -249,6 +261,7 @@
     {"path": ".claude", "scope": "marketplace"},
     {"path": ".claude-plugin", "scope": "marketplace"},
     {"path": ".github", "scope": "ci"},
+    {"path": ".github/workflows/dead-code.yml", "scope": "dead-code"},
     {"path": ".gitattributes", "scope": "root"},
     {"path": ".gitignore", "scope": "root"},
     {"path": ".python-version", "scope": "root"},
@@ -266,11 +279,17 @@
     {"path": "assets", "scope": "root"},
     {"path": "audit", "scope": "root"},
     {"path": "docs", "scope": "docs"},
+    {"path": "docs/dead-code", "scope": "dead-code"},
+    {"path": "docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md", "scope": "dead-code"},
     {"path": "repo_contract.py", "scope": "root"},
     {"path": "schemas", "scope": "schemas"},
+    {"path": "schemas/dead-code-report-v1.schema.json", "scope": "dead-code"},
     {"path": "scripts", "scope": "root"},
+    {"path": "scripts/dead_code.py", "scope": "dead-code"},
     {"path": "scripts/promise_machine.py", "scope": "promise-machine"},
     {"path": "tests", "scope": "root"},
+    {"path": "tests/emit_dead_code_report.py", "scope": "dead-code"},
+    {"path": "tests/test_dead_code.py", "scope": "dead-code"},
     {"path": "tests/check-map-v1.json", "scope": "root"},
     {"path": "tests/promise_machine_coverage.json", "scope": "promise-machine"},
     {"path": "plugins/alexandria", "scope": "alexandria"},

--- a/tests/emit_dead_code_report.py
+++ b/tests/emit_dead_code_report.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Run the dead-code surface and emit one fresh Elenchus report.
+
+The confined report writer lives in `tests/emit_run_observation_report.py` and
+is imported rather than copied. That writer is the product of the issue #434
+audit rounds, including the C5 round 5 finding about absolute report targets; a
+second copy of three hundred hardened lines would drift away from it silently
+and would be exactly the duplication this command exists to surface.
+"""
+
+import sys
+from pathlib import Path
+import unittest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from tests.emit_run_observation_report import (  # noqa: E402
+    report_target,
+    result_payload,
+    write_report,
+)
+
+REQUIRED_SURFACE = (
+    Path("schemas/dead-code-report-v1.schema.json"),
+    Path("scripts/dead_code.py"),
+    Path("tests/test_dead_code.py"),
+)
+MODULES = ("tests.test_dead_code",)
+
+
+def missing_surface_suite(root):
+    """A suite that fails by name when the surface under test is not there."""
+    missing = [path.as_posix() for path in REQUIRED_SURFACE if not (root / path).is_file()]
+    if not missing:
+        return None
+
+    def required_surface_is_present():
+        raise AssertionError("required dead-code test surface absent: " + ", ".join(missing))
+
+    return unittest.TestSuite([unittest.FunctionTestCase(required_surface_is_present)])
+
+
+def main(argv=None):
+    target = report_target(sys.argv[1:] if argv is None else argv)
+    root = Path.cwd().resolve(strict=True)
+    suite = missing_surface_suite(root)
+    if suite is None:
+        suite = unittest.defaultTestLoader.loadTestsFromNames(MODULES)
+    result = unittest.TextTestRunner(verbosity=1).run(suite)
+    try:
+        write_report(target, result_payload(result))
+    except OSError:
+        print("emit_dead_code_report.py: report write failed", file=sys.stderr)
+        return 2
+    failed = len(result.failures) + len(result.errors)
+    print(f"{result.testsRun - failed}/{result.testsRun} tests passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/emit_dead_code_report.py
+++ b/tests/emit_dead_code_report.py
@@ -25,6 +25,7 @@ from tests.emit_run_observation_report import (  # noqa: E402
 REQUIRED_SURFACE = (
     Path("schemas/dead-code-report-v1.schema.json"),
     Path("scripts/dead_code.py"),
+    Path("scripts/dead_code_monitoring/sitecustomize.py"),
     Path("tests/test_dead_code.py"),
 )
 MODULES = ("tests.test_dead_code",)

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -724,6 +724,51 @@ class WriteBoundaryTests(TemporaryRepositoryTestCase):
             "payload" + NL,
         )
 
+    def test_repository_substitution_cannot_redirect_directory_traversal(self):
+        target = dead_code.confine(self.root, ".dead-code/report.json")
+        outside = self.root.parent / (self.root.name + "-outside-directory")
+        held = self.root.parent / (self.root.name + "-opened-repository")
+        outside.mkdir()
+
+        def restore_repository():
+            outside_report = outside / ".dead-code" / "report.json"
+            outside_report.unlink(missing_ok=True)
+            try:
+                outside_report.parent.rmdir()
+            except FileNotFoundError:
+                pass
+            if self.root.is_symlink():
+                self.root.unlink()
+            if held.exists():
+                held.rename(self.root)
+            outside.rmdir()
+
+        self.addCleanup(restore_repository)
+        real_output_parts = dead_code.output_parts
+
+        def substitute_repository(root, output):
+            parts = real_output_parts(root, output)
+            self.root.rename(held)
+            self.root.symlink_to(outside, target_is_directory=True)
+            return parts
+
+        refusal = None
+        try:
+            with mock.patch.object(
+                dead_code,
+                "output_parts",
+                side_effect=substitute_repository,
+            ):
+                dead_code.atomic_write(self.root, target, "payload" + NL)
+        except dead_code.Refusal as error:
+            refusal = str(error)
+        self.assertIsNone(refusal, refusal)
+        self.assertFalse((outside / ".dead-code" / "report.json").exists())
+        self.assertEqual(
+            (held / ".dead-code" / "report.json").read_text(encoding="utf-8"),
+            "payload" + NL,
+        )
+
     def test_atomic_write_does_not_sweep_an_unrelated_owned_temporary(self):
         directory = self.root / ".dead-code"
         directory.mkdir()

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -135,6 +135,51 @@ class UniverseDiscoveryTests(TemporaryRepositoryTestCase):
         self.assertEqual(len(universe.commit), 40)
         self.assertEqual(len(universe.tree), 40)
 
+    def test_transient_boundary_edit_cannot_change_the_commit_universe(self):
+        build_repository(
+            self.root,
+            files={
+                "a.py": "a = 1" + NL,
+                "generated.txt": "generated" + NL,
+            },
+            entries=[horos_entry("generated.txt")],
+        )
+        boundary = self.root / ".horos" / "boundary.json"
+        committed = boundary.read_text(encoding="utf-8")
+        replacement = json.dumps(
+            boundary_document([horos_entry("a.py")]),
+            sort_keys=True,
+        ) + NL
+        real_require_clean_tree = dead_code.require_clean_tree
+        real_load_boundary = dead_code.load_boundary
+
+        def edit_after_clean_check(root, *args, **kwargs):
+            real_require_clean_tree(root, *args, **kwargs)
+            boundary.write_text(replacement, encoding="utf-8")
+
+        def load_then_restore(*args, **kwargs):
+            try:
+                return real_load_boundary(*args, **kwargs)
+            finally:
+                boundary.write_text(committed, encoding="utf-8")
+
+        with (
+            mock.patch.object(
+                dead_code,
+                "require_clean_tree",
+                side_effect=edit_after_clean_check,
+            ),
+            mock.patch.object(
+                dead_code,
+                "load_boundary",
+                side_effect=load_then_restore,
+            ),
+        ):
+            universe = dead_code.discover(self.root)
+
+        self.assertIn("a.py", universe.analysed)
+        self.assertNotIn("generated.txt", universe.analysed)
+
     def test_universe_paths_are_sorted_and_identity_is_recomputed(self):
         build_repository(
             self.root,
@@ -342,6 +387,8 @@ class BoundaryRefusalTests(TemporaryRepositoryTestCase):
         target = self.root / ".horos" / "boundary.json"
         target.unlink()
         target.symlink_to(outside)
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "--quiet", "-m", "symlink boundary")
         with self.assertRaisesRegex(dead_code.Refusal, "not a regular file"):
             dead_code.load_boundary(self.root)
 
@@ -894,6 +941,53 @@ class CommandLineTests(TemporaryRepositoryTestCase):
             json.loads(report_path.read_text(encoding="utf-8"))["schema"],
             "dead-code-report/v1",
         )
+
+    def test_repository_substitution_before_discovery_keeps_the_opened_tree(self):
+        original_commit = git(self.root, "rev-parse", "HEAD").strip()
+        outside_temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(outside_temporary.cleanup)
+        outside = Path(outside_temporary.name).resolve()
+        build_repository(
+            outside,
+            files={"outside.py": "outside = True" + NL},
+        )
+        self.assertNotEqual(
+            original_commit,
+            git(outside, "rev-parse", "HEAD").strip(),
+        )
+        held = self.root.parent / (self.root.name + "-opened-repository")
+        real_build_report = dead_code.build_report
+
+        def substitute_repository(root, *args, **kwargs):
+            self.root.rename(held)
+            self.root.symlink_to(outside, target_is_directory=True)
+            return real_build_report(root, *args, **kwargs)
+
+        arguments = dead_code.argparse.Namespace(
+            directory=str(self.root),
+            json=True,
+            output=".dead-code/report.json",
+        )
+        try:
+            with mock.patch.object(
+                dead_code,
+                "build_report",
+                side_effect=substitute_repository,
+            ):
+                result = dead_code.command_report(arguments)
+            report = json.loads(
+                (held / ".dead-code" / "report.json").read_text(encoding="utf-8")
+            )
+        finally:
+            if self.root.is_symlink():
+                self.root.unlink()
+            if held.exists():
+                held.rename(self.root)
+
+        self.assertEqual(result, 0)
+        self.assertEqual(report["tree"]["commit"], original_commit)
+        self.assertIn("a.py", report["universe"]["analysed"])
+        self.assertNotIn("outside.py", report["universe"]["analysed"])
 
     def test_unsafe_output_path_exits_two(self):
         completed = self._run("report", "--output", "../escape.json")

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -1168,6 +1168,42 @@ class PythonAnalyserTests(TemporaryRepositoryTestCase):
         self.assertTrue(snapshot.degraded)
         self.assertTrue(any(item.state == "skipped" for item in snapshot.records))
 
+    def test_global_assignment_is_not_reported_as_an_unused_local(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "main.py": (
+                    "def configure():" + NL
+                    + "    global setting" + NL
+                    + "    setting = 1" + NL
+                )
+            }
+        )
+        self.assertFalse(any(item.symbol == "configure.setting@3" for item in findings))
+
+    def test_nested_assignment_is_not_attributed_to_the_enclosing_function(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "main.py": (
+                    "def outer():" + NL
+                    + "    def inner():" + NL
+                    + "        nested = 1" + NL
+                    + "    return inner" + NL
+                )
+            }
+        )
+        self.assertFalse(any(item.symbol == "outer.nested@3" for item in findings))
+
+    def test_comprehension_target_is_not_reported_as_a_function_local(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "main.py": (
+                    "def values(items):" + NL
+                    + "    return [1 for item in items]" + NL
+                )
+            }
+        )
+        self.assertFalse(any(item.symbol == "values.item@2" for item in findings))
+
 
 class CoverageAggregationTests(unittest.TestCase):
     def setUp(self):
@@ -1181,6 +1217,7 @@ class CoverageAggregationTests(unittest.TestCase):
             ],
         }
         self.run = {
+            **self.plan,
             "schema": "wildcat.check-run.v1",
             "outcome": "green",
             "checks": [
@@ -1250,6 +1287,30 @@ class CoverageAggregationTests(unittest.TestCase):
             self._aggregate([second, first]),
         )
 
+    def test_public_coverage_does_not_retain_process_argv(self):
+        root_process = self._process(pid=10)
+        first_child = self._process(
+            pid=11,
+            argv=["python3", "child.py", "--token=first-secret"],
+        )
+        second_child = self._process(
+            pid=11,
+            argv=["python3", "child.py", "--token=second-secret"],
+        )
+
+        first = self._aggregate([root_process, first_child])
+        second = self._aggregate([root_process, second_child])
+
+        self.assertTrue(all("argv" not in process for process in first["processes"]))
+        first_child_id = next(
+            process["id"] for process in first["processes"] if process["pid"] == 11
+        )
+        second_child_id = next(
+            process["id"] for process in second["processes"] if process["pid"] == 11
+        )
+        self.assertEqual(first_child_id, second_child_id)
+        self.assertNotIn("first-secret", json.dumps(first))
+
     def test_failed_check_degrades_coverage(self):
         run = {
             **self.run,
@@ -1283,6 +1344,23 @@ class CoverageAggregationTests(unittest.TestCase):
         run = {**self.run, "checks": []}
         with self.assertRaisesRegex(dead_code.Refusal, "do not match"):
             self._aggregate([self._process()], run)
+
+    def test_duplicate_terminal_check_refuses_instead_of_overwriting(self):
+        run = {**self.run, "checks": [*self.run["checks"], *self.run["checks"]]}
+        with self.assertRaisesRegex(dead_code.Refusal, "repeated"):
+            self._aggregate([self._process()], run)
+
+    def test_contradictory_complete_process_status_degrades(self):
+        process = self._process()
+        process["status"]["truncated"] = True
+        report = self._aggregate([process])
+        self.assertEqual(report["status"]["state"], "degraded")
+
+    def test_non_string_process_state_refuses_instead_of_crashing(self):
+        process = self._process()
+        process["status"]["state"] = []
+        with self.assertRaisesRegex(dead_code.Refusal, "process status"):
+            self._aggregate([process])
 
     def test_wrapper_recursion_is_detected_in_declared_argv(self):
         self.assertTrue(
@@ -1320,10 +1398,28 @@ class CoverageAggregationTests(unittest.TestCase):
             str(ROOT / dead_code.MONITOR_DIRECTORY),
         )
 
+    def test_run_map_digest_must_match_the_preflight_plan(self):
+        run = {**self.run, "map_digest": "c" * 64}
+        with self.assertRaisesRegex(dead_code.Refusal, "preflight plan"):
+            self._aggregate([self._process()], run)
+
 
 class MonitoringProbeTests(TemporaryRepositoryTestCase):
     def _free_tool_id(self):
         return next(identifier for identifier in range(6) if sys.monitoring.get_tool(identifier) is None)
+
+    @staticmethod
+    def _release_tool_id(identifier):
+        if sys.monitoring.get_tool(identifier) is None:
+            return
+        sys.monitoring.set_events(identifier, 0)
+        for event in (
+            sys.monitoring.events.LINE,
+            sys.monitoring.events.BRANCH_LEFT,
+            sys.monitoring.events.BRANCH_RIGHT,
+        ):
+            sys.monitoring.register_callback(identifier, event, None)
+        sys.monitoring.free_tool_id(identifier)
 
     def test_probe_restores_its_tool_id_and_event_mask(self):
         output = self.root / "records"
@@ -1347,6 +1443,23 @@ class MonitoringProbeTests(TemporaryRepositoryTestCase):
         self.assertFalse(probe.start())
         probe.close()
         self.assertEqual(sys.monitoring.get_tool(identifier), "fixture-owner")
+
+    def test_probe_does_not_clobber_a_reassigned_tool_id(self):
+        identifier = self._free_tool_id()
+        output = self.root / "records"
+        output.mkdir()
+        probe = dead_code_monitor.MonitoringProbe(output, ROOT, "a" * 32)
+        probe.tool_id = identifier
+        self.assertTrue(probe.start())
+        self._release_tool_id(identifier)
+        sys.monitoring.use_tool_id(identifier, "replacement-owner")
+        self.addCleanup(self._release_tool_id, identifier)
+
+        probe.close()
+
+        self.assertEqual(sys.monitoring.get_tool(identifier), "replacement-owner")
+        document = json.loads(next(output.iterdir()).read_text(encoding="utf-8"))
+        self.assertIn("restore:ownership-changed", document["status"]["errors"])
 
     def test_probe_writes_named_lines_and_branches(self):
         output = self.root / "records"
@@ -1387,6 +1500,71 @@ class MonitoringProbeTests(TemporaryRepositoryTestCase):
         self.assertIs(result, sys.monitoring.DISABLE)
 
 
+class CoverageContainmentTests(unittest.TestCase):
+    @staticmethod
+    def _stop(process):
+        if process.poll() is None:
+            process.kill()
+        process.wait(timeout=5)
+
+    def test_recovery_terminates_a_process_carrying_the_run_identity(self):
+        run_id = "d" * 32
+        environment = dict(os.environ)
+        environment[dead_code.COVERAGE_ACTIVE_ENV] = run_id
+        process = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            env=environment,
+            start_new_session=True,
+        )
+        self.addCleanup(self._stop, process)
+        dead_code._terminate_coverage_processes(run_id)
+        process.wait(timeout=5)
+        self.assertIsNotNone(process.returncode)
+
+
+class CoverageCommandTests(TemporaryRepositoryTestCase):
+    def test_green_report_cannot_disagree_with_the_runner_exit(self):
+        build_repository(self.root)
+        universe = dead_code.discover(self.root)
+        plan = {
+            "schema": "wildcat.check-plan.v1",
+            "map_digest": "a" * 64,
+            "requested_scopes": ["dead-code"],
+            "selected_checks": [
+                {"id": "alpha", "argv": [sys.executable, "a.py"], "cwd": "."}
+            ],
+        }
+        run = {
+            **plan,
+            "schema": "wildcat.check-run.v1",
+            "outcome": "green",
+            "checks": [
+                {"check": "alpha", "status": "passed", "duration_seconds": 0.1}
+            ],
+        }
+
+        def failed_runner(*_args, **_kwargs):
+            target = self.root / ".dead-code" / "checks.json"
+            target.write_text(json.dumps(run), encoding="utf-8")
+            return b"", b"runner failed", 1
+
+        arguments = dead_code.argparse.Namespace(
+            directory=str(self.root),
+            scope=["dead-code"],
+            output=".dead-code/coverage.json",
+        )
+        with (
+            mock.patch.object(dead_code, "repository_root", return_value=self.root),
+            mock.patch.object(dead_code, "discover", return_value=universe),
+            mock.patch.object(dead_code, "_runner_plan", return_value=plan),
+            mock.patch.object(dead_code, "run_process", side_effect=failed_runner),
+            mock.patch.object(dead_code, "_coverage_survivor_pids", return_value=[]),
+            mock.patch.dict(os.environ, {dead_code.COVERAGE_ACTIVE_ENV: ""}),
+        ):
+            with self.assertRaisesRegex(dead_code.Refusal, "exit 1.*green"):
+                dead_code.command_coverage(arguments)
+
+
 class CoverageAnalyserTests(TemporaryRepositoryTestCase):
     SOURCE = (
         "def plain(flag):" + NL
@@ -1396,8 +1574,11 @@ class CoverageAnalyserTests(TemporaryRepositoryTestCase):
         + "        return 2" + NL
     )
 
-    def _fixture(self, *, state="ran", branches=None, lines=None):
-        build_repository(self.root, files={"app.py": self.SOURCE})
+    def _fixture(self, *, state="ran", branches=None, lines=None, source=None):
+        build_repository(
+            self.root,
+            files={"app.py": self.SOURCE if source is None else source},
+        )
         universe = dead_code.discover(self.root)
         target = self.root / ".dead-code" / "coverage.json"
         target.parent.mkdir()
@@ -1427,6 +1608,8 @@ class CoverageAnalyserTests(TemporaryRepositoryTestCase):
             ],
             "processes": [
                 {
+                    "check": "alpha",
+                    "bytes": 100,
                     "status": {"state": "ran", "truncated": False, "errors": []},
                     "lines": [] if lines is None else lines,
                     "branches": [] if branches is None else branches,
@@ -1463,6 +1646,44 @@ class CoverageAnalyserTests(TemporaryRepositoryTestCase):
         self.assertNotIn("branch:2->3:body", symbols)
         self.assertIn("branch:2->5:else", symbols)
 
+    def test_observed_function_skips_its_optimised_away_docstring(self):
+        source = (
+            "def documented():" + NL
+            + "    \"\"\"metadata, not an executable body line\"\"\"" + NL
+            + "    return 1" + NL
+        )
+        universe, _target, _document = self._fixture(
+            source=source,
+            lines=[{"path": "app.py", "function": "documented", "line": 3}],
+        )
+
+        status, findings = dead_code.analyse_coverage(
+            self.root, universe, ".dead-code/coverage.json"
+        )
+
+        self.assertEqual(status.state, "ran")
+        self.assertFalse(any(item.symbol.startswith("documented@") for item in findings))
+
+    def test_coverage_tool_identity_is_required(self):
+        universe, target, document = self._fixture()
+        document["tool"]["id"] = "not-sys-monitoring"
+        target.write_text(json.dumps(document), encoding="utf-8")
+
+        with self.assertRaisesRegex(dead_code.Refusal, "sys.monitoring"):
+            dead_code.analyse_coverage(
+                self.root, universe, ".dead-code/coverage.json"
+            )
+
+    def test_coverage_plan_schema_is_required(self):
+        universe, target, document = self._fixture()
+        document["plan"]["schema"] = "unknown-plan"
+        target.write_text(json.dumps(document), encoding="utf-8")
+
+        with self.assertRaisesRegex(dead_code.Refusal, "check-plan"):
+            dead_code.analyse_coverage(
+                self.root, universe, ".dead-code/coverage.json"
+            )
+
     def test_stale_coverage_identity_degrades_without_findings(self):
         universe, target, document = self._fixture()
         document["tree"]["commit"] = "f" * 40
@@ -1477,6 +1698,55 @@ class CoverageAnalyserTests(TemporaryRepositoryTestCase):
         build_repository(self.root, files={"app.py": self.SOURCE})
         with self.assertRaisesRegex(dead_code.Refusal, "requires --coverage"):
             dead_code.analyse_coverage(self.root, dead_code.discover(self.root), None)
+
+    def test_claimed_complete_without_process_aggregate_degrades(self):
+        universe, target, document = self._fixture()
+        document["checks"][0]["processes"] = 1
+        document["processes"] = []
+        target.write_text(json.dumps(document), encoding="utf-8")
+        status, findings = dead_code.analyse_coverage(
+            self.root, universe, ".dead-code/coverage.json"
+        )
+        self.assertEqual(status.state, "degraded")
+        self.assertEqual(findings, ())
+
+    def test_malformed_line_event_refuses_instead_of_implying_absence(self):
+        universe, target, document = self._fixture(
+            lines=[{"path": "app.py", "function": "plain", "line": "two"}]
+        )
+        target.write_text(json.dumps(document), encoding="utf-8")
+        with self.assertRaisesRegex(dead_code.Refusal, "line event"):
+            dead_code.analyse_coverage(
+                self.root, universe, ".dead-code/coverage.json"
+            )
+
+    def test_boolean_line_identity_refuses_instead_of_aliasing_line_one(self):
+        universe, target, document = self._fixture(
+            lines=[{"path": "app.py", "function": "plain", "line": True}]
+        )
+        target.write_text(json.dumps(document), encoding="utf-8")
+        with self.assertRaisesRegex(dead_code.Refusal, "line event"):
+            dead_code.analyse_coverage(
+                self.root, universe, ".dead-code/coverage.json"
+            )
+
+    def test_non_string_branch_direction_refuses_instead_of_crashing(self):
+        universe, target, document = self._fixture(
+            branches=[
+                {
+                    "path": "app.py",
+                    "function": "plain",
+                    "from_line": 2,
+                    "to_line": 3,
+                    "direction": [],
+                }
+            ]
+        )
+        target.write_text(json.dumps(document), encoding="utf-8")
+        with self.assertRaisesRegex(dead_code.Refusal, "branch event"):
+            dead_code.analyse_coverage(
+                self.root, universe, ".dead-code/coverage.json"
+            )
 
 
 class ShippedSurfaceTests(unittest.TestCase):

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -637,15 +637,19 @@ class WriteBoundaryTests(TemporaryRepositoryTestCase):
             dead_code.confine(self.root, "out" + chr(0) + ".json")
 
     def test_descendant_output_is_confined_to_the_repository(self):
-        target = dead_code.confine(self.root, "reports/out.json")
-        self.assertEqual(target, self.root / "reports" / "out.json")
+        target = dead_code.confine(self.root, ".dead-code/report.json")
+        self.assertEqual(target, self.root / ".dead-code" / "report.json")
+
+    def test_output_outside_the_owned_dead_code_sink_is_refused(self):
+        with self.assertRaisesRegex(dead_code.Refusal, "owned .dead-code"):
+            dead_code.confine(self.root, "a.py")
 
     def test_symlinked_output_ancestor_is_refused(self):
         outside = self.root.parent / (self.root.name + "-outside")
         outside.mkdir()
         self.addCleanup(outside.rmdir)
-        (self.root / "reports").symlink_to(outside, target_is_directory=True)
-        target = dead_code.confine(self.root, "reports/out.json")
+        (self.root / ".dead-code").symlink_to(outside, target_is_directory=True)
+        target = dead_code.confine(self.root, ".dead-code/out.json")
         with self.assertRaisesRegex(dead_code.Refusal, "not a real directory"):
             dead_code.atomic_write(self.root, target, "{}" + NL)
 
@@ -653,14 +657,15 @@ class WriteBoundaryTests(TemporaryRepositoryTestCase):
         outside = self.root.parent / (self.root.name + "-outside.json")
         outside.write_text("old", encoding="utf-8")
         self.addCleanup(outside.unlink, missing_ok=True)
-        target = self.root / "out.json"
+        (self.root / ".dead-code").mkdir()
+        target = self.root / ".dead-code" / "out.json"
         target.symlink_to(outside)
         with self.assertRaisesRegex(dead_code.Refusal, "not a regular file"):
             dead_code.atomic_write(self.root, target, "new" + NL)
         self.assertEqual(outside.read_text(encoding="utf-8"), "old")
 
     def test_atomic_write_publishes_complete_bytes_and_no_temporary(self):
-        target = dead_code.confine(self.root, "reports/out.json")
+        target = dead_code.confine(self.root, ".dead-code/report.json")
         dead_code.atomic_write(self.root, target, "payload" + NL)
         self.assertEqual(target.read_text(encoding="utf-8"), "payload" + NL)
         leftovers = [
@@ -671,7 +676,7 @@ class WriteBoundaryTests(TemporaryRepositoryTestCase):
         self.assertEqual(leftovers, [])
 
     def test_failed_replace_leaves_the_previous_report_intact(self):
-        target = dead_code.confine(self.root, "reports/out.json")
+        target = dead_code.confine(self.root, ".dead-code/report.json")
         target.parent.mkdir()
         target.write_text("previous" + NL, encoding="utf-8")
         with mock.patch.object(
@@ -689,22 +694,46 @@ class WriteBoundaryTests(TemporaryRepositoryTestCase):
         ]
         self.assertEqual(leftovers, [])
 
-    def test_orphan_sweep_removes_only_regular_files_with_the_owned_prefix(self):
-        directory = self.root / "reports"
+    def test_ancestor_substitution_cannot_redirect_the_atomic_replace(self):
+        target = dead_code.confine(self.root, ".dead-code/report.json")
+        outside = self.root.parent / (self.root.name + "-outside-directory")
+        held = self.root / ".dead-code-opened"
+        outside.mkdir()
+        self.addCleanup(outside.rmdir)
+        real_replace = os.replace
+
+        def substitute_ancestor(source, destination, **kwargs):
+            target.parent.rename(held)
+            target.parent.symlink_to(outside, target_is_directory=True)
+            real_replace(source, destination, **kwargs)
+
+        refusal = None
+        try:
+            with mock.patch.object(
+                dead_code.os,
+                "replace",
+                side_effect=substitute_ancestor,
+            ):
+                dead_code.atomic_write(self.root, target, "payload" + NL)
+        except dead_code.Refusal as error:
+            refusal = str(error)
+        self.assertIsNone(refusal, refusal)
+        self.assertFalse((outside / "report.json").exists())
+        self.assertEqual(
+            (held / "report.json").read_text(encoding="utf-8"),
+            "payload" + NL,
+        )
+
+    def test_atomic_write_does_not_sweep_an_unrelated_owned_temporary(self):
+        directory = self.root / ".dead-code"
         directory.mkdir()
         orphan = directory / (dead_code.TEMP_PREFIX + "old")
         bystander = directory / "keep.json"
-        symlink = directory / (dead_code.TEMP_PREFIX + "link")
-        outside = self.root / "outside.txt"
         orphan.write_text("half", encoding="utf-8")
         bystander.write_text("keep", encoding="utf-8")
-        outside.write_text("outside", encoding="utf-8")
-        symlink.symlink_to(outside)
-        dead_code.sweep_orphans(directory)
-        self.assertFalse(orphan.exists())
+        dead_code.atomic_write(self.root, directory / "report.json", "payload" + NL)
+        self.assertTrue(orphan.exists())
         self.assertTrue(bystander.exists())
-        self.assertTrue(symlink.is_symlink())
-        self.assertEqual(outside.read_text(encoding="utf-8"), "outside")
 
 
 class CommandLineTests(TemporaryRepositoryTestCase):
@@ -761,11 +790,11 @@ class CommandLineTests(TemporaryRepositoryTestCase):
             "report",
             "--json",
             "--output",
-            "reports/out.json",
+            ".dead-code/report.json",
         )
         self.assertEqual(completed.returncode, 0, completed.stderr)
         document = json.loads(
-            (self.root / "reports" / "out.json").read_text(encoding="utf-8")
+            (self.root / ".dead-code" / "report.json").read_text(encoding="utf-8")
         )
         schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
         self.assertEqual(set(document), set(schema["required"]))
@@ -779,6 +808,15 @@ class CommandLineTests(TemporaryRepositoryTestCase):
         completed = self._run("report", "--output", "../escape.json")
         self.assertEqual(completed.returncode, 2)
         self.assertIn("escapes", completed.stderr)
+
+    def test_output_flag_cannot_overwrite_a_tracked_source_file(self):
+        target = self.root / "a.py"
+        before = target.read_bytes()
+        completed = self._run("report", "--output", "a.py")
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("owned .dead-code", completed.stderr)
+        self.assertEqual(target.read_bytes(), before)
+        self.assertEqual(git(self.root, "status", "--porcelain"), "")
 
 
 class ShippedSurfaceTests(unittest.TestCase):

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -849,6 +849,52 @@ class CommandLineTests(TemporaryRepositoryTestCase):
             + document["universe"]["excluded_count"],
         )
 
+    def test_repository_substitution_after_render_cannot_redirect_output(self):
+        outside = self.root.parent / (self.root.name + "-outside-directory")
+        held = self.root.parent / (self.root.name + "-opened-repository")
+        outside.mkdir()
+
+        def restore_repository():
+            outside_report = outside / ".dead-code" / "report.json"
+            outside_report.unlink(missing_ok=True)
+            try:
+                outside_report.parent.rmdir()
+            except FileNotFoundError:
+                pass
+            if self.root.is_symlink():
+                self.root.unlink()
+            if held.exists():
+                held.rename(self.root)
+            outside.rmdir()
+
+        self.addCleanup(restore_repository)
+        real_render_json = dead_code.render_json
+
+        def substitute_repository(report):
+            rendered = real_render_json(report)
+            self.root.rename(held)
+            self.root.symlink_to(outside, target_is_directory=True)
+            return rendered
+
+        arguments = dead_code.argparse.Namespace(
+            directory=str(self.root),
+            json=True,
+            output=".dead-code/report.json",
+        )
+        with mock.patch.object(
+            dead_code,
+            "render_json",
+            side_effect=substitute_repository,
+        ):
+            result = dead_code.command_report(arguments)
+        self.assertEqual(result, 0)
+        self.assertFalse((outside / ".dead-code" / "report.json").exists())
+        report_path = held / ".dead-code" / "report.json"
+        self.assertEqual(
+            json.loads(report_path.read_text(encoding="utf-8"))["schema"],
+            "dead-code-report/v1",
+        )
+
     def test_unsafe_output_path_exits_two(self):
         completed = self._run("report", "--output", "../escape.json")
         self.assertEqual(completed.returncode, 2)

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -15,6 +15,7 @@ from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "dead_code.py"
+MONITOR_SCRIPT = ROOT / "scripts" / "dead_code_monitoring" / "sitecustomize.py"
 SCHEMA_PATH = ROOT / "schemas" / "dead-code-report-v1.schema.json"
 WORKFLOW_PATH = ROOT / ".github" / "workflows" / "dead-code.yml"
 CHECK_MAP_PATH = ROOT / "tests" / "check-map-v1.json"
@@ -34,6 +35,11 @@ SPEC = importlib.util.spec_from_file_location("dead_code", SCRIPT)
 dead_code = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = dead_code
 SPEC.loader.exec_module(dead_code)
+
+MONITOR_SPEC = importlib.util.spec_from_file_location("dead_code_monitor", MONITOR_SCRIPT)
+dead_code_monitor = importlib.util.module_from_spec(MONITOR_SPEC)
+sys.modules[MONITOR_SPEC.name] = dead_code_monitor
+MONITOR_SPEC.loader.exec_module(dead_code_monitor)
 
 
 def git(directory, *arguments):
@@ -1004,6 +1010,475 @@ class CommandLineTests(TemporaryRepositoryTestCase):
         self.assertEqual(git(self.root, "status", "--porcelain"), "")
 
 
+class PythonAnalyserTests(TemporaryRepositoryTestCase):
+    def _analyse(self, files):
+        build_repository(self.root, files=files)
+        universe = dead_code.discover(self.root)
+        return universe, dead_code.analyse_python(self.root, universe)
+
+    def test_every_python_file_has_a_parse_record(self):
+        _universe, (status, _findings) = self._analyse(
+            {"main.py": "x = 1" + NL, "pkg/mod.py": "y = 2" + NL}
+        )
+        self.assertEqual(status.state, "ran")
+        self.assertEqual([item.record_id for item in status.records], ["main.py", "pkg/mod.py"])
+        self.assertTrue(all(item.state == "parsed" for item in status.records))
+
+    def test_syntax_error_degrades_and_names_the_file(self):
+        _universe, (status, findings) = self._analyse(
+            {"main.py": "if True print('no')" + NL, "ok.py": "x = 1" + NL}
+        )
+        self.assertEqual(status.state, "degraded")
+        record = next(item for item in status.records if item.record_id == "main.py")
+        self.assertEqual(record.state, "parse-error")
+        self.assertIn("SyntaxError", record.detail)
+        self.assertFalse(any(item.path == "main.py" for item in findings))
+
+    def test_unused_import_is_reported(self):
+        _universe, (_status, findings) = self._analyse(
+            {"main.py": "import os" + NL + "value = 1" + NL}
+        )
+        self.assertTrue(any(item.symbol == "os@1" for item in findings))
+
+    def test_loaded_import_is_retained(self):
+        _universe, (_status, findings) = self._analyse(
+            {"main.py": "import os" + NL + "value = os.name" + NL}
+        )
+        self.assertFalse(any(item.symbol == "os@1" for item in findings))
+
+    def test_unused_local_is_reported(self):
+        _universe, (_status, findings) = self._analyse(
+            {"main.py": "def f():" + NL + "    spare = 1" + NL + "    return 2" + NL}
+        )
+        self.assertTrue(any(item.symbol == "f.spare@2" for item in findings))
+
+    def test_loaded_local_is_retained(self):
+        _universe, (_status, findings) = self._analyse(
+            {"main.py": "def f():" + NL + "    kept = 1" + NL + "    return kept" + NL}
+        )
+        self.assertFalse(any(item.symbol == "f.kept@2" for item in findings))
+
+    def test_statement_after_return_is_reported(self):
+        _universe, (_status, findings) = self._analyse(
+            {"main.py": "def f():" + NL + "    return 1" + NL + "    spare()" + NL}
+        )
+        self.assertTrue(any(item.symbol == "line:3:unreachable" for item in findings))
+
+    def test_statement_before_return_is_not_unreachable(self):
+        _universe, (_status, findings) = self._analyse(
+            {"main.py": "def f():" + NL + "    kept()" + NL + "    return 1" + NL}
+        )
+        self.assertFalse(any(item.symbol == "line:2:unreachable" for item in findings))
+
+    def test_literal_constant_branch_is_reported(self):
+        _universe, (_status, findings) = self._analyse(
+            {"main.py": "if False:" + NL + "    spare()" + NL}
+        )
+        self.assertTrue(any(item.symbol == "line:1:constant-false" for item in findings))
+
+    def test_computed_import_lowers_candidate_confidence(self):
+        _universe, (status, findings) = self._analyse(
+            {
+                "main.py": (
+                    "import os" + NL
+                    + "import importlib" + NL
+                    + "name = 'pkg.mod'" + NL
+                    + "importlib.import_module(name)" + NL
+                )
+            }
+        )
+        record = status.records[0]
+        self.assertIn("computed-import", record.detail)
+        candidate = next(item for item in findings if item.symbol == "os@1")
+        self.assertEqual(candidate.confidence, "low")
+
+    def test_literal_import_edge_reaches_the_module(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "main.py": "import live" + NL + "if __name__ == '__main__':" + NL + "    print(live.value)" + NL,
+                "live.py": "value = 1" + NL,
+            }
+        )
+        self.assertFalse(any(item.path == "live.py" and item.symbol == "<module>" for item in findings))
+
+    def test_unreachable_import_graph_module_is_low_confidence(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "main.py": "if __name__ == '__main__':" + NL + "    print('entry')" + NL,
+                "orphan.py": "value = 1" + NL,
+            }
+        )
+        candidate = next(item for item in findings if item.path == "orphan.py" and item.symbol == "<module>")
+        self.assertEqual(candidate.confidence, "low")
+
+    def test_decorator_registration_retains_the_definition(self):
+        source = "@registry" + NL + "def retained():" + NL + "    return 1" + NL
+        build_repository(self.root, files={"main.py": source})
+        snapshot = dead_code.parse_python_snapshot(self.root, dead_code.discover(self.root))
+        item = snapshot.files[0]
+        self.assertIn("retained", item.retained_names)
+        self.assertNotIn(("retained", 3), list(dead_code._function_targets(item)))
+
+    def test_dynamic_registration_argument_retains_the_definition(self):
+        source = "def retained():" + NL + "    return 1" + NL + "register(retained)" + NL
+        build_repository(self.root, files={"main.py": source})
+        item = dead_code.parse_python_snapshot(self.root, dead_code.discover(self.root)).files[0]
+        self.assertIn("retained", item.retained_names)
+
+    def test_literal_all_retains_exported_import(self):
+        _universe, (_status, findings) = self._analyse(
+            {"main.py": "from pkg import retained" + NL + "__all__ = ['retained']" + NL}
+        )
+        self.assertFalse(any(item.symbol == "retained@1" for item in findings))
+
+    def test_computed_getattr_is_a_visible_dynamic_boundary(self):
+        _universe, (status, _findings) = self._analyse(
+            {"main.py": "name = 'x'" + NL + "value = getattr(target, name)" + NL}
+        )
+        self.assertIn("computed-getattr", status.records[0].detail)
+
+    def test_main_guard_seeds_the_cli_module(self):
+        build_repository(
+            self.root,
+            files={"cli.py": "if __name__ == '__main__':" + NL + "    main()" + NL},
+        )
+        snapshot = dead_code.parse_python_snapshot(self.root, dead_code.discover(self.root))
+        self.assertIn("cli.py", snapshot.entry_paths)
+        self.assertIn("main", snapshot.files[0].retained_names)
+
+    def test_test_fixture_definitions_are_retained(self):
+        build_repository(
+            self.root,
+            files={"tests/fixtures/sample.py": "def helper():" + NL + "    return 1" + NL},
+        )
+        item = dead_code.parse_python_snapshot(self.root, dead_code.discover(self.root)).files[0]
+        self.assertIn("helper", item.retained_names)
+
+    def test_analysis_never_imports_the_parsed_module(self):
+        marker = self.root.parent / (self.root.name + "-executed")
+        source = f"from pathlib import Path{NL}Path({str(marker)!r}).write_text('bad'){NL}"
+        self._analyse({"hostile.py": source})
+        self.assertFalse(marker.exists())
+
+    def test_aggregate_python_limit_is_visible_as_skipped(self):
+        build_repository(self.root, files={"a.py": "x = 1" + NL, "b.py": "y = 2" + NL})
+        universe = dead_code.discover(self.root)
+        with mock.patch.object(dead_code, "MAX_PYTHON_TOTAL_BYTES", 1):
+            snapshot = dead_code.parse_python_snapshot(self.root, universe)
+        self.assertTrue(snapshot.degraded)
+        self.assertTrue(any(item.state == "skipped" for item in snapshot.records))
+
+
+class CoverageAggregationTests(unittest.TestCase):
+    def setUp(self):
+        self.run_id = "a" * 32
+        self.plan = {
+            "schema": "wildcat.check-plan.v1",
+            "map_digest": "b" * 64,
+            "requested_scopes": ["dead-code"],
+            "selected_checks": [
+                {"id": "alpha", "argv": ["python3", "alpha.py"], "cwd": "."}
+            ],
+        }
+        self.run = {
+            "schema": "wildcat.check-run.v1",
+            "outcome": "green",
+            "checks": [
+                {"check": "alpha", "status": "passed", "duration_seconds": 0.1}
+            ],
+        }
+        self.universe = dead_code.Universe(
+            commit="1" * 40,
+            tree="2" * 40,
+            identity="sha256:" + "3" * 64,
+            tracked_count=1,
+            analysed=("alpha.py",),
+            excluded=(),
+        )
+
+    def _process(self, *, pid=10, marker="group-a", state="ran", argv=None):
+        return {
+            "schema": "dead-code-process-coverage/v1",
+            "run": self.run_id,
+            "process": {
+                "pid": pid,
+                "parent_pid": 1,
+                "containment": marker,
+                "argv": ["python3", "alpha.py"] if argv is None else argv,
+                "cwd": "/snapshot",
+            },
+            "status": {"state": state, "truncated": False, "errors": []},
+            "lines": [{"path": "alpha.py", "function": "f", "line": 2}],
+            "branches": [
+                {
+                    "path": "alpha.py",
+                    "function": "f",
+                    "from_line": 2,
+                    "to_line": 3,
+                    "direction": "left",
+                }
+            ],
+        }
+
+    def _aggregate(self, documents, run=None):
+        return dead_code.aggregate_coverage(
+            self.plan,
+            self.run if run is None else run,
+            [(document, 100) for document in documents],
+            self.universe,
+        )
+
+    def test_line_identity_survives_aggregation(self):
+        report = self._aggregate([self._process()])
+        self.assertEqual(report["processes"][0]["lines"][0]["line"], 2)
+
+    def test_branch_identity_survives_aggregation(self):
+        report = self._aggregate([self._process()])
+        branch = report["processes"][0]["branches"][0]
+        self.assertEqual((branch["from_line"], branch["to_line"]), (2, 3))
+
+    def test_multiple_processes_are_attributed_to_one_check(self):
+        report = self._aggregate([self._process(), self._process(pid=11)])
+        self.assertEqual(report["checks"][0]["processes"], 2)
+        self.assertEqual(report["checks"][0]["bytes"], 200)
+
+    def test_aggregation_is_deterministic_across_input_order(self):
+        first = self._process(pid=10)
+        second = self._process(pid=11)
+        self.assertEqual(
+            self._aggregate([first, second]),
+            self._aggregate([second, first]),
+        )
+
+    def test_failed_check_degrades_coverage(self):
+        run = {
+            **self.run,
+            "outcome": "red",
+            "checks": [{"check": "alpha", "status": "failed", "duration_seconds": 0.1}],
+        }
+        report = self._aggregate([self._process()], run)
+        self.assertEqual(report["status"]["state"], "degraded")
+        self.assertIn("ended failed", report["status"]["detail"])
+
+    def test_not_started_check_degrades_coverage(self):
+        run = {
+            **self.run,
+            "outcome": "red",
+            "checks": [{"check": "alpha", "status": "not-started"}],
+        }
+        report = self._aggregate([], run)
+        self.assertEqual(report["status"]["state"], "degraded")
+        self.assertIn("no process record", report["status"]["detail"])
+
+    def test_degraded_process_degrades_coverage(self):
+        report = self._aggregate([self._process(state="degraded")])
+        self.assertEqual(report["status"]["state"], "degraded")
+
+    def test_unattributed_process_degrades_coverage(self):
+        report = self._aggregate([self._process(argv=["python3", "other.py"])])
+        self.assertEqual(report["status"]["state"], "degraded")
+        self.assertEqual(report["processes"], [])
+
+    def test_terminal_check_set_must_match_the_plan(self):
+        run = {**self.run, "checks": []}
+        with self.assertRaisesRegex(dead_code.Refusal, "do not match"):
+            self._aggregate([self._process()], run)
+
+    def test_wrapper_recursion_is_detected_in_declared_argv(self):
+        self.assertTrue(
+            dead_code._coverage_recurses(
+                ["python3", "scripts/dead_code.py", "coverage", "--scope", "dead-code"]
+            )
+        )
+
+    def test_non_python_declared_command_is_not_coverable(self):
+        self.assertFalse(dead_code._python_argv(["forge", "test"]))
+
+    def test_plan_scope_mismatch_refuses(self):
+        payload = json.dumps({**self.plan, "requested_scopes": ["other"]}).encode()
+        with mock.patch.object(dead_code, "run_process", return_value=(payload, b"", 0)):
+            with self.assertRaisesRegex(dead_code.Refusal, "not bound"):
+                dead_code._runner_plan(ROOT, ("dead-code",))
+
+    def test_coverage_environment_prepends_the_current_runtime(self):
+        with mock.patch.dict(
+            os.environ,
+            {"PATH": "/usr/bin", "PYTHONPATH": "/fixture"},
+            clear=True,
+        ):
+            environment = dead_code._coverage_environment(
+                ROOT,
+                ROOT / ".dead-code" / "processes",
+                self.run_id,
+            )
+        self.assertEqual(
+            environment["PATH"].split(os.pathsep)[0],
+            str(Path(sys.executable).parent),
+        )
+        self.assertEqual(
+            environment["PYTHONPATH"].split(os.pathsep)[0],
+            str(ROOT / dead_code.MONITOR_DIRECTORY),
+        )
+
+
+class MonitoringProbeTests(TemporaryRepositoryTestCase):
+    def _free_tool_id(self):
+        return next(identifier for identifier in range(6) if sys.monitoring.get_tool(identifier) is None)
+
+    def test_probe_restores_its_tool_id_and_event_mask(self):
+        output = self.root / "records"
+        output.mkdir()
+        probe = dead_code_monitor.MonitoringProbe(output, ROOT, "a" * 32)
+        probe.tool_id = self._free_tool_id()
+        self.assertTrue(probe.start())
+        self.assertNotEqual(sys.monitoring.get_events(probe.tool_id), 0)
+        probe.close()
+        self.assertIsNone(sys.monitoring.get_tool(probe.tool_id))
+        self.assertEqual(sys.monitoring.get_events(probe.tool_id), 0)
+
+    def test_probe_does_not_clobber_an_occupied_tool_id(self):
+        identifier = self._free_tool_id()
+        sys.monitoring.use_tool_id(identifier, "fixture-owner")
+        self.addCleanup(sys.monitoring.free_tool_id, identifier)
+        output = self.root / "records"
+        output.mkdir()
+        probe = dead_code_monitor.MonitoringProbe(output, ROOT, "a" * 32)
+        probe.tool_id = identifier
+        self.assertFalse(probe.start())
+        probe.close()
+        self.assertEqual(sys.monitoring.get_tool(identifier), "fixture-owner")
+
+    def test_probe_writes_named_lines_and_branches(self):
+        output = self.root / "records"
+        output.mkdir()
+        probe = dead_code_monitor.MonitoringProbe(output, ROOT, "a" * 32)
+        probe.tool_id = self._free_tool_id()
+        probe.start()
+
+        def exercised(value):
+            if value:
+                return "left"
+            return "right"
+
+        exercised(True)
+        probe.close()
+        documents = [json.loads(path.read_text(encoding="utf-8")) for path in output.iterdir()]
+        self.assertEqual(len(documents), 1)
+        self.assertTrue(any(item["function"].endswith("exercised") for item in documents[0]["lines"]))
+        self.assertTrue(documents[0]["branches"])
+
+    def test_event_cap_marks_the_process_record_truncated(self):
+        output = self.root / "records"
+        output.mkdir()
+        probe = dead_code_monitor.MonitoringProbe(output, ROOT, "a" * 32)
+        with mock.patch.object(dead_code_monitor, "MAX_EVENTS", 0):
+            probe._remember_line(self.test_event_cap_marks_the_process_record_truncated.__code__, 1)
+        self.assertTrue(probe.truncated)
+
+    def test_line_callback_never_resolves_the_filesystem(self):
+        output = self.root / "records"
+        output.mkdir()
+        probe = dead_code_monitor.MonitoringProbe(output, ROOT, "a" * 32)
+        with mock.patch.object(Path, "resolve", side_effect=AssertionError("hot-path resolve")):
+            result = probe._remember_line(
+                self.test_line_callback_never_resolves_the_filesystem.__code__,
+                1,
+            )
+        self.assertIs(result, sys.monitoring.DISABLE)
+
+
+class CoverageAnalyserTests(TemporaryRepositoryTestCase):
+    SOURCE = (
+        "def plain(flag):" + NL
+        + "    if flag:" + NL
+        + "        return 1" + NL
+        + "    else:" + NL
+        + "        return 2" + NL
+    )
+
+    def _fixture(self, *, state="ran", branches=None, lines=None):
+        build_repository(self.root, files={"app.py": self.SOURCE})
+        universe = dead_code.discover(self.root)
+        target = self.root / ".dead-code" / "coverage.json"
+        target.parent.mkdir()
+        document = {
+            "schema": dead_code.COVERAGE_SCHEMA_ID,
+            "tool": {"id": "sys.monitoring", "python": "3.14.6"},
+            "tree": {
+                "commit": universe.commit,
+                "git_tree": universe.tree,
+                "universe": universe.identity,
+            },
+            "plan": {
+                "schema": "wildcat.check-plan.v1",
+                "map_digest": "a" * 64,
+                "requested_scopes": ["dead-code"],
+                "selected_checks": ["alpha"],
+            },
+            "status": {"state": state, "detail": "fixture status"},
+            "checks": [
+                {
+                    "id": "alpha",
+                    "state": "passed" if state == "ran" else "failed",
+                    "duration_seconds": 0.1,
+                    "processes": 1,
+                    "bytes": 100,
+                }
+            ],
+            "processes": [
+                {
+                    "status": {"state": "ran", "truncated": False, "errors": []},
+                    "lines": [] if lines is None else lines,
+                    "branches": [] if branches is None else branches,
+                }
+            ],
+        }
+        target.write_text(json.dumps(document), encoding="utf-8")
+        return universe, target, document
+
+    def test_incomplete_coverage_emits_no_never_executed_findings(self):
+        universe, _target, _document = self._fixture(state="degraded")
+        status, findings = dead_code.analyse_coverage(
+            self.root, universe, ".dead-code/coverage.json"
+        )
+        self.assertEqual(status.state, "degraded")
+        self.assertEqual(findings, ())
+
+    def test_observed_branch_is_not_reported_and_other_branch_is(self):
+        branch = {
+            "path": "app.py",
+            "function": "plain",
+            "from_line": 2,
+            "to_line": 3,
+            "direction": "left",
+        }
+        universe, _target, _document = self._fixture(
+            branches=[branch], lines=[{"path": "app.py", "function": "plain", "line": 2}]
+        )
+        status, findings = dead_code.analyse_coverage(
+            self.root, universe, ".dead-code/coverage.json"
+        )
+        self.assertEqual(status.state, "ran")
+        symbols = {item.symbol for item in findings}
+        self.assertNotIn("branch:2->3:body", symbols)
+        self.assertIn("branch:2->5:else", symbols)
+
+    def test_stale_coverage_identity_degrades_without_findings(self):
+        universe, target, document = self._fixture()
+        document["tree"]["commit"] = "f" * 40
+        target.write_text(json.dumps(document), encoding="utf-8")
+        status, findings = dead_code.analyse_coverage(
+            self.root, universe, ".dead-code/coverage.json"
+        )
+        self.assertEqual(status.state, "degraded")
+        self.assertEqual(findings, ())
+
+    def test_missing_coverage_argument_refuses_by_name(self):
+        build_repository(self.root, files={"app.py": self.SOURCE})
+        with self.assertRaisesRegex(dead_code.Refusal, "requires --coverage"):
+            dead_code.analyse_coverage(self.root, dead_code.discover(self.root), None)
+
+
 class ShippedSurfaceTests(unittest.TestCase):
     def test_receipted_study_and_runbook_digests_are_preserved(self):
         self.assertEqual(
@@ -1039,6 +1514,7 @@ class ShippedSurfaceTests(unittest.TestCase):
             "universeIdentity",
             "analysisStatus",
             "analyserStatus",
+            "analyserRecord",
             "finding",
         ):
             self.assertFalse(schema["$defs"][name]["additionalProperties"])
@@ -1066,6 +1542,7 @@ class ShippedSurfaceTests(unittest.TestCase):
             "docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md",
             "schemas/dead-code-report-v1.schema.json",
             "scripts/dead_code.py",
+            "scripts/dead_code_monitoring",
             "tests/emit_dead_code_report.py",
             "tests/test_dead_code.py",
         )
@@ -1096,6 +1573,8 @@ class ShippedSurfaceTests(unittest.TestCase):
         self.assertIn(dead_code.TEMP_PREFIX, text)
         self.assertIn("/.dead-code/report.json", text)
         self.assertIn("/.dead-code/checks.json", text)
+        self.assertIn("/.dead-code/coverage.json", text)
+        self.assertIn("/.dead-code/coverage-processes-*/", text)
 
 
 if __name__ == "__main__":

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -1,0 +1,879 @@
+"""Focused tests for the report-only dead-code scaffold."""
+
+import gc
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+import warnings
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "dead_code.py"
+SCHEMA_PATH = ROOT / "schemas" / "dead-code-report-v1.schema.json"
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "dead-code.yml"
+CHECK_MAP_PATH = ROOT / "tests" / "check-map-v1.json"
+STUDY_PATH = ROOT / "docs" / "dead-code" / "study.md"
+RUNBOOK_PATH = ROOT / "docs" / "dead-code" / "runbook.md"
+ADR_PATH = (
+    ROOT
+    / "docs"
+    / "decisions"
+    / "ADR-051-keep-dead-code-discovery-report-only.md"
+)
+EXPECTED_STUDY_SHA256 = "da8ceed7ee91168e4ab60b1d3ba27c4e59df40be3a9dadd87d0dba17af8059e6"
+EXPECTED_RUNBOOK_SHA256 = "e5ea55c688615d9d1d0322e8c82bba335acfd6745cac99f49b471a564f860857"
+NL = chr(10)
+
+SPEC = importlib.util.spec_from_file_location("dead_code", SCRIPT)
+dead_code = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = dead_code
+SPEC.loader.exec_module(dead_code)
+
+
+def git(directory, *arguments):
+    return subprocess.run(
+        ["git", "-C", str(directory), *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def horos_entry(
+    path,
+    *,
+    category="generated",
+    evidence="classified by the fixture",
+    grade="hard",
+):
+    return {
+        "path": path,
+        "category": category,
+        "evidence": evidence,
+        "grade": grade,
+        "bytes": 1,
+    }
+
+
+def boundary_document(entries):
+    return {
+        "schema": 2,
+        "tool": "horos",
+        "universe": "tracked",
+        "counts": {},
+        "entries": entries,
+    }
+
+
+def build_repository(
+    directory,
+    *,
+    files=None,
+    entries=None,
+    boundary_text=None,
+    commit=True,
+):
+    files = {"a.py": "x = 1" + NL} if files is None else files
+    entries = [] if entries is None else entries
+    git(directory, "init", "--quiet", "--initial-branch=main")
+    git(directory, "config", "user.email", "test@example.invalid")
+    git(directory, "config", "user.name", "Test")
+    git(directory, "config", "commit.gpgsign", "false")
+    for relative, content in files.items():
+        target = directory / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    target = directory / ".horos" / "boundary.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if boundary_text is None:
+        boundary_text = json.dumps(boundary_document(entries), sort_keys=True) + NL
+    target.write_text(boundary_text, encoding="utf-8")
+    git(directory, "add", "-A")
+    if commit:
+        git(directory, "commit", "--quiet", "-m", "fixture")
+    return directory
+
+
+class TemporaryRepositoryTestCase(unittest.TestCase):
+    def setUp(self):
+        self._temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self._temporary.cleanup)
+        self.root = Path(self._temporary.name).resolve()
+
+
+class UniverseDiscoveryTests(TemporaryRepositoryTestCase):
+    def test_bounded_process_closes_both_capture_pipes(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", ResourceWarning)
+            dead_code.run_process(
+                ["git", "--version"],
+                cwd=self.root,
+                timeout_seconds=5,
+                output_limit=4096,
+            )
+            gc.collect()
+        leaked = [item for item in caught if item.category is ResourceWarning]
+        self.assertEqual(leaked, [])
+
+    def test_universe_binds_the_exact_commit_and_git_tree(self):
+        build_repository(
+            self.root,
+            files={"b.py": "b = 2" + NL, "a.py": "a = 1" + NL},
+        )
+        universe = dead_code.discover(self.root)
+        self.assertEqual(universe.commit, git(self.root, "rev-parse", "HEAD").strip())
+        self.assertEqual(
+            universe.tree,
+            git(self.root, "rev-parse", "HEAD^{tree}").strip(),
+        )
+        self.assertEqual(len(universe.commit), 40)
+        self.assertEqual(len(universe.tree), 40)
+
+    def test_universe_paths_are_sorted_and_identity_is_recomputed(self):
+        build_repository(
+            self.root,
+            files={"z.py": "z = 1" + NL, "a.py": "a = 1" + NL},
+        )
+        universe = dead_code.discover(self.root)
+        self.assertEqual(universe.analysed, tuple(sorted(universe.analysed)))
+        self.assertEqual(
+            universe.identity,
+            dead_code.universe_identity(
+                universe.tree,
+                universe.analysed,
+                universe.excluded,
+            ),
+        )
+
+    def test_untracked_files_do_not_enter_the_committed_universe(self):
+        build_repository(self.root)
+        (self.root / "scratch.txt").write_text("scratch", encoding="utf-8")
+        universe = dead_code.discover(self.root)
+        self.assertNotIn("scratch.txt", universe.analysed)
+
+    def test_modified_tracked_bytes_refuse_before_discovery(self):
+        build_repository(self.root)
+        (self.root / "a.py").write_text("x = 2" + NL, encoding="utf-8")
+        with self.assertRaisesRegex(dead_code.Refusal, "modified tracked"):
+            dead_code.discover(self.root)
+
+    def test_staged_tracked_bytes_refuse_before_discovery(self):
+        build_repository(self.root)
+        (self.root / "a.py").write_text("x = 2" + NL, encoding="utf-8")
+        git(self.root, "add", "a.py")
+        with self.assertRaisesRegex(dead_code.Refusal, "modified tracked"):
+            dead_code.discover(self.root)
+
+    def test_empty_analysed_walk_refuses_instead_of_reporting_clean(self):
+        build_repository(
+            self.root,
+            files={"generated.txt": "generated" + NL},
+            entries=[
+                horos_entry("generated.txt"),
+                horos_entry(".horos/boundary.json"),
+            ],
+        )
+        with self.assertRaisesRegex(dead_code.Refusal, "collapsed walk"):
+            dead_code.discover(self.root)
+
+    def test_discovery_outside_a_git_worktree_refuses(self):
+        with self.assertRaises(dead_code.Refusal):
+            dead_code.repository_root(self.root)
+
+
+class ClassificationJoinTests(TemporaryRepositoryTestCase):
+    def test_hard_file_classification_excludes_and_carries_evidence(self):
+        build_repository(
+            self.root,
+            files={
+                "a.py": "x = 1" + NL,
+                "CONTRIBUTORS.md": "generated" + NL,
+            },
+            entries=[
+                horos_entry(
+                    "CONTRIBUTORS.md",
+                    evidence="generation marker in the first 4096 bytes",
+                )
+            ],
+        )
+        universe = dead_code.discover(self.root)
+        excluded = {entry.path: entry for entry in universe.excluded}
+        self.assertNotIn("CONTRIBUTORS.md", universe.analysed)
+        self.assertIn("generation marker", excluded["CONTRIBUTORS.md"].evidence)
+        self.assertEqual(excluded["CONTRIBUTORS.md"].grade, "hard")
+
+    def test_candidate_grade_remains_in_the_fail_open_universe(self):
+        build_repository(
+            self.root,
+            files={"a.py": "x = 1" + NL, "maybe.txt": "maybe" + NL},
+            entries=[horos_entry("maybe.txt", grade="candidate")],
+        )
+        universe = dead_code.discover(self.root)
+        self.assertIn("maybe.txt", universe.analysed)
+
+    def test_boundary_entry_for_an_absent_path_excludes_nothing(self):
+        build_repository(self.root, entries=[horos_entry("gone.txt")])
+        self.assertEqual(dead_code.discover(self.root).excluded, ())
+
+    def test_hard_directory_classification_excludes_every_descendant(self):
+        build_repository(
+            self.root,
+            files={
+                "a.py": "x = 1" + NL,
+                "vendor/pkg/a.py": "a = 1" + NL,
+                "vendor/pkg/b.py": "b = 1" + NL,
+            },
+            entries=[
+                horos_entry(
+                    "vendor/",
+                    category="vendored",
+                    evidence="directory name vendor",
+                )
+            ],
+        )
+        universe = dead_code.discover(self.root)
+        self.assertIn("a.py", universe.analysed)
+        self.assertNotIn("vendor/pkg/a.py", universe.analysed)
+        self.assertNotIn("vendor/pkg/b.py", universe.analysed)
+        self.assertEqual(universe.excluded_by_category(), {"vendored": 2})
+
+    def test_inherited_exclusion_names_the_classified_tree(self):
+        build_repository(
+            self.root,
+            files={"a.py": "x = 1" + NL, "build/out.json": "{}" + NL},
+            entries=[
+                horos_entry(
+                    "build/",
+                    evidence="directory name build",
+                )
+            ],
+        )
+        excluded = {
+            entry.path: entry for entry in dead_code.discover(self.root).excluded
+        }
+        self.assertIn("directory name build", excluded["build/out.json"].evidence)
+        self.assertIn("classified tree build/", excluded["build/out.json"].evidence)
+
+    def test_directory_prefix_does_not_capture_a_sibling_with_the_same_stem(self):
+        build_repository(
+            self.root,
+            files={
+                "lib/vendored.py": "x = 1" + NL,
+                "libexec/kept.py": "y = 2" + NL,
+            },
+            entries=[
+                horos_entry(
+                    "lib/",
+                    category="vendored",
+                    evidence="directory name lib",
+                )
+            ],
+        )
+        universe = dead_code.discover(self.root)
+        self.assertNotIn("lib/vendored.py", universe.analysed)
+        self.assertIn("libexec/kept.py", universe.analysed)
+
+    def test_longest_classified_directory_supplies_descendant_evidence(self):
+        build_repository(
+            self.root,
+            files={
+                "a.py": "x = 1" + NL,
+                "tree/nested/item.txt": "item" + NL,
+            },
+            entries=[
+                horos_entry("tree/", evidence="outer tree"),
+                horos_entry("tree/nested/", evidence="inner tree"),
+            ],
+        )
+        excluded = {
+            entry.path: entry for entry in dead_code.discover(self.root).excluded
+        }
+        self.assertIn("inner tree", excluded["tree/nested/item.txt"].evidence)
+        self.assertNotIn("outer tree", excluded["tree/nested/item.txt"].evidence)
+
+    def test_exclusion_counts_are_sorted_by_category(self):
+        build_repository(
+            self.root,
+            files={
+                "a.py": "x" + NL,
+                "z.txt": "z" + NL,
+                "a.txt": "a" + NL,
+            },
+            entries=[
+                horos_entry("z.txt", category="vendored"),
+                horos_entry("a.txt", category="binary"),
+            ],
+        )
+        counts = dead_code.discover(self.root).excluded_by_category()
+        self.assertEqual(list(counts), ["binary", "vendored"])
+
+
+class BoundaryRefusalTests(TemporaryRepositoryTestCase):
+    def _replace_boundary(self, text):
+        build_repository(self.root)
+        target = self.root / ".horos" / "boundary.json"
+        target.write_text(text, encoding="utf-8")
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "--quiet", "-m", "boundary")
+
+    def test_absent_boundary_refuses_by_name(self):
+        build_repository(self.root)
+        target = self.root / ".horos" / "boundary.json"
+        target.unlink()
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "--quiet", "-m", "drop boundary")
+        with self.assertRaisesRegex(dead_code.Refusal, ".horos/boundary.json"):
+            dead_code.load_boundary(self.root)
+
+    def test_boundary_symlink_refuses_as_non_regular(self):
+        outside = self.root.parent / (self.root.name + "-outside.json")
+        self.addCleanup(outside.unlink, missing_ok=True)
+        outside.write_text(
+            json.dumps(boundary_document([])),
+            encoding="utf-8",
+        )
+        build_repository(self.root)
+        target = self.root / ".horos" / "boundary.json"
+        target.unlink()
+        target.symlink_to(outside)
+        with self.assertRaisesRegex(dead_code.Refusal, "not a regular file"):
+            dead_code.load_boundary(self.root)
+
+    def test_oversized_boundary_refuses_before_json_parse(self):
+        build_repository(self.root)
+        with mock.patch.object(dead_code, "MAX_BOUNDARY_BYTES", 8):
+            with self.assertRaisesRegex(dead_code.Refusal, "exceeds 8 bytes"):
+                dead_code.load_boundary(self.root)
+
+    def test_malformed_boundary_json_refuses(self):
+        self._replace_boundary("{not json")
+        with self.assertRaisesRegex(dead_code.Refusal, "not valid JSON"):
+            dead_code.load_boundary(self.root)
+
+    def test_duplicate_json_key_refuses_instead_of_overwriting(self):
+        self._replace_boundary(
+            '{"schema":2,"tool":"horos","tool":"other","entries":[]}'
+        )
+        with self.assertRaisesRegex(dead_code.Refusal, "repeats JSON key tool"):
+            dead_code.load_boundary(self.root)
+
+    def test_wrong_boundary_schema_refuses_as_stale(self):
+        self._replace_boundary(
+            json.dumps({"schema": 1, "tool": "horos", "entries": []})
+        )
+        with self.assertRaisesRegex(dead_code.Refusal, "schema 2"):
+            dead_code.load_boundary(self.root)
+
+    def test_wrong_boundary_tool_refuses(self):
+        self._replace_boundary(
+            json.dumps({"schema": 2, "tool": "other", "entries": []})
+        )
+        with self.assertRaisesRegex(dead_code.Refusal, "tool horos"):
+            dead_code.load_boundary(self.root)
+
+    def test_missing_entries_list_refuses(self):
+        self._replace_boundary(json.dumps({"schema": 2, "tool": "horos"}))
+        with self.assertRaisesRegex(dead_code.Refusal, "no entries list"):
+            dead_code.load_boundary(self.root)
+
+    def test_entry_missing_evidence_refuses(self):
+        broken = {
+            "path": "a.py",
+            "category": "generated",
+            "grade": "hard",
+        }
+        self._replace_boundary(
+            json.dumps(
+                {
+                    "schema": 2,
+                    "tool": "horos",
+                    "entries": [broken],
+                }
+            )
+        )
+        with self.assertRaisesRegex(dead_code.Refusal, "evidence"):
+            dead_code.load_boundary(self.root)
+
+    def test_duplicate_classified_path_refuses(self):
+        duplicate = horos_entry("a.py")
+        self._replace_boundary(
+            json.dumps(
+                {
+                    "schema": 2,
+                    "tool": "horos",
+                    "entries": [duplicate, duplicate],
+                }
+            )
+        )
+        with self.assertRaisesRegex(dead_code.Refusal, "repeats classified path"):
+            dead_code.load_boundary(self.root)
+
+    def test_unsafe_classified_path_refuses(self):
+        self._replace_boundary(
+            json.dumps(
+                {
+                    "schema": 2,
+                    "tool": "horos",
+                    "entries": [horos_entry("../outside")],
+                }
+            )
+        )
+        with self.assertRaisesRegex(dead_code.Refusal, "safe repository-relative"):
+            dead_code.load_boundary(self.root)
+
+
+class RenderingTests(TemporaryRepositoryTestCase):
+    def _report(self):
+        build_repository(
+            self.root,
+            files={
+                "b.py": "b = 2" + NL,
+                "a.py": "a = 1" + NL,
+                "generated.txt": "g" + NL,
+            },
+            entries=[horos_entry("generated.txt")],
+        )
+        return dead_code.build_report(self.root)
+
+    def test_json_has_the_schema_fixed_top_level_shape(self):
+        document = json.loads(dead_code.render_json(self._report()))
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(set(document), set(schema["required"]))
+        self.assertEqual(document["schema"], "dead-code-report/v1")
+        self.assertEqual(document["tool"], {"id": "dead-code", "version": "1"})
+
+    def test_schema_fixes_tool_universe_status_and_finding_identities(self):
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        definitions = schema["$defs"]
+        self.assertEqual(
+            definitions["toolIdentity"]["properties"]["id"]["const"],
+            "dead-code",
+        )
+        self.assertEqual(
+            definitions["analysisStatus"]["properties"]["id"]["const"],
+            "analysis",
+        )
+        self.assertEqual(
+            definitions["universeIdentity"]["properties"]["id"]["$ref"],
+            "#/$defs/sha256Identity",
+        )
+        self.assertEqual(
+            definitions["finding"]["properties"]["id"]["$ref"],
+            "#/$defs/sha256Identity",
+        )
+
+    def test_text_and_json_carry_the_same_tree_universe_status_and_counts(self):
+        report = self._report()
+        document = json.loads(dead_code.render_json(report))
+        text = dead_code.render_text(report)
+        for value in (
+            document["tree"]["commit"],
+            document["tree"]["git_tree"],
+            document["universe"]["id"],
+            document["status"]["state"],
+        ):
+            self.assertIn(value, text)
+        self.assertIn(
+            f"{document['universe']['analysed_count']} analysed",
+            text,
+        )
+        self.assertIn(
+            f"{document['universe']['excluded_count']} excluded",
+            text,
+        )
+
+    def test_report_explicitly_says_that_no_analyser_ran(self):
+        report = self._report()
+        document = json.loads(dead_code.render_json(report))
+        text = dead_code.render_text(report)
+        self.assertEqual(document["status"]["state"], "not-run")
+        self.assertEqual(document["analysers"], [])
+        self.assertIn("none ran", text)
+        self.assertIn("no reachability result", text)
+
+    def test_finding_identity_and_evidence_match_in_both_renderings(self):
+        base = self._report()
+        status = dead_code.AnalyserStatus(
+            analyser_id="python",
+            state="ran",
+            version="1",
+            detail="fixture analyser completed",
+        )
+        finding = dead_code.Finding(
+            analyser_id="python",
+            path=base.universe.analysed[0],
+            symbol="candidate",
+            evidence="no static reference in the fixture graph",
+            confidence="medium",
+            false_positive_boundary="a computed import could reach the symbol",
+        )
+        report = dead_code.Report(
+            universe=base.universe,
+            statuses=(status,),
+            findings=(finding,),
+        )
+        dead_code.validate_report(report)
+        document = json.loads(dead_code.render_json(report))
+        text = dead_code.render_text(report)
+        self.assertEqual(document["findings"][0]["id"], finding.identity)
+        for value in (
+            finding.identity,
+            finding.path,
+            finding.symbol,
+            finding.evidence,
+            finding.false_positive_boundary,
+        ):
+            self.assertIn(value, text)
+
+    def test_collect_sorts_statuses_and_findings_from_one_model(self):
+        build_repository(
+            self.root,
+            files={"b.py": "b = 1" + NL, "a.py": "a = 1" + NL},
+        )
+        universe = dead_code.discover(self.root)
+
+        def analyser(name, path):
+            def run(root, supplied_universe):
+                self.assertEqual(supplied_universe, universe)
+                return (
+                    dead_code.AnalyserStatus(name, "ran", "1", "done"),
+                    (
+                        dead_code.Finding(
+                            name,
+                            path,
+                            None,
+                            "fixture evidence",
+                            "low",
+                            "fixture boundary",
+                        ),
+                    ),
+                )
+            return run
+
+        with mock.patch.dict(
+            dead_code.ANALYSERS,
+            {
+                "zeta": analyser("zeta", "b.py"),
+                "alpha": analyser("alpha", "a.py"),
+            },
+            clear=True,
+        ):
+            statuses, findings = dead_code.collect(self.root, universe)
+        self.assertEqual(
+            [item.analyser_id for item in statuses],
+            ["alpha", "zeta"],
+        )
+        self.assertEqual(
+            [(item.analyser_id, item.path) for item in findings],
+            [("alpha", "a.py"), ("zeta", "b.py")],
+        )
+
+    def test_unreported_analyser_cannot_supply_a_finding(self):
+        base = self._report()
+        finding = dead_code.Finding(
+            "missing",
+            base.universe.analysed[0],
+            None,
+            "evidence",
+            "low",
+            "boundary",
+        )
+        report = dead_code.Report(base.universe, (), (finding,))
+        with self.assertRaisesRegex(dead_code.Refusal, "unreported analyser"):
+            dead_code.validate_report(report)
+
+    def test_candidate_count_does_not_change_the_report_exit_contract(self):
+        base = self._report()
+        status = dead_code.AnalyserStatus("python", "ran", "1", "done")
+        finding = dead_code.Finding(
+            "python",
+            base.universe.analysed[0],
+            None,
+            "evidence",
+            "low",
+            "boundary",
+        )
+        report = dead_code.Report(base.universe, (status,), (finding,))
+        dead_code.validate_report(report)
+        self.assertIn("1 candidate(s); report-only", dead_code.render_text(report))
+
+    def test_rendering_never_strengthens_candidates_into_deletion_authority(self):
+        report = self._report()
+        rendered = (dead_code.render_text(report) + dead_code.render_json(report)).lower()
+        for forbidden in (
+            "is dead",
+            "safe to delete",
+            "can be removed",
+            "proves unused",
+        ):
+            self.assertNotIn(forbidden, rendered)
+
+
+class WriteBoundaryTests(TemporaryRepositoryTestCase):
+    def setUp(self):
+        super().setUp()
+        build_repository(self.root)
+
+    def test_parent_escape_is_refused(self):
+        with self.assertRaisesRegex(dead_code.Refusal, "escapes"):
+            dead_code.confine(self.root, "../escape.json")
+
+    def test_absolute_output_is_refused(self):
+        with self.assertRaisesRegex(dead_code.Refusal, "repository-relative"):
+            dead_code.confine(self.root, str(self.root / "out.json"))
+
+    def test_repository_root_is_not_an_output_file(self):
+        with self.assertRaises(dead_code.Refusal):
+            dead_code.confine(self.root, ".")
+
+    def test_null_byte_output_is_refused(self):
+        with self.assertRaisesRegex(dead_code.Refusal, "null byte"):
+            dead_code.confine(self.root, "out" + chr(0) + ".json")
+
+    def test_descendant_output_is_confined_to_the_repository(self):
+        target = dead_code.confine(self.root, "reports/out.json")
+        self.assertEqual(target, self.root / "reports" / "out.json")
+
+    def test_symlinked_output_ancestor_is_refused(self):
+        outside = self.root.parent / (self.root.name + "-outside")
+        outside.mkdir()
+        self.addCleanup(outside.rmdir)
+        (self.root / "reports").symlink_to(outside, target_is_directory=True)
+        target = dead_code.confine(self.root, "reports/out.json")
+        with self.assertRaisesRegex(dead_code.Refusal, "not a real directory"):
+            dead_code.atomic_write(self.root, target, "{}" + NL)
+
+    def test_symlinked_output_target_is_refused(self):
+        outside = self.root.parent / (self.root.name + "-outside.json")
+        outside.write_text("old", encoding="utf-8")
+        self.addCleanup(outside.unlink, missing_ok=True)
+        target = self.root / "out.json"
+        target.symlink_to(outside)
+        with self.assertRaisesRegex(dead_code.Refusal, "not a regular file"):
+            dead_code.atomic_write(self.root, target, "new" + NL)
+        self.assertEqual(outside.read_text(encoding="utf-8"), "old")
+
+    def test_atomic_write_publishes_complete_bytes_and_no_temporary(self):
+        target = dead_code.confine(self.root, "reports/out.json")
+        dead_code.atomic_write(self.root, target, "payload" + NL)
+        self.assertEqual(target.read_text(encoding="utf-8"), "payload" + NL)
+        leftovers = [
+            item
+            for item in target.parent.iterdir()
+            if item.name.startswith(dead_code.TEMP_PREFIX)
+        ]
+        self.assertEqual(leftovers, [])
+
+    def test_failed_replace_leaves_the_previous_report_intact(self):
+        target = dead_code.confine(self.root, "reports/out.json")
+        target.parent.mkdir()
+        target.write_text("previous" + NL, encoding="utf-8")
+        with mock.patch.object(
+            dead_code.os,
+            "replace",
+            side_effect=OSError("fixture interruption"),
+        ):
+            with self.assertRaisesRegex(dead_code.Refusal, "report write failed"):
+                dead_code.atomic_write(self.root, target, "replacement" + NL)
+        self.assertEqual(target.read_text(encoding="utf-8"), "previous" + NL)
+        leftovers = [
+            item
+            for item in target.parent.iterdir()
+            if item.name.startswith(dead_code.TEMP_PREFIX)
+        ]
+        self.assertEqual(leftovers, [])
+
+    def test_orphan_sweep_removes_only_regular_files_with_the_owned_prefix(self):
+        directory = self.root / "reports"
+        directory.mkdir()
+        orphan = directory / (dead_code.TEMP_PREFIX + "old")
+        bystander = directory / "keep.json"
+        symlink = directory / (dead_code.TEMP_PREFIX + "link")
+        outside = self.root / "outside.txt"
+        orphan.write_text("half", encoding="utf-8")
+        bystander.write_text("keep", encoding="utf-8")
+        outside.write_text("outside", encoding="utf-8")
+        symlink.symlink_to(outside)
+        dead_code.sweep_orphans(directory)
+        self.assertFalse(orphan.exists())
+        self.assertTrue(bystander.exists())
+        self.assertTrue(symlink.is_symlink())
+        self.assertEqual(outside.read_text(encoding="utf-8"), "outside")
+
+
+class CommandLineTests(TemporaryRepositoryTestCase):
+    def setUp(self):
+        super().setUp()
+        build_repository(
+            self.root,
+            files={
+                "a.py": "a = 1" + NL,
+                "b.py": "b = 1" + NL,
+                "generated.txt": "generated" + NL,
+            },
+            entries=[horos_entry("generated.txt")],
+        )
+
+    def _run(self, *arguments):
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--directory",
+                str(self.root),
+                *arguments,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_text_report_exits_zero_with_tree_and_not_run_status(self):
+        completed = self._run("report")
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("dead-code 1 report", completed.stdout)
+        self.assertIn("tree      ", completed.stdout)
+        self.assertIn("status    not-run", completed.stdout)
+
+    def test_json_report_exits_zero_and_parses(self):
+        completed = self._run("report", "--json")
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        document = json.loads(completed.stdout)
+        self.assertEqual(document["schema"], "dead-code-report/v1")
+        self.assertEqual(document["universe"]["analysed_count"], 3)
+        self.assertEqual(document["status"]["state"], "not-run")
+
+    def test_dirty_tree_refusal_exits_two_without_stdout(self):
+        (self.root / "a.py").write_text("changed" + NL, encoding="utf-8")
+        completed = self._run("report")
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("modified tracked", completed.stderr)
+        self.assertEqual(completed.stdout, "")
+
+    def test_output_flag_writes_schema_valid_shape_inside_repository(self):
+        completed = self._run(
+            "report",
+            "--json",
+            "--output",
+            "reports/out.json",
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        document = json.loads(
+            (self.root / "reports" / "out.json").read_text(encoding="utf-8")
+        )
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(set(document), set(schema["required"]))
+        self.assertEqual(
+            document["universe"]["tracked_count"],
+            document["universe"]["analysed_count"]
+            + document["universe"]["excluded_count"],
+        )
+
+    def test_unsafe_output_path_exits_two(self):
+        completed = self._run("report", "--output", "../escape.json")
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("escapes", completed.stderr)
+
+
+class ShippedSurfaceTests(unittest.TestCase):
+    def test_receipted_study_and_runbook_digests_are_preserved(self):
+        self.assertEqual(
+            hashlib.sha256(STUDY_PATH.read_bytes()).hexdigest(),
+            EXPECTED_STUDY_SHA256,
+        )
+        self.assertEqual(
+            hashlib.sha256(RUNBOOK_PATH.read_bytes()).hexdigest(),
+            EXPECTED_RUNBOOK_SHA256,
+        )
+
+    def test_adr_has_the_repository_shape_and_records_both_ownership_boundaries(self):
+        text = ADR_PATH.read_text(encoding="utf-8")
+        for heading in (
+            "## Status",
+            "## Context",
+            "## Decision",
+            "## Alternatives",
+            "## Consequences",
+        ):
+            self.assertIn(heading, text)
+        self.assertIn("report-only", text)
+        self.assertIn("Horos", text)
+        self.assertIn("checked runner", text)
+        self.assertIn("one analyser in every plugin", text)
+
+    def test_schema_is_closed_at_every_named_record_identity(self):
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        self.assertFalse(schema["additionalProperties"])
+        for name in (
+            "toolIdentity",
+            "treeIdentity",
+            "universeIdentity",
+            "analysisStatus",
+            "analyserStatus",
+            "finding",
+        ):
+            self.assertFalse(schema["$defs"][name]["additionalProperties"])
+
+    def test_check_map_declares_the_focused_dead_code_scope(self):
+        check_map = json.loads(CHECK_MAP_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(
+            check_map["scopes"]["dead-code"]["checks"],
+            ["dead-code-suite"],
+        )
+        self.assertEqual(
+            check_map["checks"]["dead-code-suite"]["argv"],
+            ["python3", "-m", "unittest", "tests.test_dead_code", "-v"],
+        )
+
+    def test_check_map_assigns_every_dead_code_surface_to_the_scope(self):
+        check_map = json.loads(CHECK_MAP_PATH.read_text(encoding="utf-8"))
+        owners = {
+            entry["path"]: entry["scope"]
+            for entry in check_map["owners"]
+        }
+        expected = (
+            ".github/workflows/dead-code.yml",
+            "docs/dead-code",
+            "docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md",
+            "schemas/dead-code-report-v1.schema.json",
+            "scripts/dead_code.py",
+            "tests/emit_dead_code_report.py",
+            "tests/test_dead_code.py",
+        )
+        for path in expected:
+            self.assertEqual(owners.get(path), "dead-code", path)
+
+    def test_workflow_is_read_only_and_runs_the_checked_scope(self):
+        text = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn("contents: read", text)
+        self.assertNotIn("contents: write", text)
+        self.assertIn("scripts/run_checks.py --scope dead-code", text)
+        self.assertIn('python-version-file: ".python-version"', text)
+
+    def test_workflow_summary_names_tree_universe_analyser_and_non_gating_state(self):
+        text = WORKFLOW_PATH.read_text(encoding="utf-8")
+        for field in ("commit", "git_tree", "universe", "status", "analysers"):
+            self.assertIn(field, text)
+        self.assertIn("Candidates are reported, not gated", text)
+        self.assertNotIn("findings']) > 0", text)
+
+    def test_source_contains_no_source_removal_or_shell_execution(self):
+        source = SCRIPT.read_text(encoding="utf-8")
+        for forbidden in ("shutil.rmtree", "os.remove(", "shell=True"):
+            self.assertNotIn(forbidden, source)
+
+    def test_owned_temporary_and_report_paths_are_ignored(self):
+        text = (ROOT / ".gitignore").read_text(encoding="utf-8")
+        self.assertIn(dead_code.TEMP_PREFIX, text)
+        self.assertIn("/.dead-code/report.json", text)
+        self.assertIn("/.dead-code/checks.json", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_python_contract.py
+++ b/tests/test_python_contract.py
@@ -31,6 +31,7 @@ REQUIRED_MINOR = "==3.14.*"
 EXACT_VERSION = "3.14.6"
 PYTHON_WORKFLOWS = {
     "contributors.yml",
+    "dead-code.yml",
     "janus.yml",
     "lazarus.yml",
     "pandects.yml",


### PR DESCRIPTION
## What changed

Add Python AST candidates for unused imports and locals, unreachable
statements, constant branches, and modules outside the bounded static import
graph. Computed imports, `getattr`, decorators, registrations, `__all__`,
CLI entry points, and test fixtures retain or lower confidence instead of
becoming deletion claims.

Wrap only the Python checks selected by `scripts/run_checks.py` with Python
3.14 `sys.monitoring`. The aggregate records named line and branch events per
check and process, then binds them to the exact plan and Git universe. It emits
no never-executed candidate when evidence is failed, incomplete, malformed, or
stale.

The audit fixes reconcile declared and observed process counts and drain
orphaned monitored processes. They preserve lexical scopes and monitoring
ownership, validate tool and plan identity, skip optimised-away function
docstrings, and remove child argv from the persistent aggregate.

## Why

This is Step 2 of issue #437. It adds bounded Python evidence to the Step 1
report model without importing analysed modules, replacing the checked runner,
failing on candidate count, or authorising source deletion. It stacks on
[Step 1](https://github.com/wildcat-finance/skills/pull/850).

## Audit

- Record: `audit/rounds/fiat-437-establish-a-report-only-dead-code-baseline.md`
- Stacked audit PR: https://github.com/wildcat-finance/skills/pull/910
- Task issue: https://github.com/wildcat-finance/skills/issues/437

Five rounds fixed twelve findings; the fifth round found no new issue. The
requested dead-code scope passes. The inherited macOS `receipt.path` failure
in `test_selected_directory_works_as_an_isolated_copy` remains outside this
step.

## Proof

```bash
python3 tests/emit_dead_code_report.py .elenchus/fiat-437-step-2.json
python3 scripts/dead_code.py coverage --scope dead-code --output .dead-code/coverage.json
python3 scripts/dead_code.py report --json --coverage .dead-code/coverage.json --analyser python,coverage
python3 scripts/run_checks.py --scope dead-code
```

<!-- wildcat-origin: shoggoth -->