### PR TITLE
Add repository graph and Solidity dead-code signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ plugins/*/harness/cache/
 **/.dead-code-tmp-*
 /.dead-code/report.json
 /.dead-code/checks.json
+/.dead-code/coverage.json
+/.dead-code/coverage-processes-*/
 
 # Elenchus reports. ADR-038 keeps them inside the invocation checkout and
 # outside every Git control namespace, so they land here as ordinary untracked

--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 2038
+    "files_walked": 2039
   },
   "entries": [
     {

--- a/schemas/dead-code-report-v1.schema.json
+++ b/schemas/dead-code-report-v1.schema.json
@@ -180,7 +180,7 @@
     "analyserStatus": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "state", "version", "detail"],
+      "required": ["id", "state", "version", "detail", "records"],
       "properties": {
         "id": {
           "type": "string",
@@ -196,6 +196,37 @@
         "detail": {
           "type": "string",
           "minLength": 1
+        },
+        "records": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/analyserRecord"
+          }
+        }
+      }
+    },
+    "analyserRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "state", "detail", "bytes"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "enum": ["file", "check"]
+        },
+        "state": {
+          "enum": ["parsed", "parse-error", "skipped", "passed", "failed", "unavailable"]
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1
+        },
+        "bytes": {
+          "type": "integer",
+          "minimum": 0
         }
       }
     },

--- a/schemas/dead-code-report-v1.schema.json
+++ b/schemas/dead-code-report-v1.schema.json
@@ -208,14 +208,24 @@
     "analyserRecord": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "kind", "state", "detail", "bytes"],
+      "required": [
+        "id",
+        "kind",
+        "state",
+        "detail",
+        "bytes",
+        "version",
+        "duration_ms",
+        "evidence_count",
+        "reason"
+      ],
       "properties": {
         "id": {
           "type": "string",
           "minLength": 1
         },
         "kind": {
-          "enum": ["file", "check"]
+          "enum": ["file", "check", "family", "project"]
         },
         "state": {
           "enum": ["parsed", "parse-error", "skipped", "passed", "failed", "unavailable"]
@@ -227,6 +237,22 @@
         "bytes": {
           "type": "integer",
           "minimum": 0
+        },
+        "version": {
+          "type": ["string", "null"],
+          "minLength": 1
+        },
+        "duration_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "evidence_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "reason": {
+          "type": ["string", "null"],
+          "minLength": 1
         }
       }
     },

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -74,6 +74,8 @@ SOLIDITY_VERSION_TIMEOUT_SECONDS = 30
 SOLIDITY_TOOL_TIMEOUT_SECONDS = 600
 MAX_SOLIDITY_VERSION_BYTES = 64 * 1024
 MAX_SOLIDITY_OUTPUT_BYTES = 32 * 1024 * 1024
