### PR TITLE
Resolve single-assignment locals in Phylax

### DIFF
--- a/.agents/skills/promise-machine/runtime/MANIFEST.json
+++ b/.agents/skills/promise-machine/runtime/MANIFEST.json
@@ -3,7 +3,7 @@
   "contract": "promise-machine/v1",
   "generated_by": "scripts/portable_promise_machine.py",
   "file_count": 994,
-  "total_bytes": 21525541,
+  "total_bytes": 21529549,
   "omissions": [
     {
       "pattern": "plugins/*/.claude-plugin/**",
@@ -2721,9 +2721,9 @@
       "source": "plugins/hexaemeron/skills/phylax/scripts/model_proxy_lib/transport.py"
     },
     {
-      "bytes": 42566,
+      "bytes": 46574,
       "path": "plugins/hexaemeron/skills/phylax/scripts/phylax.py",
-      "sha256": "199f28782b85acb093c3ba9f3bc7de5dd42a91edc9d26f558ca7f16fbe3878de",
+      "sha256": "a8c998c586ebc0d3d7ac59fc1867a4b54b5d482f34e1b96aea75a0e4d41cafda",
       "source": "plugins/hexaemeron/skills/phylax/scripts/phylax.py"
     },
     {

--- a/.agents/skills/promise-machine/runtime/MANIFEST.json
+++ b/.agents/skills/promise-machine/runtime/MANIFEST.json
@@ -3,7 +3,7 @@
   "contract": "promise-machine/v1",
   "generated_by": "scripts/portable_promise_machine.py",
   "file_count": 994,
-  "total_bytes": 21513368,
+  "total_bytes": 21525541,
   "omissions": [
     {
       "pattern": "plugins/*/.claude-plugin/**",
@@ -2619,15 +2619,15 @@
       "source": "plugins/hexaemeron/skills/metron/scripts/metron.py"
     },
     {
-      "bytes": 2983,
+      "bytes": 3500,
       "path": "plugins/hexaemeron/skills/phylax/EVOLUTION.md",
-      "sha256": "0ebd24ade9b2db09fa5992370e3cb60b2c2193154181dd36c54ea2c4c0cad67a",
+      "sha256": "5bcc5d1e3846f64ad0ea89177eeb309a989a8918f4c68726b7534d3ef551904c",
       "source": "plugins/hexaemeron/skills/phylax/EVOLUTION.md"
     },
     {
-      "bytes": 23458,
+      "bytes": 24141,
       "path": "plugins/hexaemeron/skills/phylax/SKILL.md",
-      "sha256": "fc910735a3f1df7390bf4544d4f8863724615f48b4d0413e92f8d98d7bc0e73d",
+      "sha256": "945c6d103fb333cba8436d860f94aca67f3903083ed6ff79067b96a0c15669f8",
       "source": "plugins/hexaemeron/skills/phylax/SKILL.md"
     },
     {
@@ -2721,9 +2721,9 @@
       "source": "plugins/hexaemeron/skills/phylax/scripts/model_proxy_lib/transport.py"
     },
     {
-      "bytes": 31593,
+      "bytes": 42566,
       "path": "plugins/hexaemeron/skills/phylax/scripts/phylax.py",
-      "sha256": "52a77227d9489039ec0c85b4deea7eb66c82998a2a26336c99a2668a426102fa",
+      "sha256": "199f28782b85acb093c3ba9f3bc7de5dd42a91edc9d26f558ca7f16fbe3878de",
       "source": "plugins/hexaemeron/skills/phylax/scripts/phylax.py"
     },
     {

--- a/.agents/skills/promise-machine/runtime/plugins/hexaemeron/skills/phylax/EVOLUTION.md
+++ b/.agents/skills/promise-machine/runtime/plugins/hexaemeron/skills/phylax/EVOLUTION.md
@@ -4,7 +4,7 @@
 
 Policy: [../VERSIONING.md](../VERSIONING.md)
 
-- Current version: `phylax-v1.4.0`
+- Current version: `phylax-v1.5.0`
 
 ## Frontier
 
@@ -22,3 +22,4 @@ Policy: [../VERSIONING.md](../VERSIONING.md)
 | `phylax-v1.2.0` | generation | `off-chain-boundary-controls` | `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604` | [credential argv fixtures](../../tests/test_phylax_checker.py), [study](../../../../docs/phylax-credential-argv/study.md) | P004 now walks only the inline argv expression of a resolved subprocess runner for credential-named values; assignment dataflow remains deliberately out of scope. |
 | `phylax-v1.3.0` | generation | `off-chain-boundary-controls` | `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604` | [unsafe-deserialization fixtures](../../tests/test_phylax_checker.py), [study](../../../../docs/phylax-unsafe-deserialization/study.md) | P008 adds source-local import resolution for the issue's pickle, marshal, YAML and dynamic-execution calls; assignment dataflow, custom-loader proofs and `marshal.loads` remain deliberately out of scope. |
 | `phylax-v1.4.0` | generation | `off-chain-boundary-controls` | `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604` | [hostile conformance manifest](../../tests/fixtures/model-proxy-v1/manifest.json), [component guards](../../tests/test_phylax_model_proxy.py), [normative reference](references/model-proxy-v1.md), [ADR-046](../../../../docs/decisions/ADR-046-use-a-job-scoped-model-proxy.md) | The synthetic job-scoped model proxy now has one digest-bound positive-and-hostile conformance command, content-free proof output, and explicit #698, #699, live-provider, public-pilot, and #702 Fiat integration/end-to-end dependency gaps; the mature lint frontier is unchanged. |
+| `phylax-v1.5.0` | generation | `off-chain-boundary-controls` | `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604` | [single-assignment fixtures](../../tests/test_phylax_checker.py), [study](../../../../docs/phylax-single-assignment-locals/study.md) | P002, P004 and P008 share an eight-hop resolver for preceding, once-bound direct function locals; rebinding, compound and unsupported targets, comprehensions, nested and closure scope, module scope and interprocedural analysis remain unresolved. |

--- a/.agents/skills/promise-machine/runtime/plugins/hexaemeron/skills/phylax/SKILL.md
+++ b/.agents/skills/promise-machine/runtime/plugins/hexaemeron/skills/phylax/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   Solidity, which belongs to solidity-auditor and x-ray, and do not use it to
   diagnose a failure that has already happened, which belongs to elenchus.
 metadata:
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 <p align="center">
@@ -42,7 +42,7 @@ an off-chain boundary, expose protected data, or authorise a control change.
 Its version, held frontier, next job, and maturity state live in
 [EVOLUTION.md](EVOLUTION.md).
 
-**Current state.** Phylax mechanically checks its established Python boundaries and source-local TypeScript controls for raw HTML ordering, persisted session credentials and runtime-selected absolute fetch hosts. This frontier is mature.
+**Current state.** Phylax mechanically checks its established Python boundaries and source-local TypeScript controls for raw HTML ordering, persisted session credentials and runtime-selected absolute fetch hosts. This frontier is mature. The Python pass also resolves preceding single-assignment locals in the exact containing function for P002, P004 and P008; every unsupported binding or scope stays unresolved.
 
 It also ships a synthetic job-scoped model proxy component: closed policy,
 framing, provider, lifecycle, receipt, operator-disclosure, and hostile-
@@ -326,8 +326,15 @@ The last rule resolves module and direct-import aliases for `pickle.load`,
 `yaml.load` call stays clean only when its second positional argument or
 `Loader=` value resolves directly to `SafeLoader` or `CSafeLoader`. An `eval`
 or `exec` call stays clean only when its first argument is an inline string or
-bytes constant. The parser does not follow assignments, prove input
-provenance, inspect custom loader classes or include `marshal.loads`.
+bytes constant. For P002, P004 and P008, one index per `FunctionDef` or
+`AsyncFunctionDef` exposes a name only when its one direct simple-name
+assignment precedes the use and no other binding or deletion of that name
+exists in the function. Resolution follows at most eight name assignments,
+checks P004 credential names before substitution, and leaves forward writes,
+rebinding, compound-statement writes, unsupported targets, imports,
+parameters, comprehensions, nested scopes, closures, module and class scope,
+cycles and longer chains unresolved. It does not prove input provenance,
+inspect custom loader classes or include `marshal.loads`.
 
 For tracked `.ts` and `.tsx` source it reports three source-local cases. A
 `rehype-raw` binding in a rendered plugin array needs a later

--- a/.agents/skills/promise-machine/runtime/plugins/hexaemeron/skills/phylax/scripts/phylax.py
+++ b/.agents/skills/promise-machine/runtime/plugins/hexaemeron/skills/phylax/scripts/phylax.py
@@ -40,6 +40,7 @@ BOUNDARY_CALLS = {
     "builtins": frozenset({"eval", "exec"}),
 }
 SAFE_YAML_LOADERS = frozenset({"SafeLoader", "CSafeLoader"})
+LOCAL_RESOLUTION_MAX_DEPTH = 8
 P008_MESSAGES = {
     "pickle": "pickle deserialization may execute untrusted code",
     "marshal": "marshal deserialization accepts untrusted data",
@@ -136,6 +137,174 @@ def _is_dynamic_literal(node: ast.AST) -> bool:
         isinstance(node, ast.Constant)
         and isinstance(node.value, (str, bytes))
     )
+
+
+def _position(node: ast.AST) -> tuple[int, int]:
+    return (getattr(node, "lineno", 0), getattr(node, "col_offset", 0))
+
+
+class _FunctionBindings:
+    """Eligible direct assignments in one exact function body."""
+
+    def __init__(
+        self,
+        assignments: dict[str, tuple[tuple[int, int], ast.AST]],
+    ) -> None:
+        self.assignments = assignments
+
+    def preceding(
+        self,
+        name: str,
+        before: tuple[int, int],
+    ) -> tuple[tuple[int, int], ast.AST] | None:
+        assignment = self.assignments.get(name)
+        if assignment is None or assignment[0] >= before:
+            return None
+        return assignment
+
+
+class _FunctionBindingCollector(ast.NodeVisitor):
+    """Collect one exact function without borrowing bindings from nested scopes."""
+
+    def __init__(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self.candidates: dict[str, tuple[tuple[int, int], ast.AST]] = {}
+        self.binding_counts: dict[str, int] = {}
+        arguments = node.args
+        for argument in (
+            *arguments.posonlyargs,
+            *arguments.args,
+            *arguments.kwonlyargs,
+        ):
+            self._bind(argument.arg)
+        if arguments.vararg is not None:
+            self._bind(arguments.vararg.arg)
+        if arguments.kwarg is not None:
+            self._bind(arguments.kwarg.arg)
+        for parameter in getattr(node, "type_params", ()):
+            self._bind(parameter.name)
+
+        for statement in node.body:
+            if (
+                isinstance(statement, ast.Assign)
+                and len(statement.targets) == 1
+                and isinstance(statement.targets[0], ast.Name)
+            ):
+                self.candidates[statement.targets[0].id] = (
+                    _position(statement),
+                    statement.value,
+                )
+            elif (
+                isinstance(statement, ast.AnnAssign)
+                and isinstance(statement.target, ast.Name)
+                and statement.value is not None
+            ):
+                self.candidates[statement.target.id] = (
+                    _position(statement),
+                    statement.value,
+                )
+            self.visit(statement)
+        self.bindings = _FunctionBindings({
+            name: candidate
+            for name, candidate in self.candidates.items()
+            if self.binding_counts.get(name) == 1
+        })
+
+    def _bind(self, name: str) -> None:
+        self.binding_counts[name] = self.binding_counts.get(name, 0) + 1
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            self._bind(node.id)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self._bind(alias.asname or alias.name.split(".", 1)[0])
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for alias in node.names:
+            if alias.name != "*":
+                self._bind(alias.asname or alias.name)
+
+    def visit_Global(self, node: ast.Global) -> None:
+        for name in node.names:
+            self._bind(name)
+
+    def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+        for name in node.names:
+            self._bind(name)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        if node.name:
+            self._bind(node.name)
+        self.generic_visit(node)
+
+    def visit_MatchAs(self, node: ast.MatchAs) -> None:
+        if node.name:
+            self._bind(node.name)
+        if node.pattern is not None:
+            self.visit(node.pattern)
+
+    def visit_MatchStar(self, node: ast.MatchStar) -> None:
+        if node.name:
+            self._bind(node.name)
+
+    def visit_MatchMapping(self, node: ast.MatchMapping) -> None:
+        if node.rest:
+            self._bind(node.rest)
+        self.generic_visit(node)
+
+    def _visit_function_header(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda,
+    ) -> None:
+        arguments = node.args
+        for argument in (
+            *arguments.posonlyargs,
+            *arguments.args,
+            *arguments.kwonlyargs,
+        ):
+            if argument.annotation is not None:
+                self.visit(argument.annotation)
+        if arguments.vararg is not None and arguments.vararg.annotation is not None:
+            self.visit(arguments.vararg.annotation)
+        if arguments.kwarg is not None and arguments.kwarg.annotation is not None:
+            self.visit(arguments.kwarg.annotation)
+        for default in (*arguments.defaults, *arguments.kw_defaults):
+            if default is not None:
+                self.visit(default)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._bind(node.name)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        self._visit_function_header(node)
+        if node.returns is not None:
+            self.visit(node.returns)
+        for parameter in getattr(node, "type_params", ()):
+            self.visit(parameter)
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._bind(node.name)
+        for expression in (
+            *node.decorator_list,
+            *node.bases,
+            *(keyword.value for keyword in node.keywords),
+            *getattr(node, "type_params", ()),
+        ):
+            self.visit(expression)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self._visit_function_header(node)
+
+
+def _function_bindings(tree: ast.AST) -> dict[ast.AST, _FunctionBindings]:
+    return {
+        node: _FunctionBindingCollector(node).bindings
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
 
 
 def _boundary_bindings(
@@ -239,6 +408,8 @@ class Visitor(ast.NodeVisitor):
         self.findings: list[Finding] = []
         self.modules: set[str] = set()
         self.direct: set[str] = set()
+        self.function_bindings = _function_bindings(tree)
+        self.local_bindings: _FunctionBindings | None = None
         (
             self.boundary_modules,
             self.boundary_direct,
@@ -246,6 +417,83 @@ class Visitor(ast.NodeVisitor):
             self.safe_yaml_loaders,
             self.ambiguous_boundary_calls,
         ) = _boundary_bindings(tree)
+
+    def _visit_function_header(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda,
+    ) -> None:
+        arguments = node.args
+        for argument in (
+            *arguments.posonlyargs,
+            *arguments.args,
+            *arguments.kwonlyargs,
+        ):
+            if argument.annotation is not None:
+                self.visit(argument.annotation)
+        if arguments.vararg is not None and arguments.vararg.annotation is not None:
+            self.visit(arguments.vararg.annotation)
+        if arguments.kwarg is not None and arguments.kwarg.annotation is not None:
+            self.visit(arguments.kwarg.annotation)
+        for default in (*arguments.defaults, *arguments.kw_defaults):
+            if default is not None:
+                self.visit(default)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        self._visit_function_header(node)
+        if node.returns is not None:
+            self.visit(node.returns)
+        for parameter in getattr(node, "type_params", ()):
+            self.visit(parameter)
+
+        previous = self.local_bindings
+        self.local_bindings = self.function_bindings[node]
+        try:
+            for statement in node.body:
+                self.visit(statement)
+        finally:
+            self.local_bindings = previous
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        for expression in (
+            *node.decorator_list,
+            *node.bases,
+            *(keyword.value for keyword in node.keywords),
+            *getattr(node, "type_params", ()),
+        ):
+            self.visit(expression)
+        previous = self.local_bindings
+        self.local_bindings = None
+        try:
+            for statement in node.body:
+                self.visit(statement)
+        finally:
+            self.local_bindings = previous
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self._visit_function_header(node)
+        previous = self.local_bindings
+        self.local_bindings = None
+        try:
+            self.visit(node.body)
+        finally:
+            self.local_bindings = previous
+
+    def _visit_comprehension_scope(self, node: ast.AST) -> None:
+        previous = self.local_bindings
+        self.local_bindings = None
+        try:
+            self.generic_visit(node)
+        finally:
+            self.local_bindings = previous
+
+    visit_ListComp = _visit_comprehension_scope
+    visit_SetComp = _visit_comprehension_scope
+    visit_DictComp = _visit_comprehension_scope
+    visit_GeneratorExp = _visit_comprehension_scope
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
@@ -266,6 +514,72 @@ class Visitor(ast.NodeVisitor):
             return (isinstance(base, ast.Name) and base.id in self.modules
                     and func.attr in RUNNERS)
         return isinstance(func, ast.Name) and func.id in self.direct
+
+    def _resolve_local(
+        self,
+        node: ast.AST,
+        *,
+        before: tuple[int, int] | None = None,
+        seen: frozenset[str] = frozenset(),
+        depth: int = 0,
+    ) -> ast.AST:
+        if self.local_bindings is None or not isinstance(node, ast.Name):
+            return node
+        if depth >= LOCAL_RESOLUTION_MAX_DEPTH or node.id in seen:
+            return node
+        assignment = self.local_bindings.preceding(
+            node.id,
+            before if before is not None else _position(node),
+        )
+        if assignment is None:
+            return node
+        position, value = assignment
+        return self._resolve_local(
+            value,
+            before=position,
+            seen=seen | {node.id},
+            depth=depth + 1,
+        )
+
+    def _credential_names(
+        self,
+        node: ast.AST,
+        *,
+        before: tuple[int, int] | None = None,
+        seen: frozenset[str] = frozenset(),
+        depth: int = 0,
+    ):
+        if isinstance(node, ast.Name):
+            if CREDENTIAL.search(node.id):
+                yield node.id
+                return
+            if (
+                self.local_bindings is None
+                or depth >= LOCAL_RESOLUTION_MAX_DEPTH
+                or node.id in seen
+            ):
+                return
+            assignment = self.local_bindings.preceding(
+                node.id,
+                before if before is not None else _position(node),
+            )
+            if assignment is None:
+                return
+            position, value = assignment
+            yield from self._credential_names(
+                value,
+                before=position,
+                seen=seen | {node.id},
+                depth=depth + 1,
+            )
+            return
+        for child in ast.iter_child_nodes(node):
+            yield from self._credential_names(
+                child,
+                before=before,
+                seen=seen,
+                depth=depth,
+            )
 
     def _add(self, node: ast.AST, code: str, message: str) -> None:
         self.findings.append(Finding(self.path, node.lineno, code, message))
@@ -293,22 +607,26 @@ class Visitor(ast.NodeVisitor):
         return isinstance(loader, ast.Name) and loader.id in self.safe_yaml_loaders
 
     def _check_p008(self, node: ast.Call) -> None:
+        function = self._resolve_local(node.func)
         binding = (
-            node.func.value.id
-            if isinstance(node.func, ast.Attribute)
-            and isinstance(node.func.value, ast.Name)
-            else node.func.id if isinstance(node.func, ast.Name) else None
+            function.value.id
+            if isinstance(function, ast.Attribute)
+            and isinstance(function.value, ast.Name)
+            else function.id if isinstance(function, ast.Name) else None
         )
         loader = next(
             (keyword.value for keyword in node.keywords if keyword.arg == "Loader"),
             node.args[1] if len(node.args) > 1 else None,
         )
-        for module in sorted(self._boundary_modules(node.func)):
+        if loader is not None:
+            loader = self._resolve_local(loader)
+        dynamic_source = self._resolve_local(node.args[0]) if node.args else None
+        for module in sorted(self._boundary_modules(function)):
             if module == "yaml":
                 if loader is not None and self._safe_yaml_loader(loader):
                     continue
             elif module == "builtins":
-                if not node.args or _is_dynamic_literal(node.args[0]):
+                if dynamic_source is None or _is_dynamic_literal(dynamic_source):
                     continue
             message = (
                 P008_AMBIGUOUS_MESSAGE
@@ -324,20 +642,24 @@ class Visitor(ast.NodeVisitor):
             for kw in node.keywords:
                 if kw.arg == "shell" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
                     self._add(node, "P001", "shell invocation; pass an argument list instead")
-            if node.args and _is_string(node.args[0]):
-                built = " built by formatting" if _is_formatted(node.args[0]) else ""
-                self._add(node, "P002", f"command passed as a string{built}; pass a list")
-            argv = node.args[0] if node.args else next(
+            command = node.args[0] if node.args else next(
                 (kw.value for kw in node.keywords if kw.arg == "args"), None
             )
-            if argv is not None:
-                for value in ast.walk(argv):
-                    if isinstance(value, ast.Name) and CREDENTIAL.search(value.id):
-                        self._add(
-                            node,
-                            "P004",
-                            f"credential-named value `{value.id}` passed in command arguments",
-                        )
+            resolved_command = (
+                self._resolve_local(command) if command is not None else None
+            )
+            if resolved_command is not None and _is_string(resolved_command):
+                built = (
+                    " built by formatting" if _is_formatted(resolved_command) else ""
+                )
+                self._add(node, "P002", f"command passed as a string{built}; pass a list")
+            if command is not None:
+                for name in self._credential_names(command):
+                    self._add(
+                        node,
+                        "P004",
+                        f"credential-named value `{name}` passed in command arguments",
+                    )
 
         if _attr_name(node.func) in WRITERS:
             for arg in node.args + [kw.value for kw in node.keywords]:

--- a/.agents/skills/promise-machine/runtime/plugins/hexaemeron/skills/phylax/scripts/phylax.py
+++ b/.agents/skills/promise-machine/runtime/plugins/hexaemeron/skills/phylax/scripts/phylax.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+from collections import deque
 import json
 import re
 import sys
@@ -143,6 +144,14 @@ def _position(node: ast.AST) -> tuple[int, int]:
     return (getattr(node, "lineno", 0), getattr(node, "col_offset", 0))
 
 
+def _binding_position(node: ast.AST) -> tuple[int, int]:
+    """Return the point after an assignment's RHS has been evaluated."""
+    return (
+        getattr(node, "end_lineno", getattr(node, "lineno", 0)),
+        getattr(node, "end_col_offset", getattr(node, "col_offset", 0)),
+    )
+
+
 class _FunctionBindings:
     """Eligible direct assignments in one exact function body."""
 
@@ -190,7 +199,7 @@ class _FunctionBindingCollector(ast.NodeVisitor):
                 and isinstance(statement.targets[0], ast.Name)
             ):
                 self.candidates[statement.targets[0].id] = (
-                    _position(statement),
+                    _binding_position(statement),
                     statement.value,
                 )
             elif (
@@ -199,7 +208,7 @@ class _FunctionBindingCollector(ast.NodeVisitor):
                 and statement.value is not None
             ):
                 self.candidates[statement.target.id] = (
-                    _position(statement),
+                    _binding_position(statement),
                     statement.value,
                 )
             self.visit(statement)
@@ -297,6 +306,28 @@ class _FunctionBindingCollector(ast.NodeVisitor):
 
     def visit_Lambda(self, node: ast.Lambda) -> None:
         self._visit_function_header(node)
+
+    def _visit_comprehension_scope(
+        self,
+        node: ast.ListComp | ast.SetComp | ast.DictComp | ast.GeneratorExp,
+    ) -> None:
+        # Comprehension targets belong to the implicit comprehension scope.
+        # The other expressions can still contain a NamedExpr, whose target
+        # Python binds in this containing function and must count as a write.
+        if isinstance(node, ast.DictComp):
+            self.visit(node.key)
+            self.visit(node.value)
+        else:
+            self.visit(node.elt)
+        for generator in node.generators:
+            self.visit(generator.iter)
+            for condition in generator.ifs:
+                self.visit(condition)
+
+    visit_ListComp = _visit_comprehension_scope
+    visit_SetComp = _visit_comprehension_scope
+    visit_DictComp = _visit_comprehension_scope
+    visit_GeneratorExp = _visit_comprehension_scope
 
 
 def _function_bindings(tree: ast.AST) -> dict[ast.AST, _FunctionBindings]:
@@ -410,6 +441,9 @@ class Visitor(ast.NodeVisitor):
         self.direct: set[str] = set()
         self.function_bindings = _function_bindings(tree)
         self.local_bindings: _FunctionBindings | None = None
+        self.credential_names_cache: dict[
+            tuple[_FunctionBindings, str, int], tuple[str, ...]
+        ] = {}
         (
             self.boundary_modules,
             self.boundary_direct,
@@ -548,38 +582,99 @@ class Visitor(ast.NodeVisitor):
         before: tuple[int, int] | None = None,
         seen: frozenset[str] = frozenset(),
         depth: int = 0,
+        resolution_enabled: bool = True,
     ):
-        if isinstance(node, ast.Name):
-            if CREDENTIAL.search(node.id):
-                yield node.id
-                return
-            if (
-                self.local_bindings is None
-                or depth >= LOCAL_RESOLUTION_MAX_DEPTH
-                or node.id in seen
-            ):
-                return
-            assignment = self.local_bindings.preceding(
+        cache_key = None
+        if (
+            resolution_enabled
+            and self.local_bindings is not None
+            and isinstance(node, ast.Name)
+            and not CREDENTIAL.search(node.id)
+            and not seen
+            and depth < LOCAL_RESOLUTION_MAX_DEPTH
+            and node.id not in seen
+            and self.local_bindings.preceding(
                 node.id,
                 before if before is not None else _position(node),
             )
-            if assignment is None:
+            is not None
+        ):
+            cache_key = (self.local_bindings, node.id, depth)
+            cached = self.credential_names_cache.get(cache_key)
+            if cached is not None:
+                yield from cached
                 return
-            position, value = assignment
-            yield from self._credential_names(
-                value,
-                before=position,
-                seen=seen | {node.id},
-                depth=depth + 1,
+
+        found = []
+        expanded: set[tuple[str, int]] = set()
+        worklist = deque([(node, resolution_enabled, before, seen, depth)])
+        while worklist:
+            current, can_resolve, current_before, current_seen, current_depth = (
+                worklist.popleft()
             )
-            return
-        for child in ast.iter_child_nodes(node):
-            yield from self._credential_names(
-                child,
-                before=before,
-                seen=seen,
-                depth=depth,
+            if isinstance(current, ast.Name):
+                if CREDENTIAL.search(current.id):
+                    found.append(current.id)
+                    continue
+                if (
+                    not can_resolve
+                    or self.local_bindings is None
+                    or current_depth >= LOCAL_RESOLUTION_MAX_DEPTH
+                    or current.id in current_seen
+                ):
+                    continue
+                assignment = self.local_bindings.preceding(
+                    current.id,
+                    current_before
+                    if current_before is not None
+                    else _position(current),
+                )
+                if assignment is None:
+                    continue
+                expansion = (current.id, current_depth)
+                if expansion in expanded:
+                    continue
+                expanded.add(expansion)
+                position, value = assignment
+                worklist.append(
+                    (
+                        value,
+                        True,
+                        position,
+                        current_seen | {current.id},
+                        current_depth + 1,
+                    )
+                )
+                continue
+
+            child_resolution = can_resolve and not isinstance(
+                current,
+                (
+                    ast.Lambda,
+                    ast.ListComp,
+                    ast.SetComp,
+                    ast.DictComp,
+                    ast.GeneratorExp,
+                    ast.Attribute,
+                    ast.Subscript,
+                    ast.Starred,
+                ),
             )
+            worklist.extend(
+                (
+                    child,
+                    child_resolution,
+                    current_before,
+                    current_seen,
+                    current_depth,
+                )
+                for child in ast.iter_child_nodes(current)
+            )
+
+        result = tuple(found)
+        if cache_key is not None:
+            self.credential_names_cache[cache_key] = result
+        yield from result
 
     def _add(self, node: ast.AST, code: str, message: str) -> None:
         self.findings.append(Finding(self.path, node.lineno, code, message))
@@ -608,6 +703,12 @@ class Visitor(ast.NodeVisitor):
 
     def _check_p008(self, node: ast.Call) -> None:
         function = self._resolve_local(node.func)
+        original_binding = (
+            node.func.value.id
+            if isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            else node.func.id if isinstance(node.func, ast.Name) else None
+        )
         binding = (
             function.value.id
             if isinstance(function, ast.Attribute)
@@ -621,7 +722,13 @@ class Visitor(ast.NodeVisitor):
         if loader is not None:
             loader = self._resolve_local(loader)
         dynamic_source = self._resolve_local(node.args[0]) if node.args else None
-        for module in sorted(self._boundary_modules(function)):
+        modules = self._boundary_modules(node.func) | self._boundary_modules(function)
+        ambiguous = (
+            len(modules) > 1
+            or original_binding in self.ambiguous_boundary_calls
+            or binding in self.ambiguous_boundary_calls
+        )
+        for module in sorted(modules):
             if module == "yaml":
                 if loader is not None and self._safe_yaml_loader(loader):
                     continue
@@ -630,7 +737,7 @@ class Visitor(ast.NodeVisitor):
                     continue
             message = (
                 P008_AMBIGUOUS_MESSAGE
-                if binding in self.ambiguous_boundary_calls
+                if ambiguous
                 else P008_MESSAGES[module]
             )
             self._add(node, "P008", message)

--- a/.dead-code/baseline.json
+++ b/.dead-code/baseline.json
@@ -3076,10 +3076,10 @@
     "version": "1"
   },
   "tree": {
-    "commit": "3c67a6e293accc9ea2c00b4231c32a4894d83c80",
-    "git_tree": "015270bfdc83a516dc76542bd7b537760729f40e"
+    "commit": "14d562fb9457ed1dec8d0da2f049a3bcd9685422",
+    "git_tree": "424ed36a3e11c958e6cb269a48eb019b1343f354"
   },
   "universe": {
-    "id": "sha256:d706d597fdd8343c8907e78bd681c8a57a118689050ef3fad35bf1be34d52bbc"
+    "id": "sha256:c6c1707b3aaafa25a879eca32de44f4881fa3ffcbfbc81c641481e75e4f9313a"
   }
 }

--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -2,7 +2,7 @@
   "counts": {
     "bytes_binary": 54682912,
     "bytes_content_addressed": 7844971,
-    "bytes_generated": 21837683,
+    "bytes_generated": 21841691,
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
@@ -10,7 +10,7 @@
   },
   "entries": [
     {
-      "bytes": 21770613,
+      "bytes": 21774621,
       "category": "generated",
       "evidence": "linguist-generated for '.agents/skills/promise-machine/runtime/**' in .gitattributes",
       "files": 989,

--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -2,15 +2,15 @@
   "counts": {
     "bytes_binary": 54682912,
     "bytes_content_addressed": 7844971,
-    "bytes_generated": 21825510,
+    "bytes_generated": 21837683,
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 2091
+    "files_walked": 2093
   },
   "entries": [
     {
-      "bytes": 21758440,
+      "bytes": 21770613,
       "category": "generated",
       "evidence": "linguist-generated for '.agents/skills/promise-machine/runtime/**' in .gitattributes",
       "files": 989,

--- a/docs/phylax-single-assignment-locals/runbook.md
+++ b/docs/phylax-single-assignment-locals/runbook.md
@@ -1,0 +1,354 @@
+# runbook: resolve single-assignment locals for Phylax rules
+
+This runbook derives from the receipted study. Issue #502 is one bounded
+classification capability, so one auditable step both scaffolds and
+demonstrates it. The repository already supplies its layout, Python pin,
+licences, CI and Phylax CLI. This step verifies those foundations and does not
+replace them.
+
+```version-relations
+phylax | plugins/hexaemeron/skills/phylax/EVOLUTION.md | next-generation-after-integration-base
+```
+
+## Step 1: resolve and demonstrate eligible local bindings
+
+**Goal.** Add one shared same-function resolver that exposes eligible local
+values to P002, P004 and P008 without claiming branch, rebinding, attribute,
+comprehension, closure or interprocedural analysis.
+
+**Entry.** The clean run branch at
+`7e97b5195d5b0e43146b4200f26cd41b89003413`, with the Fiat study and this
+runbook receipted, the focused Phylax checker suite green at 79 tests under the
+repository-declared Python 3.14.6 interpreter, and the complete audit synopsis
+set verified current. Existing repository layout, Python pin, licences and CI
+are the scaffold; no dependency, toolchain or workflow change enters this
+step.
+
+**Exit.** P002 reports an assigned subprocess string command; P004 reports a
+credential-named value in assigned argv without erasing the existing
+name-first signal; P008 reports an assigned dangerous callable while assigned
+literal dynamic input and assigned `yaml.SafeLoader` or `yaml.CSafeLoader`
+remain clean. Reassignment, late assignment, branch-local writes, attributes,
+subscripts, destructuring, comprehensions, parameters, nested scopes,
+closures, module scope, cycles and over-depth chains earn no resolution.
+Finding codes, sink locations, reason-bearing suppression, fixed diagnostics
+and secret-free text and JSON output remain unchanged.
+
+The Phylax contract and generation ledger describe that exact boundary while
+retaining the complete mature frontier tuple. The portable Promise Machine
+copy and coverage digest match the canonical source. Byte-identical tracked
+copies of the receipted study and runbook exist under
+`docs/phylax-single-assignment-locals/`; the configured Fiat audit record and
+its generated synopsis are current; the Horos boundary describes the final
+tracked tree; and every command below exits zero:
+
+```bash
+python3 -c 'import platform; assert platform.python_version() == "3.14.6"'
+cmp .hexaemeron/study.md docs/phylax-single-assignment-locals/study.md
+cmp .hexaemeron/runbook.md docs/phylax-single-assignment-locals/runbook.md
+python3 -m unittest plugins.hexaemeron.tests.test_phylax_checker
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+python3 scripts/portable_promise_machine.py check
+python3 scripts/promise_machine.py check
+python3 scripts/promise_machine.py coverage --check
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/phylax-single-assignment-locals/study.md
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/phylax-single-assignment-locals/runbook.md
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/phylax-single-assignment-locals/study.md docs/phylax-single-assignment-locals/runbook.md plugins/hexaemeron/skills/phylax/SKILL.md plugins/hexaemeron/skills/phylax/EVOLUTION.md
+python3 plugins/brevitas/skills/brevitas/scripts/brevitas.py --mode report docs/phylax-single-assignment-locals/runbook.md
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents/skills/promise-machine/SKILL.md .agents/skills/promise-machine/PORTABLE.md plugins docs
+python3 plugins/hexaemeron/skills/fiat/scripts/audit_synopsis.py --check .
+python3 plugins/horos/skills/horos/scripts/horos.py check .
+python3 scripts/run_checks.py
+git diff --check
+```
+
+**Files.** Change
+`plugins/hexaemeron/skills/phylax/scripts/phylax.py`,
+`plugins/hexaemeron/tests/test_phylax_checker.py`,
+`plugins/hexaemeron/skills/phylax/SKILL.md`,
+`plugins/hexaemeron/skills/phylax/EVOLUTION.md`, and
+`tests/promise_machine_coverage.json`. Create byte-identical tracked copies at
+`docs/phylax-single-assignment-locals/study.md` and
+`docs/phylax-single-assignment-locals/runbook.md`. Regenerate the matching
+Phylax files under
+`.agents/skills/promise-machine/runtime/plugins/hexaemeron/skills/phylax/`
+with `python3 scripts/portable_promise_machine.py sync`. Permit the configured
+Fiat audit record and generated synopsis companion, plus
+`.horos/boundary.json`, only when their owning phase or deterministic generator
+changes them. No other product path is in scope without a study amendment.
+
+**Tests.** Before changing the resolver, add focused fixtures for the five
+baseline probes and record their exact red classifications. Add positive and
+safe-neighbour cases for positional and keyword subprocess args, direct and
+aliased runners, P004's name-first ordering, assigned dangerous callables,
+dynamic literal input, and safe YAML loaders. Add refusal cases for every
+excluded binding shape, forward assignment, cycles and depth exhaustion.
+Retain reason-bearing and bare pragma behaviour, P000 through P008 neighbours,
+sink-line anchoring, and fixed text/JSON diagnostics with a sentinel value that
+must not appear. Preserve all 79 existing focused tests and report the final
+count.
+
+The source-bound Elenchus runner contract for any audit repair is exact: test
+command `python3 plugins/hexaemeron/tests/run_tests.py --elenchus-report {report}`;
+report format `unittest-json-v1`; expected report schema
+`elenchus.unittest.v1`; report file `.elenchus/fiat-502-step-1.json`. The report
+path must be fresh. A missing, stale, empty, malformed, zero-test or
+infrastructure-failed report is `inconclusive`, not guard evidence.
+
+**Disciplines.** phylax: untrusted Python source reaches a new binding index,
+so parsing stays source-only, ambiguity fails unresolved, and diagnostics stay
+fixed and secret-free. ephoros: none, because this local CLI adds no unattended
+path or telemetry and preserves path, sink line, code, message and exit as its
+operator signals. metron: none, because no performance budget or optimisation
+claim exists; one collection pass and bounded resolution are structural
+limits, not a speed result. elenchus: the five observed misclassifications are
+captured red before the cause-level resolver change and retained as regression
+guards under the exact runner above. hypomnema: the governed Phylax ledger is
+the standing home for this skill-local decision and rejected broad-dataflow
+alternatives; the tracked study and runbook preserve the accepted
+specification without minting a repository-wide ADR.
+
+Implementation order inside the step is fixed: preserve the red probe results;
+add the smallest shared binding index and resolver; turn the focused suite
+green; update the public contract, generation row and coverage digest;
+synchronise the portable payload; copy the receipted documents; regenerate the
+Horos boundary; run the complete exit set; then enter Fiat audit and prose
+gates. Any need for general control flow, taint, type inference, another
+finding code, a dependency, a changed runner grammar or changed mature
+frontier bytes stops the step for a study amendment.
+
+### Amendment -- 2026-08-29
+
+**What changed.** Complete replacement Exit: P002 reports an assigned
+subprocess string command; P004 reports a credential-named value in assigned
+argv without erasing the existing name-first signal; P008 reports an assigned
+dangerous callable while assigned literal dynamic input and assigned
+`yaml.SafeLoader` or `yaml.CSafeLoader` remain clean. Reassignment, late
+assignment, branch-local writes, attributes, subscripts, destructuring,
+comprehensions, parameters, nested scopes, closures, module scope, cycles and
+over-depth chains earn no resolution. Finding codes, sink locations,
+reason-bearing suppression, fixed diagnostics and secret-free text and JSON
+output remain unchanged. The Phylax contract and generation ledger describe
+that exact boundary while retaining the complete mature frontier tuple. The
+portable Promise Machine copy and coverage digest match the canonical source.
+Byte-identical tracked copies of the receipted study and runbook exist under
+`docs/phylax-single-assignment-locals/`; the configured Fiat audit record and
+its generated synopsis are current; the Horos boundary describes the final
+tracked tree; and every command below exits zero:
+
+```bash
+python3 -c 'import platform; assert platform.python_version() == "3.14.6"'
+cmp .hexaemeron/study.md docs/phylax-single-assignment-locals/study.md
+cmp .hexaemeron/runbook.md docs/phylax-single-assignment-locals/runbook.md
+python3 -m unittest plugins.hexaemeron.tests.test_phylax_checker
+python3 plugins/hexaemeron/tests/run_tests.py
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+python3 scripts/portable_promise_machine.py check
+python3 scripts/promise_machine.py check
+python3 scripts/promise_machine.py coverage --check
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/phylax-single-assignment-locals/study.md
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/phylax-single-assignment-locals/runbook.md
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/phylax-single-assignment-locals/study.md docs/phylax-single-assignment-locals/runbook.md plugins/hexaemeron/skills/phylax/SKILL.md plugins/hexaemeron/skills/phylax/EVOLUTION.md
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents/skills/promise-machine/SKILL.md .agents/skills/promise-machine/PORTABLE.md plugins docs
+python3 plugins/hexaemeron/skills/fiat/scripts/audit_synopsis.py --check .
+python3 plugins/horos/skills/horos/scripts/horos.py check .
+python3 scripts/run_checks.py
+git diff --check
+```
+
+**Why.** The receipted Exit incorrectly applied Brevitas report mode to this
+completeness-oriented specification. Brevitas excludes that document class,
+and B010 correctly refuses its one-section report shape. Protasis and
+Imprimatur remain the specification's applicable mechanical prose gates.
+
+**Steps touched.** Step 1's Exit.
+
+**Still holding.** Step 1: entry holds; exit holds.
+
+### Amendment -- 2026-08-29
+
+**What changed.** Complete replacement Files: Change
+`plugins/hexaemeron/skills/phylax/scripts/phylax.py`,
+`plugins/hexaemeron/tests/test_phylax_checker.py`,
+`plugins/hexaemeron/tests/test_phylax_model_proxy.py`,
+`plugins/hexaemeron/skills/phylax/SKILL.md`,
+`plugins/hexaemeron/skills/phylax/EVOLUTION.md`, and
+`tests/promise_machine_coverage.json`. Create byte-identical tracked copies at
+`docs/phylax-single-assignment-locals/study.md` and
+`docs/phylax-single-assignment-locals/runbook.md`. Regenerate the matching
+Phylax files under
+`.agents/skills/promise-machine/runtime/plugins/hexaemeron/skills/phylax/`
+with `python3 scripts/portable_promise_machine.py sync`. Permit the configured
+Fiat audit record and generated synopsis companion, plus
+`.horos/boundary.json`, only when their owning phase or deterministic generator
+changes them. No other product path is in scope without a study amendment.
+Complete replacement Tests: Before changing the resolver, add focused fixtures
+for the five baseline probes and record their exact red classifications. Add
+positive and safe-neighbour cases for positional and keyword subprocess args,
+direct and aliased runners, P004's name-first ordering, assigned dangerous
+callables, dynamic literal input, and safe YAML loaders. Add refusal cases for
+every excluded binding shape, forward assignment, cycles and depth exhaustion.
+Retain reason-bearing and bare pragma behaviour, P000 through P008 neighbours,
+sink-line anchoring, and fixed text/JSON diagnostics with a sentinel value that
+must not appear. Preserve all 79 existing focused tests and report the final
+count. Update
+`ConformanceTests.test_skill_package_marketplace_coverage_and_portable_versions_are_exact`
+to require the controller-projected Phylax generation in both the canonical
+contract and evolution ledger while retaining its canonical/portable parity
+assertions. The source-bound Elenchus runner contract for any audit repair is
+exact: test command
+`python3 plugins/hexaemeron/tests/run_tests.py --elenchus-report {report}`;
+report format `unittest-json-v1`; expected report schema
+`elenchus.unittest.v1`; report file `.elenchus/fiat-502-step-1.json`. The report
+path must be fresh. A missing, stale, empty, malformed, zero-test or
+infrastructure-failed report is `inconclusive`, not guard evidence.
+
+**Why.** The complete Hexaemeron suite exposed one existing integration guard
+that intentionally pins the canonical and portable Phylax version bytes. The
+generation-only increment makes that assertion stale, so its named test must
+advance with the governed ledger rather than be bypassed.
+
+**Steps touched.** Step 1's Files and Tests.
+
+**Still holding.** Step 1: entry holds; exit holds.
+
+### Amendment -- 2026-08-29
+
+**What changed.** Complete replacement Exit: P002 reports an assigned
+subprocess string command; P004 reports a credential-named value in assigned
+argv without erasing the existing name-first signal; P008 reports an assigned
+dangerous callable while assigned literal dynamic input and assigned
+`yaml.SafeLoader` or `yaml.CSafeLoader` remain clean. Reassignment, late
+assignment, branch-local writes, attributes, subscripts, destructuring,
+comprehensions, parameters, nested scopes, closures, module scope, cycles and
+over-depth chains earn no resolution. Finding codes, sink locations,
+reason-bearing suppression, fixed diagnostics and secret-free text and JSON
+output remain unchanged. The Phylax contract and generation ledger describe
+that exact boundary while retaining the complete mature frontier tuple. The
+portable Promise Machine copy and coverage digest match the canonical source.
+Byte-identical tracked copies of the receipted study and runbook exist under
+`docs/phylax-single-assignment-locals/`; the configured Fiat audit record and
+its generated synopsis are current; and the Horos boundary describes the
+final tracked tree.
+
+The complete Hexaemeron runner is executed and recorded but is not promoted to
+an in-scope green claim while exact base
+`7e97b5195d5b0e43146b4200f26cd41b89003413` already fails its Homologia
+check-map ownership predicate, Node 26 fixture-version predicate, macOS
+long-path checkpoint fixture, and root-audit digest pin. The candidate must
+introduce no additional failure or error, and both Phylax suites must be green.
+Every in-scope command below exits zero:
+
+```bash
+python3 -c 'import platform; assert platform.python_version() == "3.14.6"'
+cmp .hexaemeron/study.md docs/phylax-single-assignment-locals/study.md
+cmp .hexaemeron/runbook.md docs/phylax-single-assignment-locals/runbook.md
+python3 -m unittest plugins.hexaemeron.tests.test_phylax_checker
+python3 -m unittest plugins.hexaemeron.tests.test_phylax_model_proxy.ConformanceTests.test_skill_package_marketplace_coverage_and_portable_versions_are_exact
+python3 -m unittest tests.test_evolution_contract
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+python3 scripts/portable_promise_machine.py check
+python3 scripts/promise_machine.py check
+python3 scripts/promise_machine.py coverage --check
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/phylax-single-assignment-locals/study.md
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/phylax-single-assignment-locals/runbook.md
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/phylax-single-assignment-locals/study.md docs/phylax-single-assignment-locals/runbook.md plugins/hexaemeron/skills/phylax/SKILL.md plugins/hexaemeron/skills/phylax/EVOLUTION.md
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents/skills/promise-machine/SKILL.md .agents/skills/promise-machine/PORTABLE.md plugins docs
+python3 plugins/hexaemeron/skills/fiat/scripts/audit_synopsis.py --check .
+python3 plugins/horos/skills/horos/scripts/horos.py check .
+git diff --check
+```
+
+**Why.** The complete Hexaemeron run on the amended candidate returned three
+failures and one error, all outside this step. Each exact predicate was then
+reproduced unchanged on the entry commit. Repairing Homologia ownership, the
+host Node installation, a pre-existing macOS path-length fixture, or the
+root-audit pin would widen #502 and contaminate its regression evidence.
+
+**Steps touched.** Step 1's Exit.
+
+**Still holding.** Step 1: entry holds; exit holds.
+
+### Amendment -- 2026-08-29
+
+**What changed.** Complete replacement Exit: P002 reports an assigned
+subprocess string command; P004 reports a credential-named value in assigned
+argv without erasing the existing name-first signal; P008 reports an assigned
+dangerous callable while assigned literal dynamic input and assigned
+`yaml.SafeLoader` or `yaml.CSafeLoader` remain clean. Reassignment, late
+assignment, branch-local writes, attributes, subscripts, destructuring,
+comprehensions, parameters, nested scopes, closures, module scope, cycles and
+over-depth chains earn no resolution. Finding codes, sink locations,
+reason-bearing suppression, fixed diagnostics and secret-free text and JSON
+output remain unchanged. The Phylax contract and generation ledger describe
+that exact boundary while retaining the complete mature frontier tuple. The
+portable Promise Machine copy and coverage digest match the canonical source.
+The tracked runbook is byte-identical to its receipted artifact. The tracked
+study differs from its receipt only by rebasing exactly five Markdown links
+from `.hexaemeron/` depth to
+`docs/phylax-single-assignment-locals/` depth; a normalization check proves all
+other bytes identical. The configured Fiat audit record and its generated
+synopsis are current, and the Horos boundary describes the final tracked tree.
+
+The complete Hexaemeron runner is executed and recorded but is not promoted to
+an in-scope green claim while exact base
+`7e97b5195d5b0e43146b4200f26cd41b89003413` already fails its Homologia
+check-map ownership predicate, Node 26 fixture-version predicate, macOS
+long-path checkpoint fixture, and root-audit digest pin. The candidate must
+introduce no additional failure or error, and both Phylax suites must be green.
+Every in-scope command below exits zero:
+
+```bash
+python3 -c 'import platform; assert platform.python_version() == "3.14.6"'
+python3 -c 'from pathlib import Path; source = Path(".hexaemeron/study.md").read_text(); tracked = Path("docs/phylax-single-assignment-locals/study.md").read_text(); assert source.count("(../plugins/") == 5; assert tracked.count("(../../plugins/") == 5; assert tracked.replace("(../../plugins/", "(../plugins/") == source'
+cmp .hexaemeron/runbook.md docs/phylax-single-assignment-locals/runbook.md
+python3 -m unittest plugins.hexaemeron.tests.test_phylax_checker
+python3 -m unittest plugins.hexaemeron.tests.test_phylax_model_proxy.ConformanceTests.test_skill_package_marketplace_coverage_and_portable_versions_are_exact
+python3 -m unittest tests.test_evolution_contract
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py plugins tests
+python3 scripts/portable_promise_machine.py check
+python3 scripts/promise_machine.py check
+python3 scripts/promise_machine.py coverage --check
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/phylax-single-assignment-locals/study.md
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/phylax-single-assignment-locals/runbook.md
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/phylax-single-assignment-locals/study.md docs/phylax-single-assignment-locals/runbook.md plugins/hexaemeron/skills/phylax/SKILL.md plugins/hexaemeron/skills/phylax/EVOLUTION.md
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py plugins tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py README.md AGENTS.md .agents/skills/promise-machine/SKILL.md .agents/skills/promise-machine/PORTABLE.md plugins docs
+python3 plugins/hexaemeron/skills/fiat/scripts/audit_synopsis.py --check .
+python3 plugins/horos/skills/horos/scripts/horos.py check .
+git diff --check
+```
+
+Complete replacement Files: Change
+`plugins/hexaemeron/skills/phylax/scripts/phylax.py`,
+`plugins/hexaemeron/tests/test_phylax_checker.py`,
+`plugins/hexaemeron/tests/test_phylax_model_proxy.py`,
+`plugins/hexaemeron/skills/phylax/SKILL.md`,
+`plugins/hexaemeron/skills/phylax/EVOLUTION.md`, and
+`tests/promise_machine_coverage.json`. Create a path-rebased tracked study at
+`docs/phylax-single-assignment-locals/study.md` and a byte-identical tracked
+runbook at `docs/phylax-single-assignment-locals/runbook.md`. The study
+publication changes only its five `../plugins/` link prefixes to
+`../../plugins/`; the Exit normalization command checks exact content parity.
+Regenerate the matching Phylax files under
+`.agents/skills/promise-machine/runtime/plugins/hexaemeron/skills/phylax/`
+with `python3 scripts/portable_promise_machine.py sync`. Permit the configured
+Fiat audit record and generated synopsis companion, plus
+`.horos/boundary.json`, only when their owning phase or deterministic generator
+changes them. No other product path is in scope without a study amendment.
+
+**Why.** Hypomnema correctly rejected the receipted study's five
+artifact-relative links after an exact copy moved them two directory levels
+deeper. Rewriting the receipt would destroy evidence continuity; retaining the
+broken links would ship false pointers. A closed five-token path rebase keeps
+both properties checkable.
+
+**Steps touched.** Step 1's Exit and Files.
+
+**Still holding.** Step 1: entry holds; exit holds.

--- a/docs/phylax-single-assignment-locals/study.md
+++ b/docs/phylax-single-assignment-locals/study.md
@@ -1,0 +1,242 @@
+# resolve single-assignment locals for Phylax rules
+
+## assumptions
+
+- "same function scope" means one `FunctionDef` or `AsyncFunctionDef`. Module, class, lambda, comprehension, generator and nested-function bindings do not qualify.
+- "assigned exactly once" means a direct statement in that function body with one simple `Name` target and a value. A simple valued `AnnAssign` may qualify; chained, unpacking, attribute and subscript targets do not.
+- The qualifying write must precede the use. Any other binding or deletion of the same name in that function, including a parameter, import, augmented assignment, named expression, loop target, exception name or pattern capture, disqualifies resolution.
+- Assignments under `if`, `match`, loops, `try`, `with` or another compound statement are branch-sensitive and therefore excluded even when static syntax makes a path look obvious.
+- Resolution is a bounded, source-only substitution used by P002, P004 and P008. It does not execute code, prove types, infer taint, follow attributes, or establish interprocedural facts.
+- Existing rules remain conservative when a name cannot be proved eligible. This work adds the issue's narrow positive cases; it does not turn a previously reported dangerous call into a clean result except where a proven single assignment exposes an existing safe neighbour such as a literal `eval` input or `yaml.SafeLoader`.
+- Issue #502 is optional generation work on mature `phylax-v1.4.0`. Integration may add one generation row, but the frontier status, revision, next job and digest stay byte-for-byte unchanged.
+
+## 1. Problem statement
+
+Phylax presently understands the expression written directly at a sink but not the same expression placed in one local. That creates three related classification defects:
+
+- P002 misses a subprocess string command held in a local.
+- P004 misses credential-named values when the subprocess argv expression is held in a local.
+- P008 misses an assigned dangerous callable, and overclaims assigned literal dynamic-execution input and assigned safe YAML loader as dangerous.
+
+Build one narrow function-local resolver for those three existing rules. A working prototype resolves only an eligible preceding single assignment, retains each rule's current finding code, runner/import grammar, suppression line, diagnostic text and no-secret output, and refuses to infer through every excluded form above.
+
+The demonstration path is the focused checker suite:
+
+```bash
+python3 -m unittest plugins.hexaemeron.tests.test_phylax_checker
+```
+
+It starts at 79 passing tests on `main`. The prototype must add red-then-green fixtures for the five live probes and the exclusion matrix. At the study base the probes produce:
+
+```text
+assigned P002 command       -> []
+assigned P004 argv          -> []
+assigned literal eval       -> P008
+assigned SafeLoader         -> P008
+assigned pickle callable    -> []
+```
+
+The intended post-change classifications are P002, P004, clean, clean and P008 respectively. The same focused suite must also prove that reassignment, branch-local writes, attributes, comprehensions and cross-function flow do not earn resolution.
+
+## 2. Prior art
+
+### current repository
+
+`plugins/hexaemeron/skills/phylax/scripts/phylax.py` already has the right source-only substrate:
+
+- `_boundary_bindings` pre-collects import evidence without importing the target.
+- `_starts_process` resolves the existing source-local subprocess forms.
+- `_boundary_modules`, `_safe_yaml_loader` and `_check_p008` classify import-bound calls and YAML loaders.
+- `visit_Call` owns P002, P004 and the P008 dispatch; `visit_Assign` currently checks only credential literals.
+- the TypeScript-only `_assigned_object` performs a lexical previous-assignment lookup, but it neither proves exactly one write nor models Python function scope. It is nearby prior art, not a reusable correctness argument.
+
+`plugins/hexaemeron/tests/test_phylax_checker.py` is the shared classification and diagnostic-secrecy harness. Its current fixtures cover P000-P008, subprocess import shapes, P004 inline argv, P008 late and conflicting imports, safe YAML loader forms, dynamic literals, suppression and cross-scope collisions. The repository-declared Python 3.14.6 interpreter passed all 79 focused tests at this base and remains the release authority.
+
+Simple AST assignment extraction also exists in `scripts/dead_code.py`, `scripts/contributors.py` and Ariadne tests. Those readers deliberately handle literal declarations; none is a general scope or dataflow engine. Repository search found no existing Python function-local single-assignment resolver.
+
+### shipped studies and audit evidence
+
+`docs/phylax-credential-argv/study.md` deliberately selected an inline argv subtree and excluded separately assigned argv. `docs/phylax-unsafe-deserialization/study.md` selected source-local import-aware AST analysis and excluded assignment, general lexical scope, taint and control flow. This issue accepts only the common single-assignment slice of those exclusions; it does not silently absorb the rest.
+
+`python3 plugins/hexaemeron/skills/fiat/scripts/audit_synopsis.py --check .` exited zero for the complete target. I therefore read the fresh `audit/AUDIT_SYNOPSIS.md` view, not `audit/AUDIT.md`. The in-scope records are:
+
+- `Phylax credential argv, step 1, round 1`: `review-code`, `review-tests` and `review-records` are clean. Separately assigned argv is an explicit lead not pursued and is accepted here. `API_TOKEN` grammar, attribute/subscript values, star expansion, `**kwargs`, runner rebinding and flag interpretation remain outside scope.
+- `Phylax unsafe deserialization, step 1, round 1`: S1-R1-01 medium, late-import discovery, fixed and guarded; S1-R1-02 low, conflicting import identities, fixed and guarded. Assignment/scope/taint/control-flow work remained excluded.
+- round 2: S1-R2-01 low, ambiguous identities could emit the wrong family-specific diagnostic, fixed and guarded.
+- round 3: S1-R3-01 medium, a cross-scope YAML alias could displace a built-in dynamic call, fixed and guarded.
+- round 4: no new finding; the final code, test and record reviews were clean. The existing source-local exclusions remained deliberate.
+
+For all five legacy entries, `audit-schema`, `Covered`, `Not checked` and `Elenchus verdict` are recorded as `[missing legacy field: ...]` and remain unknown. Their risk tables are useful evidence but do not repair those missing fields. Their named leads not pursued remain open unless this study explicitly accepts or preserves them. No dedicated P002 audit block was discovered in the verified root synopsis; P002 evidence therefore comes from current source, tests and git history rather than an invented audit verdict. No in-scope Phylax record exists in `plugins/hexaemeron/audit/AUDIT_SYNOPSIS.md`.
+
+### last semantically relevant merged pull requests
+
+- [PR #486](https://github.com/wildcat-finance/skills/pull/486), merged as `454bf3c9`, added P008. Its four audit rounds went `2 -> 1 -> 1 -> 0`, and its body carries forward `marshal.loads`, relative/wildcard/dynamic imports, assignment/general lexical scope/taint/control flow, custom-loader proofs, pragma-in-string behaviour and Python file-size policy. This study accepts only eligible local assignment resolution and preserves every other item.
+- [PR #481](https://github.com/wildcat-finance/skills/pull/481), merged as `64096f4d`, added P004 inline argv scanning. Its body explicitly leaves `env=`, separately assigned argv and local runner names out. This study accepts separately assigned argv only; it preserves the other runner and argument-shape limits.
+
+Local merge `68039a87` says `Merge pull request #666` and touched the Phylax test path only to remove duplicated whole-tree lint coverage. Public issue and pull endpoints for #666 return 404, and GitHub's commit-to-pull association for that merge is empty. That is negative evidence: no public body exists to carry semantic unfinished work, and the local diff changes test plumbing rather than P002/P004/P008 semantics. It does not displace #486 and #481 as the last two semantically relevant merged pull requests.
+
+### outside prior art
+
+Python's [`ast` documentation](https://docs.python.org/3.14/library/ast.html) exposes the binding shapes directly: `Assign` has target lists, while `AnnAssign` and `AugAssign` are distinct nodes and comprehension targets are explicit. Python's [`symtable` documentation](https://docs.python.org/3.14/library/symtable.html) supplies compiler scope identities but not the binding RHS and source-order substitution this feature needs. [LibCST's `ScopeProvider`](https://libcst.readthedocs.io/en/latest/_modules/libcst/metadata/scope_provider.html) models assignments and accesses across a much broader Python grammar. [Pyflakes](https://github.com/PyCQA/pyflakes) is useful precedent for per-file AST analysis that avoids importing targets, but adopting an external analyser would widen Phylax's dependency and semantics far beyond this wish.
+
+## 3. Constraints and non-goals
+
+- Base, target and `origin/main` are the same commit: `7e97b5195d5b0e43146b4200f26cd41b89003413`.
+- The repository pins Python `3.14.6` in `.python-version` and `==3.14.*` in `pyproject.toml`. All receipted gates must run under that declared interpreter.
+- Limit implementation to `plugins/hexaemeron/skills/phylax/scripts/phylax.py`, focused tests, Phylax mechanical prose, the tracked study/runbook copies and a generation-only evolution row. Do not change finding codes or output schema.
+- Do not import or execute scanned Python. Add no third-party dependency, subprocess, filesystem write, network call, persistent cache or model call.
+- Do not resolve module/class locals, closures, globals, nonlocals, nested scopes, attributes, subscripts, imports, parameters, destructuring, branches, comprehensions, loops, exception handlers, pattern captures or cross-function values.
+- Do not add general reaching-definitions, taint, type, constant-folding, control-flow or interprocedural analysis. Do not interpret string flags or extend the credential grammar.
+- Keep P002 tied to resolved subprocess runners, P004 tied to the existing inline-argv slot after local substitution, and P008 tied to the current import/call-family grammar. Do not absorb #323 or the unrelated model-proxy gaps #698, #699 and #702.
+- Do not reopen or advance the mature frontier. A new generation row must retain `mature`, `off-chain-boundary-controls`, no next job, and digest `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604`.
+
+Always: parse source only, fail conservatively on ambiguity, report at the sink call, preserve fixed diagnostics and prove every accepted/excluded binding shape with a fixture.
+
+Ask first: any proposal to resolve another scope, infer a credential from its value, change the existing ambiguity posture, add a dependency, change a finding grammar, or change the mature frontier tuple.
+
+Never: execute scanned code, print a scanned value, follow runtime imports, claim an unresolved name is safe, mutate controller state from an implementation step, or mint a held frontier job for #502.
+
+## 4. Design options
+
+### option A: one narrow function binding index and bounded resolver (selected)
+
+Build a per-function index once, recording eligible direct-body assignments and every disqualifying write. Resolve a `Name` only when there is exactly one eligible prior write and no other binding of that name in the function. Follow eligible name-to-name chains with a visited set and a fixed maximum depth. Feed the resolved AST expression into the three existing rule seams.
+
+Trade: this adds one small shared semantic layer and an explicit write taxonomy, but keeps rule identity, output and source-only operation intact. It is the cheapest design that prevents P002, P004 and P008 from inventing three subtly different meanings of "single assignment."
+
+P004 has one rule-specific ordering constraint: test a visited `Name` against the existing credential grammar before substituting it. Thus `secret = read(); argv = ["tool", secret]` still reports `secret`; substitution is for exposing an argv expression, not erasing the existing name signal.
+
+### option B: rule-local backward lookups
+
+Teach each of P002, P004 and P008 to scan earlier statements for one assignment. This is initially shorter, but it duplicates scope, reassignment, branch, ordering and cycle policy three times. The implementations would drift and recreate the inconsistent classifications the issue groups together. Reject.
+
+### option C: `symtable` plus AST mapping
+
+Use Python compiler symbol tables for scope and a second AST pass for definitions and RHS nodes. This gets robust local/global/free classification, but `symtable` does not itself answer which RHS reaches a use or whether a binding is direct and preceding. Mapping the two representations costs more comprehension than the excluded grammar needs. Reject for this prototype.
+
+### option D: LibCST, Pyflakes or another external semantic engine
+
+Adopt a mature assignment/access model. This handles far more Python constructs and preserves concrete syntax, at the cost of a new dependency, a much larger trust surface and semantics that would have to be clipped back to this tiny promise. Reject; revisit only if a later approved job requests general Python scope analysis.
+
+Implementation shape for option A:
+
+1. Entering a function creates a scope record without traversing nested functions/classes/comprehensions as that scope.
+2. Collect direct-body eligible assignments and all same-function disqualifying writes. Preserve statement order.
+3. Resolve on demand only at P002 command, P004 argv and P008 callable/loader/dynamic-source seams. A missing, late, repeated, cyclic or over-depth binding returns unresolved.
+4. P002 asks the existing string-command predicate about the resolved command expression. P004 walks the resolved argv expression, checking credential names before further substitution. P008 resolves the callable before current import-family matching and resolves only the loader and first positional dynamic-source expression before current safety/literal predicates.
+5. Keep findings anchored to `ast.Call` so reason-bearing suppression and output locations do not move to assignment lines.
+
+## 5. Risk register seed
+
+The audit loop must enumerate every line; a clean overall suite is not a substitute for a disposition.
+
+```risk-register
+source-parse | untrusted Python source entering ast.parse and the visitor | the checker never imports executes evaluates or deserializes target code
+scope-identity | names shared by module class nested and sibling function scopes | only the exact containing FunctionDef or AsyncFunctionDef supplies bindings
+write-count | every syntax form that can bind or delete a local name | a second or unsupported binding disqualifies resolution instead of selecting a convenient write
+statement-order | a sink before or after its only assignment | only a proven preceding binding resolves and forward references remain conservative
+branch-exclusion | assignments nested below compound statements | branch loop try with match and comprehension writes never earn straight-line trust
+resolution-cycle | chains such as a-equals-b and b-equals-a | a visited set and finite depth stop resolution and preserve the unresolved classification
+p002-classification | the resolved subprocess command expression | assigned strings report P002 while list argv and unresolved names preserve existing behaviour
+p004-name-first | credential names inside an assigned argv tree | the credential grammar runs before substitution so resolution cannot erase an existing signal
+p008-call-identity | assigned pickle marshal yaml and dynamic-execution callables | resolution feeds current import ambiguity logic without bypassing the four fixed audit guards
+safe-neighbour | assigned literal dynamic input and assigned SafeLoader or CSafeLoader | exact safe forms become clean while unknown custom and unsafe values still report
+diagnostic-output | findings produced from source containing secret material | text and JSON retain fixed messages and never echo assignment values or payload sentinels
+classification-drift | all checker families P000 through P008 and suppression | non-target rules messages locations and reason-bearing suppression remain guarded
+analysis-work | large functions with many names and alias chains | collection is linear per function and resolution is memoized or bounded rather than rescanning per use
+partial-run | an interrupted test lint or audit command | no partial output is promoted to a passing receipt and reruns start from complete source evidence
+ledger-integrity | a generation row added to mature Phylax | version advances generation only and the complete frontier tuple and digest remain unchanged
+```
+
+## 6. Glossary seeds
+
+eligible assignment: one direct-body simple-name `Assign`, or valued `AnnAssign`, that precedes the use and is the name's only binding in the function.
+
+disqualifying write: any additional or excluded binding or deletion of the candidate name in the same function.
+
+function scope: the exact `FunctionDef` or `AsyncFunctionDef` containing both assignment and sink, excluding nested scope bodies.
+
+binding index: the per-function record of eligible assignments, disqualifying writes and source order.
+
+resolver: the bounded source-only operation that replaces an eligible `Name` with its RHS AST expression.
+
+sink: the existing subprocess or unsafe-deserialization/dynamic-execution call at which Phylax classifies and reports.
+
+unresolved: no proof satisfying the eligible-assignment grammar; existing conservative rule behaviour applies.
+
+safe neighbour: an expression the current rule already treats as clean when inline, such as a literal dynamic input or `yaml.SafeLoader`.
+
+generation-only: a skill version row that records new artefacts without changing the mature frontier tuple or minting a next job.
+
+## 7. Sources
+
+- live scope and status: [issue #502](https://github.com/wildcat-finance/skills/issues/502), checked open, unassigned and labelled `wish` at study time.
+- integration base: git commit `7e97b5195d5b0e43146b4200f26cd41b89003413`; `.python-version`; `pyproject.toml`.
+- canonical Phylax contract and ledger: `plugins/hexaemeron/skills/phylax/SKILL.md`; `plugins/hexaemeron/skills/phylax/EVOLUTION.md`.
+- implementation: `plugins/hexaemeron/skills/phylax/scripts/phylax.py`, especially `_boundary_bindings`, `_starts_process`, `_boundary_modules`, `_safe_yaml_loader`, `_check_p008`, `visit_Call`, `visit_Assign` and `_assigned_object`.
+- fixtures: `plugins/hexaemeron/tests/test_phylax_checker.py`.
+- shipped specifications: `docs/phylax-credential-argv/study.md`; `docs/phylax-unsafe-deserialization/study.md`.
+- audit view: `audit/AUDIT_SYNOPSIS.md`, accepted only after `python3 plugins/hexaemeron/skills/fiat/scripts/audit_synopsis.py --check .` exited zero; `plugins/hexaemeron/audit/AUDIT_SYNOPSIS.md` was searched and contains no in-scope Phylax record.
+- merged history: [PR #486](https://github.com/wildcat-finance/skills/pull/486), merge `454bf3c9`; [PR #481](https://github.com/wildcat-finance/skills/pull/481), merge `64096f4d`; local negative evidence at merge `68039a87` for unavailable #666.
+- upstream Python grammar and scope references: [`ast`](https://docs.python.org/3.14/library/ast.html); [`symtable`](https://docs.python.org/3.14/library/symtable.html).
+- external alternatives: [LibCST `ScopeProvider`](https://libcst.readthedocs.io/en/latest/_modules/libcst/metadata/scope_provider.html); [Pyflakes](https://github.com/PyCQA/pyflakes).
+- study schema: `plugins/hexaemeron/skills/protasis/SKILL.md`.
+
+## 8. Signals, and the questions behind them
+
+This is a deterministic local lint, not an unattended service. It needs no exporter, metric backend or new telemetry. The existing finding stream and command exit answer the useful operator questions:
+
+1. Did analysis complete? The test/lint step emits its normal terminal summary and exit status; an interruption or nonzero exit is never recorded as clean.
+2. Which sink was classified? The implementation/test step preserves `path`, sink-call `line`, finding `code` and fixed bounded `message` in text and JSON.
+3. Which local-resolution family regressed? The focused test step names separate P002 command, P004 name-first argv, P008 callable, loader, literal, reassignment, branch and cross-scope cases.
+4. Did generation mutate the mature frontier? The records step emits the evolution check and an exact before/after comparison of status, revision, next job and digest.
+
+Signal ownership and field discipline remain with [Ephoros](../../plugins/hexaemeron/skills/ephoros/SKILL.md); this study adds no second telemetry contract.
+
+## 9. Boundaries, per capability
+
+The build is held to [Phylax](../../plugins/hexaemeron/skills/phylax/SKILL.md).
+
+- Python parsing boundary: worth taking syntax and AST structure only. Control: `ast.parse`; never import, evaluate, call or deserialize target code; P000 remains the parse-failure path.
+- local-binding boundary: worth taking an exact direct-body, preceding, single simple-name assignment. Control: explicit scope identity, all-write disqualification, branch exclusion, cycle/depth guard and unresolved fallback.
+- subprocess boundary: worth taking only the current resolved subprocess runner plus command/argv expression. Control: no shell execution, no runner-name expansion, no flag interpretation and no `env=` widening.
+- secret-material boundary: worth taking identifier spelling needed by the current `CREDENTIAL` grammar. Control: check names before substitution and emit only fixed diagnostics; never copy RHS values or payloads.
+- P008 trust boundary: worth taking only the current source-local import families plus eligible local aliases and safe neighbours. Control: retain ambiguous-import, cross-scope and loader conservatism fixed by S1-R1-01/02, S1-R2-01 and S1-R3-01.
+- repository-write boundary: worth taking only implementation, fixtures and governed records during later receipted steps. Control: no cache or target-file write from the checker; generation-only ledger verification; controller mutations remain controller-owned.
+
+## 10. The budget, or its absence
+
+No wall-time or throughput budget is justified: this is a local lint extension with no user-requested performance claim, and [Metron](../../plugins/hexaemeron/skills/metron/SKILL.md) forbids inventing one after the fact.
+
+The structural work bound is nevertheless testable: one collection pass per function, then bounded or memoized resolution; no per-call full-function rescan. The audit inspects that property and the focused suite exercises long/cyclic chains. There is no benchmark command because no performance budget exists. The correctness command is:
+
+```bash
+python3 -m unittest plugins.hexaemeron.tests.test_phylax_checker
+```
+
+It is evidence of behaviour, not a Metron performance measurement.
+
+## 11. The fail-closed posture
+
+The build is held to [Elenchus](../../plugins/hexaemeron/skills/elenchus/SKILL.md). Stop on parse failure, ambiguous scope identity, any second or unsupported write, a non-preceding assignment, a branch-local definition, a resolution cycle/depth limit, a changed diagnostic, secret echo, a focused regression, stale audit view, failed prose/tree lint, failed evolution check or changed frontier tuple.
+
+Each defect follows red, fix, green:
+
+1. Add the smallest focused fixture that reproduces the wrong classification on the exact base.
+2. Capture the expected current mismatch without treating a known red as a suite pass.
+3. Make one semantic change.
+4. Run the named fixture, the full focused checker suite and the complete selected repository gates.
+
+The five baseline probes in section 1 are the initial red evidence. Exclusion fixtures are guard tests even when already green: they prevent the narrow resolver from becoming accidental control-flow analysis. A nonzero, interrupted or wrong-interpreter run cannot close the guard.
+
+## 12. Decisions and their homes
+
+Decision ownership remains with [Hypomnema](../../plugins/hexaemeron/skills/hypomnema/SKILL.md).
+
+- The exact eligible-assignment grammar, rejected broad alternatives and accepted exclusions are skill-local and live in the tracked `docs/phylax-single-assignment-locals/study.md` copy plus its runbook. They do not earn a repository-wide ADR.
+- The implementation seam and name-first P004 ordering live beside the code in `plugins/hexaemeron/skills/phylax/scripts/phylax.py` and executable fixtures, not in a separate essay.
+- The durable release fact lives in one new `plugins/hexaemeron/skills/phylax/EVOLUTION.md` generation row. It must say single-assignment locals were added for P002/P004/P008 and list the exclusions that remain.
+- Audit dispositions live in the Fiat run's authoritative audit record and synopsis path chosen by the controller. Every risk-register id must be named reviewed or not applicable; legacy unknown fields remain unknown.
+- No decision in this prototype changes repository-wide architecture, an external interface or the mature frontier. If implementation discovers that a general scope engine or dependency is required, stop and seek a new decision rather than smuggling one into #502.
+
+The later implementation exit is complete only when the focused demonstration and selected full gates pass under Python 3.14.6, all tracked records agree, and the frontier tuple comparison is unchanged. This survey writes only this study artifact and does not receipt the controller.

--- a/plugins/hexaemeron/skills/phylax/EVOLUTION.md
+++ b/plugins/hexaemeron/skills/phylax/EVOLUTION.md
@@ -4,7 +4,7 @@
 
 Policy: [../VERSIONING.md](../VERSIONING.md)
 
-- Current version: `phylax-v1.4.0`
+- Current version: `phylax-v1.5.0`
 
 ## Frontier
 
@@ -22,3 +22,4 @@ Policy: [../VERSIONING.md](../VERSIONING.md)
 | `phylax-v1.2.0` | generation | `off-chain-boundary-controls` | `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604` | [credential argv fixtures](../../tests/test_phylax_checker.py), [study](../../../../docs/phylax-credential-argv/study.md) | P004 now walks only the inline argv expression of a resolved subprocess runner for credential-named values; assignment dataflow remains deliberately out of scope. |
 | `phylax-v1.3.0` | generation | `off-chain-boundary-controls` | `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604` | [unsafe-deserialization fixtures](../../tests/test_phylax_checker.py), [study](../../../../docs/phylax-unsafe-deserialization/study.md) | P008 adds source-local import resolution for the issue's pickle, marshal, YAML and dynamic-execution calls; assignment dataflow, custom-loader proofs and `marshal.loads` remain deliberately out of scope. |
 | `phylax-v1.4.0` | generation | `off-chain-boundary-controls` | `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604` | [hostile conformance manifest](../../tests/fixtures/model-proxy-v1/manifest.json), [component guards](../../tests/test_phylax_model_proxy.py), [normative reference](references/model-proxy-v1.md), [ADR-046](../../../../docs/decisions/ADR-046-use-a-job-scoped-model-proxy.md) | The synthetic job-scoped model proxy now has one digest-bound positive-and-hostile conformance command, content-free proof output, and explicit #698, #699, live-provider, public-pilot, and #702 Fiat integration/end-to-end dependency gaps; the mature lint frontier is unchanged. |
+| `phylax-v1.5.0` | generation | `off-chain-boundary-controls` | `3d0057bb195f303c0e40b5782bf59ab0cba53e3172478c6a331d5990236ac604` | [single-assignment fixtures](../../tests/test_phylax_checker.py), [study](../../../../docs/phylax-single-assignment-locals/study.md) | P002, P004 and P008 share an eight-hop resolver for preceding, once-bound direct function locals; rebinding, compound and unsupported targets, comprehensions, nested and closure scope, module scope and interprocedural analysis remain unresolved. |

--- a/plugins/hexaemeron/skills/phylax/SKILL.md
+++ b/plugins/hexaemeron/skills/phylax/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   Solidity, which belongs to solidity-auditor and x-ray, and do not use it to
   diagnose a failure that has already happened, which belongs to elenchus.
 metadata:
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 <p align="center">
@@ -42,7 +42,7 @@ an off-chain boundary, expose protected data, or authorise a control change.
 Its version, held frontier, next job, and maturity state live in
 [EVOLUTION.md](EVOLUTION.md).
 
-**Current state.** Phylax mechanically checks its established Python boundaries and source-local TypeScript controls for raw HTML ordering, persisted session credentials and runtime-selected absolute fetch hosts. This frontier is mature.
+**Current state.** Phylax mechanically checks its established Python boundaries and source-local TypeScript controls for raw HTML ordering, persisted session credentials and runtime-selected absolute fetch hosts. This frontier is mature. The Python pass also resolves preceding single-assignment locals in the exact containing function for P002, P004 and P008; every unsupported binding or scope stays unresolved.
 
 It also ships a synthetic job-scoped model proxy component: closed policy,
 framing, provider, lifecycle, receipt, operator-disclosure, and hostile-
@@ -326,8 +326,15 @@ The last rule resolves module and direct-import aliases for `pickle.load`,
 `yaml.load` call stays clean only when its second positional argument or
 `Loader=` value resolves directly to `SafeLoader` or `CSafeLoader`. An `eval`
 or `exec` call stays clean only when its first argument is an inline string or
-bytes constant. The parser does not follow assignments, prove input
-provenance, inspect custom loader classes or include `marshal.loads`.
+bytes constant. For P002, P004 and P008, one index per `FunctionDef` or
+`AsyncFunctionDef` exposes a name only when its one direct simple-name
+assignment precedes the use and no other binding or deletion of that name
+exists in the function. Resolution follows at most eight name assignments,
+checks P004 credential names before substitution, and leaves forward writes,
+rebinding, compound-statement writes, unsupported targets, imports,
+parameters, comprehensions, nested scopes, closures, module and class scope,
+cycles and longer chains unresolved. It does not prove input provenance,
+inspect custom loader classes or include `marshal.loads`.
 
 For tracked `.ts` and `.tsx` source it reports three source-local cases. A
 `rehype-raw` binding in a rendered plugin array needs a later

--- a/plugins/hexaemeron/skills/phylax/scripts/phylax.py
+++ b/plugins/hexaemeron/skills/phylax/scripts/phylax.py
@@ -40,6 +40,7 @@ BOUNDARY_CALLS = {
     "builtins": frozenset({"eval", "exec"}),
 }
 SAFE_YAML_LOADERS = frozenset({"SafeLoader", "CSafeLoader"})
+LOCAL_RESOLUTION_MAX_DEPTH = 8
 P008_MESSAGES = {
     "pickle": "pickle deserialization may execute untrusted code",
     "marshal": "marshal deserialization accepts untrusted data",
@@ -136,6 +137,174 @@ def _is_dynamic_literal(node: ast.AST) -> bool:
         isinstance(node, ast.Constant)
         and isinstance(node.value, (str, bytes))
     )
+
+
+def _position(node: ast.AST) -> tuple[int, int]:
+    return (getattr(node, "lineno", 0), getattr(node, "col_offset", 0))
+
+
+class _FunctionBindings:
+    """Eligible direct assignments in one exact function body."""
+
+    def __init__(
+        self,
+        assignments: dict[str, tuple[tuple[int, int], ast.AST]],
+    ) -> None:
+        self.assignments = assignments
+
+    def preceding(
+        self,
+        name: str,
+        before: tuple[int, int],
+    ) -> tuple[tuple[int, int], ast.AST] | None:
+        assignment = self.assignments.get(name)
+        if assignment is None or assignment[0] >= before:
+            return None
+        return assignment
+
+
+class _FunctionBindingCollector(ast.NodeVisitor):
+    """Collect one exact function without borrowing bindings from nested scopes."""
+
+    def __init__(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self.candidates: dict[str, tuple[tuple[int, int], ast.AST]] = {}
+        self.binding_counts: dict[str, int] = {}
+        arguments = node.args
+        for argument in (
+            *arguments.posonlyargs,
+            *arguments.args,
+            *arguments.kwonlyargs,
+        ):
+            self._bind(argument.arg)
+        if arguments.vararg is not None:
+            self._bind(arguments.vararg.arg)
+        if arguments.kwarg is not None:
+            self._bind(arguments.kwarg.arg)
+        for parameter in getattr(node, "type_params", ()):
+            self._bind(parameter.name)
+
+        for statement in node.body:
+            if (
+                isinstance(statement, ast.Assign)
+                and len(statement.targets) == 1
+                and isinstance(statement.targets[0], ast.Name)
+            ):
+                self.candidates[statement.targets[0].id] = (
+                    _position(statement),
+                    statement.value,
+                )
+            elif (
+                isinstance(statement, ast.AnnAssign)
+                and isinstance(statement.target, ast.Name)
+                and statement.value is not None
+            ):
+                self.candidates[statement.target.id] = (
+                    _position(statement),
+                    statement.value,
+                )
+            self.visit(statement)
+        self.bindings = _FunctionBindings({
+            name: candidate
+            for name, candidate in self.candidates.items()
+            if self.binding_counts.get(name) == 1
+        })
+
+    def _bind(self, name: str) -> None:
+        self.binding_counts[name] = self.binding_counts.get(name, 0) + 1
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            self._bind(node.id)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self._bind(alias.asname or alias.name.split(".", 1)[0])
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for alias in node.names:
+            if alias.name != "*":
+                self._bind(alias.asname or alias.name)
+
+    def visit_Global(self, node: ast.Global) -> None:
+        for name in node.names:
+            self._bind(name)
+
+    def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+        for name in node.names:
+            self._bind(name)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        if node.name:
+            self._bind(node.name)
+        self.generic_visit(node)
+
+    def visit_MatchAs(self, node: ast.MatchAs) -> None:
+        if node.name:
+            self._bind(node.name)
+        if node.pattern is not None:
+            self.visit(node.pattern)
+
+    def visit_MatchStar(self, node: ast.MatchStar) -> None:
+        if node.name:
+            self._bind(node.name)
+
+    def visit_MatchMapping(self, node: ast.MatchMapping) -> None:
+        if node.rest:
+            self._bind(node.rest)
+        self.generic_visit(node)
+
+    def _visit_function_header(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda,
+    ) -> None:
+        arguments = node.args
+        for argument in (
+            *arguments.posonlyargs,
+            *arguments.args,
+            *arguments.kwonlyargs,
+        ):
+            if argument.annotation is not None:
+                self.visit(argument.annotation)
+        if arguments.vararg is not None and arguments.vararg.annotation is not None:
+            self.visit(arguments.vararg.annotation)
+        if arguments.kwarg is not None and arguments.kwarg.annotation is not None:
+            self.visit(arguments.kwarg.annotation)
+        for default in (*arguments.defaults, *arguments.kw_defaults):
+            if default is not None:
+                self.visit(default)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._bind(node.name)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        self._visit_function_header(node)
+        if node.returns is not None:
+            self.visit(node.returns)
+        for parameter in getattr(node, "type_params", ()):
+            self.visit(parameter)
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._bind(node.name)
+        for expression in (
+            *node.decorator_list,
+            *node.bases,
+            *(keyword.value for keyword in node.keywords),
+            *getattr(node, "type_params", ()),
+        ):
+            self.visit(expression)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self._visit_function_header(node)
+
+
+def _function_bindings(tree: ast.AST) -> dict[ast.AST, _FunctionBindings]:
+    return {
+        node: _FunctionBindingCollector(node).bindings
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
 
 
 def _boundary_bindings(
@@ -239,6 +408,8 @@ class Visitor(ast.NodeVisitor):
         self.findings: list[Finding] = []
         self.modules: set[str] = set()
         self.direct: set[str] = set()
+        self.function_bindings = _function_bindings(tree)
+        self.local_bindings: _FunctionBindings | None = None
         (
             self.boundary_modules,
             self.boundary_direct,
@@ -246,6 +417,83 @@ class Visitor(ast.NodeVisitor):
             self.safe_yaml_loaders,
             self.ambiguous_boundary_calls,
         ) = _boundary_bindings(tree)
+
+    def _visit_function_header(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda,
+    ) -> None:
+        arguments = node.args
+        for argument in (
+            *arguments.posonlyargs,
+            *arguments.args,
+            *arguments.kwonlyargs,
+        ):
+            if argument.annotation is not None:
+                self.visit(argument.annotation)
+        if arguments.vararg is not None and arguments.vararg.annotation is not None:
+            self.visit(arguments.vararg.annotation)
+        if arguments.kwarg is not None and arguments.kwarg.annotation is not None:
+            self.visit(arguments.kwarg.annotation)
+        for default in (*arguments.defaults, *arguments.kw_defaults):
+            if default is not None:
+                self.visit(default)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        self._visit_function_header(node)
+        if node.returns is not None:
+            self.visit(node.returns)
+        for parameter in getattr(node, "type_params", ()):
+            self.visit(parameter)
+
+        previous = self.local_bindings
+        self.local_bindings = self.function_bindings[node]
+        try:
+            for statement in node.body:
+                self.visit(statement)
+        finally:
+            self.local_bindings = previous
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        for expression in (
+            *node.decorator_list,
+            *node.bases,
+            *(keyword.value for keyword in node.keywords),
+            *getattr(node, "type_params", ()),
+        ):
+            self.visit(expression)
+        previous = self.local_bindings
+        self.local_bindings = None
+        try:
+            for statement in node.body:
+                self.visit(statement)
+        finally:
+            self.local_bindings = previous
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self._visit_function_header(node)
+        previous = self.local_bindings
+        self.local_bindings = None
+        try:
+            self.visit(node.body)
+        finally:
+            self.local_bindings = previous
+
+    def _visit_comprehension_scope(self, node: ast.AST) -> None:
+        previous = self.local_bindings
+        self.local_bindings = None
+        try:
+            self.generic_visit(node)
+        finally:
+            self.local_bindings = previous
+
+    visit_ListComp = _visit_comprehension_scope
+    visit_SetComp = _visit_comprehension_scope
+    visit_DictComp = _visit_comprehension_scope
+    visit_GeneratorExp = _visit_comprehension_scope
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
@@ -266,6 +514,72 @@ class Visitor(ast.NodeVisitor):
             return (isinstance(base, ast.Name) and base.id in self.modules
                     and func.attr in RUNNERS)
         return isinstance(func, ast.Name) and func.id in self.direct
+
+    def _resolve_local(
+        self,
+        node: ast.AST,
+        *,
+        before: tuple[int, int] | None = None,
+        seen: frozenset[str] = frozenset(),
+        depth: int = 0,
+    ) -> ast.AST:
+        if self.local_bindings is None or not isinstance(node, ast.Name):
+            return node
+        if depth >= LOCAL_RESOLUTION_MAX_DEPTH or node.id in seen:
+            return node
+        assignment = self.local_bindings.preceding(
+            node.id,
+            before if before is not None else _position(node),
+        )
+        if assignment is None:
+            return node
+        position, value = assignment
+        return self._resolve_local(
+            value,
+            before=position,
+            seen=seen | {node.id},
+            depth=depth + 1,
+        )
+
+    def _credential_names(
+        self,
+        node: ast.AST,
+        *,
+        before: tuple[int, int] | None = None,
+        seen: frozenset[str] = frozenset(),
+        depth: int = 0,
+    ):
+        if isinstance(node, ast.Name):
+            if CREDENTIAL.search(node.id):
+                yield node.id
+                return
+            if (
+                self.local_bindings is None
+                or depth >= LOCAL_RESOLUTION_MAX_DEPTH
+                or node.id in seen
+            ):
+                return
+            assignment = self.local_bindings.preceding(
+                node.id,
+                before if before is not None else _position(node),
+            )
+            if assignment is None:
+                return
+            position, value = assignment
+            yield from self._credential_names(
+                value,
+                before=position,
+                seen=seen | {node.id},
+                depth=depth + 1,
+            )
+            return
+        for child in ast.iter_child_nodes(node):
+            yield from self._credential_names(
+                child,
+                before=before,
+                seen=seen,
+                depth=depth,
+            )
 
     def _add(self, node: ast.AST, code: str, message: str) -> None:
         self.findings.append(Finding(self.path, node.lineno, code, message))
@@ -293,22 +607,26 @@ class Visitor(ast.NodeVisitor):
         return isinstance(loader, ast.Name) and loader.id in self.safe_yaml_loaders
 
     def _check_p008(self, node: ast.Call) -> None:
+        function = self._resolve_local(node.func)
         binding = (
-            node.func.value.id
-            if isinstance(node.func, ast.Attribute)
-            and isinstance(node.func.value, ast.Name)
-            else node.func.id if isinstance(node.func, ast.Name) else None
+            function.value.id
+            if isinstance(function, ast.Attribute)
+            and isinstance(function.value, ast.Name)
+            else function.id if isinstance(function, ast.Name) else None
         )
         loader = next(
             (keyword.value for keyword in node.keywords if keyword.arg == "Loader"),
             node.args[1] if len(node.args) > 1 else None,
         )
-        for module in sorted(self._boundary_modules(node.func)):
+        if loader is not None:
+            loader = self._resolve_local(loader)
+        dynamic_source = self._resolve_local(node.args[0]) if node.args else None
+        for module in sorted(self._boundary_modules(function)):
             if module == "yaml":
                 if loader is not None and self._safe_yaml_loader(loader):
                     continue
             elif module == "builtins":
-                if not node.args or _is_dynamic_literal(node.args[0]):
+                if dynamic_source is None or _is_dynamic_literal(dynamic_source):
                     continue
             message = (
                 P008_AMBIGUOUS_MESSAGE
@@ -324,20 +642,24 @@ class Visitor(ast.NodeVisitor):
             for kw in node.keywords:
                 if kw.arg == "shell" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
                     self._add(node, "P001", "shell invocation; pass an argument list instead")
-            if node.args and _is_string(node.args[0]):
-                built = " built by formatting" if _is_formatted(node.args[0]) else ""
-                self._add(node, "P002", f"command passed as a string{built}; pass a list")
-            argv = node.args[0] if node.args else next(
+            command = node.args[0] if node.args else next(
                 (kw.value for kw in node.keywords if kw.arg == "args"), None
             )
-            if argv is not None:
-                for value in ast.walk(argv):
-                    if isinstance(value, ast.Name) and CREDENTIAL.search(value.id):
-                        self._add(
-                            node,
-                            "P004",
-                            f"credential-named value `{value.id}` passed in command arguments",
-                        )
+            resolved_command = (
+                self._resolve_local(command) if command is not None else None
+            )
+            if resolved_command is not None and _is_string(resolved_command):
+                built = (
+                    " built by formatting" if _is_formatted(resolved_command) else ""
+                )
+                self._add(node, "P002", f"command passed as a string{built}; pass a list")
+            if command is not None:
+                for name in self._credential_names(command):
+                    self._add(
+                        node,
+                        "P004",
+                        f"credential-named value `{name}` passed in command arguments",
+                    )
 
         if _attr_name(node.func) in WRITERS:
             for arg in node.args + [kw.value for kw in node.keywords]:

--- a/plugins/hexaemeron/skills/phylax/scripts/phylax.py
+++ b/plugins/hexaemeron/skills/phylax/scripts/phylax.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+from collections import deque
 import json
 import re
 import sys
@@ -143,6 +144,14 @@ def _position(node: ast.AST) -> tuple[int, int]:
     return (getattr(node, "lineno", 0), getattr(node, "col_offset", 0))
 
 
+def _binding_position(node: ast.AST) -> tuple[int, int]:
+    """Return the point after an assignment's RHS has been evaluated."""
+    return (
+        getattr(node, "end_lineno", getattr(node, "lineno", 0)),
+        getattr(node, "end_col_offset", getattr(node, "col_offset", 0)),
+    )
+
+
 class _FunctionBindings:
     """Eligible direct assignments in one exact function body."""
 
@@ -190,7 +199,7 @@ class _FunctionBindingCollector(ast.NodeVisitor):
                 and isinstance(statement.targets[0], ast.Name)
             ):
                 self.candidates[statement.targets[0].id] = (
-                    _position(statement),
+                    _binding_position(statement),
                     statement.value,
                 )
             elif (
@@ -199,7 +208,7 @@ class _FunctionBindingCollector(ast.NodeVisitor):
                 and statement.value is not None
             ):
                 self.candidates[statement.target.id] = (
-                    _position(statement),
+                    _binding_position(statement),
                     statement.value,
                 )
             self.visit(statement)
@@ -297,6 +306,28 @@ class _FunctionBindingCollector(ast.NodeVisitor):
 
     def visit_Lambda(self, node: ast.Lambda) -> None:
         self._visit_function_header(node)
+
+    def _visit_comprehension_scope(
+        self,
+        node: ast.ListComp | ast.SetComp | ast.DictComp | ast.GeneratorExp,
+    ) -> None:
+        # Comprehension targets belong to the implicit comprehension scope.
+        # The other expressions can still contain a NamedExpr, whose target
+        # Python binds in this containing function and must count as a write.
+        if isinstance(node, ast.DictComp):
+            self.visit(node.key)
+            self.visit(node.value)
+        else:
+            self.visit(node.elt)
+        for generator in node.generators:
+            self.visit(generator.iter)
+            for condition in generator.ifs:
+                self.visit(condition)
+
+    visit_ListComp = _visit_comprehension_scope
+    visit_SetComp = _visit_comprehension_scope
+    visit_DictComp = _visit_comprehension_scope
+    visit_GeneratorExp = _visit_comprehension_scope
 
 
 def _function_bindings(tree: ast.AST) -> dict[ast.AST, _FunctionBindings]:
@@ -410,6 +441,9 @@ class Visitor(ast.NodeVisitor):
         self.direct: set[str] = set()
         self.function_bindings = _function_bindings(tree)
         self.local_bindings: _FunctionBindings | None = None
+        self.credential_names_cache: dict[
+            tuple[_FunctionBindings, str, int], tuple[str, ...]
+        ] = {}
         (
             self.boundary_modules,
             self.boundary_direct,
@@ -548,38 +582,99 @@ class Visitor(ast.NodeVisitor):
         before: tuple[int, int] | None = None,
         seen: frozenset[str] = frozenset(),
         depth: int = 0,
+        resolution_enabled: bool = True,
     ):
-        if isinstance(node, ast.Name):
-            if CREDENTIAL.search(node.id):
-                yield node.id
-                return
-            if (
-                self.local_bindings is None
-                or depth >= LOCAL_RESOLUTION_MAX_DEPTH
-                or node.id in seen
-            ):
-                return
-            assignment = self.local_bindings.preceding(
+        cache_key = None
+        if (
+            resolution_enabled
+            and self.local_bindings is not None
+            and isinstance(node, ast.Name)
+            and not CREDENTIAL.search(node.id)
+            and not seen
+            and depth < LOCAL_RESOLUTION_MAX_DEPTH
+            and node.id not in seen
+            and self.local_bindings.preceding(
                 node.id,
                 before if before is not None else _position(node),
             )
-            if assignment is None:
+            is not None
+        ):
+            cache_key = (self.local_bindings, node.id, depth)
+            cached = self.credential_names_cache.get(cache_key)
+            if cached is not None:
+                yield from cached
                 return
-            position, value = assignment
-            yield from self._credential_names(
-                value,
-                before=position,
-                seen=seen | {node.id},
-                depth=depth + 1,
+
+        found = []
+        expanded: set[tuple[str, int]] = set()
+        worklist = deque([(node, resolution_enabled, before, seen, depth)])
+        while worklist:
+            current, can_resolve, current_before, current_seen, current_depth = (
+                worklist.popleft()
             )
-            return
-        for child in ast.iter_child_nodes(node):
-            yield from self._credential_names(
-                child,
-                before=before,
-                seen=seen,
-                depth=depth,
+            if isinstance(current, ast.Name):
+                if CREDENTIAL.search(current.id):
+                    found.append(current.id)
+                    continue
+                if (
+                    not can_resolve
+                    or self.local_bindings is None
+                    or current_depth >= LOCAL_RESOLUTION_MAX_DEPTH
+                    or current.id in current_seen
+                ):
+                    continue
+                assignment = self.local_bindings.preceding(
+                    current.id,
+                    current_before
+                    if current_before is not None
+                    else _position(current),
+                )
+                if assignment is None:
+                    continue
+                expansion = (current.id, current_depth)
+                if expansion in expanded:
+                    continue
+                expanded.add(expansion)
+                position, value = assignment
+                worklist.append(
+                    (
+                        value,
+                        True,
+                        position,
+                        current_seen | {current.id},
+                        current_depth + 1,
+                    )
+                )
+                continue
+
+            child_resolution = can_resolve and not isinstance(
+                current,
+                (
+                    ast.Lambda,
+                    ast.ListComp,
+                    ast.SetComp,
+                    ast.DictComp,
+                    ast.GeneratorExp,
+                    ast.Attribute,
+                    ast.Subscript,
+                    ast.Starred,
+                ),
             )
+            worklist.extend(
+                (
+                    child,
+                    child_resolution,
+                    current_before,
+                    current_seen,
+                    current_depth,
+                )
+                for child in ast.iter_child_nodes(current)
+            )
+
+        result = tuple(found)
+        if cache_key is not None:
+            self.credential_names_cache[cache_key] = result
+        yield from result
 
     def _add(self, node: ast.AST, code: str, message: str) -> None:
         self.findings.append(Finding(self.path, node.lineno, code, message))
@@ -608,6 +703,12 @@ class Visitor(ast.NodeVisitor):
 
     def _check_p008(self, node: ast.Call) -> None:
         function = self._resolve_local(node.func)
+        original_binding = (
+            node.func.value.id
+            if isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            else node.func.id if isinstance(node.func, ast.Name) else None
+        )
         binding = (
             function.value.id
             if isinstance(function, ast.Attribute)
@@ -621,7 +722,13 @@ class Visitor(ast.NodeVisitor):
         if loader is not None:
             loader = self._resolve_local(loader)
         dynamic_source = self._resolve_local(node.args[0]) if node.args else None
-        for module in sorted(self._boundary_modules(function)):
+        modules = self._boundary_modules(node.func) | self._boundary_modules(function)
+        ambiguous = (
+            len(modules) > 1
+            or original_binding in self.ambiguous_boundary_calls
+            or binding in self.ambiguous_boundary_calls
+        )
+        for module in sorted(modules):
             if module == "yaml":
                 if loader is not None and self._safe_yaml_loader(loader):
                     continue
@@ -630,7 +737,7 @@ class Visitor(ast.NodeVisitor):
                     continue
             message = (
                 P008_AMBIGUOUS_MESSAGE
-                if binding in self.ambiguous_boundary_calls
+                if ambiguous
                 else P008_MESSAGES[module]
             )
             self._add(node, "P008", message)

--- a/plugins/hexaemeron/tests/test_phylax_checker.py
+++ b/plugins/hexaemeron/tests/test_phylax_checker.py
@@ -36,6 +36,504 @@ def findings(source, name="sample.ts"):
         return phylax.check(path)
 
 
+class SingleAssignmentLocalProbes(unittest.TestCase):
+    def assert_codes(self, expected, specimens):
+        for label, source in specimens.items():
+            with self.subTest(label=label):
+                self.assertEqual(expected, codes(source))
+
+    def test_the_five_observed_misclassifications_are_corrected(self):
+        specimens = {
+            "assigned-p002-command": (
+                "import subprocess\n"
+                "def run():\n"
+                "    command = 'git status'\n"
+                "    subprocess.run(command)\n",
+                ["P002"],
+            ),
+            "assigned-p004-argv": (
+                "import subprocess\n"
+                "def run():\n"
+                "    secret = load()\n"
+                "    argv = ['tool', secret]\n"
+                "    subprocess.run(argv)\n",
+                ["P004"],
+            ),
+            "assigned-literal-eval": (
+                "def run():\n"
+                "    source = '1 + 1'\n"
+                "    return eval(source)\n",
+                [],
+            ),
+            "assigned-safe-loader": (
+                "import yaml\n"
+                "def run(payload):\n"
+                "    loader = yaml.SafeLoader\n"
+                "    return yaml.load(payload, Loader=loader)\n",
+                [],
+            ),
+            "assigned-pickle-callable": (
+                "import pickle\n"
+                "def run(payload):\n"
+                "    decode = pickle.loads\n"
+                "    return decode(payload)\n",
+                ["P008"],
+            ),
+        }
+        for label, (source, expected) in specimens.items():
+            with self.subTest(label=label):
+                self.assertEqual(expected, codes(source))
+
+    def test_subprocess_slots_and_runner_aliases_resolve(self):
+        self.assert_codes(["P002"], {
+            "module-positional": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    command = 'git status'\n"
+                "    subprocess.run(command)\n"
+            ),
+            "module-alias-keyword": (
+                "import subprocess as sp\n"
+                "def invoke():\n"
+                "    command = 'git status'\n"
+                "    sp.check_call(args=command)\n"
+            ),
+            "direct-positional": (
+                "from subprocess import check_output\n"
+                "def invoke():\n"
+                "    command: str = 'git status'\n"
+                "    check_output(command)\n"
+            ),
+            "direct-alias-keyword-async": (
+                "from subprocess import Popen as spawn\n"
+                "async def invoke():\n"
+                "    command = 'git status'\n"
+                "    spawn(args=command)\n"
+            ),
+        })
+        self.assert_codes(["P004"], {
+            "module-positional": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    secret = load()\n"
+                "    argv = ['tool', secret]\n"
+                "    subprocess.run(argv)\n"
+            ),
+            "module-alias-keyword": (
+                "import subprocess as sp\n"
+                "def invoke():\n"
+                "    auth_token = load()\n"
+                "    argv = ['tool', auth_token]\n"
+                "    sp.call(args=argv)\n"
+            ),
+            "direct-alias-keyword": (
+                "from subprocess import check_output as invoke\n"
+                "def run():\n"
+                "    private_key = load()\n"
+                "    argv = ('tool', private_key)\n"
+                "    invoke(args=argv)\n"
+            ),
+        })
+
+    def test_p004_checks_names_before_substitution(self):
+        sentinel = "assigned-argv-sentinel"
+        result = findings(
+            "import subprocess\n"
+            "def invoke():\n"
+            f"    secret = load('{sentinel}')\n"
+            "    value = secret\n"
+            "    argv = ['tool', value]\n"
+            "    subprocess.run(argv)\n",
+            "sample.py",
+        )
+        self.assertEqual(["P004"], [finding.code for finding in result])
+        self.assertEqual(6, result[0].line)
+        self.assertEqual(
+            "credential-named value `secret` passed in command arguments",
+            result[0].message,
+        )
+        self.assertNotIn(sentinel, str(result[0]))
+        self.assertNotIn(sentinel, json.dumps(result[0].as_dict()))
+
+    def test_p008_callable_and_safe_neighbour_resolution(self):
+        self.assert_codes(["P008"], {
+            "module-callable": (
+                "import pickle\n"
+                "def decode(payload):\n"
+                "    dangerous = pickle.loads\n"
+                "    return dangerous(payload)\n"
+            ),
+            "module-alias-callable": (
+                "import marshal as codec\n"
+                "def decode(stream):\n"
+                "    dangerous = codec.load\n"
+                "    return dangerous(stream)\n"
+            ),
+            "direct-callable": (
+                "from pickle import load as deserialize\n"
+                "def decode(stream):\n"
+                "    dangerous = deserialize\n"
+                "    return dangerous(stream)\n"
+            ),
+            "bare-dynamic-callable": (
+                "def decode(payload):\n"
+                "    dangerous = eval\n"
+                "    return dangerous(payload)\n"
+            ),
+            "unsafe-loader": (
+                "import yaml\n"
+                "def decode(payload):\n"
+                "    loader = yaml.FullLoader\n"
+                "    return yaml.load(payload, Loader=loader)\n"
+            ),
+            "assigned-nonliteral-dynamic-input": (
+                "def decode(payload):\n"
+                "    source = payload\n"
+                "    return eval(source)\n"
+            ),
+        })
+        self.assert_codes([], {
+            "literal-eval": (
+                "def decode():\n"
+                "    source = '1 + 1'\n"
+                "    return eval(source)\n"
+            ),
+            "literal-bytes-direct-alias": (
+                "from builtins import exec as execute\n"
+                "def decode():\n"
+                "    source = b'pass'\n"
+                "    return execute(source)\n"
+            ),
+            "module-safe-loader-keyword": (
+                "import yaml\n"
+                "def decode(payload):\n"
+                "    loader = yaml.SafeLoader\n"
+                "    return yaml.load(payload, Loader=loader)\n"
+            ),
+            "module-csafe-loader-positional": (
+                "import yaml as parser\n"
+                "def decode(payload):\n"
+                "    loader = parser.CSafeLoader\n"
+                "    return parser.load(payload, loader)\n"
+            ),
+            "direct-safe-loader-keyword": (
+                "from yaml import load, SafeLoader as Safe\n"
+                "def decode(payload):\n"
+                "    loader = Safe\n"
+                "    return load(payload, Loader=loader)\n"
+            ),
+            "assigned-argv-list": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    argv = ['git', 'status']\n"
+                "    subprocess.run(argv)\n"
+            ),
+        })
+
+    def test_ambiguous_import_guards_survive_callable_resolution(self):
+        result = findings(
+            "import pickle as codec\n"
+            "import yaml as codec\n"
+            "def decode(payload):\n"
+            "    dangerous = codec.load\n"
+            "    return dangerous(payload)\n",
+            "sample.py",
+        )
+        self.assertEqual(["P008"], [finding.code for finding in result])
+        self.assertEqual(
+            "source-local bindings leave the boundary call family unresolved",
+            result[0].message,
+        )
+
+    def test_each_chain_definition_must_precede_its_rhs_use(self):
+        self.assertEqual(["P002"], codes(
+            "import subprocess\n"
+            "def invoke():\n"
+            "    literal = 'git status'\n"
+            "    command = literal\n"
+            "    subprocess.run(command)\n"
+        ))
+        self.assertEqual([], codes(
+            "import subprocess\n"
+            "def invoke():\n"
+            "    command = later\n"
+            "    later = 'git status'\n"
+            "    subprocess.run(command)\n"
+        ))
+
+    def test_reassignments_and_nonassignment_writes_refuse_resolution(self):
+        self.assert_codes([], {
+            "reassignment": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    command = 'git status'\n"
+                "    command = 'git diff'\n"
+                "    subprocess.run(command)\n"
+            ),
+            "augmented-assignment": (
+                "import subprocess\n"
+                "def invoke(suffix):\n"
+                "    command = 'git'\n"
+                "    command += suffix\n"
+                "    subprocess.run(command)\n"
+            ),
+            "deletion": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    command = 'git status'\n"
+                "    del command\n"
+                "    subprocess.run(command)\n"
+            ),
+            "named-expression": (
+                "import subprocess\n"
+                "def invoke(other):\n"
+                "    command = 'git status'\n"
+                "    consume(command := other)\n"
+                "    subprocess.run(command)\n"
+            ),
+            "unvalued-annotation": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    command = 'git status'\n"
+                "    command: str\n"
+                "    subprocess.run(command)\n"
+            ),
+        })
+
+    def test_compound_statement_bindings_refuse_resolution(self):
+        self.assert_codes([], {
+            "branch-local-assignment": (
+                "import subprocess\n"
+                "def invoke(flag):\n"
+                "    if flag:\n"
+                "        command = 'git status'\n"
+                "    subprocess.run(command)\n"
+            ),
+            "branch-reassignment": (
+                "import subprocess\n"
+                "def invoke(flag):\n"
+                "    command = 'git status'\n"
+                "    if flag:\n"
+                "        command = 'git diff'\n"
+                "    subprocess.run(command)\n"
+            ),
+            "loop-target": (
+                "import subprocess\n"
+                "def invoke(values):\n"
+                "    command = 'git status'\n"
+                "    for command in values:\n"
+                "        pass\n"
+                "    subprocess.run(command)\n"
+            ),
+            "with-target": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    command = 'git status'\n"
+                "    with opened() as command:\n"
+                "        pass\n"
+                "    subprocess.run(command)\n"
+            ),
+            "exception-name": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    command = 'git status'\n"
+                "    try:\n"
+                "        work()\n"
+                "    except Exception as command:\n"
+                "        pass\n"
+                "    subprocess.run(command)\n"
+            ),
+            "match-capture": (
+                "import subprocess\n"
+                "def invoke(value):\n"
+                "    command = 'git status'\n"
+                "    match value:\n"
+                "        case {'command': command}:\n"
+                "            pass\n"
+                "    subprocess.run(command)\n"
+            ),
+        })
+
+    def test_unsupported_targets_definitions_imports_and_declarations_refuse(self):
+        self.assert_codes([], {
+            "chained-targets": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    command = alias = 'git status'\n"
+                "    subprocess.run(command)\n"
+            ),
+            "destructuring": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    command, other = pair()\n"
+                "    subprocess.run(command)\n"
+            ),
+            "attribute": (
+                "import subprocess\n"
+                "def invoke(holder):\n"
+                "    holder.command = 'git status'\n"
+                "    subprocess.run(holder.command)\n"
+            ),
+            "subscript": (
+                "import subprocess\n"
+                "def invoke(values):\n"
+                "    values[0] = 'git status'\n"
+                "    subprocess.run(values[0])\n"
+            ),
+            "parameter": (
+                "import subprocess\n"
+                "def invoke(command):\n"
+                "    subprocess.run(command)\n"
+            ),
+            "import-binding": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    command = 'git status'\n"
+                "    import package as command\n"
+                "    subprocess.run(command)\n"
+            ),
+            "nested-function-name": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    command = 'git status'\n"
+                "    def command():\n"
+                "        pass\n"
+                "    subprocess.run(command)\n"
+            ),
+            "nested-class-name": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    command = 'git status'\n"
+                "    class command:\n"
+                "        pass\n"
+                "    subprocess.run(command)\n"
+            ),
+            "global-declaration": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    global command\n"
+                "    command = 'git status'\n"
+                "    subprocess.run(command)\n"
+            ),
+            "nonlocal-declaration": (
+                "import subprocess\n"
+                "def outer():\n"
+                "    command = 'git status'\n"
+                "    def invoke():\n"
+                "        nonlocal command\n"
+                "        subprocess.run(command)\n"
+            ),
+        })
+
+    def test_scope_boundaries_refuse_resolution(self):
+        self.assert_codes([], {
+            "module-scope": (
+                "import subprocess\n"
+                "command = 'git status'\n"
+                "def invoke():\n"
+                "    subprocess.run(command)\n"
+            ),
+            "closure": (
+                "import subprocess\n"
+                "def outer():\n"
+                "    command = 'git status'\n"
+                "    def invoke():\n"
+                "        subprocess.run(command)\n"
+            ),
+            "sibling-function": (
+                "import subprocess\n"
+                "def first():\n"
+                "    command = 'git status'\n"
+                "def invoke():\n"
+                "    subprocess.run(command)\n"
+            ),
+            "lambda-closure": (
+                "import subprocess\n"
+                "def outer():\n"
+                "    command = 'git status'\n"
+                "    return lambda: subprocess.run(command)\n"
+            ),
+            "comprehension-closure": (
+                "import subprocess\n"
+                "def outer(values):\n"
+                "    command = 'git status'\n"
+                "    return [subprocess.run(command) for _ in values]\n"
+            ),
+            "comprehension-target": (
+                "import subprocess\n"
+                "def invoke(values):\n"
+                "    [command for command in values]\n"
+                "    subprocess.run(command)\n"
+            ),
+        })
+
+    def test_forward_cycles_and_depth_exhaustion_refuse_resolution(self):
+        self.assert_codes([], {
+            "forward-assignment": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    subprocess.run(command)\n"
+                "    command = 'git status'\n"
+            ),
+            "self-cycle": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    command = command\n"
+                "    subprocess.run(command)\n"
+            ),
+            "two-name-cycle": (
+                "import subprocess\n"
+                "def invoke():\n"
+                "    first = second\n"
+                "    second = first\n"
+                "    subprocess.run(first)\n"
+            ),
+        })
+        limit = phylax.LOCAL_RESOLUTION_MAX_DEPTH
+
+        def chained(alias_count):
+            lines = ["import subprocess", "def invoke():"]
+            lines.append(f"    value_{alias_count} = 'git status'")
+            for index in range(alias_count - 1, -1, -1):
+                lines.append(f"    value_{index} = value_{index + 1}")
+            lines.append("    subprocess.run(value_0)")
+            return "\n".join(lines) + "\n"
+
+        self.assertEqual(["P002"], codes(chained(limit - 1)))
+        self.assertEqual([], codes(chained(limit)))
+
+    def test_sink_line_suppressions_and_fixed_diagnostics_survive_resolution(self):
+        self.assertEqual([], codes(
+            "import subprocess\n"
+            "def invoke():\n"
+            "    command = 'git status'\n"
+            "    subprocess.run(command)  # phylax: allow reviewed wrapper\n"
+        ))
+        self.assertEqual(["P002"], codes(
+            "import subprocess\n"
+            "def invoke():\n"
+            "    command = 'git status'\n"
+            "    subprocess.run(command)  # phylax: allow\n"
+        ))
+        sentinel = "assigned-diagnostic-sentinel"
+        result = findings(
+            "import pickle\n"
+            "def decode():\n"
+            "    dangerous = pickle.loads\n"
+            f"    payload = receive('{sentinel}')\n"
+            "    dangerous(payload)\n",
+            "sample.py",
+        )
+        self.assertEqual(["P008"], [finding.code for finding in result])
+        self.assertEqual(5, result[0].line)
+        self.assertEqual(
+            "pickle deserialization may execute untrusted code",
+            result[0].message,
+        )
+        self.assertNotIn(sentinel, str(result[0]))
+        self.assertNotIn(sentinel, json.dumps(result[0].as_dict()))
+
+
 class UnsafeDeserialization(unittest.TestCase):
     def assert_p008(self, specimens):
         for label, source in specimens.items():

--- a/plugins/hexaemeron/tests/test_phylax_checker.py
+++ b/plugins/hexaemeron/tests/test_phylax_checker.py
@@ -13,6 +13,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "skills" / "phylax" / "scripts" / "phylax.py"
@@ -155,6 +156,157 @@ class SingleAssignmentLocalProbes(unittest.TestCase):
         self.assertNotIn(sentinel, str(result[0]))
         self.assertNotIn(sentinel, json.dumps(result[0].as_dict()))
 
+    def test_p004_preserves_inline_breadth_first_diagnostic_order(self):
+        result = findings(
+            "import subprocess\n"
+            "subprocess.run([[secret], auth_token])\n",
+            "sample.py",
+        )
+        self.assertEqual(
+            [
+                "credential-named value `auth_token` passed in command arguments",
+                "credential-named value `secret` passed in command arguments",
+            ],
+            [finding.message for finding in result],
+        )
+
+    def test_p004_preserves_breadth_first_order_across_local_expansion(self):
+        result = findings(
+            "import subprocess\n"
+            "def invoke(secret, auth_token):\n"
+            "    alias = [auth_token]\n"
+            "    subprocess.run([[secret], alias])\n",
+            "sample.py",
+        )
+        self.assertEqual(
+            [
+                "credential-named value `secret` passed in command arguments",
+                "credential-named value `auth_token` passed in command arguments",
+            ],
+            [finding.message for finding in result],
+        )
+
+    def test_p004_alias_fanout_does_not_multiply_findings(self):
+        result = findings(
+            "import subprocess\n"
+            "def invoke(secret):\n"
+            "    value_0 = [secret]\n"
+            "    value_1 = [value_0, value_0]\n"
+            "    value_2 = [value_1, value_1]\n"
+            "    subprocess.run(value_2)\n",
+            "sample.py",
+        )
+        self.assertEqual(
+            ["credential-named value `secret` passed in command arguments"],
+            [finding.message for finding in result],
+        )
+
+    def test_p004_does_not_resolve_through_nested_expression_scopes(self):
+        prefix = (
+            "import subprocess\n"
+            "def invoke(items):\n"
+            "    secret = load()\n"
+            "    value = secret\n"
+        )
+        suffix = "    subprocess.run(argv)\n"
+        self.assert_codes([], {
+            "lambda": prefix + "    argv = ['tool', lambda: value]\n" + suffix,
+            "list-comprehension": (
+                prefix
+                + "    argv = ['tool', *[value for _ in items]]\n"
+                + suffix
+            ),
+            "set-comprehension": (
+                prefix
+                + "    argv = ['tool', {value for _ in items}]\n"
+                + suffix
+            ),
+            "dict-comprehension": (
+                prefix
+                + "    argv = ['tool', {item: value for item in items}]\n"
+                + suffix
+            ),
+            "generator-expression": (
+                prefix
+                + "    argv = ['tool', *(value for _ in items)]\n"
+                + suffix
+            ),
+        })
+        self.assertEqual(["P004"], codes(
+            "import subprocess\n"
+            "def invoke(items, auth_token):\n"
+            "    argv = ['tool', *[auth_token for _ in items]]\n"
+            "    subprocess.run(argv)\n"
+        ))
+
+    def test_p004_does_not_resolve_through_excluded_expression_shapes(self):
+        prefix = (
+            "import subprocess\n"
+            "def invoke():\n"
+            "    secret = load()\n"
+            "    value = secret\n"
+        )
+        self.assert_codes([], {
+            "starred-command": prefix + "    subprocess.run(*value)\n",
+            "assigned-starred-element": (
+                prefix
+                + "    argv = ['tool', *value]\n"
+                + "    subprocess.run(argv)\n"
+            ),
+            "attribute-command": prefix + "    subprocess.run(value.argv)\n",
+            "subscript-command": prefix + "    subprocess.run(value[0])\n",
+        })
+        self.assert_codes(["P004"], {
+            "direct-starred-name": (
+                "import subprocess\n"
+                "def invoke(auth_token):\n"
+                "    subprocess.run(*auth_token)\n"
+            ),
+            "direct-attribute-base": (
+                "import subprocess\n"
+                "def invoke(auth_token):\n"
+                "    subprocess.run(auth_token.argv)\n"
+            ),
+            "direct-subscript-base": (
+                "import subprocess\n"
+                "def invoke(auth_token):\n"
+                "    subprocess.run(auth_token[0])\n"
+            ),
+        })
+
+    def test_reused_assigned_argv_is_scanned_once(self):
+        source = (
+            "import subprocess\n"
+            "def invoke():\n"
+            "    value = ordinary()\n"
+            "    argv = ['tool', value]\n"
+            + "    subprocess.run(argv)\n" * 20
+        )
+        tree = phylax.ast.parse(source)
+        argv = next(
+            node.value
+            for node in phylax.ast.walk(tree)
+            if isinstance(node, phylax.ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], phylax.ast.Name)
+            and node.targets[0].id == "argv"
+        )
+        visitor = phylax.Visitor(Path("sample.py"), tree)
+        original = phylax.ast.iter_child_nodes
+        argv_visits = 0
+
+        def counted(node):
+            nonlocal argv_visits
+            if node is argv:
+                argv_visits += 1
+            return original(node)
+
+        with mock.patch.object(phylax.ast, "iter_child_nodes", side_effect=counted):
+            visitor.visit(tree)
+
+        self.assertEqual([], visitor.findings)
+        self.assertEqual(1, argv_visits)
+
     def test_p008_callable_and_safe_neighbour_resolution(self):
         self.assert_codes(["P008"], {
             "module-callable": (
@@ -245,6 +397,30 @@ class SingleAssignmentLocalProbes(unittest.TestCase):
             result[0].message,
         )
 
+    def test_p008_resolution_does_not_erase_original_boundary_evidence(self):
+        self.assert_codes(["P008"], {
+            "bare-dynamic-shadow": (
+                "def decode(payload):\n"
+                "    eval = harmless\n"
+                "    return eval(payload)\n"
+            ),
+            "module-imported-direct-shadow": (
+                "from pickle import loads\n"
+                "def decode(payload):\n"
+                "    loads = harmless\n"
+                "    return loads(payload)\n"
+            ),
+        })
+        result = findings(
+            "import pickle\n"
+            "def decode(payload):\n"
+            "    eval = pickle.loads\n"
+            "    return eval(payload)\n",
+            "sample.py",
+        )
+        self.assertEqual(["P008"], [finding.code for finding in result])
+        self.assertEqual(phylax.P008_AMBIGUOUS_MESSAGE, result[0].message)
+
     def test_each_chain_definition_must_precede_its_rhs_use(self):
         self.assertEqual(["P002"], codes(
             "import subprocess\n"
@@ -259,6 +435,29 @@ class SingleAssignmentLocalProbes(unittest.TestCase):
             "    command = later\n"
             "    later = 'git status'\n"
             "    subprocess.run(command)\n"
+        ))
+
+    def test_assignment_is_not_visible_inside_its_own_rhs(self):
+        self.assertEqual(["P002"], codes(
+            "import subprocess\n"
+            "def invoke():\n"
+            "    command = 'git status'; subprocess.run(command)\n"
+        ))
+        self.assert_codes(["P008"], {
+            "bare-dynamic-call": (
+                "def decode(payload):\n"
+                "    eval = eval(payload)\n"
+            ),
+            "direct-boundary-call": (
+                "from pickle import loads as decode\n"
+                "def invoke(payload):\n"
+                "    decode = decode(payload)\n"
+            ),
+        })
+        self.assertEqual([], codes(
+            "import subprocess\n"
+            "def invoke(secret):\n"
+            "    argv = subprocess.run(argv, env={'X': secret})\n"
         ))
 
     def test_reassignments_and_nonassignment_writes_refuse_resolution(self):
@@ -463,6 +662,28 @@ class SingleAssignmentLocalProbes(unittest.TestCase):
                 "import subprocess\n"
                 "def invoke(values):\n"
                 "    [command for command in values]\n"
+                "    subprocess.run(command)\n"
+            ),
+        })
+
+    def test_comprehension_targets_do_not_disqualify_outer_assignments(self):
+        self.assert_codes(["P002"], {
+            "same-name-target": (
+                "import subprocess\n"
+                "def invoke(values):\n"
+                "    command = 'git status'\n"
+                "    [command for command in values]\n"
+                "    subprocess.run(command)\n"
+            ),
+        })
+
+    def test_comprehension_named_expression_disqualifies_outer_assignment(self):
+        self.assert_codes([], {
+            "containing-function-write": (
+                "import subprocess\n"
+                "def invoke(values):\n"
+                "    command = 'git status'\n"
+                "    [value for value in values if (command := value)]\n"
                 "    subprocess.run(command)\n"
             ),
         })

--- a/plugins/hexaemeron/tests/test_phylax_model_proxy.py
+++ b/plugins/hexaemeron/tests/test_phylax_model_proxy.py
@@ -5621,8 +5621,8 @@ class ConformanceTests(unittest.TestCase):
         skill_root = PLUGIN_ROOT / "skills" / "phylax"
         skill = (skill_root / "SKILL.md").read_text(encoding="utf-8")
         evolution = (skill_root / "EVOLUTION.md").read_text(encoding="utf-8")
-        self.assertIn('metadata:\n  version: "1.4.0"', skill)
-        self.assertIn("- Current version: `phylax-v1.4.0`", evolution)
+        self.assertIn('metadata:\n  version: "1.5.0"', skill)
+        self.assertIn("- Current version: `phylax-v1.5.0`", evolution)
         for unchanged in (
             "- Frontier status: `mature`",
             "- Frontier revision: `off-chain-boundary-controls`",

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -3581,7 +3581,7 @@
         "transition": "review acceptance joined to the canonical Authorises field",
         "unknowns": "unreviewed capabilities and unavailable adversarial evidence"
       },
-      "sha256": "fc910735a3f1df7390bf4544d4f8863724615f48b4d0413e92f8d98d7bc0e73d",
+      "sha256": "945c6d103fb333cba8436d860f94aca67f3903083ed6ff79067b96a0c15669f8",
       "source": "plugins/hexaemeron/skills/phylax/SKILL.md"
     },
     "probitas-dossier-verification": {


### PR DESCRIPTION

## What changed

Add one shared, eight-hop resolver for direct function locals assigned once
before a sink. P002 now sees assigned subprocess string commands. P004 sees
credential-named values in assigned argv without losing its name-first signal.
P008 sees assigned dangerous callables and recognises assigned literal dynamic
input and `yaml.SafeLoader` or `yaml.CSafeLoader` as the existing safe forms.

The resolver leaves reassignment, late writes, branch-local writes, attributes,
subscripts, destructuring, comprehensions, parameters, nested scopes, closures,
module scope, cycles and over-depth chains unresolved. Finding codes, sink
locations, suppression, fixed diagnostics and secret-free output stay
unchanged.

Phylax advances from `phylax-v1.4.0` to generation `phylax-v1.5.0`. Its mature
frontier tuple is unchanged. The tracked study and runbook record the accepted
boundary and rejected broader-dataflow alternatives for issue #502.

## Audit

- Record: `audit/rounds/fiat-502-resolve-single-assignment-locals-for-phylax.md`
- Stacked audit PR URL: https://github.com/wildcat-finance/skills/pull/952
- Task issue: https://github.com/wildcat-finance/skills/issues/502

Five independent rounds recorded findings `2 -> 1 -> 4 -> 2 -> 0`. The first
four rounds fixed every reported item; the fifth found none. The final focused
suite passes 101/101, and the root suite passes 736/736.

The broad Hexaemeron run discovered 2,011 tests and executed 2,006, with 3
failures, 1 error, 5 fixture-blocked and 1 skip. Its remaining events are the
entry-commit Homologia check-map ownership, Node 26 fixture vs host Node 22,
macOS long-path Errno 63 and root-audit digest pin predicates. There is no
candidate-added failure or error.

## Proof

```bash
python3 -m unittest plugins.hexaemeron.tests.test_phylax_checker
```

<!-- wildcat-origin: shoggoth -->