+MAX_SOLIDITY_PROJECT_BYTES = 160 * 1024 * 1024
+MAX_SOLIDITY_PROJECT_FILES = 20_000
 REPOSITORY_FAMILIES = (
     "check-map",
     "cli",
@@ -1631,6 +1633,18 @@ def analyse_repository(
 
     objects: dict[str, list[RepositoryNode]] = {family: [] for family in REPOSITORY_FAMILIES}
     family_errors: dict[str, set[str]] = {family: set() for family in REPOSITORY_FAMILIES}
+    unreadable_sources = sorted(
+        f"{source.path}: {source.error}"
+        for source in sources.values()
+        if source.error is not None
+    )
+    if unreadable_sources:
+        visible = unreadable_sources[:5]
+        if len(unreadable_sources) > len(visible):
+            visible.append(f"and {len(unreadable_sources) - len(visible)} more")
+        reason = "unreadable declaration source(s): " + "; ".join(visible)
+        for family in REPOSITORY_FAMILIES:
+            family_errors[family].add(reason)
     analysed = set(universe.analysed)
     for path in universe.analysed:
         source = sources.get(path)
@@ -1839,9 +1853,7 @@ def _tool_version(invocation: ToolInvocation, tool: str) -> str:
     if not text:
         raise Refusal(f"{tool} version output is empty")
     first = text.splitlines()[0].strip()
-    if len(first.encode("utf-8")) > 256:
-        raise Refusal(f"{tool} version identity exceeds 256 bytes")
-    return first
+    return _bounded_tool_identity(first, f"{tool} version identity")
 
 
 def _project_repository_path(
@@ -1939,6 +1951,23 @@ def _slither_findings(
 
 
 FORGE_METRIC = re.compile(r"^(\d+(?:\.\d+)?)%\s*\((\d+)/(\d+)\)$")
+FORGE_COVERAGE_HEADER = ("file", "% lines", "% statements", "% branches", "% funcs")
+
+
+def _forge_metrics(cells: Sequence[str], project: str) -> tuple[tuple[int, int], ...]:
+    if len(cells) != 5:
+        raise Refusal(f"Forge coverage for {project} has a malformed table row")
+    metrics: list[tuple[int, int]] = []
+    for cell in cells[1:5]:
+        match = FORGE_METRIC.fullmatch(cell)
+        if match is None:
+            raise Refusal(f"Forge coverage for {project} has a malformed metric row")
+        covered = int(match.group(2))
+        total = int(match.group(3))
+        if covered > total:
+            raise Refusal(f"Forge coverage for {project} has an impossible metric")
+        metrics.append((covered, total))
+    return tuple(metrics)
 
 
 def _forge_findings(
@@ -1950,32 +1979,58 @@ def _forge_findings(
     text = decode_output(payload, f"Forge coverage for {project}")
     tracked = set(universe.analysed)
     rows: list[tuple[str, tuple[tuple[int, int], ...]]] = []
+    seen_paths: set[str] = set()
+    saw_header = False
+    saw_total = False
+    reading_coverage = False
+    total_metrics: tuple[tuple[int, int], ...] | None = None
     for line in text.splitlines():
         stripped = re.sub(r"\x1b\[[0-9;]*m", "", line).strip()
         if not stripped.startswith("|") or not stripped.endswith("|"):
             continue
-        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
-        if len(cells) < 5 or cells[0].lower() in {"file", "total"}:
+        separator = stripped[1:-1]
+        if separator and "-" in separator and set(separator) <= {"-", "+", ":", " "}:
             continue
-        metrics: list[tuple[int, int]] = []
-        for cell in cells[1:5]:
-            match = FORGE_METRIC.fullmatch(cell)
-            if match is None:
-                metrics = []
-                break
-            covered = int(match.group(2))
-            total = int(match.group(3))
-            if covered > total:
-                raise Refusal(f"Forge coverage for {project} has an impossible metric")
-            metrics.append((covered, total))
-        if not metrics:
+        cells = tuple(cell.strip() for cell in stripped.strip("|").split("|"))
+        lowered = tuple(cell.lower() for cell in cells)
+        if lowered == FORGE_COVERAGE_HEADER:
+            if saw_header:
+                raise Refusal(f"Forge coverage for {project} repeats its coverage table")
+            saw_header = True
+            reading_coverage = True
+            continue
+        if not reading_coverage:
+            continue
+        metrics = _forge_metrics(cells, project)
+        if cells[0].lower() == "total":
+            if not rows:
+                raise Refusal(f"Forge coverage for {project} has a total before source rows")
+            saw_total = True
+            reading_coverage = False
+            total_metrics = metrics
             continue
         path = _project_repository_path(project, cells[0], tracked)
         if path not in tracked or not path.endswith(".sol"):
             raise Refusal(f"Forge coverage for {project} names path outside the report universe: {path}")
-        rows.append((path, tuple(metrics)))
+        if path in seen_paths:
+            raise Refusal(f"Forge coverage for {project} repeats source row {path}")
+        seen_paths.add(path)
+        rows.append((path, metrics))
+    if not saw_header:
+        raise Refusal(f"Forge coverage for {project} has no coverage table")
+    if reading_coverage or not saw_total or total_metrics is None:
+        raise Refusal(f"Forge coverage for {project} has an incomplete coverage table")
     if not rows:
         raise Refusal(f"Forge coverage for {project} has no parseable source rows")
+    expected_total = tuple(
+        (
+            sum(metrics[index][0] for _path, metrics in rows),
+            sum(metrics[index][1] for _path, metrics in rows),
+        )
+        for index in range(4)
+    )
+    if total_metrics != expected_total:
+        raise Refusal(f"Forge coverage for {project} has inconsistent total metrics")
     findings: list[Finding] = []
     for path, metrics in rows:
         lines, _statements, _branches, functions = metrics
@@ -1998,10 +2053,107 @@ def _forge_findings(
     return tuple(findings), len(rows)
 
 
+def _materialise_solidity_project(
+    root: Path,
+    universe: Universe,
+    project: str,
+    destination: Path,
+) -> Path:
+    prefix = "" if project == "." else project.rstrip("/") + "/"
+    allowed = {
+        path
+        for path in universe.analysed
+        if project == "." or path.startswith(prefix)
+    }
+    config = "foundry.toml" if project == "." else prefix + "foundry.toml"
+    if config not in allowed:
+        raise Refusal(f"Foundry project {project} has no analysed foundry.toml")
+    if len(allowed) > MAX_SOLIDITY_PROJECT_FILES:
+        raise Refusal(
+            f"Foundry project {project} exceeds {MAX_SOLIDITY_PROJECT_FILES} tracked files"
+        )
+    argv = ["git", "archive", "--format=tar", universe.commit]
+    if project != ".":
+        argv.extend(["--", project])
+    root_fd = open_repository_directory(root)
+    try:
+        stdout, stderr, returncode = run_process(
+            argv,
+            cwd=root,
+            timeout_seconds=GIT_TIMEOUT_SECONDS,
+            output_limit=MAX_SOLIDITY_PROJECT_BYTES,
+            cwd_fd=root_fd,
+        )
+    finally:
+        os.close(root_fd)
+    if returncode != 0:
+        detail = decode_output(stderr, "git archive stderr").strip() or f"exit {returncode}"
+        raise Refusal(f"Foundry project {project} snapshot failed: {detail}")
+
+    destination.mkdir(mode=0o700)
+    seen: set[str] = set()
+    total_bytes = 0
+    try:
+        with tarfile.open(fileobj=io.BytesIO(stdout), mode="r:") as archive:
+            for member in archive:
+                if member.isdir():
+                    continue
+                path = validate_repository_path(member.name, "Foundry snapshot path")
+                if path not in allowed:
+                    continue
+                if path in seen:
+                    raise Refusal(f"Foundry project {project} snapshot repeats {path}")
+                if not member.isfile() or member.size < 0:
+                    raise Refusal(f"Foundry project {project} path {path} is not a regular file")
+                if member.size > MAX_REPOSITORY_FILE_BYTES:
+                    raise Refusal(
+                        f"Foundry project {project} path {path} exceeds "
+                        f"{MAX_REPOSITORY_FILE_BYTES} bytes"
+                    )
+                handle = archive.extractfile(member)
+                if handle is None:
+                    raise Refusal(f"Foundry project {project} path {path} cannot be read")
+                payload = handle.read(MAX_REPOSITORY_FILE_BYTES + 1)
+                if len(payload) != member.size or len(payload) > MAX_REPOSITORY_FILE_BYTES:
+                    raise Refusal(f"Foundry project {project} path {path} changed size while read")
+                total_bytes += len(payload)
+                if total_bytes > MAX_SOLIDITY_PROJECT_BYTES:
+                    raise Refusal(
+                        f"Foundry project {project} snapshot exceeded "
+                        f"{MAX_SOLIDITY_PROJECT_BYTES} bytes"
+                    )
+                target = destination.joinpath(*PurePosixPath(path).parts)
+                target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+                flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+                mode = 0o700 if member.mode & 0o111 else 0o600
+                try:
+                    descriptor = os.open(target, flags, mode)
+                    with os.fdopen(descriptor, "wb") as output:
+                        output.write(payload)
+                except OSError as error:
+                    raise Refusal(
+                        f"Foundry project {project} path {path} cannot be materialised: {error}"
+                    ) from error
+                seen.add(path)
+    except (tarfile.TarError, OSError, EOFError) as error:
+        raise Refusal(f"Foundry project {project} snapshot is malformed: {error}") from error
+    missing = sorted(allowed - seen)
+    if missing:
+        raise Refusal(
+            f"Foundry project {project} snapshot omitted analysed path(s): "
+            + ", ".join(missing[:5])
+        )
+    project_root = destination if project == "." else destination.joinpath(*PurePosixPath(project).parts)
+    if not (project_root / "foundry.toml").is_file():
+        raise Refusal(f"Foundry project {project} snapshot omitted foundry.toml")
+    return project_root
+
+
 def _solidity_project_tool(
     tool: str,
     *,
     project: str,
+    repository_root: Path,
     project_root: Path,
     universe: Universe,
 ) -> tuple[AnalyserRecord, tuple[Finding, ...]]:
@@ -2053,6 +2205,44 @@ def _solidity_project_tool(
         ignore_cleanup_errors=True,
     ) as temporary:
         temporary_root = Path(temporary).resolve(strict=True)
+        snapshot_started = time.monotonic_ns()
+        try:
+            snapshot_project_root = _materialise_solidity_project(
+                repository_root,
+                universe,
+                project,
+                temporary_root / "repository",
+            )
+            for name in ("out", "cache", "broadcast"):
+                try:
+                    (snapshot_project_root / name).mkdir(mode=0o700, exist_ok=True)
+                except OSError as error:
+                    raise Refusal(
+                        f"Foundry project {project} disposable {name} directory failed: {error}"
+                    ) from error
+        except Refusal as error:
+            snapshot_duration = max(
+                0,
+                (time.monotonic_ns() - snapshot_started) // 1_000_000,
+            )
+            return (
+                AnalyserRecord(
+                    f"{project}:{tool}",
+                    "project",
+                    "failed",
+                    f"project={project}; disposable tracked snapshot could not be materialised",
+                    len(version_run.stdout) + len(version_run.stderr),
+                    version,
+                    version_run.duration_ms + snapshot_duration,
+                    0,
+                    str(error),
+                ),
+                (),
+            )
+        snapshot_duration = max(
+            0,
+            (time.monotonic_ns() - snapshot_started) // 1_000_000,
+        )
         environment = dict(os.environ)
         environment.update(
             {
@@ -2068,12 +2258,12 @@ def _solidity_project_tool(
             (temporary_root / name).mkdir(mode=0o700)
         run = _invoke_optional_tool(
             argv,
-            cwd=project_root,
+            cwd=snapshot_project_root,
             timeout_seconds=SOLIDITY_TOOL_TIMEOUT_SECONDS,
             output_limit=MAX_SOLIDITY_OUTPUT_BYTES,
             env=environment,
         )
-    total_duration = version_run.duration_ms + run.duration_ms
+    total_duration = version_run.duration_ms + snapshot_duration + run.duration_ms
     total_bytes = (
         len(version_run.stdout)
         + len(version_run.stderr)
@@ -2178,6 +2368,7 @@ def analyse_solidity(
             record, produced = _solidity_project_tool(
                 tool,
                 project=project,
+                repository_root=root,
                 project_root=project_root,
                 universe=universe,
             )
@@ -3160,6 +3351,11 @@ def render_json(report: Report) -> str:
     ) + chr(10)
 
 
+def _text_field(value: object) -> str:
+    rendered = json.dumps(str(value), ensure_ascii=False)[1:-1]
+    return rendered.replace("\u2028", r"\u2028").replace("\u2029", r"\u2029")
+
+
 def render_text(report: Report) -> str:
     document = report.as_dict()
     tree = document["tree"]
@@ -3175,31 +3371,32 @@ def render_text(report: Report) -> str:
             f"{universe['analysed_count']} analysed, "
             f"{universe['excluded_count']} excluded"
         ),
-        f"status    {status['state']}  {status['detail']}",
+        f"status    {_text_field(status['state'])}  {_text_field(status['detail'])}",
     ]
     by_category = universe["excluded_by_category"]
     if by_category:
         summary = ", ".join(
-            f"{name} {by_category[name]}" for name in sorted(by_category)
+            f"{_text_field(name)} {by_category[name]}" for name in sorted(by_category)
         )
         lines.append(f"excluded  {summary}")
     lines.extend(["", "analysers"])
     if not document["analysers"]:
         lines.append("  none ran; no reachability result was established")
     for analyser in document["analysers"]:
-        version = f" {analyser['version']}" if analyser["version"] else ""
+        version = f" {_text_field(analyser['version'])}" if analyser["version"] else ""
         lines.append(
-            f"  {analyser['id']}{version}  {analyser['state']}  "
-            f"{analyser['detail']}"
+            f"  {_text_field(analyser['id'])}{version}  "
+            f"{_text_field(analyser['state'])}  {_text_field(analyser['detail'])}"
         )
         for record in analyser["records"]:
-            version = record["version"] or "unknown"
-            reason = f"  reason={record['reason']}" if record["reason"] else ""
+            version = _text_field(record["version"] or "unknown")
+            reason = f"  reason={_text_field(record['reason'])}" if record["reason"] else ""
             lines.append(
-                f"    {record['kind']} {record['id']}  {record['state']}  "
+                f"    {_text_field(record['kind'])} {_text_field(record['id'])}  "
+                f"{_text_field(record['state'])}  "
                 f"{record['bytes']} byte(s)  version={version}  "
                 f"duration_ms={record['duration_ms']}  "
-                f"evidence={record['evidence_count']}  {record['detail']}{reason}"
+                f"evidence={record['evidence_count']}  {_text_field(record['detail'])}{reason}"
             )
 
     findings = document["findings"]
@@ -3207,13 +3404,13 @@ def render_text(report: Report) -> str:
     if not findings:
         lines.append("  none reported")
     for finding in findings:
-        symbol = f" {finding['symbol']}" if finding["symbol"] else ""
+        symbol = f" {_text_field(finding['symbol'])}" if finding["symbol"] else ""
         lines.append(
             f"  [{finding['confidence']}] {finding['id']}  "
-            f"{finding['analyser_id']}  {finding['path']}{symbol}"
+            f"{_text_field(finding['analyser_id'])}  {_text_field(finding['path'])}{symbol}"
         )
-        lines.append(f"      saw     {finding['evidence']}")
-        lines.append(f"      but     {finding['false_positive_boundary']}")
+        lines.append(f"      saw     {_text_field(finding['evidence'])}")
+        lines.append(f"      but     {_text_field(finding['false_positive_boundary'])}")
     return chr(10).join(lines) + chr(10)
 
 

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -1808,10 +1808,17 @@ def _invoke_optional_tool(
         )
     duration_ms = max(0, (time.monotonic_ns() - started) // 1_000_000)
     if returncode != 0:
-        try:
-            detail = decode_output(stderr, f"{argv[0]} stderr").strip()
-        except Refusal:
-            detail = "non-UTF-8 stderr"
+        details: list[str] = []
+        for label, payload in (("stderr", stderr), ("stdout", stdout)):
+            if not payload:
+                continue
+            try:
+                text = decode_output(payload, f"{argv[0]} {label}").strip()
+            except Refusal:
+                text = f"non-UTF-8 {label}"
+            if text:
+                details.append(f"{label}: {text}")
+        detail = "; ".join(details)
         if len(detail) > 512:
             detail = detail[:96] + " ... " + detail[-411:]
         return ToolInvocation(

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -2081,6 +2081,33 @@ def _solidity_project_tool(
         + len(run.stderr)
     )
     if run.state != "passed":
+        if tool == "slither" and run.state == "failed" and run.stdout:
+            try:
+                findings, evidence_count = _slither_findings(
+                    run.stdout,
+                    project=project,
+                    universe=universe,
+                )
+            except Refusal:
+                pass
+            else:
+                return (
+                    AnalyserRecord(
+                        f"{project}:{tool}",
+                        "project",
+                        "failed",
+                        (
+                            f"project={project}; non-zero exit supplied "
+                            f"{evidence_count} parseable positive evidence record(s)"
+                        ),
+                        total_bytes,
+                        version,
+                        total_duration,
+                        evidence_count,
+                        run.reason,
+                    ),
+                    findings,
+                )
         return (
             AnalyserRecord(
                 f"{project}:{tool}",

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -16,6 +16,7 @@ import json
 import os
 import re
 import selectors
+import signal
 import stat
 import subprocess
 import sys
@@ -49,6 +50,7 @@ MAX_COVERAGE_PROCESS_BYTES = 16 * 1024 * 1024
 MAX_COVERAGE_PROCESSES = 4096
 MAX_RUNNER_OUTPUT_BYTES = 32 * 1024 * 1024
 RUNNER_TIMEOUT_SECONDS = 3600
+COVERAGE_DRAIN_SECONDS = 5.0
 CHECK_RUNNER = Path("scripts") / "run_checks.py"
 MONITOR_DIRECTORY = Path("scripts") / "dead_code_monitoring"
 COVERAGE_SCHEMA_ID = "dead-code-coverage/v1"
@@ -1064,6 +1066,29 @@ def _candidate(
     return Finding(analyser_id, path, symbol, evidence, confidence, boundary)
 
 
+def _function_scope_nodes(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> Iterable[ast.AST]:
+    """Walk stores in one function scope without entering child scopes."""
+    boundaries = (
+        ast.FunctionDef,
+        ast.AsyncFunctionDef,
+        ast.Lambda,
+        ast.ClassDef,
+        ast.ListComp,
+        ast.SetComp,
+        ast.DictComp,
+        ast.GeneratorExp,
+    )
+    pending = list(reversed(function.body))
+    while pending:
+        node = pending.pop()
+        yield node
+        if isinstance(node, boundaries):
+            continue
+        pending.extend(reversed(list(ast.iter_child_nodes(node))))
+
+
 def _unused_bindings(item: ParsedPython) -> Iterable[Finding]:
     loads = {
         node.id
@@ -1110,12 +1135,19 @@ def _unused_bindings(item: ParsedPython) -> Iterable[Finding]:
             for node in ast.walk(function)
             if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
         }
+        scope_nodes = tuple(_function_scope_nodes(function))
         assignments: dict[str, int] = {}
-        for node in ast.walk(function):
+        external_bindings = {
+            name
+            for declaration in scope_nodes
+            if isinstance(declaration, (ast.Global, ast.Nonlocal))
+            for name in declaration.names
+        }
+        for node in scope_nodes:
             if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
                 assignments.setdefault(node.id, node.lineno)
         for name, line in sorted(assignments.items()):
-            if name in function_loads or name.startswith("_"):
+            if name in function_loads or name in external_bindings or name.startswith("_"):
                 continue
             yield _candidate(
                 item.path,
@@ -1366,7 +1398,13 @@ def _normalise_coverage_events(
         path = item.get("path")
         function = item.get("function")
         line = item.get("line")
-        if not isinstance(path, str) or not isinstance(function, str) or not isinstance(line, int) or line < 1:
+        if (
+            not isinstance(path, str)
+            or not isinstance(function, str)
+            or not isinstance(line, int)
+            or isinstance(line, bool)
+            or line < 1
+        ):
             raise Refusal("coverage line event has an invalid identity")
         validate_repository_path(path, "coverage line path")
         if path in analysed:
@@ -1383,9 +1421,12 @@ def _normalise_coverage_events(
             not isinstance(path, str)
             or not isinstance(function, str)
             or not isinstance(source, int)
+            or isinstance(source, bool)
             or source < 1
             or not isinstance(target, int)
+            or isinstance(target, bool)
             or target < 1
+            or not isinstance(direction, str)
             or direction not in {"left", "right"}
         ):
             raise Refusal("coverage branch event has an invalid identity")
@@ -1410,12 +1451,34 @@ def _normalise_coverage_events(
     )
 
 
+def _coverage_process_complete(status: object) -> bool:
+    if not isinstance(status, dict):
+        raise Refusal("coverage process status is not an object")
+    state = status.get("state")
+    truncated = status.get("truncated")
+    errors = status.get("errors")
+    if (
+        not isinstance(state, str)
+        or state not in {"ran", "degraded"}
+        or not isinstance(truncated, bool)
+        or not isinstance(errors, list)
+        or not all(isinstance(error, str) and error for error in errors)
+    ):
+        raise Refusal("coverage process status is malformed")
+    return state == "ran" and not truncated and not errors
+
+
 def aggregate_coverage(
     plan: dict[str, object],
     run: dict[str, object],
     process_documents: list[tuple[dict[str, object], int]],
     universe: Universe,
 ) -> dict[str, object]:
+    for field in ("map_digest", "requested_scopes", "selected_checks"):
+        if run.get(field) != plan.get(field):
+            raise Refusal(
+                f"checked runner result does not match the preflight plan field {field}"
+            )
     selected = plan.get("selected_checks")
     results = run.get("checks")
     if not isinstance(selected, list) or not isinstance(results, list):
@@ -1424,12 +1487,18 @@ def aggregate_coverage(
     for item in selected:
         if not isinstance(item, dict) or not isinstance(item.get("id"), str):
             raise Refusal("checked runner selected-check record is malformed")
-        planned[item["id"]] = item
+        identifier = item["id"]
+        if not identifier or identifier in planned:
+            raise Refusal("checked runner plan has an empty or repeated check identity")
+        planned[identifier] = item
     terminal: dict[str, dict[str, object]] = {}
     for item in results:
         if not isinstance(item, dict) or not isinstance(item.get("check"), str):
             raise Refusal("checked runner terminal record is malformed")
-        terminal[item["check"]] = item
+        identifier = item["check"]
+        if not identifier or identifier in terminal:
+            raise Refusal("checked runner terminal record has an empty or repeated check identity")
+        terminal[identifier] = item
     if set(terminal) != set(planned):
         raise Refusal("checked runner terminal records do not match its plan")
 
@@ -1476,7 +1545,7 @@ def aggregate_coverage(
             branches,
             set(universe.analysed),
         )
-        if status.get("state") != "ran":
+        if not _coverage_process_complete(status):
             degraded_reasons.add(f"check {check_id} emitted a degraded process record")
         bytes_by_check[check_id] += size
         process_count_by_check[check_id] += 1
@@ -1486,7 +1555,6 @@ def aggregate_coverage(
                 "group": group_id,
                 "pid": process.get("pid"),
                 "parent_pid": process.get("parent_pid"),
-                "argv": process.get("argv"),
                 "lines": lines,
                 "branches": branches,
             }
@@ -1498,7 +1566,6 @@ def aggregate_coverage(
                 "check": check_id,
                 "pid": process.get("pid"),
                 "parent_pid": process.get("parent_pid"),
-                "argv": process.get("argv"),
                 "status": status,
                 "bytes": size,
                 "lines": lines,
@@ -1567,6 +1634,55 @@ def _coverage_environment(root: Path, process_directory: Path, run_id: str) -> d
     return environment
 
 
+def _coverage_survivor_pids(run_id: str) -> list[int]:
+    if len(run_id) != 32 or any(character not in "0123456789abcdef" for character in run_id):
+        raise Refusal("coverage run identity is malformed")
+    try:
+        listing = subprocess.run(
+            ["ps", "axeww", "-o", "pid=,command="],
+            capture_output=True,
+            shell=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise Refusal(f"coverage process sweep is unavailable: {error}") from error
+    if listing.returncode != 0 or len(listing.stdout) > MAX_GIT_OUTPUT_BYTES:
+        raise Refusal("coverage process sweep failed or exceeded its output bound")
+    token = f"{COVERAGE_ACTIVE_ENV}={run_id}"
+    pids: list[int] = []
+    for line in listing.stdout.decode("utf-8", "replace").splitlines():
+        stripped = line.strip()
+        if token not in stripped:
+            continue
+        pid_text = stripped.split(None, 1)[0]
+        if pid_text.isdigit() and int(pid_text) != os.getpid():
+            pids.append(int(pid_text))
+    return sorted(set(pids))
+
+
+def _terminate_coverage_processes(run_id: str) -> None:
+    survivors = _coverage_survivor_pids(run_id)
+    for requested_signal in (signal.SIGTERM, signal.SIGKILL):
+        if not survivors:
+            return
+        for pid in survivors:
+            try:
+                os.kill(pid, requested_signal)
+            except OSError:
+                continue
+        deadline = time.monotonic() + COVERAGE_DRAIN_SECONDS
+        while time.monotonic() < deadline:
+            survivors = _coverage_survivor_pids(run_id)
+            if not survivors:
+                return
+            time.sleep(0.05)
+    if survivors:
+        raise Refusal(
+            "coverage process recovery could not drain pid(s): "
+            + ", ".join(str(pid) for pid in survivors)
+        )
+
+
 def command_coverage(arguments: argparse.Namespace) -> int:
     if os.environ.get(COVERAGE_ACTIVE_ENV):
         raise Refusal("coverage wrapper recursion is active in this process")
@@ -1592,19 +1708,37 @@ def command_coverage(arguments: argparse.Namespace) -> int:
         for scope in scopes:
             argv.extend(["--scope", scope])
         argv.extend(["--report", runner_report])
-        _stdout, _stderr, _returncode = run_process(
-            argv,
-            cwd=root,
-            timeout_seconds=RUNNER_TIMEOUT_SECONDS,
-            output_limit=MAX_RUNNER_OUTPUT_BYTES,
-            env=environment,
-        )
+        try:
+            _stdout, _stderr, _returncode = run_process(
+                argv,
+                cwd=root,
+                timeout_seconds=RUNNER_TIMEOUT_SECONDS,
+                output_limit=MAX_RUNNER_OUTPUT_BYTES,
+                env=environment,
+            )
+        except BaseException as error:
+            try:
+                _terminate_coverage_processes(run_id)
+            except Refusal as cleanup_error:
+                if isinstance(error, Refusal):
+                    raise Refusal(f"{error}; {cleanup_error}") from error
+            raise
+        unexpected_survivors = _coverage_survivor_pids(run_id)
+        if unexpected_survivors:
+            _terminate_coverage_processes(run_id)
+            raise Refusal("checked runner returned with monitored processes still active")
         run_raw = read_bounded_regular(
             root / runner_report,
             limit=MAX_COVERAGE_BYTES,
             label=runner_report,
         )
         run = _json_document(run_raw, runner_report)
+        outcome = run.get("outcome")
+        expected_returncode = 0 if outcome == "green" else 1 if outcome == "red" else None
+        if expected_returncode is None or _returncode != expected_returncode:
+            raise Refusal(
+                f"checked runner exit {_returncode} does not match {outcome} outcome"
+            )
         documents = _read_process_documents(process_directory, process_fd, run_id)
         coverage = aggregate_coverage(plan, run, documents, universe)
         atomic_write(root, target, json.dumps(coverage, indent=2, sort_keys=True) + chr(10), root_fd=root_fd)
@@ -1627,6 +1761,28 @@ def _coverage_file(
     document = _json_document(raw, coverage_path)
     if document.get("schema") != COVERAGE_SCHEMA_ID:
         raise Refusal(f"{coverage_path} does not declare {COVERAGE_SCHEMA_ID}")
+    tool = document.get("tool")
+    if (
+        not isinstance(tool, dict)
+        or tool.get("id") != "sys.monitoring"
+        or not isinstance(tool.get("python"), str)
+        or re.fullmatch(r"3\.14\.\d+", tool["python"]) is None
+    ):
+        raise Refusal(f"{coverage_path} does not declare Python 3.14 sys.monitoring")
+    plan = document.get("plan")
+    if not isinstance(plan, dict) or plan.get("schema") != "wildcat.check-plan.v1":
+        raise Refusal(f"{coverage_path} does not declare wildcat.check-plan.v1")
+    map_digest = plan.get("map_digest")
+    requested_scopes = plan.get("requested_scopes")
+    if (
+        not isinstance(map_digest, str)
+        or re.fullmatch(r"[0-9a-f]{64}", map_digest) is None
+        or not isinstance(requested_scopes, list)
+        or not requested_scopes
+        or not all(isinstance(scope, str) and scope for scope in requested_scopes)
+        or len(requested_scopes) != len(set(requested_scopes))
+    ):
+        raise Refusal(f"{coverage_path} carries malformed checked-runner plan identity")
     tree = document.get("tree")
     if not isinstance(tree, dict):
         raise Refusal(f"{coverage_path} omits tree identity")
@@ -1651,7 +1807,15 @@ def _function_targets(item: ParsedPython) -> Iterable[tuple[str, int]]:
             continue
         if node.name in item.retained_names:
             continue
-        yield node.name, node.body[0].lineno
+        body = node.body
+        if (
+            isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)
+        ):
+            body = body[1:]
+        if body:
+            yield node.name, body[0].lineno
 
 
 def _branch_targets(item: ParsedPython) -> Iterable[tuple[int, int, str]]:
@@ -1676,22 +1840,100 @@ def analyse_coverage(
     if not isinstance(status, dict) or not isinstance(checks, list) or not isinstance(processes, list):
         raise Refusal("coverage record omits status, checks or processes")
     records: list[AnalyserRecord] = []
+    check_claims: dict[str, tuple[int, int]] = {}
     for item in checks:
         if not isinstance(item, dict) or not isinstance(item.get("id"), str):
             raise Refusal("coverage check record is malformed")
+        identifier = item["id"]
+        process_count = item.get("processes")
+        byte_count = item.get("bytes")
+        if (
+            not identifier
+            or identifier in check_claims
+            or not isinstance(process_count, int)
+            or isinstance(process_count, bool)
+            or process_count < 0
+            or not isinstance(byte_count, int)
+            or isinstance(byte_count, bool)
+            or byte_count < 0
+        ):
+            raise Refusal("coverage check record has an invalid identity or count")
+        check_claims[identifier] = (process_count, byte_count)
         state = item.get("state")
         mapped = "passed" if state == "passed" else "unavailable" if state == "unavailable" else "failed"
-        size = item.get("bytes")
         records.append(
             AnalyserRecord(
-                item["id"],
+                identifier,
                 "check",
                 mapped,
-                f"runner state {state}; {item.get('processes')} process record(s)",
-                size if isinstance(size, int) and size >= 0 else 0,
+                f"runner state {state}; {process_count} process record(s)",
+                byte_count,
             )
         )
     records.sort(key=lambda item: item.record_id)
+    plan = document.get("plan")
+    selected_checks = plan.get("selected_checks") if isinstance(plan, dict) else None
+    if (
+        not isinstance(selected_checks, list)
+        or not all(isinstance(item, str) and item for item in selected_checks)
+        or len(selected_checks) != len(set(selected_checks))
+        or set(selected_checks) != set(check_claims)
+    ):
+        raise Refusal("coverage plan and check records do not name the same checks")
+
+    observed_lines: set[tuple[str, int]] = set()
+    observed_branches: set[tuple[str, int, int]] = set()
+    actual_counts = {identifier: [0, 0] for identifier in check_claims}
+    incomplete: set[str] = set()
+    analysed_paths = set(universe.analysed)
+    for process in processes:
+        if not isinstance(process, dict):
+            raise Refusal("coverage process aggregate is malformed")
+        check_id = process.get("check")
+        size = process.get("bytes")
+        lines = process.get("lines")
+        branches = process.get("branches")
+        process_status = process.get("status")
+        if (
+            not isinstance(check_id, str)
+            or check_id not in check_claims
+            or not isinstance(size, int)
+            or isinstance(size, bool)
+            or size < 0
+            or not isinstance(lines, list)
+            or not isinstance(branches, list)
+            or not isinstance(process_status, dict)
+        ):
+            raise Refusal("coverage process aggregate omits a valid check, size, status or event list")
+        normal_lines, normal_branches = _normalise_coverage_events(
+            lines,
+            branches,
+            analysed_paths,
+        )
+        if normal_lines != lines or normal_branches != branches:
+            raise Refusal("coverage process events are not canonical for the report universe")
+        actual_counts[check_id][0] += 1
+        actual_counts[check_id][1] += size
+        if not _coverage_process_complete(process_status):
+            incomplete.add(f"process for {check_id} was degraded")
+        observed_lines.update(
+            (line["path"], line["line"])
+            for line in normal_lines
+        )
+        observed_branches.update(
+            (branch["path"], branch["from_line"], branch["to_line"])
+            for branch in normal_branches
+        )
+    for check_id, claimed in check_claims.items():
+        actual = tuple(actual_counts[check_id])
+        if actual != claimed:
+            incomplete.add(
+                f"check {check_id} claimed {claimed[0]} process record(s) and {claimed[1]} bytes; "
+                f"the aggregate carries {actual[0]} and {actual[1]}"
+            )
+        if claimed[0] == 0:
+            incomplete.add(f"check {check_id} carries no process record")
+
     if status.get("state") != "ran":
         return (
             AnalyserStatus(
@@ -1699,6 +1941,17 @@ def analyse_coverage(
                 "degraded",
                 COVERAGE_ANALYSER_VERSION,
                 str(status.get("detail") or "coverage did not complete"),
+                tuple(records),
+            ),
+            (),
+        )
+    if incomplete:
+        return (
+            AnalyserStatus(
+                "coverage",
+                "degraded",
+                COVERAGE_ANALYSER_VERSION,
+                "; ".join(sorted(incomplete)),
                 tuple(records),
             ),
             (),
@@ -1714,39 +1967,6 @@ def analyse_coverage(
             ),
             (),
         )
-
-    observed_lines: set[tuple[str, int]] = set()
-    observed_branches: set[tuple[str, int, int]] = set()
-    for process in processes:
-        if not isinstance(process, dict):
-            raise Refusal("coverage process aggregate is malformed")
-        lines = process.get("lines")
-        branches = process.get("branches")
-        if not isinstance(lines, list) or not isinstance(branches, list):
-            raise Refusal("coverage process aggregate omits lines or branches")
-        process_status = process.get("status")
-        if not isinstance(process_status, dict) or process_status.get("state") != "ran":
-            return (
-                AnalyserStatus(
-                    "coverage",
-                    "degraded",
-                    COVERAGE_ANALYSER_VERSION,
-                    "coverage claimed completion but one process record was degraded",
-                    tuple(records),
-                ),
-                (),
-            )
-        for line in lines:
-            if isinstance(line, dict) and isinstance(line.get("path"), str) and isinstance(line.get("line"), int):
-                observed_lines.add((line["path"], line["line"]))
-        for branch in branches:
-            if (
-                isinstance(branch, dict)
-                and isinstance(branch.get("path"), str)
-                and isinstance(branch.get("from_line"), int)
-                and isinstance(branch.get("to_line"), int)
-            ):
-                observed_branches.add((branch["path"], branch["from_line"], branch["to_line"]))
 
     snapshot = parse_python_snapshot(root, universe)
     if snapshot.degraded:

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -10,17 +10,20 @@ deletes source and a finding count is never an exit gate.
 from __future__ import annotations
 
 import argparse
+import ast
 import hashlib
 import json
 import os
+import re
 import selectors
 import stat
 import subprocess
 import sys
 import time
+import uuid
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Callable
+from typing import Callable, Iterable
 
 SCHEMA_ID = "dead-code-report/v1"
 TOOL_ID = "dead-code"
@@ -39,8 +42,27 @@ MAX_BOUNDARY_BYTES = 4 * 1024 * 1024
 MAX_REPORT_BYTES = 32 * 1024 * 1024
 MAX_TRACKED_PATHS = 100_000
 MAX_PATH_BYTES = 4096
+MAX_PYTHON_FILE_BYTES = 4 * 1024 * 1024
+MAX_PYTHON_TOTAL_BYTES = 96 * 1024 * 1024
+MAX_COVERAGE_BYTES = 32 * 1024 * 1024
+MAX_COVERAGE_PROCESS_BYTES = 16 * 1024 * 1024
+MAX_COVERAGE_PROCESSES = 4096
+MAX_RUNNER_OUTPUT_BYTES = 32 * 1024 * 1024
+RUNNER_TIMEOUT_SECONDS = 3600
+CHECK_RUNNER = Path("scripts") / "run_checks.py"
+MONITOR_DIRECTORY = Path("scripts") / "dead_code_monitoring"
+COVERAGE_SCHEMA_ID = "dead-code-coverage/v1"
+COVERAGE_ACTIVE_ENV = "WILDCAT_DEAD_CODE_COVERAGE_ACTIVE"
+COVERAGE_OUTPUT_ENV = "WILDCAT_DEAD_CODE_COVERAGE_OUTPUT"
+CHECK_CONTAINMENT_ENV = "WILDCAT_CHECK_CONTAINMENT"
+PYTHON_ANALYSER_VERSION = "1"
+COVERAGE_ANALYSER_VERSION = "sys.monitoring/3.14"
 ANALYSER_STATES = frozenset({"ran", "not-available", "degraded", "failed"})
 CONFIDENCE_LEVELS = frozenset({"high", "medium", "low"})
+ANALYSER_RECORD_KINDS = frozenset({"file", "check"})
+ANALYSER_RECORD_STATES = frozenset(
+    {"parsed", "parse-error", "skipped", "passed", "failed", "unavailable"}
+)
 
 Analyser = Callable[
     [Path, "Universe"],
@@ -124,11 +146,30 @@ class Universe:
 
 
 @dataclass(frozen=True)
+class AnalyserRecord:
+    record_id: str
+    kind: str
+    state: str
+    detail: str
+    bytes_count: int
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.record_id,
+            "kind": self.kind,
+            "state": self.state,
+            "detail": self.detail,
+            "bytes": self.bytes_count,
+        }
+
+
+@dataclass(frozen=True)
 class AnalyserStatus:
     analyser_id: str
     state: str
     version: str | None
     detail: str
+    records: tuple[AnalyserRecord, ...] = ()
 
     def as_dict(self) -> dict[str, object]:
         return {
@@ -136,6 +177,7 @@ class AnalyserStatus:
             "state": self.state,
             "version": self.version,
             "detail": self.detail,
+            "records": [record.as_dict() for record in self.records],
         }
 
 
@@ -237,6 +279,7 @@ def run_process(
     timeout_seconds: int,
     output_limit: int,
     cwd_fd: int | None = None,
+    env: dict[str, str] | None = None,
 ) -> tuple[bytes, bytes, int]:
     """Run fixed argv while bounding time and combined captured output."""
     process_cwd: Path | None = cwd
@@ -261,6 +304,7 @@ def run_process(
             shell=False,
             pass_fds=pass_fds,
             preexec_fn=preexec_fn,
+            env=env,
         )
     except FileNotFoundError as error:
         raise Refusal(f"{argv[0]} is not available on PATH") from error
@@ -680,14 +724,1100 @@ def discover(root: Path, *, root_fd: int | None = None) -> Universe:
     )
 
 
+@dataclass(frozen=True)
+class ParsedPython:
+    path: str
+    module: str | None
+    tree: ast.Module
+    bytes_count: int
+    dynamic_boundaries: tuple[str, ...]
+    retained_names: frozenset[str]
+    imports: tuple[tuple[str, int], ...]
+
+
+@dataclass(frozen=True)
+class PythonSnapshot:
+    files: tuple[ParsedPython, ...]
+    records: tuple[AnalyserRecord, ...]
+    module_paths: dict[str, str]
+    reachable_paths: frozenset[str]
+    entry_paths: frozenset[str]
+    degraded: bool
+
+
+def python_module_name(path: str) -> str | None:
+    if not path.endswith(".py"):
+        return None
+    parts = list(PurePosixPath(path).parts)
+    if parts[-1] == "__init__.py":
+        parts.pop()
+    else:
+        parts[-1] = parts[-1][:-3]
+    if not parts or any(not part.isidentifier() for part in parts):
+        return None
+    return ".".join(parts)
+
+
+def _main_guard(node: ast.AST) -> bool:
+    if not isinstance(node, ast.If):
+        return False
+    test = node.test
+    if not isinstance(test, ast.Compare) or len(test.ops) != 1:
+        return False
+    if not isinstance(test.ops[0], (ast.Eq, ast.NotEq)) or len(test.comparators) != 1:
+        return False
+    sides = (test.left, test.comparators[0])
+    return any(
+        isinstance(left, ast.Name)
+        and left.id == "__name__"
+        and isinstance(right, ast.Constant)
+        and right.value == "__main__"
+        for left, right in (sides, tuple(reversed(sides)))
+    )
+
+
+def _call_name(node: ast.Call) -> str:
+    target = node.func
+    if isinstance(target, ast.Name):
+        return target.id
+    if isinstance(target, ast.Attribute):
+        return target.attr
+    return ""
+
+
+def _literal_exports(tree: ast.Module) -> set[str]:
+    exports: set[str] = set()
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if not any(isinstance(target, ast.Name) and target.id == "__all__" for target in targets):
+            continue
+        value = node.value
+        if not isinstance(value, (ast.List, ast.Tuple, ast.Set)):
+            continue
+        exports.update(
+            item.value
+            for item in value.elts
+            if isinstance(item, ast.Constant) and isinstance(item.value, str)
+        )
+    return exports
+
+
+def _python_dynamic_boundaries(tree: ast.Module) -> tuple[str, ...]:
+    boundaries: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.decorator_list:
+                boundaries.add("decorator-registration")
+        if not isinstance(node, ast.Call):
+            continue
+        name = _call_name(node)
+        lowered = name.lower()
+        if any(token in lowered for token in ("register", "callback", "fixture", "route")):
+            boundaries.add("dynamic-registration")
+        if name in {"__import__", "import_module"}:
+            if not node.args or not (
+                isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                boundaries.add("computed-import")
+        if name == "getattr" and (
+            len(node.args) < 2
+            or not (
+                isinstance(node.args[1], ast.Constant)
+                and isinstance(node.args[1].value, str)
+            )
+        ):
+            boundaries.add("computed-getattr")
+    if _literal_exports(tree):
+        boundaries.add("literal-__all__")
+    return tuple(sorted(boundaries))
+
+
+def _retained_names(path: str, tree: ast.Module) -> frozenset[str]:
+    retained = _literal_exports(tree)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.decorator_list or node.name.startswith("test_"):
+                retained.add(node.name)
+        if isinstance(node, ast.Call):
+            lowered = _call_name(node).lower()
+            if any(token in lowered for token in ("register", "callback", "fixture", "route")):
+                retained.update(
+                    argument.id for argument in node.args if isinstance(argument, ast.Name)
+                )
+        if _main_guard(node):
+            retained.update(
+                child.id
+                for child in ast.walk(node)
+                if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Load)
+            )
+    if path.startswith("tests/") or "/fixtures/" in f"/{path}":
+        retained.update(
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+        )
+    return frozenset(retained)
+
+
+def _import_targets(
+    module: str | None,
+    tree: ast.Module,
+    *,
+    package_module: bool,
+) -> tuple[tuple[str, int], ...]:
+    targets: set[tuple[str, int]] = set()
+    package = [] if module is None else module.split(".")
+    if not package_module:
+        package = package[:-1]
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            targets.update((alias.name, node.lineno) for alias in node.names)
+            continue
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if node.level:
+            remove = node.level - 1
+            base = package[: max(0, len(package) - remove)]
+        else:
+            base = []
+        if node.module:
+            base.extend(node.module.split("."))
+        if base:
+            targets.add((".".join(base), node.lineno))
+        for alias in node.names:
+            if alias.name != "*" and base:
+                targets.add((".".join([*base, alias.name]), node.lineno))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or _call_name(node) not in {"__import__", "import_module"}:
+            continue
+        if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+            targets.add((node.args[0].value, node.lineno))
+    return tuple(sorted(targets))
+
+
+def _check_map_entry_paths(
+    root: Path,
+    universe: Universe,
+    module_paths: dict[str, str],
+    *,
+    root_fd: int,
+) -> set[str]:
+    path = "tests/check-map-v1.json"
+    if path not in universe.analysed:
+        return set()
+    try:
+        raw = read_commit_regular(
+            root,
+            universe.commit,
+            path,
+            limit=MAX_BOUNDARY_BYTES,
+            label=path,
+            root_fd=root_fd,
+        )
+        document = json.loads(raw, object_pairs_hook=reject_duplicate_keys)
+    except (Refusal, DuplicateKey, json.JSONDecodeError):
+        return set()
+    checks = document.get("checks") if isinstance(document, dict) else None
+    if not isinstance(checks, dict):
+        return set()
+    seeds: set[str] = set()
+    for body in checks.values():
+        if not isinstance(body, dict):
+            continue
+        script = body.get("script")
+        if isinstance(script, str) and script.endswith(".py"):
+            seeds.add(script)
+        argv = body.get("argv")
+        if not isinstance(argv, list) or not argv or not all(isinstance(item, str) for item in argv):
+            continue
+        for item in argv[1:]:
+            if item.endswith(".py"):
+                seeds.add(item)
+            elif item in module_paths:
+                seeds.add(module_paths[item])
+    return seeds
+
+
+def parse_python_snapshot(root: Path, universe: Universe) -> PythonSnapshot:
+    parsed: list[ParsedPython] = []
+    records: list[AnalyserRecord] = []
+    total = 0
+    degraded = False
+    root_fd = open_repository_directory(root)
+    try:
+        for path in (item for item in universe.analysed if item.endswith(".py")):
+            if total >= MAX_PYTHON_TOTAL_BYTES:
+                degraded = True
+                records.append(
+                    AnalyserRecord(path, "file", "skipped", "aggregate Python byte limit reached", 0)
+                )
+                continue
+            try:
+                source = read_commit_regular(
+                    root,
+                    universe.commit,
+                    path,
+                    limit=MAX_PYTHON_FILE_BYTES,
+                    label=path,
+                    root_fd=root_fd,
+                )
+            except Refusal as error:
+                degraded = True
+                records.append(AnalyserRecord(path, "file", "parse-error", str(error), 0))
+                continue
+            size = len(source.encode("utf-8"))
+            total += size
+            if total > MAX_PYTHON_TOTAL_BYTES:
+                degraded = True
+                records.append(
+                    AnalyserRecord(path, "file", "skipped", "aggregate Python byte limit exceeded", size)
+                )
+                continue
+            try:
+                tree = ast.parse(source, filename=path, type_comments=True)
+            except (SyntaxError, ValueError, MemoryError) as error:
+                degraded = True
+                line = getattr(error, "lineno", None)
+                suffix = f" at line {line}" if isinstance(line, int) else ""
+                records.append(
+                    AnalyserRecord(path, "file", "parse-error", f"{type(error).__name__}{suffix}", size)
+                )
+                continue
+            dynamic = _python_dynamic_boundaries(tree)
+            detail = "parsed"
+            if dynamic:
+                detail += "; dynamic boundaries: " + ", ".join(dynamic)
+            records.append(AnalyserRecord(path, "file", "parsed", detail, size))
+            module = python_module_name(path)
+            parsed.append(
+                ParsedPython(
+                    path=path,
+                    module=module,
+                    tree=tree,
+                    bytes_count=size,
+                    dynamic_boundaries=dynamic,
+                    retained_names=_retained_names(path, tree),
+                    imports=_import_targets(
+                        module,
+                        tree,
+                        package_module=path.endswith("/__init__.py") or path == "__init__.py",
+                    ),
+                )
+            )
+
+        module_paths = {
+            item.module: item.path
+            for item in parsed
+            if item.module is not None
+        }
+        seeds = {
+            item.path
+            for item in parsed
+            if item.path.startswith("tests/")
+            or item.path.endswith("/__main__.py")
+            or any(_main_guard(node) for node in item.tree.body)
+        }
+        seeds.update(_check_map_entry_paths(root, universe, module_paths, root_fd=root_fd))
+    finally:
+        os.close(root_fd)
+
+    edges: dict[str, set[str]] = {item.path: set() for item in parsed}
+    for item in parsed:
+        for target, _line in item.imports:
+            probe = target
+            while probe:
+                destination = module_paths.get(probe)
+                if destination is not None:
+                    edges[item.path].add(destination)
+                    break
+                probe = probe.rpartition(".")[0]
+    reachable = set(path for path in seeds if path in edges)
+    pending = list(reachable)
+    while pending:
+        source = pending.pop()
+        for destination in edges[source]:
+            if destination not in reachable:
+                reachable.add(destination)
+                pending.append(destination)
+    return PythonSnapshot(
+        files=tuple(parsed),
+        records=tuple(sorted(records, key=lambda item: item.record_id)),
+        module_paths=module_paths,
+        reachable_paths=frozenset(reachable),
+        entry_paths=frozenset(path for path in seeds if path in edges),
+        degraded=degraded,
+    )
+
+
+def _candidate(
+    path: str,
+    symbol: str,
+    evidence: str,
+    confidence: str,
+    boundary: str,
+    *,
+    analyser_id: str = "python",
+) -> Finding:
+    return Finding(analyser_id, path, symbol, evidence, confidence, boundary)
+
+
+def _unused_bindings(item: ParsedPython) -> Iterable[Finding]:
+    loads = {
+        node.id
+        for node in ast.walk(item.tree)
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
+    } | set(_literal_exports(item.tree))
+    confidence = "low" if item.dynamic_boundaries else "high"
+    boundary = (
+        "computed references or registration may consume this binding"
+        if item.dynamic_boundaries
+        else "scope-insensitive name loading can retain a shadowed binding"
+    )
+    seen_imports: set[tuple[str, int]] = set()
+    for node in ast.walk(item.tree):
+        if isinstance(node, ast.Import):
+            aliases = node.names
+        elif isinstance(node, ast.ImportFrom):
+            aliases = node.names
+        else:
+            continue
+        for alias in aliases:
+            if alias.name == "*":
+                continue
+            binding = alias.asname or alias.name.split(".")[0]
+            identity = (binding, node.lineno)
+            if binding in loads or binding.startswith("_") or identity in seen_imports:
+                continue
+            seen_imports.add(identity)
+            yield _candidate(
+                item.path,
+                f"{binding}@{node.lineno}",
+                f"import binding {binding} has no Name load in the parsed file",
+                confidence,
+                boundary,
+            )
+
+    for function in (
+        node
+        for node in ast.walk(item.tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ):
+        function_loads = {
+            node.id
+            for node in ast.walk(function)
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
+        }
+        assignments: dict[str, int] = {}
+        for node in ast.walk(function):
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+                assignments.setdefault(node.id, node.lineno)
+        for name, line in sorted(assignments.items()):
+            if name in function_loads or name.startswith("_"):
+                continue
+            yield _candidate(
+                item.path,
+                f"{function.name}.{name}@{line}",
+                f"local binding {name} is stored but has no Name load in {function.name}",
+                confidence,
+                "a nested dynamic lookup or scope-insensitive shadow may consume the binding",
+            )
+
+
+def _block_findings(item: ParsedPython) -> Iterable[Finding]:
+    confidence = "low" if item.dynamic_boundaries else "high"
+
+    def inspect(block: list[ast.stmt]) -> Iterable[Finding]:
+        terminator_line: int | None = None
+        for statement in block:
+            if terminator_line is not None:
+                yield _candidate(
+                    item.path,
+                    f"line:{statement.lineno}:unreachable",
+                    f"statement follows an unconditional terminator at line {terminator_line}",
+                    confidence,
+                    "exception handling, generated bytecode or parser limitations may alter control flow",
+                )
+            for field in ("body", "orelse", "finalbody"):
+                child = getattr(statement, field, None)
+                if isinstance(child, list):
+                    yield from inspect(child)
+            if isinstance(statement, ast.Try):
+                for handler in statement.handlers:
+                    yield from inspect(handler.body)
+            if isinstance(statement, (ast.Return, ast.Raise, ast.Break, ast.Continue)):
+                terminator_line = statement.lineno
+
+    yield from inspect(item.tree.body)
+    for node in ast.walk(item.tree):
+        if not isinstance(node, (ast.If, ast.While)):
+            continue
+        truth: bool | None = None
+        if isinstance(node.test, ast.Constant) and isinstance(node.test.value, (bool, type(None))):
+            truth = bool(node.test.value)
+        if truth is None:
+            continue
+        direction = "true" if truth else "false"
+        yield _candidate(
+            item.path,
+            f"line:{node.lineno}:constant-{direction}",
+            f"branch condition is the literal constant {node.test.value!r}",
+            confidence,
+            "the syntax may be an intentional feature flag or type-checking guard",
+        )
+
+
+def analyse_python(root: Path, universe: Universe) -> tuple[AnalyserStatus, tuple[Finding, ...]]:
+    snapshot = parse_python_snapshot(root, universe)
+    findings: list[Finding] = []
+    for item in snapshot.files:
+        findings.extend(_unused_bindings(item))
+        findings.extend(_block_findings(item))
+        if (
+            item.module is not None
+            and snapshot.entry_paths
+            and item.path not in snapshot.reachable_paths
+            and not item.path.endswith("/__init__.py")
+        ):
+            findings.append(
+                _candidate(
+                    item.path,
+                    "<module>",
+                    "no path from a declared check, test or __main__ seed reaches this module over static imports",
+                    "low",
+                    "computed imports, plugin manifests and prose entry points are outside the static import graph",
+                )
+            )
+    state = "degraded" if snapshot.degraded else "ran"
+    parsed_count = sum(record.state == "parsed" for record in snapshot.records)
+    detail = (
+        f"parsed {parsed_count}/{len(snapshot.records)} bounded Python files; "
+        f"{len(snapshot.entry_paths)} entry seed(s)"
+    )
+    if snapshot.degraded:
+        detail += "; one or more files did not parse"
+    return (
+        AnalyserStatus("python", state, PYTHON_ANALYSER_VERSION, detail, snapshot.records),
+        tuple(findings),
+    )
+
+
+def _json_document(payload: bytes | str, label: str) -> dict[str, object]:
+    try:
+        document = json.loads(payload, object_pairs_hook=reject_duplicate_keys)
+    except DuplicateKey as error:
+        raise Refusal(f"{label} repeats JSON key {error.args[0]}") from error
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise Refusal(f"{label} is not valid UTF-8 JSON: {error}") from error
+    if not isinstance(document, dict):
+        raise Refusal(f"{label} is not a JSON object")
+    return document
+
+
+def _python_argv(argv: object) -> bool:
+    if not isinstance(argv, list) or not argv or not all(isinstance(item, str) and item for item in argv):
+        return False
+    executable = PurePosixPath(argv[0]).name
+    return re.fullmatch(r"python(?:3(?:\.14)?)?", executable) is not None
+
+
+def _coverage_recurses(argv: list[str]) -> bool:
+    normalised = [item.replace(chr(92), "/") for item in argv]
+    return any(item.endswith("scripts/dead_code.py") for item in normalised) and "coverage" in argv
+
+
+def _runner_plan(root: Path, scopes: tuple[str, ...]) -> dict[str, object]:
+    argv = [sys.executable, CHECK_RUNNER.as_posix()]
+    for scope in scopes:
+        argv.extend(["--scope", scope])
+    argv.extend(["--plan", "--format", "json"])
+    stdout, stderr, returncode = run_process(
+        argv,
+        cwd=root,
+        timeout_seconds=GIT_TIMEOUT_SECONDS,
+        output_limit=MAX_RUNNER_OUTPUT_BYTES,
+    )
+    if returncode != 0:
+        detail = decode_output(stderr, "check-plan stderr").strip() or f"exit {returncode}"
+        raise Refusal(f"checked runner plan failed: {detail}")
+    plan = _json_document(stdout, "checked runner plan")
+    if plan.get("schema") != "wildcat.check-plan.v1":
+        raise Refusal("checked runner returned an unknown plan schema")
+    if plan.get("requested_scopes") != list(scopes):
+        raise Refusal("checked runner plan is not bound to the requested scopes")
+    selected = plan.get("selected_checks")
+    if not isinstance(selected, list) or not selected:
+        raise Refusal("checked runner selected no checks for coverage")
+    identifiers: set[str] = set()
+    for index, check in enumerate(selected):
+        if not isinstance(check, dict):
+            raise Refusal(f"checked runner plan check {index} is not an object")
+        identifier = check.get("id")
+        argv_value = check.get("argv")
+        if not isinstance(identifier, str) or not identifier or identifier in identifiers:
+            raise Refusal("checked runner plan has empty or repeated check identities")
+        identifiers.add(identifier)
+        if not _python_argv(argv_value):
+            raise Refusal(
+                f"coverage scope includes non-Python check {identifier}; select a Python-only scope"
+            )
+        assert isinstance(argv_value, list)
+        if _coverage_recurses(argv_value):
+            raise Refusal(f"coverage check {identifier} recursively invokes dead_code.py coverage")
+    return plan
+
+
+def _create_process_directory(root: Path, root_fd: int, run_id: str) -> tuple[Path, int]:
+    relative = f"{OWNED_OUTPUT_DIRECTORY}/coverage-processes-{run_id}/record.json"
+    target = confine(root, relative)
+    parts = output_parts(root, target)
+    directory_fd = open_output_directory(root_fd, parts)
+    return target.parent, directory_fd
+
+
+def _read_process_documents(
+    directory: Path,
+    directory_fd: int,
+    run_id: str,
+) -> list[tuple[dict[str, object], int]]:
+    try:
+        names = sorted(os.listdir(directory_fd))
+    except OSError as error:
+        raise Refusal(f"coverage process directory cannot be listed: {error}") from error
+    if len(names) > MAX_COVERAGE_PROCESSES:
+        raise Refusal(f"coverage emitted more than {MAX_COVERAGE_PROCESSES} process records")
+    documents: list[tuple[dict[str, object], int]] = []
+    total_bytes = 0
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    for name in names:
+        if re.fullmatch(r"process-[0-9]+-[0-9a-f]{32}\.json", name) is None:
+            raise Refusal(f"coverage process directory contains foreign entry {name}")
+        try:
+            fd = os.open(name, flags, dir_fd=directory_fd)
+            info = os.fstat(fd)
+            if not stat.S_ISREG(info.st_mode):
+                raise Refusal(f"coverage process record {name} is not regular")
+            if info.st_size > MAX_COVERAGE_PROCESS_BYTES:
+                raise Refusal(f"coverage process record {name} exceeds its byte limit")
+            with os.fdopen(fd, "rb") as handle:
+                payload = handle.read(MAX_COVERAGE_PROCESS_BYTES + 1)
+        except Refusal:
+            raise
+        except OSError as error:
+            raise Refusal(f"coverage process record {name} cannot be read: {error}") from error
+        if len(payload) > MAX_COVERAGE_PROCESS_BYTES or len(payload) != info.st_size:
+            raise Refusal(f"coverage process record {name} changed or exceeded its byte limit")
+        total_bytes += len(payload)
+        if total_bytes > MAX_COVERAGE_BYTES:
+            raise Refusal(f"coverage process records exceed {MAX_COVERAGE_BYTES} aggregate bytes")
+        document = _json_document(payload, f"coverage process record {name}")
+        if document.get("schema") != "dead-code-process-coverage/v1" or document.get("run") != run_id:
+            raise Refusal(f"coverage process record {name} has the wrong identity")
+        documents.append((document, len(payload)))
+    return documents
+
+
+def _remove_process_directory(directory_fd: int, root_fd: int, name: str) -> None:
+    try:
+        for entry in os.listdir(directory_fd):
+            if re.fullmatch(r"process-[0-9]+-[0-9a-f]{32}\.json", entry):
+                try:
+                    os.unlink(entry, dir_fd=directory_fd)
+                except OSError:
+                    pass
+    finally:
+        os.close(directory_fd)
+    try:
+        dead_code_fd = os.open(
+            OWNED_OUTPUT_DIRECTORY,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=root_fd,
+        )
+    except OSError:
+        return
+    try:
+        os.rmdir(name, dir_fd=dead_code_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(dead_code_fd)
+
+
+def _argv_matches(process_argv: object, planned_argv: object) -> bool:
+    if not _python_argv(process_argv) or not _python_argv(planned_argv):
+        return False
+    assert isinstance(process_argv, list)
+    assert isinstance(planned_argv, list)
+    return process_argv[1:] == planned_argv[1:]
+
+
+def _normalise_coverage_events(
+    lines: list[object],
+    branches: list[object],
+    analysed: set[str],
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    normal_lines: set[tuple[str, str, int]] = set()
+    normal_branches: set[tuple[str, str, int, int, str]] = set()
+    for item in lines:
+        if not isinstance(item, dict):
+            raise Refusal("coverage line event is not an object")
+        path = item.get("path")
+        function = item.get("function")
+        line = item.get("line")
+        if not isinstance(path, str) or not isinstance(function, str) or not isinstance(line, int) or line < 1:
+            raise Refusal("coverage line event has an invalid identity")
+        validate_repository_path(path, "coverage line path")
+        if path in analysed:
+            normal_lines.add((path, function, line))
+    for item in branches:
+        if not isinstance(item, dict):
+            raise Refusal("coverage branch event is not an object")
+        path = item.get("path")
+        function = item.get("function")
+        source = item.get("from_line")
+        target = item.get("to_line")
+        direction = item.get("direction")
+        if (
+            not isinstance(path, str)
+            or not isinstance(function, str)
+            or not isinstance(source, int)
+            or source < 1
+            or not isinstance(target, int)
+            or target < 1
+            or direction not in {"left", "right"}
+        ):
+            raise Refusal("coverage branch event has an invalid identity")
+        validate_repository_path(path, "coverage branch path")
+        if path in analysed:
+            normal_branches.add((path, function, source, target, direction))
+    return (
+        [
+            {"path": path, "function": function, "line": line}
+            for path, function, line in sorted(normal_lines)
+        ],
+        [
+            {
+                "path": path,
+                "function": function,
+                "from_line": source,
+                "to_line": target,
+                "direction": direction,
+            }
+            for path, function, source, target, direction in sorted(normal_branches)
+        ],
+    )
+
+
+def aggregate_coverage(
+    plan: dict[str, object],
+    run: dict[str, object],
+    process_documents: list[tuple[dict[str, object], int]],
+    universe: Universe,
+) -> dict[str, object]:
+    selected = plan.get("selected_checks")
+    results = run.get("checks")
+    if not isinstance(selected, list) or not isinstance(results, list):
+        raise Refusal("checked runner record omits selected checks or results")
+    planned: dict[str, dict[str, object]] = {}
+    for item in selected:
+        if not isinstance(item, dict) or not isinstance(item.get("id"), str):
+            raise Refusal("checked runner selected-check record is malformed")
+        planned[item["id"]] = item
+    terminal: dict[str, dict[str, object]] = {}
+    for item in results:
+        if not isinstance(item, dict) or not isinstance(item.get("check"), str):
+            raise Refusal("checked runner terminal record is malformed")
+        terminal[item["check"]] = item
+    if set(terminal) != set(planned):
+        raise Refusal("checked runner terminal records do not match its plan")
+
+    marker_to_check: dict[str, str] = {}
+    degraded_reasons: set[str] = set()
+    for document, _size in process_documents:
+        process = document.get("process")
+        if not isinstance(process, dict):
+            raise Refusal("coverage process record omits process identity")
+        marker = process.get("containment")
+        argv = process.get("argv")
+        if not isinstance(marker, str) or not marker:
+            raise Refusal("coverage process record omits containment identity")
+        matches = [
+            check_id
+            for check_id, check in planned.items()
+            if _argv_matches(argv, check.get("argv"))
+        ]
+        if len(matches) == 1:
+            prior = marker_to_check.get(marker)
+            if prior is not None and prior != matches[0]:
+                degraded_reasons.add("one process group matched multiple checks")
+            marker_to_check[marker] = matches[0]
+
+    public_processes: list[dict[str, object]] = []
+    bytes_by_check = {check_id: 0 for check_id in planned}
+    process_count_by_check = {check_id: 0 for check_id in planned}
+    for document, size in process_documents:
+        process = document["process"]
+        assert isinstance(process, dict)
+        marker = process["containment"]
+        assert isinstance(marker, str)
+        check_id = marker_to_check.get(marker)
+        if check_id is None:
+            degraded_reasons.add("one monitored process group could not be attributed")
+            continue
+        status = document.get("status")
+        lines = document.get("lines")
+        branches = document.get("branches")
+        if not isinstance(status, dict) or not isinstance(lines, list) or not isinstance(branches, list):
+            raise Refusal("coverage process record omits status, lines or branches")
+        lines, branches = _normalise_coverage_events(
+            lines,
+            branches,
+            set(universe.analysed),
+        )
+        if status.get("state") != "ran":
+            degraded_reasons.add(f"check {check_id} emitted a degraded process record")
+        bytes_by_check[check_id] += size
+        process_count_by_check[check_id] += 1
+        group_id = digest_json({"run": document.get("run"), "containment": marker})
+        process_id = digest_json(
+            {
+                "group": group_id,
+                "pid": process.get("pid"),
+                "parent_pid": process.get("parent_pid"),
+                "argv": process.get("argv"),
+                "lines": lines,
+                "branches": branches,
+            }
+        )
+        public_processes.append(
+            {
+                "id": process_id,
+                "group": group_id,
+                "check": check_id,
+                "pid": process.get("pid"),
+                "parent_pid": process.get("parent_pid"),
+                "argv": process.get("argv"),
+                "status": status,
+                "bytes": size,
+                "lines": lines,
+                "branches": branches,
+            }
+        )
+
+    check_records: list[dict[str, object]] = []
+    for check_id in sorted(planned):
+        result = terminal[check_id]
+        state = result.get("status")
+        if state != "passed":
+            degraded_reasons.add(f"check {check_id} ended {state}")
+        if process_count_by_check[check_id] == 0:
+            degraded_reasons.add(f"check {check_id} emitted no process record")
+        check_records.append(
+            {
+                "id": check_id,
+                "state": state,
+                "duration_seconds": result.get("duration_seconds"),
+                "processes": process_count_by_check[check_id],
+                "bytes": bytes_by_check[check_id],
+            }
+        )
+    if run.get("schema") != "wildcat.check-run.v1" or run.get("outcome") != "green":
+        degraded_reasons.add(f"checked runner outcome was {run.get('outcome')}")
+    public_processes.sort(key=lambda item: (str(item["check"]), str(item["id"])))
+    state = "degraded" if degraded_reasons else "ran"
+    return {
+        "schema": COVERAGE_SCHEMA_ID,
+        "tool": {"id": "sys.monitoring", "python": sys.version.split()[0]},
+        "tree": {"commit": universe.commit, "git_tree": universe.tree, "universe": universe.identity},
+        "plan": {
+            "schema": plan.get("schema"),
+            "map_digest": plan.get("map_digest"),
+            "requested_scopes": plan.get("requested_scopes"),
+            "selected_checks": sorted(planned),
+        },
+        "status": {
+            "state": state,
+            "detail": (
+                "every selected Python check completed with process coverage"
+                if not degraded_reasons
+                else "; ".join(sorted(degraded_reasons))
+            ),
+        },
+        "checks": check_records,
+        "processes": public_processes,
+    }
+
+
+def _coverage_environment(root: Path, process_directory: Path, run_id: str) -> dict[str, str]:
+    environment = dict(os.environ)
+    monitoring_path = str(root / MONITOR_DIRECTORY)
+    inherited_python_path = environment.get("PYTHONPATH")
+    environment["PYTHONPATH"] = monitoring_path + (
+        os.pathsep + inherited_python_path if inherited_python_path else ""
+    )
+    runtime_directory = str(Path(sys.executable).parent)
+    inherited_path = environment.get("PATH")
+    environment["PATH"] = runtime_directory + (
+        os.pathsep + inherited_path if inherited_path else ""
+    )
+    environment[COVERAGE_ACTIVE_ENV] = run_id
+    environment[COVERAGE_OUTPUT_ENV] = str(process_directory)
+    return environment
+
+
+def command_coverage(arguments: argparse.Namespace) -> int:
+    if os.environ.get(COVERAGE_ACTIVE_ENV):
+        raise Refusal("coverage wrapper recursion is active in this process")
+    if sys.version_info[:2] != (3, 14) or not hasattr(sys, "monitoring"):
+        raise Refusal("coverage requires the repository Python 3.14 sys.monitoring runtime")
+    scopes = tuple(arguments.scope)
+    if not scopes or len(scopes) != len(set(scopes)):
+        raise Refusal("coverage requires one or more unique --scope values")
+    root = repository_root(Path(arguments.directory).resolve())
+    root_fd = open_repository_directory(root)
+    process_fd: int | None = None
+    process_name = ""
+    try:
+        target = confine(root, arguments.output)
+        universe = discover(root, root_fd=root_fd)
+        plan = _runner_plan(root, scopes)
+        run_id = uuid.uuid4().hex
+        process_directory, process_fd = _create_process_directory(root, root_fd, run_id)
+        process_name = process_directory.name
+        environment = _coverage_environment(root, process_directory, run_id)
+        runner_report = f"{OWNED_OUTPUT_DIRECTORY}/checks.json"
+        argv = [sys.executable, CHECK_RUNNER.as_posix()]
+        for scope in scopes:
+            argv.extend(["--scope", scope])
+        argv.extend(["--report", runner_report])
+        _stdout, _stderr, _returncode = run_process(
+            argv,
+            cwd=root,
+            timeout_seconds=RUNNER_TIMEOUT_SECONDS,
+            output_limit=MAX_RUNNER_OUTPUT_BYTES,
+            env=environment,
+        )
+        run_raw = read_bounded_regular(
+            root / runner_report,
+            limit=MAX_COVERAGE_BYTES,
+            label=runner_report,
+        )
+        run = _json_document(run_raw, runner_report)
+        documents = _read_process_documents(process_directory, process_fd, run_id)
+        coverage = aggregate_coverage(plan, run, documents, universe)
+        atomic_write(root, target, json.dumps(coverage, indent=2, sort_keys=True) + chr(10), root_fd=root_fd)
+        return 0
+    finally:
+        if process_fd is not None:
+            _remove_process_directory(process_fd, root_fd, process_name)
+        os.close(root_fd)
+
+
+def _coverage_file(
+    root: Path,
+    universe: Universe,
+    coverage_path: str | None,
+) -> dict[str, object]:
+    if coverage_path is None:
+        raise Refusal("coverage analyser requires --coverage")
+    target = confine(root, coverage_path)
+    raw = read_bounded_regular(target, limit=MAX_COVERAGE_BYTES, label=coverage_path)
+    document = _json_document(raw, coverage_path)
+    if document.get("schema") != COVERAGE_SCHEMA_ID:
+        raise Refusal(f"{coverage_path} does not declare {COVERAGE_SCHEMA_ID}")
+    tree = document.get("tree")
+    if not isinstance(tree, dict):
+        raise Refusal(f"{coverage_path} omits tree identity")
+    if (
+        tree.get("commit") != universe.commit
+        or tree.get("git_tree") != universe.tree
+        or tree.get("universe") != universe.identity
+    ):
+        return {
+            **document,
+            "status": {
+                "state": "degraded",
+                "detail": "coverage identity does not match the report universe",
+            },
+        }
+    return document
+
+
+def _function_targets(item: ParsedPython) -> Iterable[tuple[str, int]]:
+    for node in ast.walk(item.tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or not node.body:
+            continue
+        if node.name in item.retained_names:
+            continue
+        yield node.name, node.body[0].lineno
+
+
+def _branch_targets(item: ParsedPython) -> Iterable[tuple[int, int, str]]:
+    for node in ast.walk(item.tree):
+        if not isinstance(node, ast.If) or not node.body or not node.orelse:
+            continue
+        if isinstance(node.test, ast.Constant):
+            continue
+        yield node.lineno, node.body[0].lineno, "body"
+        yield node.lineno, node.orelse[0].lineno, "else"
+
+
+def analyse_coverage(
+    root: Path,
+    universe: Universe,
+    coverage_path: str | None,
+) -> tuple[AnalyserStatus, tuple[Finding, ...]]:
+    document = _coverage_file(root, universe, coverage_path)
+    status = document.get("status")
+    checks = document.get("checks")
+    processes = document.get("processes")
+    if not isinstance(status, dict) or not isinstance(checks, list) or not isinstance(processes, list):
+        raise Refusal("coverage record omits status, checks or processes")
+    records: list[AnalyserRecord] = []
+    for item in checks:
+        if not isinstance(item, dict) or not isinstance(item.get("id"), str):
+            raise Refusal("coverage check record is malformed")
+        state = item.get("state")
+        mapped = "passed" if state == "passed" else "unavailable" if state == "unavailable" else "failed"
+        size = item.get("bytes")
+        records.append(
+            AnalyserRecord(
+                item["id"],
+                "check",
+                mapped,
+                f"runner state {state}; {item.get('processes')} process record(s)",
+                size if isinstance(size, int) and size >= 0 else 0,
+            )
+        )
+    records.sort(key=lambda item: item.record_id)
+    if status.get("state") != "ran":
+        return (
+            AnalyserStatus(
+                "coverage",
+                "degraded",
+                COVERAGE_ANALYSER_VERSION,
+                str(status.get("detail") or "coverage did not complete"),
+                tuple(records),
+            ),
+            (),
+        )
+    if not records or any(record.state != "passed" for record in records):
+        return (
+            AnalyserStatus(
+                "coverage",
+                "degraded",
+                COVERAGE_ANALYSER_VERSION,
+                "coverage claimed completion but one or more check records were not passed",
+                tuple(records),
+            ),
+            (),
+        )
+
+    observed_lines: set[tuple[str, int]] = set()
+    observed_branches: set[tuple[str, int, int]] = set()
+    for process in processes:
+        if not isinstance(process, dict):
+            raise Refusal("coverage process aggregate is malformed")
+        lines = process.get("lines")
+        branches = process.get("branches")
+        if not isinstance(lines, list) or not isinstance(branches, list):
+            raise Refusal("coverage process aggregate omits lines or branches")
+        process_status = process.get("status")
+        if not isinstance(process_status, dict) or process_status.get("state") != "ran":
+            return (
+                AnalyserStatus(
+                    "coverage",
+                    "degraded",
+                    COVERAGE_ANALYSER_VERSION,
+                    "coverage claimed completion but one process record was degraded",
+                    tuple(records),
+                ),
+                (),
+            )
+        for line in lines:
+            if isinstance(line, dict) and isinstance(line.get("path"), str) and isinstance(line.get("line"), int):
+                observed_lines.add((line["path"], line["line"]))
+        for branch in branches:
+            if (
+                isinstance(branch, dict)
+                and isinstance(branch.get("path"), str)
+                and isinstance(branch.get("from_line"), int)
+                and isinstance(branch.get("to_line"), int)
+            ):
+                observed_branches.add((branch["path"], branch["from_line"], branch["to_line"]))
+
+    snapshot = parse_python_snapshot(root, universe)
+    if snapshot.degraded:
+        return (
+            AnalyserStatus(
+                "coverage",
+                "degraded",
+                COVERAGE_ANALYSER_VERSION,
+                "coverage completed but the bounded Python source inventory was incomplete",
+                tuple(records),
+            ),
+            (),
+        )
+    findings: list[Finding] = []
+    for item in snapshot.files:
+        for name, line in _function_targets(item):
+            if (item.path, line) not in observed_lines:
+                findings.append(
+                    _candidate(
+                        item.path,
+                        f"{name}@{line}",
+                        f"no body line for {name} was observed in the completed named checks",
+                        "low",
+                        "coverage names only the selected checks and cannot prove other entry points absent",
+                        analyser_id="coverage",
+                    )
+                )
+        for source, target, direction in _branch_targets(item):
+            if (item.path, source, target) not in observed_branches:
+                findings.append(
+                    _candidate(
+                        item.path,
+                        f"branch:{source}->{target}:{direction}",
+                        f"the {direction} branch from line {source} to line {target} was not observed",
+                        "low",
+                        "sys.monitoring observed only the completed named checks",
+                        analyser_id="coverage",
+                    )
+                )
+    return (
+        AnalyserStatus(
+            "coverage",
+            "ran",
+            COVERAGE_ANALYSER_VERSION,
+            f"consumed {len(processes)} process record(s) from {len(checks)} completed check(s)",
+            tuple(records),
+        ),
+        tuple(findings),
+    )
+
+
+ANALYSERS["python"] = analyse_python
+
+
 def collect(
     root: Path,
     universe: Universe,
+    analyser_ids: tuple[str, ...] | None = None,
+    coverage_path: str | None = None,
 ) -> tuple[tuple[AnalyserStatus, ...], tuple[Finding, ...]]:
     statuses: list[AnalyserStatus] = []
     findings: list[Finding] = []
-    for analyser_id in sorted(ANALYSERS):
-        status, produced = ANALYSERS[analyser_id](root, universe)
+    selected = tuple(sorted(ANALYSERS)) if analyser_ids is None else tuple(sorted(analyser_ids))
+    for analyser_id in selected:
+        if analyser_id == "coverage":
+            status, produced = analyse_coverage(root, universe, coverage_path)
+        else:
+            analyser = ANALYSERS.get(analyser_id)
+            if analyser is None:
+                raise Refusal(f"unknown analyser {analyser_id}")
+            status, produced = analyser(root, universe)
         if status.analyser_id != analyser_id:
             raise Refusal(
                 f"analyser {analyser_id} returned status for {status.analyser_id}"
@@ -739,6 +1869,20 @@ def validate_report(report: Report) -> None:
             )
         if not item.detail:
             raise Refusal(f"analyser {item.analyser_id} has no detail")
+        record_ids: set[tuple[str, str]] = set()
+        for record in item.records:
+            identity = (record.kind, record.record_id)
+            if not record.record_id or identity in record_ids:
+                raise Refusal(f"analyser {item.analyser_id} has empty or repeated records")
+            if record.kind not in ANALYSER_RECORD_KINDS:
+                raise Refusal(f"analyser {item.analyser_id} has unknown record kind {record.kind}")
+            if record.state not in ANALYSER_RECORD_STATES:
+                raise Refusal(f"analyser {item.analyser_id} has unknown record state {record.state}")
+            if not record.detail or record.bytes_count < 0:
+                raise Refusal(f"analyser {item.analyser_id} has an invalid record")
+            record_ids.add(identity)
+        if item.records != tuple(sorted(item.records, key=lambda record: (record.kind, record.record_id))):
+            raise Refusal(f"analyser {item.analyser_id} records are not sorted")
         status_ids.add(item.analyser_id)
     if tuple(item.analyser_id for item in report.statuses) != tuple(sorted(status_ids)):
         raise Refusal("analyser statuses are not sorted by identity")
@@ -778,9 +1922,15 @@ def validate_report(report: Report) -> None:
         raise Refusal("findings are not sorted by stable report identity")
 
 
-def build_report(root: Path, *, root_fd: int | None = None) -> Report:
+def build_report(
+    root: Path,
+    *,
+    root_fd: int | None = None,
+    analyser_ids: tuple[str, ...] = (),
+    coverage_path: str | None = None,
+) -> Report:
     universe = discover(root, root_fd=root_fd)
-    statuses, findings = collect(root, universe)
+    statuses, findings = collect(root, universe, analyser_ids, coverage_path)
     report = Report(universe=universe, statuses=statuses, findings=findings)
     validate_report(report)
     return report
@@ -827,6 +1977,11 @@ def render_text(report: Report) -> str:
             f"  {analyser['id']}{version}  {analyser['state']}  "
             f"{analyser['detail']}"
         )
+        for record in analyser["records"]:
+            lines.append(
+                f"    {record['kind']} {record['id']}  {record['state']}  "
+                f"{record['bytes']} byte(s)  {record['detail']}"
+            )
 
     findings = document["findings"]
     lines.extend(["", f"findings  {len(findings)} candidate(s); report-only"])
@@ -1032,9 +2187,16 @@ def command_report(arguments: argparse.Namespace) -> int:
     root_fd = open_repository_directory(root)
     target: Path | None = None
     try:
+        analyser_ids = parse_analyser_ids(getattr(arguments, "analyser", None))
+        coverage_path = getattr(arguments, "coverage", None)
         if arguments.output is not None:
             target = confine(root, arguments.output)
-        report = build_report(root, root_fd=root_fd)
+        report = build_report(
+            root,
+            root_fd=root_fd,
+            analyser_ids=analyser_ids,
+            coverage_path=coverage_path,
+        )
         rendered = render_json(report) if arguments.json else render_text(report)
         if arguments.output is None:
             sys.stdout.write(rendered)
@@ -1045,6 +2207,21 @@ def command_report(arguments: argparse.Namespace) -> int:
     finally:
         if root_fd is not None:
             os.close(root_fd)
+
+
+def parse_analyser_ids(value: str | None) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    identifiers = tuple(value.split(","))
+    if not identifiers or any(not item for item in identifiers):
+        raise Refusal("--analyser must be a comma-separated list of identities")
+    if len(identifiers) != len(set(identifiers)):
+        raise Refusal("--analyser repeats an identity")
+    supported = {*ANALYSERS, "coverage"}
+    unknown = sorted(set(identifiers) - supported)
+    if unknown:
+        raise Refusal("unknown analyser(s): " + ", ".join(unknown))
+    return identifiers
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -1058,6 +2235,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="a path inside the repository to analyse",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
+    coverage = subparsers.add_parser(
+        "coverage",
+        help="run a Python-only checked scope under sys.monitoring",
+    )
+    coverage.add_argument(
+        "--scope",
+        action="append",
+        default=[],
+        help="a checked-runner scope; repeatable",
+    )
+    coverage.add_argument(
+        "--output",
+        required=True,
+        help="write the coverage record inside the owned .dead-code sink",
+    )
+    coverage.set_defaults(handler=command_coverage)
     report = subparsers.add_parser(
         "report",
         help="report the universe and its candidates",
@@ -1070,6 +2263,14 @@ def build_parser() -> argparse.ArgumentParser:
     report.add_argument(
         "--output",
         help="write inside the repository instead of stdout",
+    )
+    report.add_argument(
+        "--analyser",
+        help="comma-separated analyser identities to run",
+    )
+    report.add_argument(
+        "--coverage",
+        help="coverage record below the owned .dead-code sink",
     )
     report.set_defaults(handler=command_report)
     return parser

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -2,9 +2,10 @@
 """Build a report-only dead-code inventory for one clean Git tree.
 
 The command discovers tracked paths, applies hard Horos classifications and
-renders one deterministic model as text or JSON. Step 1 registers no analyser,
-so the report says that no reachability result was established. It never
-deletes source and a finding count is never an exit gate.
+renders one model as text or JSON. Callers select bounded Python, repository,
+coverage and optional Solidity signals explicitly; selecting none records that
+no reachability result was established. It never deletes source and a finding
+count is never an exit gate.
 """
 
 from __future__ import annotations
@@ -12,15 +13,19 @@ from __future__ import annotations
 import argparse
 import ast
 import hashlib
+import io
 import json
 import os
+import posixpath
 import re
 import selectors
 import signal
 import stat
 import subprocess
 import sys
+import tarfile
 import time
+import tomllib
 import uuid
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
@@ -45,6 +50,9 @@ MAX_TRACKED_PATHS = 100_000
 MAX_PATH_BYTES = 4096
 MAX_PYTHON_FILE_BYTES = 4 * 1024 * 1024
 MAX_PYTHON_TOTAL_BYTES = 96 * 1024 * 1024
+MAX_REPOSITORY_FILE_BYTES = 4 * 1024 * 1024
+MAX_REPOSITORY_TOTAL_BYTES = 128 * 1024 * 1024
+MAX_REPOSITORY_ARCHIVE_BYTES = 160 * 1024 * 1024
 MAX_COVERAGE_BYTES = 32 * 1024 * 1024
 MAX_COVERAGE_PROCESS_BYTES = 16 * 1024 * 1024
 MAX_COVERAGE_PROCESSES = 4096
@@ -59,9 +67,25 @@ COVERAGE_OUTPUT_ENV = "WILDCAT_DEAD_CODE_COVERAGE_OUTPUT"
 CHECK_CONTAINMENT_ENV = "WILDCAT_CHECK_CONTAINMENT"
 PYTHON_ANALYSER_VERSION = "1"
 COVERAGE_ANALYSER_VERSION = "sys.monitoring/3.14"
+REPOSITORY_ANALYSER_VERSION = "repository-graph/1"
+SOLIDITY_ANALYSER_VERSION = "slither+forge/1"
+SOLIDITY_VERSION_TIMEOUT_SECONDS = 30
+SOLIDITY_TOOL_TIMEOUT_SECONDS = 600
+MAX_SOLIDITY_VERSION_BYTES = 64 * 1024
+MAX_SOLIDITY_OUTPUT_BYTES = 32 * 1024 * 1024
+REPOSITORY_FAMILIES = (
+    "check-map",
+    "cli",
+    "document",
+    "fixture",
+    "generated-copy",
+    "manifest",
+    "router",
+    "schema",
+)
 ANALYSER_STATES = frozenset({"ran", "not-available", "degraded", "failed"})
 CONFIDENCE_LEVELS = frozenset({"high", "medium", "low"})
-ANALYSER_RECORD_KINDS = frozenset({"file", "check"})
+ANALYSER_RECORD_KINDS = frozenset({"file", "check", "family", "project"})
 ANALYSER_RECORD_STATES = frozenset(
     {"parsed", "parse-error", "skipped", "passed", "failed", "unavailable"}
 )
@@ -154,6 +178,10 @@ class AnalyserRecord:
     state: str
     detail: str
     bytes_count: int
+    version: str | None = None
+    duration_ms: int = 0
+    evidence_count: int = 0
+    reason: str | None = None
 
     def as_dict(self) -> dict[str, object]:
         return {
@@ -162,6 +190,10 @@ class AnalyserRecord:
             "state": self.state,
             "detail": self.detail,
             "bytes": self.bytes_count,
+            "version": self.version,
+            "duration_ms": self.duration_ms,
+            "evidence_count": self.evidence_count,
+            "reason": self.reason,
         }
 
 
@@ -1236,6 +1268,885 @@ def analyse_python(root: Path, universe: Universe) -> tuple[AnalyserStatus, tupl
     )
 
 
+@dataclass(frozen=True)
+class RepositorySource:
+    path: str
+    text: str | None
+    bytes_count: int
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class RepositoryNode:
+    family: str
+    path: str
+    logical_id: str | None = None
+
+    @property
+    def key(self) -> str:
+        return self.path if self.logical_id is None else f"{self.path}#{self.logical_id}"
+
+    @property
+    def symbol(self) -> str:
+        return f"{self.family}:{self.logical_id or 'file'}"
+
+
+@dataclass(frozen=True)
+class RepositoryEdge:
+    source: str
+    target: str
+    parser: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"source": self.source, "target": self.target, "parser": self.parser}
+
+
+@dataclass(frozen=True)
+class ComputedBoundary:
+    source: str
+    prefix: str
+    boundary: str
+
+
+REPOSITORY_SOURCE_SUFFIXES = frozenset(
+    {".json", ".md", ".py", ".sh", ".toml", ".txt", ".yaml", ".yml"}
+)
+REPOSITORY_PATH_TOKEN = re.compile(
+    r"(?<![A-Za-z0-9_.@+-])(?:\.{0,2}/)?[A-Za-z0-9_.@+-]+"
+    r"(?:/[A-Za-z0-9_.@+:-]+)+"
+)
+MARKDOWN_LINK = re.compile(r"\]\(([^)\s]+)(?:\s+[^)]*)?\)")
+COMPUTED_PATH_PATTERNS = (
+    (re.compile(r"\bPath\(\s*['\"]([^'\"]+)['\"]\s*\)\s*/"), "computed-path:path-join"),
+    (re.compile(r"\b(?:join|joinpath)\(\s*['\"]([^'\"]+)['\"]\s*,"), "computed-path:path-join"),
+    (re.compile(r"\b(?:glob|rglob)\(\s*['\"]([^'\"]+)['\"]"), "computed-path:glob"),
+    (re.compile(r"\bf['\"]([^'\"]*/[^'\"]*)\{"), "computed-path:f-string"),
+    (re.compile(r"['\"]([^'\"]+/)\*"), "computed-path:glob"),
+    (re.compile(r"['\"]([^'\"]*/[^'\"]*)\$\{"), "computed-path:template"),
+    (re.compile(r"['\"]([^'\"]*/[^'\"]*)\{\{"), "computed-path:template"),
+)
+
+
+def _repository_source_paths(universe: Universe) -> tuple[str, ...]:
+    return tuple(
+        path
+        for path in universe.analysed
+        if PurePosixPath(path).suffix.lower() in REPOSITORY_SOURCE_SUFFIXES
+        or PurePosixPath(path).name in {"SKILL.md", "AGENTS.md", "PROMISE_MACHINE.md"}
+    )
+
+
+def _archive_sources(root: Path, universe: Universe) -> dict[str, RepositorySource]:
+    """Read bounded declaration text from the recorded tree without checkout races."""
+    selected = _repository_source_paths(universe)
+    sources: dict[str, RepositorySource] = {}
+    total_bytes = 0
+    total_archive_bytes = 0
+    root_fd = open_repository_directory(root)
+    try:
+        for offset in range(0, len(selected), 128):
+            chunk = selected[offset : offset + 128]
+            stdout, stderr, returncode = run_process(
+                ["git", "archive", "--format=tar", universe.commit, "--", *chunk],
+                cwd=root,
+                timeout_seconds=GIT_TIMEOUT_SECONDS,
+                output_limit=MAX_REPOSITORY_ARCHIVE_BYTES,
+                cwd_fd=root_fd,
+            )
+            total_archive_bytes += len(stdout) + len(stderr)
+            if total_archive_bytes > MAX_REPOSITORY_ARCHIVE_BYTES:
+                raise Refusal(
+                    f"repository declaration archive exceeded {MAX_REPOSITORY_ARCHIVE_BYTES} bytes"
+                )
+            if returncode != 0:
+                detail = decode_output(stderr, "git archive stderr").strip() or f"exit {returncode}"
+                raise Refusal(f"git archive failed: {detail}")
+            requested = set(chunk)
+            seen: set[str] = set()
+            try:
+                with tarfile.open(fileobj=io.BytesIO(stdout), mode="r:") as archive:
+                    for member in archive:
+                        if member.isdir():
+                            continue
+                        path = validate_repository_path(member.name, "repository archive path")
+                        if path not in requested or path in seen:
+                            raise Refusal(f"repository archive returned unexpected or repeated path {path}")
+                        seen.add(path)
+                        if not member.isfile() or member.size < 0:
+                            raise Refusal(f"repository archive member {path} is not a regular file")
+                        if member.size > MAX_REPOSITORY_FILE_BYTES:
+                            sources[path] = RepositorySource(
+                                path,
+                                None,
+                                member.size,
+                                f"file exceeds {MAX_REPOSITORY_FILE_BYTES} bytes",
+                            )
+                            continue
+                        handle = archive.extractfile(member)
+                        if handle is None:
+                            raise Refusal(f"repository archive member {path} cannot be read")
+                        payload = handle.read(MAX_REPOSITORY_FILE_BYTES + 1)
+                        if len(payload) != member.size or len(payload) > MAX_REPOSITORY_FILE_BYTES:
+                            raise Refusal(f"repository archive member {path} changed size while read")
+                        total_bytes += len(payload)
+                        if total_bytes > MAX_REPOSITORY_TOTAL_BYTES:
+                            raise Refusal(
+                                f"repository declarations exceeded {MAX_REPOSITORY_TOTAL_BYTES} bytes"
+                            )
+                        try:
+                            text = payload.decode("utf-8")
+                        except UnicodeDecodeError:
+                            sources[path] = RepositorySource(
+                                path,
+                                None,
+                                len(payload),
+                                "file is not UTF-8",
+                            )
+                        else:
+                            sources[path] = RepositorySource(path, text, len(payload))
+            except (tarfile.TarError, OSError, EOFError) as error:
+                raise Refusal(f"repository declaration archive is malformed: {error}") from error
+            missing = sorted(requested - seen)
+            if missing:
+                raise Refusal(
+                    "repository archive omitted tracked declaration(s): " + ", ".join(missing[:5])
+                )
+    finally:
+        os.close(root_fd)
+    return sources
+
+
+def _path_families(path: str, source: RepositorySource | None) -> set[str]:
+    pure = PurePosixPath(path)
+    parts = pure.parts
+    families: set[str] = set()
+    if "fixtures" in parts:
+        families.add("fixture")
+    if (parts and parts[0] == "schemas") or path.endswith(".schema.json"):
+        families.add("schema")
+    if parts and parts[0] == "docs" and path.endswith(".md"):
+        families.add("document")
+    if parts and parts[0] in {"bin", "scripts"} and pure.suffix in {".py", ".sh"}:
+        families.add("cli")
+    if (
+        len(parts) == 4
+        and parts[:2] == (".agents", "skills")
+        and parts[-1] == "SKILL.md"
+    ):
+        families.add("router")
+    if pure.name in {"plugin.json", "marketplace.json", "package.json", "pyproject.toml"}:
+        families.add("manifest")
+    if source is not None and source.text is not None:
+        prefix = source.text[:4096].lower()
+        if "copies=generated" in prefix or "generated from" in prefix:
+            families.add("generated-copy")
+    return families
+
+
+def _external_repository_roots(nodes: Iterable[RepositoryNode]) -> set[str]:
+    roots: set[str] = set()
+    for node in nodes:
+        if node.family == "router" and node.path == ".agents/skills/promise-machine/SKILL.md":
+            roots.add(node.key)
+        if node.family == "manifest" and any(
+            part in {".claude-plugin", ".codex-plugin", ".cursor-plugin"}
+            for part in PurePosixPath(node.path).parts
+        ):
+            roots.add(node.key)
+        if node.family == "manifest" and node.path in {"package.json", "pyproject.toml"}:
+            roots.add(node.key)
+    return roots
+
+
+def _walk_string_values(value: object) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, list):
+        for item in value:
+            yield from _walk_string_values(item)
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            yield key
+            yield from _walk_string_values(item)
+
+
+def _normalise_reference(source: str, value: str, tracked: set[str]) -> str | None:
+    candidate = value.strip().strip("'\"`<>")
+    if not candidate or "://" in candidate or any(token in candidate for token in ("${", "{{", "*")):
+        return None
+    candidate = candidate.split("#", 1)[0].split("?", 1)[0].rstrip(".,;:")
+    if candidate.startswith("/"):
+        candidate = candidate[1:]
+    if candidate in tracked:
+        return candidate
+    relative = posixpath.normpath(posixpath.join(posixpath.dirname(source), candidate))
+    if relative in tracked and not relative.startswith("../"):
+        return relative
+    if "/" not in candidate and "." in candidate and candidate.replace(".", "").isidentifier():
+        module_path = candidate.replace(".", "/") + ".py"
+        package_path = candidate.replace(".", "/") + "/__init__.py"
+        if module_path in tracked:
+            return module_path
+        if package_path in tracked:
+            return package_path
+    return None
+
+
+def _computed_boundaries(
+    source: RepositorySource,
+    tracked: set[str],
+) -> tuple[ComputedBoundary, ...]:
+    if source.text is None:
+        return ()
+    found: set[tuple[str, str]] = set()
+    for pattern, name in COMPUTED_PATH_PATTERNS:
+        for match in pattern.finditer(source.text):
+            prefix = match.group(1).strip().rstrip("/")
+            if prefix.startswith("./"):
+                prefix = prefix[2:]
+            if prefix.startswith("/"):
+                prefix = prefix[1:]
+            relative = (
+                prefix
+                if any(path == prefix or path.startswith(prefix + "/") for path in tracked)
+                else posixpath.normpath(posixpath.join(posixpath.dirname(source.path), prefix))
+            )
+            if relative and not relative.startswith("../"):
+                found.add((relative, name))
+    return tuple(
+        ComputedBoundary(source.path, prefix, name)
+        for prefix, name in sorted(found)
+    )
+
+
+def _repository_values(source: RepositorySource) -> tuple[tuple[str, str], ...]:
+    if source.text is None:
+        return ()
+    values: list[tuple[str, str]] = []
+    suffix = PurePosixPath(source.path).suffix.lower()
+    if suffix == ".json":
+        document = _json_document(source.text, source.path)
+        values.extend((value, "json-string") for value in _walk_string_values(document))
+    elif suffix == ".toml":
+        try:
+            document = tomllib.loads(source.text)
+        except tomllib.TOMLDecodeError as error:
+            raise Refusal(f"{source.path} is not valid TOML: {error}") from error
+        values.extend((value, "toml-string") for value in _walk_string_values(document))
+    elif suffix == ".py":
+        try:
+            tree = ast.parse(source.text, filename=source.path, type_comments=True)
+        except (SyntaxError, ValueError, MemoryError):
+            tree = None
+        if tree is not None:
+            values.extend(
+                (node.value, "python-string")
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Constant) and isinstance(node.value, str)
+            )
+    if suffix == ".md" or source.path.endswith("SKILL.md"):
+        values.extend((match.group(1), "markdown-link") for match in MARKDOWN_LINK.finditer(source.text))
+    values.extend((match.group(0), "path-token") for match in REPOSITORY_PATH_TOKEN.finditer(source.text))
+    return tuple(values)
+
+
+def _check_map_graph(
+    source: RepositorySource,
+) -> tuple[tuple[RepositoryNode, ...], tuple[RepositoryEdge, ...]]:
+    if source.text is None:
+        raise Refusal(source.error or "check-map source is unavailable")
+    document = _json_document(source.text, source.path)
+    if document.get("schema") != "wildcat.check-map.v1":
+        raise Refusal(f"{source.path} does not declare wildcat.check-map.v1")
+    checks = document.get("checks")
+    scopes = document.get("scopes")
+    groups = document.get("groups")
+    if not isinstance(checks, dict) or not isinstance(scopes, dict) or not isinstance(groups, dict):
+        raise Refusal(f"{source.path} omits checks, scopes or groups objects")
+    nodes: list[RepositoryNode] = []
+    for identifier, body in checks.items():
+        if not isinstance(identifier, str) or not identifier or not isinstance(body, dict):
+            raise Refusal(f"{source.path} carries a malformed check declaration")
+        nodes.append(RepositoryNode("check-map", source.path, f"check:{identifier}"))
+    node_keys = {node.logical_id: node.key for node in nodes}
+    edges: set[RepositoryEdge] = set()
+    for scope_id, body in scopes.items():
+        if not isinstance(scope_id, str) or not isinstance(body, dict):
+            raise Refusal(f"{source.path} carries a malformed scope declaration")
+        selected = body.get("checks", [])
+        if not isinstance(selected, list) or not all(isinstance(item, str) for item in selected):
+            raise Refusal(f"{source.path} scope {scope_id} has no string checks list")
+        for check_id in selected:
+            target = node_keys.get(f"check:{check_id}")
+            if target is not None:
+                edges.add(RepositoryEdge(f"{source.path}#scope:{scope_id}", target, "check-map-scope"))
+    for group_id, body in groups.items():
+        if not isinstance(group_id, str) or not isinstance(body, dict):
+            raise Refusal(f"{source.path} carries a malformed group declaration")
+        ordered = body.get("ordered", [])
+        if not isinstance(ordered, list) or not all(isinstance(item, str) for item in ordered):
+            raise Refusal(f"{source.path} group {group_id} has no string ordered list")
+        for check_id in ordered:
+            target = node_keys.get(f"check:{check_id}")
+            if target is not None:
+                edges.add(RepositoryEdge(f"{source.path}#group:{group_id}", target, "check-map-group"))
+    return tuple(nodes), tuple(sorted(edges, key=lambda edge: (edge.source, edge.target, edge.parser)))
+
+
+def _nearest_boundary(path: str, boundaries: Iterable[ComputedBoundary]) -> ComputedBoundary | None:
+    matches = [
+        item
+        for item in boundaries
+        if path == item.prefix or path.startswith(item.prefix.rstrip("/") + "/")
+    ]
+    if not matches:
+        return None
+    return sorted(matches, key=lambda item: (-len(PurePosixPath(item.prefix).parts), item.source, item.boundary))[0]
+
+
+def analyse_repository(
+    root: Path,
+    universe: Universe,
+) -> tuple[AnalyserStatus, tuple[Finding, ...]]:
+    started = time.monotonic_ns()
+    try:
+        sources = _archive_sources(root, universe)
+    except Refusal as error:
+        record = AnalyserRecord(
+            "repository-input",
+            "family",
+            "failed",
+            "recorded-tree declaration read failed",
+            0,
+            REPOSITORY_ANALYSER_VERSION,
+            max(0, (time.monotonic_ns() - started) // 1_000_000),
+            0,
+            str(error),
+        )
+        return (
+            AnalyserStatus("repository", "failed", REPOSITORY_ANALYSER_VERSION, str(error), (record,)),
+            (),
+        )
+
+    objects: dict[str, list[RepositoryNode]] = {family: [] for family in REPOSITORY_FAMILIES}
+    family_errors: dict[str, set[str]] = {family: set() for family in REPOSITORY_FAMILIES}
+    analysed = set(universe.analysed)
+    for path in universe.analysed:
+        source = sources.get(path)
+        for family in _path_families(path, source):
+            objects[family].append(RepositoryNode(family, path))
+            if source is not None and source.error is not None:
+                family_errors[family].add(f"{path}: {source.error}")
+
+    check_map_path = "tests/check-map-v1.json"
+    logical_edges: list[RepositoryEdge] = []
+    if check_map_path in analysed:
+        source = sources.get(check_map_path)
+        if source is None:
+            family_errors["check-map"].add("tracked check-map was not read as declaration text")
+        else:
+            try:
+                check_nodes, check_edges = _check_map_graph(source)
+            except Refusal as error:
+                family_errors["check-map"].add(str(error))
+            else:
+                objects["check-map"].extend(check_nodes)
+                logical_edges.extend(check_edges)
+
+    nodes = tuple(
+        sorted(
+            (node for family in REPOSITORY_FAMILIES for node in objects[family]),
+            key=lambda node: (node.family, node.path, node.logical_id or ""),
+        )
+    )
+    path_targets = {node.path for node in nodes if node.logical_id is None}
+    tracked = set(universe.analysed) | {entry.path for entry in universe.excluded}
+    edges: set[RepositoryEdge] = set(logical_edges)
+    boundaries: list[ComputedBoundary] = []
+    for source in sources.values():
+        boundaries.extend(_computed_boundaries(source, tracked))
+        try:
+            values = _repository_values(source)
+        except Refusal as error:
+            affected = _path_families(source.path, source) & {"schema", "manifest"}
+            for family in affected:
+                family_errors[family].add(str(error))
+            values = tuple(
+                (match.group(0), "path-token")
+                for match in REPOSITORY_PATH_TOKEN.finditer(source.text or "")
+            )
+        for value, parser in values:
+            target = _normalise_reference(source.path, value, tracked)
+            if target is None or target == source.path or target not in path_targets:
+                continue
+            edges.add(RepositoryEdge(source.path, target, parser))
+
+    ordered_edges = tuple(sorted(edges, key=lambda edge: (edge.source, edge.target, edge.parser)))
+    edge_set = digest_json([edge.as_dict() for edge in ordered_edges])
+    incoming = {edge.target for edge in ordered_edges}
+    roots = _external_repository_roots(nodes)
+    elapsed_ms = max(0, (time.monotonic_ns() - started) // 1_000_000)
+    findings: list[Finding] = []
+    records: list[AnalyserRecord] = []
+    excluded_generated = sum(item.category == "generated" for item in universe.excluded)
+    for family in REPOSITORY_FAMILIES:
+        family_nodes = tuple(objects[family])
+        family_edges = tuple(
+            edge for edge in ordered_edges if any(node.key == edge.target for node in family_nodes)
+        )
+        family_boundaries = {
+            (boundary.source, boundary.prefix, boundary.boundary)
+            for boundary in boundaries
+            if any(_nearest_boundary(node.path, (boundary,)) is not None for node in family_nodes)
+        }
+        candidates = [node for node in family_nodes if node.key not in incoming and node.key not in roots]
+        errors = sorted(family_errors[family])
+        if not errors:
+            for node in candidates:
+                boundary = _nearest_boundary(node.path, boundaries)
+                if boundary is None:
+                    confidence = "medium"
+                    false_positive_boundary = (
+                        "literal declaration parsers cannot resolve runtime-computed or external references"
+                    )
+                else:
+                    confidence = "low"
+                    false_positive_boundary = (
+                        f"nearest {boundary.boundary} boundary is {boundary.source} "
+                        f"for prefix {boundary.prefix}"
+                    )
+                findings.append(
+                    _candidate(
+                        node.path,
+                        node.symbol,
+                        (
+                            f"edge-set {edge_set} contains {len(ordered_edges)} parsed edge(s); "
+                            f"none reaches repository object {node.key}"
+                        ),
+                        confidence,
+                        false_positive_boundary,
+                        analyser_id="repository",
+                    )
+                )
+        object_bytes = sum(sources[node.path].bytes_count for node in family_nodes if node.path in sources)
+        reason = "; ".join(errors) if errors else None
+        visible_objects = len(family_nodes) + (excluded_generated if family == "generated-copy" else 0)
+        detail = (
+            f"objects={visible_objects}; roots={sum(node.key in roots for node in family_nodes)}; "
+            f"candidates={0 if errors else len(candidates)}; edges={len(family_edges)}; "
+            f"computed_boundaries={len(family_boundaries)}; edge_set={edge_set}"
+        )
+        records.append(
+            AnalyserRecord(
+                family,
+                "family",
+                "parse-error" if errors else "parsed",
+                detail,
+                object_bytes,
+                REPOSITORY_ANALYSER_VERSION,
+                elapsed_ms,
+                len(family_edges),
+                reason,
+            )
+        )
+    findings.sort(key=lambda item: (item.path, item.symbol or "", item.evidence))
+    degraded = any(family_errors[family] for family in REPOSITORY_FAMILIES)
+    detail = (
+        f"parsed {len(nodes)} repository object(s) and {len(ordered_edges)} literal edge(s); "
+        "consumed the Horos universe and check-map declarations while Promise Machine and "
+        "Hypomnema retain their authoritative validators"
+    )
+    if degraded:
+        detail += "; one or more declaration families were incomplete"
+    return (
+        AnalyserStatus(
+            "repository",
+            "degraded" if degraded else "ran",
+            REPOSITORY_ANALYSER_VERSION,
+            detail,
+            tuple(records),
+        ),
+        tuple(findings),
+    )
+
+
+@dataclass(frozen=True)
+class ToolInvocation:
+    state: str
+    stdout: bytes
+    stderr: bytes
+    duration_ms: int
+    reason: str | None
+
+
+def _invoke_optional_tool(
+    argv: list[str],
+    *,
+    cwd: Path,
+    timeout_seconds: int,
+    output_limit: int,
+) -> ToolInvocation:
+    started = time.monotonic_ns()
+    try:
+        stdout, stderr, returncode = run_process(
+            argv,
+            cwd=cwd,
+            timeout_seconds=timeout_seconds,
+            output_limit=output_limit,
+        )
+    except Refusal as error:
+        state = "unavailable" if "not available on PATH" in str(error) else "failed"
+        return ToolInvocation(
+            state,
+            b"",
+            b"",
+            max(0, (time.monotonic_ns() - started) // 1_000_000),
+            str(error),
+        )
+    duration_ms = max(0, (time.monotonic_ns() - started) // 1_000_000)
+    if returncode != 0:
+        try:
+            detail = decode_output(stderr, f"{argv[0]} stderr").strip()
+        except Refusal:
+            detail = "non-UTF-8 stderr"
+        return ToolInvocation(
+            "failed",
+            stdout,
+            stderr,
+            duration_ms,
+            f"exit {returncode}" + (f": {detail[:512]}" if detail else ""),
+        )
+    return ToolInvocation("passed", stdout, stderr, duration_ms, None)
+
+
+def _tool_version(invocation: ToolInvocation, tool: str) -> str:
+    if invocation.state != "passed":
+        raise Refusal(invocation.reason or f"{tool} version unavailable")
+    combined = invocation.stdout + invocation.stderr
+    text = decode_output(combined, f"{tool} version").strip()
+    if not text:
+        raise Refusal(f"{tool} version output is empty")
+    first = text.splitlines()[0].strip()
+    if len(first.encode("utf-8")) > 256:
+        raise Refusal(f"{tool} version identity exceeds 256 bytes")
+    return first
+
+
+def _project_repository_path(
+    project: str,
+    path: str,
+    tracked: set[str] | None = None,
+) -> str:
+    supplied = path.strip().replace(chr(92), "/")
+    if not supplied or supplied.startswith("/"):
+        raise Refusal("tool finding path is not repository-relative")
+    if tracked is not None and supplied in tracked:
+        return validate_repository_path(supplied, "tool finding path")
+    combined = posixpath.normpath(posixpath.join("" if project == "." else project, supplied))
+    return validate_repository_path(combined, "tool finding path")
+
+
+def _bounded_tool_identity(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value or len(value.encode("utf-8")) > 256:
+        raise Refusal(f"{label} is absent or exceeds 256 bytes")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise Refusal(f"{label} contains a control character")
+    return value
+
+
+def _slither_findings(
+    payload: bytes,
+    *,
+    project: str,
+    universe: Universe,
+) -> tuple[tuple[Finding, ...], int]:
+    document = _json_document(payload, f"Slither JSON for {project}")
+    if document.get("success") is not True:
+        raise Refusal(f"Slither JSON for {project} does not report success")
+    results = document.get("results")
+    detectors = results.get("detectors") if isinstance(results, dict) else None
+    if not isinstance(detectors, list):
+        raise Refusal(f"Slither JSON for {project} omits detector results")
+    tracked = set(universe.analysed)
+    findings: list[Finding] = []
+    evidence_count = 0
+    for detector in detectors:
+        if not isinstance(detector, dict):
+            raise Refusal(f"Slither detector for {project} is not an object")
+        check = _bounded_tool_identity(detector.get("check"), "Slither detector identity")
+        if check not in {"dead-code", "unused-state"}:
+            raise Refusal(f"Slither returned undeclared detector {check}")
+        confidence_value = _bounded_tool_identity(
+            detector.get("confidence", "Low"),
+            "Slither detector confidence",
+        ).lower()
+        confidence = confidence_value if confidence_value in CONFIDENCE_LEVELS else "low"
+        elements = detector.get("elements")
+        if not isinstance(elements, list):
+            raise Refusal(f"Slither detector {check} omits elements")
+        for element in elements:
+            if not isinstance(element, dict):
+                raise Refusal(f"Slither detector {check} carries a malformed element")
+            kind = _bounded_tool_identity(element.get("type"), "Slither element type")
+            name = _bounded_tool_identity(element.get("name"), "Slither element name")
+            mapping = element.get("source_mapping")
+            if not isinstance(mapping, dict):
+                raise Refusal(f"Slither detector {check} omits source mapping")
+            path = _project_repository_path(
+                project,
+                _bounded_tool_identity(
+                    mapping.get("filename_relative"),
+                    "Slither relative filename",
+                ),
+                tracked,
+            )
+            lines = mapping.get("lines")
+            if (
+                not isinstance(lines, list)
+                or not lines
+                or not all(isinstance(line, int) and not isinstance(line, bool) and line > 0 for line in lines)
+            ):
+                raise Refusal(f"Slither detector {check} has malformed source lines")
+            if path not in tracked:
+                raise Refusal(f"Slither detector {check} names path outside the report universe: {path}")
+            evidence_count += 1
+            findings.append(
+                _candidate(
+                    path,
+                    f"{check}:{kind}:{name}@{lines[0]}",
+                    f"Slither {check} detector reported {kind} {name} in Foundry project {project}",
+                    confidence,
+                    "Slither detector output is advisory and may not model dynamic or external execution",
+                    analyser_id="solidity",
+                )
+            )
+    findings.sort(key=lambda item: (item.path, item.symbol or "", item.evidence))
+    return tuple(findings), evidence_count
+
+
+FORGE_METRIC = re.compile(r"^(\d+(?:\.\d+)?)%\s*\((\d+)/(\d+)\)$")
+
+
+def _forge_findings(
+    payload: bytes,
+    *,
+    project: str,
+    universe: Universe,
+) -> tuple[tuple[Finding, ...], int]:
+    text = decode_output(payload, f"Forge coverage for {project}")
+    tracked = set(universe.analysed)
+    rows: list[tuple[str, tuple[tuple[int, int], ...]]] = []
+    for line in text.splitlines():
+        stripped = re.sub(r"\x1b\[[0-9;]*m", "", line).strip()
+        if not stripped.startswith("|") or not stripped.endswith("|"):
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if len(cells) < 5 or cells[0].lower() in {"file", "total"}:
+            continue
+        metrics: list[tuple[int, int]] = []
+        for cell in cells[1:5]:
+            match = FORGE_METRIC.fullmatch(cell)
+            if match is None:
+                metrics = []
+                break
+            covered = int(match.group(2))
+            total = int(match.group(3))
+            if covered > total:
+                raise Refusal(f"Forge coverage for {project} has an impossible metric")
+            metrics.append((covered, total))
+        if not metrics:
+            continue
+        path = _project_repository_path(project, cells[0], tracked)
+        if path not in tracked or not path.endswith(".sol"):
+            raise Refusal(f"Forge coverage for {project} names path outside the report universe: {path}")
+        rows.append((path, tuple(metrics)))
+    if not rows:
+        raise Refusal(f"Forge coverage for {project} has no parseable source rows")
+    findings: list[Finding] = []
+    for path, metrics in rows:
+        lines, _statements, _branches, functions = metrics
+        if all(covered == total for covered, total in metrics):
+            continue
+        findings.append(
+            _candidate(
+                path,
+                f"forge-coverage:lines={lines[0]}/{lines[1]}:functions={functions[0]}/{functions[1]}",
+                (
+                    f"Forge coverage in project {project} observed {lines[0]}/{lines[1]} lines "
+                    f"and {functions[0]}/{functions[1]} functions"
+                ),
+                "low",
+                "Forge coverage names only the project's executed tests and cannot prove other entry points absent",
+                analyser_id="solidity",
+            )
+        )
+    findings.sort(key=lambda item: (item.path, item.symbol or ""))
+    return tuple(findings), len(rows)
+
+
+def _solidity_project_tool(
+    tool: str,
+    *,
+    project: str,
+    project_root: Path,
+    universe: Universe,
+) -> tuple[AnalyserRecord, tuple[Finding, ...]]:
+    version_run = _invoke_optional_tool(
+        [tool, "--version"],
+        cwd=project_root,
+        timeout_seconds=SOLIDITY_VERSION_TIMEOUT_SECONDS,
+        output_limit=MAX_SOLIDITY_VERSION_BYTES,
+    )
+    if version_run.state != "passed":
+        return (
+            AnalyserRecord(
+                f"{project}:{tool}",
+                "project",
+                version_run.state,
+                f"project={project}; fixed version argv did not complete",
+                len(version_run.stdout) + len(version_run.stderr),
+                None,
+                version_run.duration_ms,
+                0,
+                version_run.reason,
+            ),
+            (),
+        )
+    try:
+        version = _tool_version(version_run, tool)
+    except Refusal as error:
+        return (
+            AnalyserRecord(
+                f"{project}:{tool}",
+                "project",
+                "parse-error",
+                f"project={project}; tool version output was not usable",
+                len(version_run.stdout) + len(version_run.stderr),
+                None,
+                version_run.duration_ms,
+                0,
+                str(error),
+            ),
+            (),
+        )
+    argv = (
+        ["slither", ".", "--detect", "dead-code,unused-state", "--json", "-"]
+        if tool == "slither"
+        else ["forge", "coverage", "--report", "summary"]
+    )
+    run = _invoke_optional_tool(
+        argv,
+        cwd=project_root,
+        timeout_seconds=SOLIDITY_TOOL_TIMEOUT_SECONDS,
+        output_limit=MAX_SOLIDITY_OUTPUT_BYTES,
+    )
+    total_duration = version_run.duration_ms + run.duration_ms
+    total_bytes = (
+        len(version_run.stdout)
+        + len(version_run.stderr)
+        + len(run.stdout)
+        + len(run.stderr)
+    )
+    if run.state != "passed":
+        return (
+            AnalyserRecord(
+                f"{project}:{tool}",
+                "project",
+                run.state,
+                f"project={project}; fixed analysis argv did not complete",
+                total_bytes,
+                version,
+                total_duration,
+                0,
+                run.reason,
+            ),
+            (),
+        )
+    try:
+        findings, evidence_count = (
+            _slither_findings(run.stdout, project=project, universe=universe)
+            if tool == "slither"
+            else _forge_findings(run.stdout, project=project, universe=universe)
+        )
+    except Refusal as error:
+        return (
+            AnalyserRecord(
+                f"{project}:{tool}",
+                "project",
+                "parse-error",
+                f"project={project}; bounded tool output was not usable",
+                total_bytes,
+                version,
+                total_duration,
+                0,
+                str(error),
+            ),
+            (),
+        )
+    return (
+        AnalyserRecord(
+            f"{project}:{tool}",
+            "project",
+            "passed",
+            f"project={project}; fixed argv completed with {evidence_count} evidence record(s)",
+            total_bytes,
+            version,
+            total_duration,
+            evidence_count,
+            None,
+        ),
+        findings,
+    )
+
+
+def analyse_solidity(
+    root: Path,
+    universe: Universe,
+) -> tuple[AnalyserStatus, tuple[Finding, ...]]:
+    configs = tuple(
+        path for path in universe.analysed if PurePosixPath(path).name == "foundry.toml"
+    )
+    projects = tuple(
+        "." if PurePosixPath(path).parent == PurePosixPath(".") else PurePosixPath(path).parent.as_posix()
+        for path in configs
+    )
+    records: list[AnalyserRecord] = []
+    findings: list[Finding] = []
+    for project in projects:
+        project_root = root if project == "." else root.joinpath(*PurePosixPath(project).parts)
+        for tool in ("forge", "slither"):
+            record, produced = _solidity_project_tool(
+                tool,
+                project=project,
+                project_root=project_root,
+                universe=universe,
+            )
+            records.append(record)
+            findings.extend(produced)
+    records.sort(key=lambda item: (item.kind, item.record_id))
+    findings.sort(key=lambda item: (item.path, item.symbol or "", item.evidence))
+    states = {record.state for record in records}
+    if records and states == {"unavailable"}:
+        state = "not-available"
+        detail = f"discovered {len(projects)} Foundry project(s); Slither and Forge were unavailable"
+    elif any(record.state != "passed" for record in records):
+        state = "degraded"
+        detail = f"discovered {len(projects)} Foundry project(s); one or more bounded tool signals were incomplete"
+    else:
+        state = "ran"
+        detail = f"discovered {len(projects)} Foundry project(s); every available bounded tool signal completed"
+    return (
+        AnalyserStatus(
+            "solidity",
+            state,
+            SOLIDITY_ANALYSER_VERSION,
+            detail,
+            tuple(records),
+        ),
+        tuple(findings),
+    )
+
+
 def _json_document(payload: bytes | str, label: str) -> dict[str, object]:
     try:
         document = json.loads(payload, object_pairs_hook=reject_duplicate_keys)
@@ -2018,7 +2929,13 @@ def analyse_coverage(
     )
 
 
-ANALYSERS["python"] = analyse_python
+ANALYSERS.update(
+    {
+        "python": analyse_python,
+        "repository": analyse_repository,
+        "solidity": analyse_solidity,
+    }
+)
 
 
 def collect(
@@ -2098,8 +3015,26 @@ def validate_report(report: Report) -> None:
                 raise Refusal(f"analyser {item.analyser_id} has unknown record kind {record.kind}")
             if record.state not in ANALYSER_RECORD_STATES:
                 raise Refusal(f"analyser {item.analyser_id} has unknown record state {record.state}")
-            if not record.detail or record.bytes_count < 0:
+            if (
+                not record.detail
+                or not isinstance(record.bytes_count, int)
+                or isinstance(record.bytes_count, bool)
+                or record.bytes_count < 0
+            ):
                 raise Refusal(f"analyser {item.analyser_id} has an invalid record")
+            if record.version is not None and not record.version:
+                raise Refusal(f"analyser {item.analyser_id} has an empty record version")
+            if (
+                not isinstance(record.duration_ms, int)
+                or isinstance(record.duration_ms, bool)
+                or record.duration_ms < 0
+                or not isinstance(record.evidence_count, int)
+                or isinstance(record.evidence_count, bool)
+                or record.evidence_count < 0
+            ):
+                raise Refusal(f"analyser {item.analyser_id} has invalid record telemetry")
+            if record.reason is not None and not record.reason:
+                raise Refusal(f"analyser {item.analyser_id} has an empty refusal reason")
             record_ids.add(identity)
         if item.records != tuple(sorted(item.records, key=lambda record: (record.kind, record.record_id))):
             raise Refusal(f"analyser {item.analyser_id} records are not sorted")
@@ -2198,9 +3133,13 @@ def render_text(report: Report) -> str:
             f"{analyser['detail']}"
         )
         for record in analyser["records"]:
+            version = record["version"] or "unknown"
+            reason = f"  reason={record['reason']}" if record["reason"] else ""
             lines.append(
                 f"    {record['kind']} {record['id']}  {record['state']}  "
-                f"{record['bytes']} byte(s)  {record['detail']}"
+                f"{record['bytes']} byte(s)  version={version}  "
+                f"duration_ms={record['duration_ms']}  "
+                f"evidence={record['evidence_count']}  {record['detail']}{reason}"
             )
 
     findings = document["findings"]

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -1812,12 +1812,14 @@ def _invoke_optional_tool(
             detail = decode_output(stderr, f"{argv[0]} stderr").strip()
         except Refusal:
             detail = "non-UTF-8 stderr"
+        if len(detail) > 512:
+            detail = detail[:96] + " ... " + detail[-411:]
         return ToolInvocation(
             "failed",
             stdout,
             stderr,
             duration_ms,
-            f"exit {returncode}" + (f": {detail[:512]}" if detail else ""),
+            f"exit {returncode}" + (f": {detail}" if detail else ""),
         )
     return ToolInvocation("passed", stdout, stderr, duration_ms, None)
 
@@ -1867,7 +1869,9 @@ def _slither_findings(
     if document.get("success") is not True:
         raise Refusal(f"Slither JSON for {project} does not report success")
     results = document.get("results")
-    detectors = results.get("detectors") if isinstance(results, dict) else None
+    if not isinstance(results, dict):
+        raise Refusal(f"Slither JSON for {project} omits results object")
+    detectors = results.get("detectors", [])
     if not isinstance(detectors, list):
         raise Refusal(f"Slither JSON for {project} omits detector results")
     tracked = set(universe.analysed)

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -24,6 +24,7 @@ import stat
 import subprocess
 import sys
 import tarfile
+import tempfile
 import time
 import tomllib
 import uuid
@@ -1785,6 +1786,7 @@ def _invoke_optional_tool(
     cwd: Path,
     timeout_seconds: int,
     output_limit: int,
+    env: dict[str, str] | None = None,
 ) -> ToolInvocation:
     started = time.monotonic_ns()
     try:
@@ -1793,6 +1795,7 @@ def _invoke_optional_tool(
             cwd=cwd,
             timeout_seconds=timeout_seconds,
             output_limit=output_limit,
+            env=env,
         )
     except Refusal as error:
         state = "unavailable" if "not available on PATH" in str(error) else "failed"
@@ -2034,12 +2037,31 @@ def _solidity_project_tool(
         if tool == "slither"
         else ["forge", "coverage", "--report", "summary"]
     )
-    run = _invoke_optional_tool(
-        argv,
-        cwd=project_root,
-        timeout_seconds=SOLIDITY_TOOL_TIMEOUT_SECONDS,
-        output_limit=MAX_SOLIDITY_OUTPUT_BYTES,
-    )
+    with tempfile.TemporaryDirectory(
+        prefix=f"dead-code-{tool}-",
+        ignore_cleanup_errors=True,
+    ) as temporary:
+        temporary_root = Path(temporary).resolve(strict=True)
+        environment = dict(os.environ)
+        environment.update(
+            {
+                "TMPDIR": str(temporary_root / "tmp"),
+                "FOUNDRY_OUT": str(temporary_root / "out"),
+                "FOUNDRY_CACHE_PATH": str(temporary_root / "cache"),
+                "FOUNDRY_BROADCAST": str(temporary_root / "broadcast"),
+                "FOUNDRY_FUZZ_FAILURE_PERSIST_DIR": str(temporary_root / "fuzz"),
+                "FOUNDRY_INVARIANT_FAILURE_PERSIST_DIR": str(temporary_root / "invariant"),
+            }
+        )
+        for name in ("tmp", "out", "cache", "broadcast", "fuzz", "invariant"):
+            (temporary_root / name).mkdir(mode=0o700)
+        run = _invoke_optional_tool(
+            argv,
+            cwd=project_root,
+            timeout_seconds=SOLIDITY_TOOL_TIMEOUT_SECONDS,
+            output_limit=MAX_SOLIDITY_OUTPUT_BYTES,
+            env=environment,
+        )
     total_duration = version_run.duration_ms + run.duration_ms
     total_bytes = (
         len(version_run.stdout)

--- a/scripts/dead_code_monitoring/sitecustomize.py
+++ b/scripts/dead_code_monitoring/sitecustomize.py
@@ -1,0 +1,285 @@
+"""Process-local Python 3.14 execution probe for ``dead_code.py coverage``.
+
+This module is loaded only when the coverage command prepends this directory to
+``PYTHONPATH``.  A checked-runner containment marker is also required, so the
+orchestrating runner is never monitored and recursive direct use is inert.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+import uuid
+
+ACTIVE_ENV = "WILDCAT_DEAD_CODE_COVERAGE_ACTIVE"
+OUTPUT_ENV = "WILDCAT_DEAD_CODE_COVERAGE_OUTPUT"
+CONTAINMENT_ENV = "WILDCAT_CHECK_CONTAINMENT"
+SOURCE_ROOT_ENV = "WILDCAT_DEAD_CODE_COVERAGE_SOURCE_ROOT"
+SCHEMA = "dead-code-process-coverage/v1"
+MAX_EVENTS = 50_000
+MAX_RECORD_BYTES = 16 * 1024 * 1024
+MAX_ARG_BYTES = 16 * 1024
+
+
+def _repository_root(start: Path) -> Path | None:
+    for candidate in (start, *start.parents):
+        try:
+            marker = candidate / ".git"
+            info = marker.lstat()
+        except OSError:
+            continue
+        if stat.S_ISDIR(info.st_mode) or stat.S_ISREG(info.st_mode):
+            return candidate
+    return None
+
+
+def _safe_argv() -> list[str]:
+    retained: list[str] = []
+    consumed = 0
+    for item in getattr(sys, "orig_argv", sys.argv):
+        encoded = os.fsencode(item)
+        if consumed + len(encoded) > MAX_ARG_BYTES:
+            retained.append("<truncated>")
+            break
+        retained.append(item)
+        consumed += len(encoded)
+    return retained
+
+
+class MonitoringProbe:
+    """Own one free monitoring id and put it back exactly as it was."""
+
+    def __init__(self, output_directory: Path, repository_root: Path, run_id: str):
+        self.output_directory = output_directory
+        self.repository_root = repository_root.resolve()
+        self.initial_cwd = Path.cwd()
+        self.run_id = run_id
+        self.tool_id = sys.monitoring.COVERAGE_ID
+        self.started = False
+        self.owns_tool = False
+        self.closed = False
+        self.truncated = False
+        self.errors: list[str] = []
+        self.lines: set[tuple[str, str, int]] = set()
+        self.branches: set[tuple[str, str, int, int, str]] = set()
+        self._line_cache: dict[object, dict[int, int]] = {}
+        self._location_cache: dict[object, tuple[str, str] | None] = {}
+
+    def _location(self, code: object) -> tuple[str, str] | None:
+        if code in self._location_cache:
+            return self._location_cache[code]
+        filename = getattr(code, "co_filename", None)
+        if not isinstance(filename, str) or not filename or filename.startswith("<"):
+            self._location_cache[code] = None
+            return None
+        candidate = Path(filename)
+        if not candidate.is_absolute():
+            candidate = self.initial_cwd / candidate
+        try:
+            relative = Path(os.path.normpath(candidate)).relative_to(self.repository_root)
+        except ValueError:
+            self._location_cache[code] = None
+            return None
+        path = relative.as_posix()
+        if not path.endswith(".py") or path.startswith("tmp/check-runner/"):
+            self._location_cache[code] = None
+            return None
+        qualname = getattr(code, "co_qualname", getattr(code, "co_name", "<module>"))
+        location = (path, str(qualname))
+        self._location_cache[code] = location
+        return location
+
+    def _remember_line(self, code: object, line: int) -> object:
+        if len(self.lines) >= MAX_EVENTS:
+            self.truncated = True
+            return sys.monitoring.DISABLE
+        location = self._location(code)
+        if location is None or line < 1:
+            return sys.monitoring.DISABLE
+        self.lines.add((*location, line))
+        return sys.monitoring.DISABLE
+
+    def _offset_line(self, code: object, offset: int) -> int | None:
+        mapping = self._line_cache.get(code)
+        if mapping is None:
+            mapping = {}
+            try:
+                for start, end, line in code.co_lines():
+                    if line is not None:
+                        for instruction in range(start, end, 2):
+                            mapping[instruction] = line
+            except (AttributeError, TypeError, ValueError) as error:
+                self.errors.append(f"line-map:{type(error).__name__}")
+            self._line_cache[code] = mapping
+        return mapping.get(offset)
+
+    def _remember_branch(
+        self,
+        direction: str,
+        code: object,
+        source: int,
+        target: int,
+    ) -> object:
+        if len(self.branches) >= MAX_EVENTS:
+            self.truncated = True
+            return sys.monitoring.DISABLE
+        location = self._location(code)
+        if location is None:
+            return sys.monitoring.DISABLE
+        source_line = self._offset_line(code, source)
+        target_line = self._offset_line(code, target)
+        if source_line is None or target_line is None:
+            return sys.monitoring.DISABLE
+        self.branches.add((*location, source_line, target_line, direction))
+        return sys.monitoring.DISABLE
+
+    def _left(self, code: object, source: int, target: int) -> object:
+        return self._remember_branch("left", code, source, target)
+
+    def _right(self, code: object, source: int, target: int) -> object:
+        return self._remember_branch("right", code, source, target)
+
+    def start(self) -> bool:
+        monitoring = sys.monitoring
+        if monitoring.get_tool(self.tool_id) is not None:
+            self.errors.append("coverage-tool-id-in-use")
+            return False
+        monitoring.use_tool_id(self.tool_id, "wildcat-dead-code-coverage")
+        self.owns_tool = True
+        try:
+            monitoring.register_callback(self.tool_id, monitoring.events.LINE, self._remember_line)
+            monitoring.register_callback(self.tool_id, monitoring.events.BRANCH_LEFT, self._left)
+            monitoring.register_callback(self.tool_id, monitoring.events.BRANCH_RIGHT, self._right)
+            monitoring.set_events(
+                self.tool_id,
+                monitoring.events.LINE
+                | monitoring.events.BRANCH_LEFT
+                | monitoring.events.BRANCH_RIGHT,
+            )
+        except BaseException:
+            self._restore()
+            raise
+        self.started = True
+        return True
+
+    def _restore(self) -> None:
+        monitoring = sys.monitoring
+        try:
+            if not self.owns_tool or monitoring.get_tool(self.tool_id) is None:
+                return
+            monitoring.set_events(self.tool_id, 0)
+            for event in (
+                monitoring.events.LINE,
+                monitoring.events.BRANCH_LEFT,
+                monitoring.events.BRANCH_RIGHT,
+            ):
+                monitoring.register_callback(self.tool_id, event, None)
+            monitoring.free_tool_id(self.tool_id)
+            self.owns_tool = False
+        except (RuntimeError, ValueError) as error:
+            self.errors.append(f"restore:{type(error).__name__}")
+
+    def _document(self) -> dict[str, object]:
+        containment = os.environ.get(CONTAINMENT_ENV, "")
+        return {
+            "schema": SCHEMA,
+            "run": self.run_id,
+            "process": {
+                "pid": os.getpid(),
+                "parent_pid": os.getppid(),
+                "containment": containment,
+                "argv": _safe_argv(),
+                "cwd": Path.cwd().as_posix(),
+            },
+            "status": {
+                "state": "degraded" if self.truncated or self.errors or not self.started else "ran",
+                "truncated": self.truncated,
+                "errors": sorted(set(self.errors)),
+            },
+            "lines": [
+                {"path": path, "function": function, "line": line}
+                for path, function, line in sorted(self.lines)
+            ],
+            "branches": [
+                {
+                    "path": path,
+                    "function": function,
+                    "from_line": source,
+                    "to_line": target,
+                    "direction": direction,
+                }
+                for path, function, source, target, direction in sorted(self.branches)
+            ],
+        }
+
+    def _write(self) -> None:
+        document = self._document()
+        payload = (json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n").encode()
+        if len(payload) > MAX_RECORD_BYTES:
+            document["lines"] = []
+            document["branches"] = []
+            document["status"] = {
+                "state": "degraded",
+                "truncated": True,
+                "errors": sorted(set([*self.errors, "record-byte-limit"])),
+            }
+            payload = (json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n").encode()
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        directory_fd = os.open(
+            self.output_directory,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+        try:
+            name = f"process-{os.getpid()}-{uuid.uuid4().hex}.json"
+            fd = os.open(name, flags, 0o600, dir_fd=directory_fd)
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        self._restore()
+        try:
+            self._write()
+        except OSError:
+            pass
+
+
+def _activate() -> MonitoringProbe | None:
+    run_id = os.environ.get(ACTIVE_ENV, "")
+    output = os.environ.get(OUTPUT_ENV, "")
+    if not run_id or not output or not os.environ.get(CONTAINMENT_ENV):
+        return None
+    if not hasattr(sys, "monitoring"):
+        return None
+    if len(run_id) != 32 or any(character not in "0123456789abcdef" for character in run_id):
+        return None
+    inherited_root = os.environ.get(SOURCE_ROOT_ENV)
+    root = Path(inherited_root) if inherited_root else _repository_root(Path.cwd().resolve())
+    if root is None:
+        return None
+    try:
+        root = root.resolve(strict=True)
+    except OSError:
+        return None
+    os.environ[SOURCE_ROOT_ENV] = str(root)
+    probe = MonitoringProbe(Path(output), root, run_id)
+    try:
+        probe.start()
+    except (RuntimeError, ValueError):
+        probe.errors.append("monitoring-start-failed")
+    atexit.register(probe.close)
+    return probe
+
+
+PROBE = _activate() if __name__ == "sitecustomize" else None

--- a/scripts/dead_code_monitoring/sitecustomize.py
+++ b/scripts/dead_code_monitoring/sitecustomize.py
@@ -23,6 +23,7 @@ SCHEMA = "dead-code-process-coverage/v1"
 MAX_EVENTS = 50_000
 MAX_RECORD_BYTES = 16 * 1024 * 1024
 MAX_ARG_BYTES = 16 * 1024
+TOOL_NAME = "wildcat-dead-code-coverage"
 
 
 def _repository_root(start: Path) -> Path | None:
@@ -148,7 +149,7 @@ class MonitoringProbe:
         if monitoring.get_tool(self.tool_id) is not None:
             self.errors.append("coverage-tool-id-in-use")
             return False
-        monitoring.use_tool_id(self.tool_id, "wildcat-dead-code-coverage")
+        monitoring.use_tool_id(self.tool_id, TOOL_NAME)
         self.owns_tool = True
         try:
             monitoring.register_callback(self.tool_id, monitoring.events.LINE, self._remember_line)
@@ -168,9 +169,15 @@ class MonitoringProbe:
 
     def _restore(self) -> None:
         monitoring = sys.monitoring
+        if not self.owns_tool:
+            return
+        owner = monitoring.get_tool(self.tool_id)
+        if owner != TOOL_NAME:
+            reason = "ownership-lost" if owner is None else "ownership-changed"
+            self.errors.append(f"restore:{reason}")
+            self.owns_tool = False
+            return
         try:
-            if not self.owns_tool or monitoring.get_tool(self.tool_id) is None:
-                return
             monitoring.set_events(self.tool_id, 0)
             for event in (
                 monitoring.events.LINE,
@@ -179,9 +186,10 @@ class MonitoringProbe:
             ):
                 monitoring.register_callback(self.tool_id, event, None)
             monitoring.free_tool_id(self.tool_id)
-            self.owns_tool = False
         except (RuntimeError, ValueError) as error:
             self.errors.append(f"restore:{type(error).__name__}")
+        finally:
+            self.owns_tool = False
 
     def _document(self) -> dict[str, object]:
         containment = os.environ.get(CONTAINMENT_ENV, "")

--- a/tests/check-map-v1.json
+++ b/tests/check-map-v1.json
@@ -286,6 +286,7 @@
     {"path": "schemas/dead-code-report-v1.schema.json", "scope": "dead-code"},
     {"path": "scripts", "scope": "root"},
     {"path": "scripts/dead_code.py", "scope": "dead-code"},
+    {"path": "scripts/dead_code_monitoring", "scope": "dead-code"},
     {"path": "scripts/promise_machine.py", "scope": "promise-machine"},
     {"path": "tests", "scope": "root"},
     {"path": "tests/emit_dead_code_report.py", "scope": "dead-code"},

--- a/tests/emit_dead_code_report.py
+++ b/tests/emit_dead_code_report.py
@@ -25,6 +25,7 @@ from tests.emit_run_observation_report import (  # noqa: E402
 REQUIRED_SURFACE = (
     Path("schemas/dead-code-report-v1.schema.json"),
     Path("scripts/dead_code.py"),
+    Path("scripts/dead_code_monitoring/sitecustomize.py"),
     Path("tests/test_dead_code.py"),
 )
 MODULES = ("tests.test_dead_code",)

--- a/tests/emit_dead_code_report.py
+++ b/tests/emit_dead_code_report.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the dead-code surface and emit one fresh Elenchus report.
+"""Run the Python, repository-graph and Solidity dead-code surface.
 
 The confined report writer lives in `tests/emit_run_observation_report.py` and
 is imported rather than copied. That writer is the product of the issue #434
@@ -28,12 +28,25 @@ REQUIRED_SURFACE = (
     Path("scripts/dead_code_monitoring/sitecustomize.py"),
     Path("tests/test_dead_code.py"),
 )
+REQUIRED_ANALYSER_DECLARATIONS = (
+    "def analyse_python(",
+    "def analyse_repository(",
+    "def analyse_solidity(",
+)
 MODULES = ("tests.test_dead_code",)
 
 
 def missing_surface_suite(root):
     """A suite that fails by name when the surface under test is not there."""
     missing = [path.as_posix() for path in REQUIRED_SURFACE if not (root / path).is_file()]
+    script = root / "scripts" / "dead_code.py"
+    if not missing:
+        source = script.read_text(encoding="utf-8")
+        missing.extend(
+            declaration
+            for declaration in REQUIRED_ANALYSER_DECLARATIONS
+            if declaration not in source
+        )
     if not missing:
         return None
 

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -1578,6 +1578,20 @@ class SolidityAnalyserTests(TemporaryRepositoryTestCase):
         self.assertEqual(findings, ())
         self.assertIn("exit 1", next(item for item in status.records if item.record_id.endswith(":slither")).reason)
 
+    def test_non_zero_tool_stdout_preserves_json_failure_reason(self):
+        universe = self._universe()
+        successful = self._successful_runner([])
+
+        def run(argv, **kwargs):
+            if argv[:2] == ["slither", "."]:
+                return b'{"success":false,"error":"compiler root cause"}', b"warning", 255
+            return successful(argv, **kwargs)
+
+        with mock.patch.object(dead_code, "run_process", side_effect=run):
+            status, _findings = dead_code.analyse_solidity(self.root, universe)
+        record = next(item for item in status.records if item.record_id.endswith(":slither"))
+        self.assertIn("compiler root cause", record.reason)
+
     def test_long_tool_stderr_preserves_the_terminal_failure_reason(self):
         universe = self._universe()
         successful = self._successful_runner([])

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -641,6 +641,26 @@ class RenderingTests(TemporaryRepositoryTestCase):
         with self.assertRaisesRegex(dead_code.Refusal, "unreported analyser"):
             dead_code.validate_report(report)
 
+    def test_boolean_record_telemetry_is_not_an_integer(self):
+        base = self._report()
+        status = dead_code.AnalyserStatus(
+            "repository",
+            "ran",
+            "repository-graph/1",
+            "done",
+            (
+                dead_code.AnalyserRecord(
+                    "fixture",
+                    "family",
+                    "parsed",
+                    "done",
+                    True,
+                ),
+            ),
+        )
+        with self.assertRaisesRegex(dead_code.Refusal, "invalid record"):
+            dead_code.validate_report(dead_code.Report(base.universe, (status,), ()))
+
     def test_candidate_count_does_not_change_the_report_exit_contract(self):
         base = self._report()
         status = dead_code.AnalyserStatus("python", "ran", "1", "done")
@@ -1203,6 +1223,482 @@ class PythonAnalyserTests(TemporaryRepositoryTestCase):
             }
         )
         self.assertFalse(any(item.symbol == "values.item@2" for item in findings))
+
+
+class RepositoryAnalyserTests(TemporaryRepositoryTestCase):
+    @staticmethod
+    def _check_map(*, checks=None, scopes=None):
+        return json.dumps(
+            {
+                "schema": "wildcat.check-map.v1",
+                "checks": {} if checks is None else checks,
+                "groups": {},
+                "scopes": {} if scopes is None else scopes,
+            },
+            sort_keys=True,
+        ) + NL
+
+    def _analyse(self, files):
+        build_repository(self.root, files=files)
+        universe = dead_code.discover(self.root)
+        return universe, dead_code.analyse_repository(self.root, universe)
+
+    @staticmethod
+    def _family_findings(findings, family):
+        return [item for item in findings if item.symbol and item.symbol.startswith(f"{family}:")]
+
+    def test_unreferenced_fixture_is_reported(self):
+        _universe, (_status, findings) = self._analyse(
+            {"tests/fixtures/orphan.json": "{}" + NL, "README.md": "root" + NL}
+        )
+        self.assertEqual(
+            [item.path for item in self._family_findings(findings, "fixture")],
+            ["tests/fixtures/orphan.json"],
+        )
+
+    def test_literal_fixture_reference_retains_it(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "tests/fixtures/live.json": "{}" + NL,
+                "tests/test_live.py": "FIXTURE = 'tests/fixtures/live.json'" + NL,
+            }
+        )
+        self.assertFalse(self._family_findings(findings, "fixture"))
+
+    def test_unreferenced_schema_is_reported(self):
+        _universe, (_status, findings) = self._analyse(
+            {"schemas/orphan.schema.json": "{}" + NL, "README.md": "root" + NL}
+        )
+        self.assertEqual(
+            [item.path for item in self._family_findings(findings, "schema")],
+            ["schemas/orphan.schema.json"],
+        )
+
+    def test_markdown_schema_link_retains_it(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "schemas/live.schema.json": "{}" + NL,
+                "README.md": "[schema](schemas/live.schema.json)" + NL,
+            }
+        )
+        self.assertFalse(self._family_findings(findings, "schema"))
+
+    def test_unreferenced_document_is_reported(self):
+        _universe, (_status, findings) = self._analyse(
+            {"docs/orphan.md": "# orphan" + NL, "README.md": "root" + NL}
+        )
+        self.assertEqual(
+            [item.path for item in self._family_findings(findings, "document")],
+            ["docs/orphan.md"],
+        )
+
+    def test_markdown_document_link_retains_it(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "docs/live.md": "# live" + NL,
+                "README.md": "[live](docs/live.md)" + NL,
+            }
+        )
+        self.assertFalse(self._family_findings(findings, "document"))
+
+    def test_unreferenced_cli_target_is_reported(self):
+        _universe, (_status, findings) = self._analyse(
+            {"scripts/orphan.py": "print('orphan')" + NL, "README.md": "root" + NL}
+        )
+        self.assertEqual(
+            [item.path for item in self._family_findings(findings, "cli")],
+            ["scripts/orphan.py"],
+        )
+
+    def test_check_map_cli_declaration_retains_target(self):
+        check_map = self._check_map(
+            checks={"live": {"argv": ["python3", "scripts/live.py"]}},
+            scopes={"root": {"checks": ["live"]}},
+        )
+        _universe, (_status, findings) = self._analyse(
+            {"scripts/live.py": "print('live')" + NL, "tests/check-map-v1.json": check_map}
+        )
+        self.assertFalse(self._family_findings(findings, "cli"))
+
+    def test_unreferenced_generated_copy_is_reported(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "copies/law.md": "<!-- canonical=PROMISE_MACHINE.md; copies=generated -->" + NL,
+                "PROMISE_MACHINE.md": "law" + NL,
+            }
+        )
+        self.assertEqual(
+            [item.path for item in self._family_findings(findings, "generated-copy")],
+            ["copies/law.md"],
+        )
+
+    def test_canonical_generated_copy_reference_retains_it(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "copies/law.md": "<!-- canonical=PROMISE_MACHINE.md; copies=generated -->" + NL,
+                "PROMISE_MACHINE.md": "[copy](copies/law.md)" + NL,
+            }
+        )
+        self.assertFalse(self._family_findings(findings, "generated-copy"))
+
+    def test_unreferenced_router_is_reported(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                ".agents/skills/orphan/SKILL.md": "---" + NL + "name: orphan" + NL + "---" + NL,
+                "README.md": "root" + NL,
+            }
+        )
+        self.assertEqual(
+            [item.path for item in self._family_findings(findings, "router")],
+            [".agents/skills/orphan/SKILL.md"],
+        )
+
+    def test_portable_promise_machine_router_is_an_external_root(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                ".agents/skills/promise-machine/SKILL.md": "---" + NL + "name: promise-machine" + NL + "---" + NL,
+                "README.md": "root" + NL,
+            }
+        )
+        self.assertFalse(self._family_findings(findings, "router"))
+
+    def test_unreferenced_manifest_is_reported(self):
+        _universe, (_status, findings) = self._analyse(
+            {"orphan/plugin.json": "{}" + NL, "README.md": "root" + NL}
+        )
+        self.assertEqual(
+            [item.path for item in self._family_findings(findings, "manifest")],
+            ["orphan/plugin.json"],
+        )
+
+    def test_host_manifest_is_an_external_root(self):
+        _universe, (_status, findings) = self._analyse(
+            {".codex-plugin/plugin.json": "{}" + NL, "README.md": "root" + NL}
+        )
+        self.assertFalse(self._family_findings(findings, "manifest"))
+
+    def test_unscoped_check_map_object_is_reported(self):
+        check_map = self._check_map(
+            checks={"orphan": {"argv": ["python3", "-V"]}},
+            scopes={"root": {"checks": []}},
+        )
+        _universe, (_status, findings) = self._analyse(
+            {"tests/check-map-v1.json": check_map, "README.md": "root" + NL}
+        )
+        self.assertEqual(
+            [item.symbol for item in self._family_findings(findings, "check-map")],
+            ["check-map:check:orphan"],
+        )
+
+    def test_scoped_check_map_object_is_retained(self):
+        check_map = self._check_map(
+            checks={"live": {"argv": ["python3", "-V"]}},
+            scopes={"root": {"checks": ["live"]}},
+        )
+        _universe, (_status, findings) = self._analyse(
+            {"tests/check-map-v1.json": check_map, "README.md": "root" + NL}
+        )
+        self.assertFalse(self._family_findings(findings, "check-map"))
+
+    def test_computed_reference_lowers_confidence_and_names_boundary(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "tests/fixtures/orphan.json": "{}" + NL,
+                "tests/test_dynamic.py": "target = Path('tests/fixtures') / name" + NL,
+            }
+        )
+        candidate = self._family_findings(findings, "fixture")[0]
+        self.assertEqual(candidate.confidence, "low")
+        self.assertIn("computed-path", candidate.false_positive_boundary)
+        self.assertIn("tests/test_dynamic.py", candidate.false_positive_boundary)
+
+    def test_family_record_names_parsed_edge_set_and_computed_boundary_count(self):
+        _universe, (status, _findings) = self._analyse(
+            {
+                "tests/fixtures/live.json": "{}" + NL,
+                "tests/test_live.py": "FIXTURE = 'tests/fixtures/live.json'" + NL,
+                "tests/test_dynamic.py": "target = Path('tests/fixtures') / name" + NL,
+            }
+        )
+        record = next(item for item in status.records if item.record_id == "fixture")
+        self.assertRegex(record.detail, r"edge_set=sha256:[0-9a-f]{64}")
+        self.assertIn("computed_boundaries=1", record.detail)
+        self.assertGreaterEqual(record.evidence_count, 1)
+
+    def test_f_string_reference_is_a_named_dynamic_boundary(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "tests/fixtures/orphan.json": "{}" + NL,
+                "tests/test_dynamic.py": "target = f'tests/fixtures/{name}.json'" + NL,
+            }
+        )
+        candidate = self._family_findings(findings, "fixture")[0]
+        self.assertEqual(candidate.confidence, "low")
+        self.assertIn("computed-path:f-string", candidate.false_positive_boundary)
+
+    def test_malformed_check_map_degrades_only_its_family(self):
+        _universe, (status, findings) = self._analyse(
+            {"tests/check-map-v1.json": "{not json" + NL, "README.md": "root" + NL}
+        )
+        self.assertEqual(status.state, "degraded")
+        record = next(item for item in status.records if item.record_id == "check-map")
+        self.assertEqual(record.state, "parse-error")
+        self.assertIsNotNone(record.reason)
+        self.assertFalse(self._family_findings(findings, "check-map"))
+
+    def test_empty_object_discovery_is_a_visible_zero_not_a_clean_claim(self):
+        _universe, (status, findings) = self._analyse({"a.txt": "plain" + NL})
+        self.assertEqual(status.state, "ran")
+        self.assertEqual(findings, ())
+        self.assertEqual(len(status.records), len(dead_code.REPOSITORY_FAMILIES))
+        self.assertTrue(all(item.evidence_count == 0 for item in status.records))
+
+    def test_repository_finding_survives_report_rendering(self):
+        universe, (status, findings) = self._analyse(
+            {"docs/orphan.md": "# orphan" + NL, "README.md": "root" + NL}
+        )
+        report = dead_code.Report(universe, (status,), findings)
+        dead_code.validate_report(report)
+        document = json.loads(dead_code.render_json(report))
+        self.assertEqual(document["findings"][0]["id"], findings[0].identity)
+        self.assertIn(findings[0].identity, dead_code.render_text(report))
+
+
+class SolidityAnalyserTests(TemporaryRepositoryTestCase):
+    @staticmethod
+    def _slither_document(detectors=None):
+        return json.dumps(
+            {
+                "success": True,
+                "error": None,
+                "results": {"detectors": [] if detectors is None else detectors},
+            }
+        ).encode()
+
+    @staticmethod
+    def _forge_summary(percent="100.00", covered="1", total="1"):
+        return (
+            "| File | % Lines | % Statements | % Branches | % Funcs |" + NL
+            + f"| src/Dead.sol | {percent}% ({covered}/{total}) | {percent}% ({covered}/{total}) | {percent}% ({covered}/{total}) | {percent}% ({covered}/{total}) |" + NL
+        ).encode()
+
+    def _project(self, prefix=""):
+        stem = f"{prefix}/" if prefix else ""
+        return {
+            f"{stem}foundry.toml": "[profile.default]" + NL + "src = 'src'" + NL,
+            f"{stem}src/Dead.sol": "pragma solidity ^0.8.20; contract Dead { uint256 value; }" + NL,
+        }
+
+    def _universe(self, files=None):
+        build_repository(self.root, files=self._project() if files is None else files)
+        return dead_code.discover(self.root)
+
+    def _successful_runner(self, calls, *, detectors=None, forge_summary=None):
+        slither = self._slither_document(detectors)
+        forge = self._forge_summary() if forge_summary is None else forge_summary
+
+        def run(argv, **kwargs):
+            calls.append((tuple(argv), kwargs["cwd"]))
+            if argv == ["slither", "--version"]:
+                return b"0.11.4\n", b"", 0
+            if argv == ["forge", "--version"]:
+                return b"forge 1.7.1\n", b"", 0
+            if argv == ["slither", ".", "--detect", "dead-code,unused-state", "--json", "-"]:
+                return slither, b"", 0
+            if argv == ["forge", "coverage", "--report", "summary"]:
+                return forge, b"", 0
+            self.fail(f"unexpected argv: {argv!r}")
+
+        return run
+
+    def test_multiple_foundry_projects_are_discovered_from_tracked_configs(self):
+        files = {**self._project("one"), **self._project("two")}
+        universe = self._universe(files)
+        calls = []
+        with mock.patch.object(dead_code, "run_process", side_effect=self._successful_runner(calls)):
+            status, _findings = dead_code.analyse_solidity(self.root, universe)
+        projects = {item.record_id.split(":", 1)[0] for item in status.records}
+        self.assertEqual(projects, {"one", "two"})
+
+    def test_absent_slither_is_degraded_not_zero_findings(self):
+        universe = self._universe()
+        successful = self._successful_runner([])
+
+        def run(argv, **kwargs):
+            if argv[0] == "slither":
+                raise dead_code.Refusal("slither is not available on PATH")
+            return successful(argv, **kwargs)
+
+        with mock.patch.object(dead_code, "run_process", side_effect=run):
+            status, findings = dead_code.analyse_solidity(self.root, universe)
+        self.assertEqual(status.state, "degraded")
+        slither = next(item for item in status.records if item.record_id.endswith(":slither"))
+        self.assertEqual(slither.state, "unavailable")
+        self.assertEqual(findings, ())
+
+    def test_absent_forge_is_degraded_not_zero_findings(self):
+        universe = self._universe()
+        successful = self._successful_runner([])
+
+        def run(argv, **kwargs):
+            if argv[0] == "forge":
+                raise dead_code.Refusal("forge is not available on PATH")
+            return successful(argv, **kwargs)
+
+        with mock.patch.object(dead_code, "run_process", side_effect=run):
+            status, findings = dead_code.analyse_solidity(self.root, universe)
+        self.assertEqual(status.state, "degraded")
+        forge = next(item for item in status.records if item.record_id.endswith(":forge"))
+        self.assertEqual(forge.state, "unavailable")
+        self.assertEqual(findings, ())
+
+    def test_both_tools_absent_is_not_available(self):
+        universe = self._universe()
+        with mock.patch.object(
+            dead_code,
+            "run_process",
+            side_effect=dead_code.Refusal("tool is not available on PATH"),
+        ):
+            status, findings = dead_code.analyse_solidity(self.root, universe)
+        self.assertEqual(status.state, "not-available")
+        self.assertEqual(findings, ())
+
+    def test_non_zero_tool_exit_degrades_project(self):
+        universe = self._universe()
+        successful = self._successful_runner([])
+
+        def run(argv, **kwargs):
+            if argv[:2] == ["slither", "."]:
+                return b"", b"compile failed", 1
+            return successful(argv, **kwargs)
+
+        with mock.patch.object(dead_code, "run_process", side_effect=run):
+            status, findings = dead_code.analyse_solidity(self.root, universe)
+        self.assertEqual(status.state, "degraded")
+        self.assertEqual(findings, ())
+        self.assertIn("exit 1", next(item for item in status.records if item.record_id.endswith(":slither")).reason)
+
+    def test_tool_timeout_degrades_project(self):
+        universe = self._universe()
+        successful = self._successful_runner([])
+
+        def run(argv, **kwargs):
+            if argv[:2] == ["slither", "."]:
+                raise dead_code.Refusal("slither timed out after 600s")
+            return successful(argv, **kwargs)
+
+        with mock.patch.object(dead_code, "run_process", side_effect=run):
+            status, _findings = dead_code.analyse_solidity(self.root, universe)
+        record = next(item for item in status.records if item.record_id.endswith(":slither"))
+        self.assertEqual(record.state, "failed")
+        self.assertIn("timed out", record.reason)
+
+    def test_oversized_tool_output_degrades_project(self):
+        universe = self._universe()
+        successful = self._successful_runner([])
+
+        def run(argv, **kwargs):
+            if argv[:2] == ["forge", "coverage"]:
+                raise dead_code.Refusal("forge output exceeded 1024 bytes")
+            return successful(argv, **kwargs)
+
+        with mock.patch.object(dead_code, "run_process", side_effect=run):
+            status, _findings = dead_code.analyse_solidity(self.root, universe)
+        record = next(item for item in status.records if item.record_id.endswith(":forge"))
+        self.assertEqual(record.state, "failed")
+        self.assertIn("exceeded", record.reason)
+
+    def test_malformed_slither_json_degrades_without_absence_findings(self):
+        universe = self._universe()
+        successful = self._successful_runner([])
+
+        def run(argv, **kwargs):
+            if argv[:2] == ["slither", "."]:
+                return b"not-json", b"", 0
+            return successful(argv, **kwargs)
+
+        with mock.patch.object(dead_code, "run_process", side_effect=run):
+            status, findings = dead_code.analyse_solidity(self.root, universe)
+        self.assertEqual(status.state, "degraded")
+        self.assertEqual(findings, ())
+        self.assertEqual(
+            next(item for item in status.records if item.record_id.endswith(":slither")).state,
+            "parse-error",
+        )
+
+    def test_fixed_argv_and_project_cwd_are_used(self):
+        universe = self._universe()
+        calls = []
+        with mock.patch.object(dead_code, "run_process", side_effect=self._successful_runner(calls)):
+            dead_code.analyse_solidity(self.root, universe)
+        self.assertIn(
+            (("slither", ".", "--detect", "dead-code,unused-state", "--json", "-"), self.root),
+            calls,
+        )
+        self.assertIn((("forge", "coverage", "--report", "summary"), self.root), calls)
+
+    def test_slither_detector_maps_to_project_attributed_finding(self):
+        universe = self._universe()
+        detector = {
+            "check": "unused-state",
+            "confidence": "High",
+            "elements": [
+                {
+                    "type": "variable",
+                    "name": "value",
+                    "source_mapping": {"filename_relative": "src/Dead.sol", "lines": [1]},
+                }
+            ],
+        }
+        with mock.patch.object(
+            dead_code,
+            "run_process",
+            side_effect=self._successful_runner([], detectors=[detector]),
+        ):
+            status, findings = dead_code.analyse_solidity(self.root, universe)
+        self.assertEqual(status.state, "ran")
+        candidate = next(item for item in findings if "unused-state" in item.evidence)
+        self.assertEqual(candidate.path, "src/Dead.sol")
+        self.assertEqual(candidate.symbol, "unused-state:variable:value@1")
+        self.assertEqual(candidate.confidence, "high")
+
+    def test_uncovered_forge_summary_row_maps_to_low_confidence_finding(self):
+        universe = self._universe()
+        with mock.patch.object(
+            dead_code,
+            "run_process",
+            side_effect=self._successful_runner(
+                [], forge_summary=self._forge_summary("0.00", "0", "1")
+            ),
+        ):
+            _status, findings = dead_code.analyse_solidity(self.root, universe)
+        candidate = next(item for item in findings if item.symbol and item.symbol.startswith("forge-coverage:"))
+        self.assertEqual(candidate.path, "src/Dead.sol")
+        self.assertEqual(candidate.confidence, "low")
+
+    def test_solidity_finding_survives_report_rendering(self):
+        universe = self._universe()
+        detector = {
+            "check": "dead-code",
+            "confidence": "Medium",
+            "elements": [
+                {
+                    "type": "function",
+                    "name": "spare",
+                    "source_mapping": {"filename_relative": "src/Dead.sol", "lines": [1]},
+                }
+            ],
+        }
+        with mock.patch.object(
+            dead_code,
+            "run_process",
+            side_effect=self._successful_runner([], detectors=[detector]),
+        ):
+            status, findings = dead_code.analyse_solidity(self.root, universe)
+        report = dead_code.Report(universe, (status,), findings)
+        dead_code.validate_report(report)
+        document = json.loads(dead_code.render_json(report))
+        self.assertEqual(document["findings"][0]["id"], findings[0].identity)
 
 
 class CoverageAggregationTests(unittest.TestCase):
@@ -1788,6 +2284,21 @@ class ShippedSurfaceTests(unittest.TestCase):
             "finding",
         ):
             self.assertFalse(schema["$defs"][name]["additionalProperties"])
+        record = dead_code.AnalyserRecord(
+            "fixture",
+            "family",
+            "parsed",
+            "fixture record",
+            1,
+            "repository-graph/1",
+            2,
+            3,
+            None,
+        ).as_dict()
+        self.assertEqual(
+            set(record),
+            set(schema["$defs"]["analyserRecord"]["required"]),
+        )
 
     def test_check_map_declares_the_focused_dead_code_scope(self):
         check_map = json.loads(CHECK_MAP_PATH.read_text(encoding="utf-8"))

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -1168,6 +1168,42 @@ class PythonAnalyserTests(TemporaryRepositoryTestCase):
         self.assertTrue(snapshot.degraded)
         self.assertTrue(any(item.state == "skipped" for item in snapshot.records))
 
+    def test_global_assignment_is_not_reported_as_an_unused_local(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "main.py": (
+                    "def configure():" + NL
+                    + "    global setting" + NL
+                    + "    setting = 1" + NL
+                )
+            }
+        )
+        self.assertFalse(any(item.symbol == "configure.setting@3" for item in findings))
+
+    def test_nested_assignment_is_not_attributed_to_the_enclosing_function(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "main.py": (
+                    "def outer():" + NL
+                    + "    def inner():" + NL
+                    + "        nested = 1" + NL
+                    + "    return inner" + NL
+                )
+            }
+        )
+        self.assertFalse(any(item.symbol == "outer.nested@3" for item in findings))
+
+    def test_comprehension_target_is_not_reported_as_a_function_local(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "main.py": (
+                    "def values(items):" + NL
+                    + "    return [1 for item in items]" + NL
+                )
+            }
+        )
+        self.assertFalse(any(item.symbol == "values.item@2" for item in findings))
+
 
 class CoverageAggregationTests(unittest.TestCase):
     def setUp(self):
@@ -1181,6 +1217,7 @@ class CoverageAggregationTests(unittest.TestCase):
             ],
         }
         self.run = {
+            **self.plan,
             "schema": "wildcat.check-run.v1",
             "outcome": "green",
             "checks": [
@@ -1250,6 +1287,30 @@ class CoverageAggregationTests(unittest.TestCase):
             self._aggregate([second, first]),
         )
 
+    def test_public_coverage_does_not_retain_process_argv(self):
+        root_process = self._process(pid=10)
+        first_child = self._process(
+            pid=11,
+            argv=["python3", "child.py", "--token=first-secret"],
+        )
+        second_child = self._process(
+            pid=11,
+            argv=["python3", "child.py", "--token=second-secret"],
+        )
+
+        first = self._aggregate([root_process, first_child])
+        second = self._aggregate([root_process, second_child])
+
+        self.assertTrue(all("argv" not in process for process in first["processes"]))
+        first_child_id = next(
+            process["id"] for process in first["processes"] if process["pid"] == 11
+        )
+        second_child_id = next(
+            process["id"] for process in second["processes"] if process["pid"] == 11
+        )
+        self.assertEqual(first_child_id, second_child_id)
+        self.assertNotIn("first-secret", json.dumps(first))
+
     def test_failed_check_degrades_coverage(self):
         run = {
             **self.run,
@@ -1283,6 +1344,23 @@ class CoverageAggregationTests(unittest.TestCase):
         run = {**self.run, "checks": []}
         with self.assertRaisesRegex(dead_code.Refusal, "do not match"):
             self._aggregate([self._process()], run)
+
+    def test_duplicate_terminal_check_refuses_instead_of_overwriting(self):
+        run = {**self.run, "checks": [*self.run["checks"], *self.run["checks"]]}
+        with self.assertRaisesRegex(dead_code.Refusal, "repeated"):
+            self._aggregate([self._process()], run)
+
+    def test_contradictory_complete_process_status_degrades(self):
+        process = self._process()
+        process["status"]["truncated"] = True
+        report = self._aggregate([process])
+        self.assertEqual(report["status"]["state"], "degraded")
+
+    def test_non_string_process_state_refuses_instead_of_crashing(self):
+        process = self._process()
+        process["status"]["state"] = []
+        with self.assertRaisesRegex(dead_code.Refusal, "process status"):
+            self._aggregate([process])
 
     def test_wrapper_recursion_is_detected_in_declared_argv(self):
         self.assertTrue(
@@ -1320,10 +1398,28 @@ class CoverageAggregationTests(unittest.TestCase):
             str(ROOT / dead_code.MONITOR_DIRECTORY),
         )
 
+    def test_run_map_digest_must_match_the_preflight_plan(self):
+        run = {**self.run, "map_digest": "c" * 64}
+        with self.assertRaisesRegex(dead_code.Refusal, "preflight plan"):
+            self._aggregate([self._process()], run)
+
 
 class MonitoringProbeTests(TemporaryRepositoryTestCase):
     def _free_tool_id(self):
         return next(identifier for identifier in range(6) if sys.monitoring.get_tool(identifier) is None)
+
+    @staticmethod
+    def _release_tool_id(identifier):
+        if sys.monitoring.get_tool(identifier) is None:
+            return
+        sys.monitoring.set_events(identifier, 0)
+        for event in (
+            sys.monitoring.events.LINE,
+            sys.monitoring.events.BRANCH_LEFT,
+            sys.monitoring.events.BRANCH_RIGHT,
+        ):
+            sys.monitoring.register_callback(identifier, event, None)
+        sys.monitoring.free_tool_id(identifier)
 
     def test_probe_restores_its_tool_id_and_event_mask(self):
         output = self.root / "records"
@@ -1347,6 +1443,23 @@ class MonitoringProbeTests(TemporaryRepositoryTestCase):
         self.assertFalse(probe.start())
         probe.close()
         self.assertEqual(sys.monitoring.get_tool(identifier), "fixture-owner")
+
+    def test_probe_does_not_clobber_a_reassigned_tool_id(self):
+        identifier = self._free_tool_id()
+        output = self.root / "records"
+        output.mkdir()
+        probe = dead_code_monitor.MonitoringProbe(output, ROOT, "a" * 32)
+        probe.tool_id = identifier
+        self.assertTrue(probe.start())
+        self._release_tool_id(identifier)
+        sys.monitoring.use_tool_id(identifier, "replacement-owner")
+        self.addCleanup(self._release_tool_id, identifier)
+
+        probe.close()
+
+        self.assertEqual(sys.monitoring.get_tool(identifier), "replacement-owner")
+        document = json.loads(next(output.iterdir()).read_text(encoding="utf-8"))
+        self.assertIn("restore:ownership-changed", document["status"]["errors"])
 
     def test_probe_writes_named_lines_and_branches(self):
         output = self.root / "records"
@@ -1387,6 +1500,71 @@ class MonitoringProbeTests(TemporaryRepositoryTestCase):
         self.assertIs(result, sys.monitoring.DISABLE)
 
 
+class CoverageContainmentTests(unittest.TestCase):
+    @staticmethod
+    def _stop(process):
+        if process.poll() is None:
+            process.kill()
+        process.wait(timeout=5)
+
+    def test_recovery_terminates_a_process_carrying_the_run_identity(self):
+        run_id = "d" * 32
+        environment = dict(os.environ)
+        environment[dead_code.COVERAGE_ACTIVE_ENV] = run_id
+        process = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            env=environment,
+            start_new_session=True,
+        )
+        self.addCleanup(self._stop, process)
+        dead_code._terminate_coverage_processes(run_id)
+        process.wait(timeout=5)
+        self.assertIsNotNone(process.returncode)
+
+
+class CoverageCommandTests(TemporaryRepositoryTestCase):
+    def test_green_report_cannot_disagree_with_the_runner_exit(self):
+        build_repository(self.root)
+        universe = dead_code.discover(self.root)
+        plan = {
+            "schema": "wildcat.check-plan.v1",
+            "map_digest": "a" * 64,
+            "requested_scopes": ["dead-code"],
+            "selected_checks": [
+                {"id": "alpha", "argv": [sys.executable, "a.py"], "cwd": "."}
+            ],
+        }
+        run = {
+            **plan,
+            "schema": "wildcat.check-run.v1",
+            "outcome": "green",
+            "checks": [
+                {"check": "alpha", "status": "passed", "duration_seconds": 0.1}
+            ],
+        }
+
+        def failed_runner(*_args, **_kwargs):
+            target = self.root / ".dead-code" / "checks.json"
+            target.write_text(json.dumps(run), encoding="utf-8")
+            return b"", b"runner failed", 1
+
+        arguments = dead_code.argparse.Namespace(
+            directory=str(self.root),
+            scope=["dead-code"],
+            output=".dead-code/coverage.json",
+        )
+        with (
+            mock.patch.object(dead_code, "repository_root", return_value=self.root),
+            mock.patch.object(dead_code, "discover", return_value=universe),
+            mock.patch.object(dead_code, "_runner_plan", return_value=plan),
+            mock.patch.object(dead_code, "run_process", side_effect=failed_runner),
+            mock.patch.object(dead_code, "_coverage_survivor_pids", return_value=[]),
+            mock.patch.dict(os.environ, {dead_code.COVERAGE_ACTIVE_ENV: ""}),
+        ):
+            with self.assertRaisesRegex(dead_code.Refusal, "exit 1.*green"):
+                dead_code.command_coverage(arguments)
+
+
 class CoverageAnalyserTests(TemporaryRepositoryTestCase):
     SOURCE = (
         "def plain(flag):" + NL
@@ -1396,8 +1574,11 @@ class CoverageAnalyserTests(TemporaryRepositoryTestCase):
         + "        return 2" + NL
     )
 
-    def _fixture(self, *, state="ran", branches=None, lines=None):
-        build_repository(self.root, files={"app.py": self.SOURCE})
+    def _fixture(self, *, state="ran", branches=None, lines=None, source=None):
+        build_repository(
+            self.root,
+            files={"app.py": self.SOURCE if source is None else source},
+        )
         universe = dead_code.discover(self.root)
         target = self.root / ".dead-code" / "coverage.json"
         target.parent.mkdir()
@@ -1427,6 +1608,8 @@ class CoverageAnalyserTests(TemporaryRepositoryTestCase):
             ],
             "processes": [
                 {
+                    "check": "alpha",
+                    "bytes": 100,
                     "status": {"state": "ran", "truncated": False, "errors": []},
                     "lines": [] if lines is None else lines,
                     "branches": [] if branches is None else branches,
@@ -1463,6 +1646,44 @@ class CoverageAnalyserTests(TemporaryRepositoryTestCase):
         self.assertNotIn("branch:2->3:body", symbols)
         self.assertIn("branch:2->5:else", symbols)
 
+    def test_observed_function_skips_its_optimised_away_docstring(self):
+        source = (
+            "def documented():" + NL
+            + "    \"\"\"metadata, not an executable body line\"\"\"" + NL
+            + "    return 1" + NL
+        )
+        universe, _target, _document = self._fixture(
+            source=source,
+            lines=[{"path": "app.py", "function": "documented", "line": 3}],
+        )
+
+        status, findings = dead_code.analyse_coverage(
+            self.root, universe, ".dead-code/coverage.json"
+        )
+
+        self.assertEqual(status.state, "ran")
+        self.assertFalse(any(item.symbol.startswith("documented@") for item in findings))
+
+    def test_coverage_tool_identity_is_required(self):
+        universe, target, document = self._fixture()
+        document["tool"]["id"] = "not-sys-monitoring"
+        target.write_text(json.dumps(document), encoding="utf-8")
+
+        with self.assertRaisesRegex(dead_code.Refusal, "sys.monitoring"):
+            dead_code.analyse_coverage(
+                self.root, universe, ".dead-code/coverage.json"
+            )
+
+    def test_coverage_plan_schema_is_required(self):
+        universe, target, document = self._fixture()
+        document["plan"]["schema"] = "unknown-plan"
+        target.write_text(json.dumps(document), encoding="utf-8")
+
+        with self.assertRaisesRegex(dead_code.Refusal, "check-plan"):
+            dead_code.analyse_coverage(
+                self.root, universe, ".dead-code/coverage.json"
+            )
+
     def test_stale_coverage_identity_degrades_without_findings(self):
         universe, target, document = self._fixture()
         document["tree"]["commit"] = "f" * 40
@@ -1477,6 +1698,55 @@ class CoverageAnalyserTests(TemporaryRepositoryTestCase):
         build_repository(self.root, files={"app.py": self.SOURCE})
         with self.assertRaisesRegex(dead_code.Refusal, "requires --coverage"):
             dead_code.analyse_coverage(self.root, dead_code.discover(self.root), None)
+
+    def test_claimed_complete_without_process_aggregate_degrades(self):
+        universe, target, document = self._fixture()
+        document["checks"][0]["processes"] = 1
+        document["processes"] = []
+        target.write_text(json.dumps(document), encoding="utf-8")
+        status, findings = dead_code.analyse_coverage(
+            self.root, universe, ".dead-code/coverage.json"
+        )
+        self.assertEqual(status.state, "degraded")
+        self.assertEqual(findings, ())
+
+    def test_malformed_line_event_refuses_instead_of_implying_absence(self):
+        universe, target, document = self._fixture(
+            lines=[{"path": "app.py", "function": "plain", "line": "two"}]
+        )
+        target.write_text(json.dumps(document), encoding="utf-8")
+        with self.assertRaisesRegex(dead_code.Refusal, "line event"):
+            dead_code.analyse_coverage(
+                self.root, universe, ".dead-code/coverage.json"
+            )
+
+    def test_boolean_line_identity_refuses_instead_of_aliasing_line_one(self):
+        universe, target, document = self._fixture(
+            lines=[{"path": "app.py", "function": "plain", "line": True}]
+        )
+        target.write_text(json.dumps(document), encoding="utf-8")
+        with self.assertRaisesRegex(dead_code.Refusal, "line event"):
+            dead_code.analyse_coverage(
+                self.root, universe, ".dead-code/coverage.json"
+            )
+
+    def test_non_string_branch_direction_refuses_instead_of_crashing(self):
+        universe, target, document = self._fixture(
+            branches=[
+                {
+                    "path": "app.py",
+                    "function": "plain",
+                    "from_line": 2,
+                    "to_line": 3,
+                    "direction": [],
+                }
+            ]
+        )
+        target.write_text(json.dumps(document), encoding="utf-8")
+        with self.assertRaisesRegex(dead_code.Refusal, "branch event"):
+            dead_code.analyse_coverage(
+                self.root, universe, ".dead-code/coverage.json"
+            )
 
 
 class ShippedSurfaceTests(unittest.TestCase):

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -1637,6 +1637,26 @@ class SolidityAnalyserTests(TemporaryRepositoryTestCase):
         )
         self.assertIn((("forge", "coverage", "--report", "summary"), self.root), calls)
 
+    def test_foundry_outputs_are_confined_outside_the_repository(self):
+        universe = self._universe()
+        environments = []
+        successful = self._successful_runner([])
+
+        def run(argv, **kwargs):
+            if argv[:2] in (["slither", "."], ["forge", "coverage"]):
+                environments.append(kwargs.get("env"))
+            return successful(argv, **kwargs)
+
+        with mock.patch.object(dead_code, "run_process", side_effect=run):
+            dead_code.analyse_solidity(self.root, universe)
+        self.assertEqual(len(environments), 2)
+        for environment in environments:
+            self.assertIsNotNone(environment)
+            for name in ("FOUNDRY_OUT", "FOUNDRY_CACHE_PATH", "FOUNDRY_BROADCAST"):
+                target = Path(environment[name])
+                self.assertTrue(target.is_absolute())
+                self.assertFalse(target.is_relative_to(self.root))
+
     def test_slither_detector_maps_to_project_attributed_finding(self):
         universe = self._universe()
         detector = {

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -1578,6 +1578,20 @@ class SolidityAnalyserTests(TemporaryRepositoryTestCase):
         self.assertEqual(findings, ())
         self.assertIn("exit 1", next(item for item in status.records if item.record_id.endswith(":slither")).reason)
 
+    def test_long_tool_stderr_preserves_the_terminal_failure_reason(self):
+        universe = self._universe()
+        successful = self._successful_runner([])
+
+        def run(argv, **kwargs):
+            if argv[:2] == ["slither", "."]:
+                return b"", b"warning\n" * 100 + b"terminal root cause", 1
+            return successful(argv, **kwargs)
+
+        with mock.patch.object(dead_code, "run_process", side_effect=run):
+            status, _findings = dead_code.analyse_solidity(self.root, universe)
+        record = next(item for item in status.records if item.record_id.endswith(":slither"))
+        self.assertIn("terminal root cause", record.reason)
+
     def test_tool_timeout_degrades_project(self):
         universe = self._universe()
         successful = self._successful_runner([])
@@ -1625,6 +1639,19 @@ class SolidityAnalyserTests(TemporaryRepositoryTestCase):
             next(item for item in status.records if item.record_id.endswith(":slither")).state,
             "parse-error",
         )
+
+    def test_successful_slither_result_without_detector_key_is_empty_evidence(self):
+        universe = self._universe()
+        payload = json.dumps(
+            {"success": True, "error": None, "results": {}}
+        ).encode()
+        findings, evidence_count = dead_code._slither_findings(
+            payload,
+            project=".",
+            universe=universe,
+        )
+        self.assertEqual(findings, ())
+        self.assertEqual(evidence_count, 0)
 
     def test_fixed_argv_and_project_cwd_are_used(self):
         universe = self._universe()

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -1592,6 +1592,34 @@ class SolidityAnalyserTests(TemporaryRepositoryTestCase):
         record = next(item for item in status.records if item.record_id.endswith(":slither"))
         self.assertIn("compiler root cause", record.reason)
 
+    def test_non_zero_slither_success_keeps_positive_detector_evidence(self):
+        universe = self._universe()
+        detector = {
+            "check": "dead-code",
+            "confidence": "Medium",
+            "elements": [
+                {
+                    "type": "function",
+                    "name": "spare",
+                    "source_mapping": {"filename_relative": "src/Dead.sol", "lines": [1]},
+                }
+            ],
+        }
+        successful = self._successful_runner([])
+
+        def run(argv, **kwargs):
+            if argv[:2] == ["slither", "."]:
+                return self._slither_document([detector]), b"warning", 255
+            return successful(argv, **kwargs)
+
+        with mock.patch.object(dead_code, "run_process", side_effect=run):
+            status, findings = dead_code.analyse_solidity(self.root, universe)
+        record = next(item for item in status.records if item.record_id.endswith(":slither"))
+        self.assertEqual(status.state, "degraded")
+        self.assertEqual(record.state, "failed")
+        self.assertEqual(record.evidence_count, 1)
+        self.assertTrue(any("dead-code" in item.evidence for item in findings))
+
     def test_long_tool_stderr_preserves_the_terminal_failure_reason(self):
         universe = self._universe()
         successful = self._successful_runner([])

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -15,6 +15,7 @@ from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "dead_code.py"
+MONITOR_SCRIPT = ROOT / "scripts" / "dead_code_monitoring" / "sitecustomize.py"
 SCHEMA_PATH = ROOT / "schemas" / "dead-code-report-v1.schema.json"
 WORKFLOW_PATH = ROOT / ".github" / "workflows" / "dead-code.yml"
 CHECK_MAP_PATH = ROOT / "tests" / "check-map-v1.json"
@@ -34,6 +35,11 @@ SPEC = importlib.util.spec_from_file_location("dead_code", SCRIPT)
 dead_code = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = dead_code
 SPEC.loader.exec_module(dead_code)
+
+MONITOR_SPEC = importlib.util.spec_from_file_location("dead_code_monitor", MONITOR_SCRIPT)
+dead_code_monitor = importlib.util.module_from_spec(MONITOR_SPEC)
+sys.modules[MONITOR_SPEC.name] = dead_code_monitor
+MONITOR_SPEC.loader.exec_module(dead_code_monitor)
 
 
 def git(directory, *arguments):
@@ -1004,6 +1010,475 @@ class CommandLineTests(TemporaryRepositoryTestCase):
         self.assertEqual(git(self.root, "status", "--porcelain"), "")
 
 
+class PythonAnalyserTests(TemporaryRepositoryTestCase):
+    def _analyse(self, files):
+        build_repository(self.root, files=files)
+        universe = dead_code.discover(self.root)
+        return universe, dead_code.analyse_python(self.root, universe)
+
+    def test_every_python_file_has_a_parse_record(self):
+        _universe, (status, _findings) = self._analyse(
+            {"main.py": "x = 1" + NL, "pkg/mod.py": "y = 2" + NL}
+        )
+        self.assertEqual(status.state, "ran")
+        self.assertEqual([item.record_id for item in status.records], ["main.py", "pkg/mod.py"])
+        self.assertTrue(all(item.state == "parsed" for item in status.records))
+
+    def test_syntax_error_degrades_and_names_the_file(self):
+        _universe, (status, findings) = self._analyse(
+            {"main.py": "if True print('no')" + NL, "ok.py": "x = 1" + NL}
+        )
+        self.assertEqual(status.state, "degraded")
+        record = next(item for item in status.records if item.record_id == "main.py")
+        self.assertEqual(record.state, "parse-error")
+        self.assertIn("SyntaxError", record.detail)
+        self.assertFalse(any(item.path == "main.py" for item in findings))
+
+    def test_unused_import_is_reported(self):
+        _universe, (_status, findings) = self._analyse(
+            {"main.py": "import os" + NL + "value = 1" + NL}
+        )
+        self.assertTrue(any(item.symbol == "os@1" for item in findings))
+
+    def test_loaded_import_is_retained(self):
+        _universe, (_status, findings) = self._analyse(
+            {"main.py": "import os" + NL + "value = os.name" + NL}
+        )
+        self.assertFalse(any(item.symbol == "os@1" for item in findings))
+
+    def test_unused_local_is_reported(self):
+        _universe, (_status, findings) = self._analyse(
+            {"main.py": "def f():" + NL + "    spare = 1" + NL + "    return 2" + NL}
+        )
+        self.assertTrue(any(item.symbol == "f.spare@2" for item in findings))
+
+    def test_loaded_local_is_retained(self):
+        _universe, (_status, findings) = self._analyse(
+            {"main.py": "def f():" + NL + "    kept = 1" + NL + "    return kept" + NL}
+        )
+        self.assertFalse(any(item.symbol == "f.kept@2" for item in findings))
+
+    def test_statement_after_return_is_reported(self):
+        _universe, (_status, findings) = self._analyse(
+            {"main.py": "def f():" + NL + "    return 1" + NL + "    spare()" + NL}
+        )
+        self.assertTrue(any(item.symbol == "line:3:unreachable" for item in findings))
+
+    def test_statement_before_return_is_not_unreachable(self):
+        _universe, (_status, findings) = self._analyse(
+            {"main.py": "def f():" + NL + "    kept()" + NL + "    return 1" + NL}
+        )
+        self.assertFalse(any(item.symbol == "line:2:unreachable" for item in findings))
+
+    def test_literal_constant_branch_is_reported(self):
+        _universe, (_status, findings) = self._analyse(
+            {"main.py": "if False:" + NL + "    spare()" + NL}
+        )
+        self.assertTrue(any(item.symbol == "line:1:constant-false" for item in findings))
+
+    def test_computed_import_lowers_candidate_confidence(self):
+        _universe, (status, findings) = self._analyse(
+            {
+                "main.py": (
+                    "import os" + NL
+                    + "import importlib" + NL
+                    + "name = 'pkg.mod'" + NL
+                    + "importlib.import_module(name)" + NL
+                )
+            }
+        )
+        record = status.records[0]
+        self.assertIn("computed-import", record.detail)
+        candidate = next(item for item in findings if item.symbol == "os@1")
+        self.assertEqual(candidate.confidence, "low")
+
+    def test_literal_import_edge_reaches_the_module(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "main.py": "import live" + NL + "if __name__ == '__main__':" + NL + "    print(live.value)" + NL,
+                "live.py": "value = 1" + NL,
+            }
+        )
+        self.assertFalse(any(item.path == "live.py" and item.symbol == "<module>" for item in findings))
+
+    def test_unreachable_import_graph_module_is_low_confidence(self):
+        _universe, (_status, findings) = self._analyse(
+            {
+                "main.py": "if __name__ == '__main__':" + NL + "    print('entry')" + NL,
+                "orphan.py": "value = 1" + NL,
+            }
+        )
+        candidate = next(item for item in findings if item.path == "orphan.py" and item.symbol == "<module>")
+        self.assertEqual(candidate.confidence, "low")
+
+    def test_decorator_registration_retains_the_definition(self):
+        source = "@registry" + NL + "def retained():" + NL + "    return 1" + NL
+        build_repository(self.root, files={"main.py": source})
+        snapshot = dead_code.parse_python_snapshot(self.root, dead_code.discover(self.root))
+        item = snapshot.files[0]
+        self.assertIn("retained", item.retained_names)
+        self.assertNotIn(("retained", 3), list(dead_code._function_targets(item)))
+
+    def test_dynamic_registration_argument_retains_the_definition(self):
+        source = "def retained():" + NL + "    return 1" + NL + "register(retained)" + NL
+        build_repository(self.root, files={"main.py": source})
+        item = dead_code.parse_python_snapshot(self.root, dead_code.discover(self.root)).files[0]
+        self.assertIn("retained", item.retained_names)
+
+    def test_literal_all_retains_exported_import(self):
+        _universe, (_status, findings) = self._analyse(
+            {"main.py": "from pkg import retained" + NL + "__all__ = ['retained']" + NL}
+        )
+        self.assertFalse(any(item.symbol == "retained@1" for item in findings))
+
+    def test_computed_getattr_is_a_visible_dynamic_boundary(self):
+        _universe, (status, _findings) = self._analyse(
+            {"main.py": "name = 'x'" + NL + "value = getattr(target, name)" + NL}
+        )
+        self.assertIn("computed-getattr", status.records[0].detail)
+
+    def test_main_guard_seeds_the_cli_module(self):
+        build_repository(
+            self.root,
+            files={"cli.py": "if __name__ == '__main__':" + NL + "    main()" + NL},
+        )
+        snapshot = dead_code.parse_python_snapshot(self.root, dead_code.discover(self.root))
+        self.assertIn("cli.py", snapshot.entry_paths)
+        self.assertIn("main", snapshot.files[0].retained_names)
+
+    def test_test_fixture_definitions_are_retained(self):
+        build_repository(
+            self.root,
+            files={"tests/fixtures/sample.py": "def helper():" + NL + "    return 1" + NL},
+        )
+        item = dead_code.parse_python_snapshot(self.root, dead_code.discover(self.root)).files[0]
+        self.assertIn("helper", item.retained_names)
+
+    def test_analysis_never_imports_the_parsed_module(self):
+        marker = self.root.parent / (self.root.name + "-executed")
+        source = f"from pathlib import Path{NL}Path({str(marker)!r}).write_text('bad'){NL}"
+        self._analyse({"hostile.py": source})
+        self.assertFalse(marker.exists())
+
+    def test_aggregate_python_limit_is_visible_as_skipped(self):
+        build_repository(self.root, files={"a.py": "x = 1" + NL, "b.py": "y = 2" + NL})
+        universe = dead_code.discover(self.root)
+        with mock.patch.object(dead_code, "MAX_PYTHON_TOTAL_BYTES", 1):
+            snapshot = dead_code.parse_python_snapshot(self.root, universe)
+        self.assertTrue(snapshot.degraded)
+        self.assertTrue(any(item.state == "skipped" for item in snapshot.records))
+
+
+class CoverageAggregationTests(unittest.TestCase):
+    def setUp(self):
+        self.run_id = "a" * 32
+        self.plan = {
+            "schema": "wildcat.check-plan.v1",
+            "map_digest": "b" * 64,
+            "requested_scopes": ["dead-code"],
+            "selected_checks": [
+                {"id": "alpha", "argv": ["python3", "alpha.py"], "cwd": "."}
+            ],
+        }
+        self.run = {
+            "schema": "wildcat.check-run.v1",
+            "outcome": "green",
+            "checks": [
+                {"check": "alpha", "status": "passed", "duration_seconds": 0.1}
+            ],
+        }
+        self.universe = dead_code.Universe(
+            commit="1" * 40,
+            tree="2" * 40,
+            identity="sha256:" + "3" * 64,
+            tracked_count=1,
+            analysed=("alpha.py",),
+            excluded=(),
+        )
+
+    def _process(self, *, pid=10, marker="group-a", state="ran", argv=None):
+        return {
+            "schema": "dead-code-process-coverage/v1",
+            "run": self.run_id,
+            "process": {
+                "pid": pid,
+                "parent_pid": 1,
+                "containment": marker,
+                "argv": ["python3", "alpha.py"] if argv is None else argv,
+                "cwd": "/snapshot",
+            },
+            "status": {"state": state, "truncated": False, "errors": []},
+            "lines": [{"path": "alpha.py", "function": "f", "line": 2}],
+            "branches": [
+                {
+                    "path": "alpha.py",
+                    "function": "f",
+                    "from_line": 2,
+                    "to_line": 3,
+                    "direction": "left",
+                }
+            ],
+        }
+
+    def _aggregate(self, documents, run=None):
+        return dead_code.aggregate_coverage(
+            self.plan,
+            self.run if run is None else run,
+            [(document, 100) for document in documents],
+            self.universe,
+        )
+
+    def test_line_identity_survives_aggregation(self):
+        report = self._aggregate([self._process()])
+        self.assertEqual(report["processes"][0]["lines"][0]["line"], 2)
+
+    def test_branch_identity_survives_aggregation(self):
+        report = self._aggregate([self._process()])
+        branch = report["processes"][0]["branches"][0]
+        self.assertEqual((branch["from_line"], branch["to_line"]), (2, 3))
+
+    def test_multiple_processes_are_attributed_to_one_check(self):
+        report = self._aggregate([self._process(), self._process(pid=11)])
+        self.assertEqual(report["checks"][0]["processes"], 2)
+        self.assertEqual(report["checks"][0]["bytes"], 200)
+
+    def test_aggregation_is_deterministic_across_input_order(self):
+        first = self._process(pid=10)
+        second = self._process(pid=11)
+        self.assertEqual(
+            self._aggregate([first, second]),
+            self._aggregate([second, first]),
+        )
+
+    def test_failed_check_degrades_coverage(self):
+        run = {
+            **self.run,
+            "outcome": "red",
+            "checks": [{"check": "alpha", "status": "failed", "duration_seconds": 0.1}],
+        }
+        report = self._aggregate([self._process()], run)
+        self.assertEqual(report["status"]["state"], "degraded")
+        self.assertIn("ended failed", report["status"]["detail"])
+
+    def test_not_started_check_degrades_coverage(self):
+        run = {
+            **self.run,
+            "outcome": "red",
+            "checks": [{"check": "alpha", "status": "not-started"}],
+        }
+        report = self._aggregate([], run)
+        self.assertEqual(report["status"]["state"], "degraded")
+        self.assertIn("no process record", report["status"]["detail"])
+
+    def test_degraded_process_degrades_coverage(self):
+        report = self._aggregate([self._process(state="degraded")])
+        self.assertEqual(report["status"]["state"], "degraded")
+
+    def test_unattributed_process_degrades_coverage(self):
+        report = self._aggregate([self._process(argv=["python3", "other.py"])])
+        self.assertEqual(report["status"]["state"], "degraded")
+        self.assertEqual(report["processes"], [])
+
+    def test_terminal_check_set_must_match_the_plan(self):
+        run = {**self.run, "checks": []}
+        with self.assertRaisesRegex(dead_code.Refusal, "do not match"):
+            self._aggregate([self._process()], run)
+
+    def test_wrapper_recursion_is_detected_in_declared_argv(self):
+        self.assertTrue(
+            dead_code._coverage_recurses(
+                ["python3", "scripts/dead_code.py", "coverage", "--scope", "dead-code"]
+            )
+        )
+
+    def test_non_python_declared_command_is_not_coverable(self):
+        self.assertFalse(dead_code._python_argv(["forge", "test"]))
+
+    def test_plan_scope_mismatch_refuses(self):
+        payload = json.dumps({**self.plan, "requested_scopes": ["other"]}).encode()
+        with mock.patch.object(dead_code, "run_process", return_value=(payload, b"", 0)):
+            with self.assertRaisesRegex(dead_code.Refusal, "not bound"):
+                dead_code._runner_plan(ROOT, ("dead-code",))
+
+    def test_coverage_environment_prepends_the_current_runtime(self):
+        with mock.patch.dict(
+            os.environ,
+            {"PATH": "/usr/bin", "PYTHONPATH": "/fixture"},
+            clear=True,
+        ):
+            environment = dead_code._coverage_environment(
+                ROOT,
+                ROOT / ".dead-code" / "processes",
+                self.run_id,
+            )
+        self.assertEqual(
+            environment["PATH"].split(os.pathsep)[0],
+            str(Path(sys.executable).parent),
+        )
+        self.assertEqual(
+            environment["PYTHONPATH"].split(os.pathsep)[0],
+            str(ROOT / dead_code.MONITOR_DIRECTORY),
+        )
+
+
+class MonitoringProbeTests(TemporaryRepositoryTestCase):
+    def _free_tool_id(self):
+        return next(identifier for identifier in range(6) if sys.monitoring.get_tool(identifier) is None)
+
+    def test_probe_restores_its_tool_id_and_event_mask(self):
+        output = self.root / "records"
+        output.mkdir()
+        probe = dead_code_monitor.MonitoringProbe(output, ROOT, "a" * 32)
+        probe.tool_id = self._free_tool_id()
+        self.assertTrue(probe.start())
+        self.assertNotEqual(sys.monitoring.get_events(probe.tool_id), 0)
+        probe.close()
+        self.assertIsNone(sys.monitoring.get_tool(probe.tool_id))
+        self.assertEqual(sys.monitoring.get_events(probe.tool_id), 0)
+
+    def test_probe_does_not_clobber_an_occupied_tool_id(self):
+        identifier = self._free_tool_id()
+        sys.monitoring.use_tool_id(identifier, "fixture-owner")
+        self.addCleanup(sys.monitoring.free_tool_id, identifier)
+        output = self.root / "records"
+        output.mkdir()
+        probe = dead_code_monitor.MonitoringProbe(output, ROOT, "a" * 32)
+        probe.tool_id = identifier
+        self.assertFalse(probe.start())
+        probe.close()
+        self.assertEqual(sys.monitoring.get_tool(identifier), "fixture-owner")
+
+    def test_probe_writes_named_lines_and_branches(self):
+        output = self.root / "records"
+        output.mkdir()
+        probe = dead_code_monitor.MonitoringProbe(output, ROOT, "a" * 32)
+        probe.tool_id = self._free_tool_id()
+        probe.start()
+
+        def exercised(value):
+            if value:
+                return "left"
+            return "right"
+
+        exercised(True)
+        probe.close()
+        documents = [json.loads(path.read_text(encoding="utf-8")) for path in output.iterdir()]
+        self.assertEqual(len(documents), 1)
+        self.assertTrue(any(item["function"].endswith("exercised") for item in documents[0]["lines"]))
+        self.assertTrue(documents[0]["branches"])
+
+    def test_event_cap_marks_the_process_record_truncated(self):
+        output = self.root / "records"
+        output.mkdir()
+        probe = dead_code_monitor.MonitoringProbe(output, ROOT, "a" * 32)
+        with mock.patch.object(dead_code_monitor, "MAX_EVENTS", 0):
+            probe._remember_line(self.test_event_cap_marks_the_process_record_truncated.__code__, 1)
+        self.assertTrue(probe.truncated)
+
+    def test_line_callback_never_resolves_the_filesystem(self):
+        output = self.root / "records"
+        output.mkdir()
+        probe = dead_code_monitor.MonitoringProbe(output, ROOT, "a" * 32)
+        with mock.patch.object(Path, "resolve", side_effect=AssertionError("hot-path resolve")):
+            result = probe._remember_line(
+                self.test_line_callback_never_resolves_the_filesystem.__code__,
+                1,
+            )
+        self.assertIs(result, sys.monitoring.DISABLE)
+
+
+class CoverageAnalyserTests(TemporaryRepositoryTestCase):
+    SOURCE = (
+        "def plain(flag):" + NL
+        + "    if flag:" + NL
+        + "        return 1" + NL
+        + "    else:" + NL
+        + "        return 2" + NL
+    )
+
+    def _fixture(self, *, state="ran", branches=None, lines=None):
+        build_repository(self.root, files={"app.py": self.SOURCE})
+        universe = dead_code.discover(self.root)
+        target = self.root / ".dead-code" / "coverage.json"
+        target.parent.mkdir()
+        document = {
+            "schema": dead_code.COVERAGE_SCHEMA_ID,
+            "tool": {"id": "sys.monitoring", "python": "3.14.6"},
+            "tree": {
+                "commit": universe.commit,
+                "git_tree": universe.tree,
+                "universe": universe.identity,
+            },
+            "plan": {
+                "schema": "wildcat.check-plan.v1",
+                "map_digest": "a" * 64,
+                "requested_scopes": ["dead-code"],
+                "selected_checks": ["alpha"],
+            },
+            "status": {"state": state, "detail": "fixture status"},
+            "checks": [
+                {
+                    "id": "alpha",
+                    "state": "passed" if state == "ran" else "failed",
+                    "duration_seconds": 0.1,
+                    "processes": 1,
+                    "bytes": 100,
+                }
+            ],
+            "processes": [
+                {
+                    "status": {"state": "ran", "truncated": False, "errors": []},
+                    "lines": [] if lines is None else lines,
+                    "branches": [] if branches is None else branches,
+                }
+            ],
+        }
+        target.write_text(json.dumps(document), encoding="utf-8")
+        return universe, target, document
+
+    def test_incomplete_coverage_emits_no_never_executed_findings(self):
+        universe, _target, _document = self._fixture(state="degraded")
+        status, findings = dead_code.analyse_coverage(
+            self.root, universe, ".dead-code/coverage.json"
+        )
+        self.assertEqual(status.state, "degraded")
+        self.assertEqual(findings, ())
+
+    def test_observed_branch_is_not_reported_and_other_branch_is(self):
+        branch = {
+            "path": "app.py",
+            "function": "plain",
+            "from_line": 2,
+            "to_line": 3,
+            "direction": "left",
+        }
+        universe, _target, _document = self._fixture(
+            branches=[branch], lines=[{"path": "app.py", "function": "plain", "line": 2}]
+        )
+        status, findings = dead_code.analyse_coverage(
+            self.root, universe, ".dead-code/coverage.json"
+        )
+        self.assertEqual(status.state, "ran")
+        symbols = {item.symbol for item in findings}
+        self.assertNotIn("branch:2->3:body", symbols)
+        self.assertIn("branch:2->5:else", symbols)
+
+    def test_stale_coverage_identity_degrades_without_findings(self):
+        universe, target, document = self._fixture()
+        document["tree"]["commit"] = "f" * 40
+        target.write_text(json.dumps(document), encoding="utf-8")
+        status, findings = dead_code.analyse_coverage(
+            self.root, universe, ".dead-code/coverage.json"
+        )
+        self.assertEqual(status.state, "degraded")
+        self.assertEqual(findings, ())
+
+    def test_missing_coverage_argument_refuses_by_name(self):
+        build_repository(self.root, files={"app.py": self.SOURCE})
+        with self.assertRaisesRegex(dead_code.Refusal, "requires --coverage"):
+            dead_code.analyse_coverage(self.root, dead_code.discover(self.root), None)
+
+
 class ShippedSurfaceTests(unittest.TestCase):
     def test_receipted_study_and_runbook_digests_are_preserved(self):
         self.assertEqual(
@@ -1039,6 +1514,7 @@ class ShippedSurfaceTests(unittest.TestCase):
             "universeIdentity",
             "analysisStatus",
             "analyserStatus",
+            "analyserRecord",
             "finding",
         ):
             self.assertFalse(schema["$defs"][name]["additionalProperties"])
@@ -1066,6 +1542,7 @@ class ShippedSurfaceTests(unittest.TestCase):
             "docs/decisions/ADR-051-keep-dead-code-discovery-report-only.md",
             "schemas/dead-code-report-v1.schema.json",
             "scripts/dead_code.py",
+            "scripts/dead_code_monitoring",
             "tests/emit_dead_code_report.py",
             "tests/test_dead_code.py",
         )
@@ -1096,6 +1573,8 @@ class ShippedSurfaceTests(unittest.TestCase):
         self.assertIn(dead_code.TEMP_PREFIX, text)
         self.assertIn("/.dead-code/report.json", text)
         self.assertIn("/.dead-code/checks.json", text)
+        self.assertIn("/.dead-code/coverage.json", text)
+        self.assertIn("/.dead-code/coverage-processes-*/", text)
 
 
 if __name__ == "__main__":

--- a/tests/test_dead_code.py
+++ b/tests/test_dead_code.py
@@ -687,6 +687,31 @@ class RenderingTests(TemporaryRepositoryTestCase):
         ):
             self.assertNotIn(forbidden, rendered)
 
+    def test_text_rendering_escapes_untrusted_record_newlines(self):
+        base = self._report()
+        status = dead_code.AnalyserStatus(
+            "solidity",
+            "degraded",
+            "slither+forge/1",
+            "tool incomplete",
+            (
+                dead_code.AnalyserRecord(
+                    ".:slither",
+                    "project",
+                    "failed",
+                    "tool failed",
+                    1,
+                    "0.11.4",
+                    1,
+                    0,
+                    "warning\nstatus forged",
+                ),
+            ),
+        )
+        text = dead_code.render_text(dead_code.Report(base.universe, (status,), ()))
+        self.assertNotIn("\nstatus forged", text)
+        self.assertIn(r"warning\nstatus forged", text)
+
 
 class WriteBoundaryTests(TemporaryRepositoryTestCase):
     def setUp(self):
@@ -1453,6 +1478,22 @@ class RepositoryAnalyserTests(TemporaryRepositoryTestCase):
         self.assertEqual(len(status.records), len(dead_code.REPOSITORY_FAMILIES))
         self.assertTrue(all(item.evidence_count == 0 for item in status.records))
 
+    def test_unreadable_referrer_degrades_every_family_and_suppresses_candidates(self):
+        build_repository(
+            self.root,
+            files={
+                "tests/fixtures/orphan.json": "{}" + NL,
+                "tests/test_large.py": "x" * 128 + NL,
+            },
+        )
+        universe = dead_code.discover(self.root)
+        with mock.patch.object(dead_code, "MAX_REPOSITORY_FILE_BYTES", 16):
+            status, findings = dead_code.analyse_repository(self.root, universe)
+        self.assertEqual(status.state, "degraded")
+        self.assertEqual(findings, ())
+        self.assertTrue(all(record.state == "parse-error" for record in status.records))
+        self.assertTrue(all(record.reason for record in status.records))
+
     def test_repository_finding_survives_report_rendering(self):
         universe, (status, findings) = self._analyse(
             {"docs/orphan.md": "# orphan" + NL, "README.md": "root" + NL}
@@ -1477,9 +1518,13 @@ class SolidityAnalyserTests(TemporaryRepositoryTestCase):
 
     @staticmethod
     def _forge_summary(percent="100.00", covered="1", total="1"):
+        metrics = f"{percent}% ({covered}/{total})"
         return (
             "| File | % Lines | % Statements | % Branches | % Funcs |" + NL
-            + f"| src/Dead.sol | {percent}% ({covered}/{total}) | {percent}% ({covered}/{total}) | {percent}% ({covered}/{total}) | {percent}% ({covered}/{total}) |" + NL
+            + "|--------------+-----------+--------------+------------+---------|" + NL
+            + f"| src/Dead.sol | {metrics} | {metrics} | {metrics} | {metrics} |" + NL
+            + "|--------------+-----------+--------------+------------+---------|" + NL
+            + f"| Total | {metrics} | {metrics} | {metrics} | {metrics} |" + NL
         ).encode()
 
     def _project(self, prefix=""):
@@ -1494,11 +1539,14 @@ class SolidityAnalyserTests(TemporaryRepositoryTestCase):
         return dead_code.discover(self.root)
 
     def _successful_runner(self, calls, *, detectors=None, forge_summary=None):
+        original_run_process = dead_code.run_process
         slither = self._slither_document(detectors)
         forge = self._forge_summary() if forge_summary is None else forge_summary
 
         def run(argv, **kwargs):
             calls.append((tuple(argv), kwargs["cwd"]))
+            if argv[0] == "git":
+                return original_run_process(argv, **kwargs)
             if argv == ["slither", "--version"]:
                 return b"0.11.4\n", b"", 0
             if argv == ["forge", "--version"]:
@@ -1700,11 +1748,16 @@ class SolidityAnalyserTests(TemporaryRepositoryTestCase):
         calls = []
         with mock.patch.object(dead_code, "run_process", side_effect=self._successful_runner(calls)):
             dead_code.analyse_solidity(self.root, universe)
-        self.assertIn(
-            (("slither", ".", "--detect", "dead-code,unused-state", "--json", "-"), self.root),
-            calls,
-        )
-        self.assertIn((("forge", "coverage", "--report", "summary"), self.root), calls)
+        expected = {
+            ("slither", ".", "--detect", "dead-code,unused-state", "--json", "-"),
+            ("forge", "coverage", "--report", "summary"),
+        }
+        analysis_calls = [(argv, cwd) for argv, cwd in calls if argv in expected]
+        self.assertEqual({argv for argv, _cwd in analysis_calls}, expected)
+        for _argv, cwd in analysis_calls:
+            self.assertTrue(cwd.is_absolute())
+            self.assertFalse(cwd.is_relative_to(self.root))
+            self.assertEqual(cwd.name, "repository")
 
     def test_foundry_outputs_are_confined_outside_the_repository(self):
         universe = self._universe()
@@ -1725,6 +1778,42 @@ class SolidityAnalyserTests(TemporaryRepositoryTestCase):
                 target = Path(environment[name])
                 self.assertTrue(target.is_absolute())
                 self.assertFalse(target.is_relative_to(self.root))
+
+    def test_tool_execution_cannot_mutate_the_live_project(self):
+        universe = self._universe()
+        source = self.root / "src" / "Dead.sol"
+        before = source.read_bytes()
+        successful = self._successful_runner([])
+
+        def run(argv, **kwargs):
+            if argv[:2] == ["forge", "coverage"]:
+                (kwargs["cwd"] / "src" / "Dead.sol").write_text(
+                    "mutated by project code" + NL,
+                    encoding="utf-8",
+                )
+            return successful(argv, **kwargs)
+
+        with mock.patch.object(dead_code, "run_process", side_effect=run):
+            dead_code.analyse_solidity(self.root, universe)
+        self.assertEqual(source.read_bytes(), before)
+
+    def test_disposable_project_has_a_conventional_foundry_output_directory(self):
+        universe = self._universe()
+        successful = self._successful_runner([])
+
+        def run(argv, **kwargs):
+            if argv[:2] == ["forge", "coverage"]:
+                (kwargs["cwd"] / "out" / "findings.test.json").write_text(
+                    "disposable evidence" + NL,
+                    encoding="utf-8",
+                )
+            return successful(argv, **kwargs)
+
+        with mock.patch.object(dead_code, "run_process", side_effect=run):
+            status, _findings = dead_code.analyse_solidity(self.root, universe)
+        forge = next(item for item in status.records if item.record_id.endswith(":forge"))
+        self.assertEqual(forge.state, "passed")
+        self.assertFalse((self.root / "out").exists())
 
     def test_slither_detector_maps_to_project_attributed_finding(self):
         universe = self._universe()
@@ -1764,6 +1853,41 @@ class SolidityAnalyserTests(TemporaryRepositoryTestCase):
         candidate = next(item for item in findings if item.symbol and item.symbol.startswith("forge-coverage:"))
         self.assertEqual(candidate.path, "src/Dead.sol")
         self.assertEqual(candidate.confidence, "low")
+
+    def test_partially_malformed_forge_table_refuses_all_rows(self):
+        files = {
+            **self._project(),
+            "src/Other.sol": "pragma solidity ^0.8.20; contract Other {}" + NL,
+        }
+        universe = self._universe(files)
+        payload = self._forge_summary("0.00", "0", "1").replace(
+            b"| Total",
+            b"| src/Other.sol | malformed | malformed | malformed | malformed |\n| Total",
+            1,
+        )
+        with self.assertRaisesRegex(dead_code.Refusal, "malformed"):
+            dead_code._forge_findings(payload, project=".", universe=universe)
+
+    def test_real_forge_summary_isolated_from_other_pipe_tables(self):
+        universe = self._universe()
+        payload = (
+            "| Contract | Selector | Calls | Reverts | Discards |" + NL
+            + "| Sound | advance | 1 | 0 | 0 |" + NL
+            + "|----------+----------+-------+---------+----------|" + NL
+            + "| File | % Lines | % Statements | % Branches | % Funcs |" + NL
+            + "|----------+-----------+--------------+------------+---------|" + NL
+            + "| src/Dead.sol | 0.00% (0/1) | 0.00% (0/1) | 0.00% (0/1) | 0.00% (0/1) |" + NL
+            + "|----------+-----------+--------------+------------+---------|" + NL
+            + "| Total | 0.00% (0/1) | 0.00% (0/1) | 0.00% (0/1) | 0.00% (0/1) |" + NL
+        ).encode()
+        findings, evidence_count = dead_code._forge_findings(
+            payload,
+            project=".",
+            universe=universe,
+        )
+        self.assertEqual(evidence_count, 1)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].path, "src/Dead.sol")
 
     def test_solidity_finding_survives_report_rendering(self):
         universe = self._universe()


### PR DESCRIPTION
## What changed

Add report-only orphan candidates for check-map objects, CLI declarations,
documents, fixtures, generated copies, manifests, routers, and schemas. Each
family carries its parsed edge-set digest and nearest computed-reference
boundary. An unreadable declaration source degrades the graph instead of
turning missing edges into absence evidence.

Discover tracked Foundry projects and record fixed-argv Slither and Forge
evidence with project, version, duration, bytes, status, reason, and evidence
count. Analysis runs from a bounded disposable snapshot of the recorded
commit. Forge parsing isolates and reconciles its coverage table; nonzero
Slither exits retain parseable positive detector evidence.

The audit also escapes tool-controlled text fields, rejects partial Forge
tables, preserves conventional Foundry output directories inside the
disposable tree, and guards that project-relative writes leave live source
byte-identical.

## Why

This is Step 3 of issue #437. It extends the Step 2 report model without
copying Promise Machine, Hypomnema, Horos, or checked-runner authority. A
candidate remains advisory: candidate count does not gate development or
authorise deletion. It stacks on
[Step 2](https://github.com/wildcat-finance/skills/pull/911).

## Audit

- Record: `audit/rounds/fiat-437-establish-a-report-only-dead-code-baseline.md`
- Stacked audit PR: https://github.com/wildcat-finance/skills/pull/914
- Task issue: https://github.com/wildcat-finance/skills/issues/437

Four rounds fixed six findings; round 4 found no new issue. The signed live
report records 59 Solidity candidates, complete Forge evidence for all four
projects, preserved positive Slither evidence, and an explicit repository
degradation at the four-megabyte declaration-source bound.

## Proof

```bash
python3 tests/emit_dead_code_report.py .elenchus/fiat-437-step-3.json
python3 scripts/dead_code.py report --json --analyser repository,solidity
python3 scripts/run_checks.py --scope dead-code
python3 scripts/portable_promise_machine.py check
```

<!-- wildcat-origin: shoggoth -->