### PR TITLE
Freeze the Noema shadow-prototype contract and seed inventory

### DIFF
--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 2091
+    "files_walked": 2100
   },
   "entries": [
     {

--- a/docs/decisions/ADR-055-evaluate-noema-as-a-sliced-instruction-ir.md
+++ b/docs/decisions/ADR-055-evaluate-noema-as-a-sliced-instruction-ir.md
@@ -1,0 +1,91 @@
+# ADR-055: evaluate Noema as a sliced instruction IR in shadow mode
+
+## Status
+
+Accepted, 2026-08-29. The prototype outcome remains open until Step 5 records
+its fixed semantic, token and model-family gates. A later ADR must supersede
+this one before any authority reversal or repository migration.
+
+## Context
+
+The repository repeatedly loads large agent-facing Markdown files. Issue #909
+is building `wildcat-agent-instruction/v1`: authored Markdown remains
+authority, a closed reviewed model carries governed meaning, and compact bytes
+are a derived full-model codec. Its active stack gives Noema a control design
+and reusable boundary lessons, but changing that stack would erase the control
+while four or more contributors are working nearby.
+
+Issue #942 asks a different question. A native instruction IR could author
+governed semantics as a typed graph, select only the constraints reachable for
+one operation and state, and let a small runtime check consequential effects
+outside model obedience. The supplied seed demonstrates a possible notation
+and one useful sliced-token result. It does not implement typed modules,
+source-span closure, a manifest-bound slicer or a policy runtime, and it has no
+cross-family behavior evidence.
+
+The choice affects an authorship format, trust boundary and runtime interface.
+Reversing it after skills depend on the format would be expensive, so the
+prototype must preserve the current authority direction while it is measured.
+
+## Decision
+
+Build Noema as bounded root tooling in shadow mode: existing Markdown remains
+authoritative; canonical `.noe`, its graph and every projection are derived;
+the runtime returns policy decisions but executes no external effect; and the
+final step accepts, narrows or rejects the hypothesis against the fixed #942
+gates.
+
+Noema is not a plugin or selectable skill during this run. It changes no
+marketplace, router, Promise Machine claim, CI workflow, #909 path or external
+repository. Native Noema authorship, a skill conversion and Shoggoth migration
+each require a later decision with separate evidence.
+
+## Alternatives
+
+### Extend `wildcat-agent-instruction/v1`
+
+Rejected for this run. #909 fixes a full derived codec and Markdown authority;
+Noema tests task-state slicing and a possible later native-authoring endpoint.
+Combining them would move the control design, couple two active stacks and make
+either result harder to interpret.
+
+### Keep Markdown and generate task-specific prose summaries
+
+Rejected as the Noema endpoint. Summaries can reduce prompt size and remain an
+evaluation baseline, but a deterministic checker cannot prove that an omitted
+prohibition, authority edge or recovery path survived model-written prose.
+
+### Compress prose into binary, base64 or private aliases
+
+Rejected. Carrier bytes are not operational semantics, base encodings can cost
+more model tokens than source, and an alias table can erase its local saving
+once bootstrap cost is counted. Opaque carriers also discard ordinary Git
+review and semantic diff.
+
+### Make Noema authoritative immediately
+
+Rejected. Source-to-graph review can establish span coverage and still encode a
+reviewer's misunderstanding. Until the fixed mutations, critical vectors,
+token measurements and two-family cases exist, an authority flip would promote
+an untested interpretation.
+
+## Consequences
+
+The prototype can reuse #909's closed-model, canonicalization, bounds,
+source-binding and stable-refusal lessons without modifying its files. GitHub
+review keeps canonical text, semantic diff, generated views, vectors and
+digests visible. Prompt-only consumers pay the complete kernel and reachable
+dictionary cost; runtime consumers can keep policy enforcement outside model
+context.
+
+The parser, type checker, module registry, projector, slicer and policy
+evaluator become a larger security-sensitive base. Every layer therefore has a
+separate stacked step, fixed resource limits, hostile fixtures and no partial
+result on refusal. Live tokenizer and model adapters remain ask-first and
+outside instruction authority.
+
+An accepted Step 5 result permits continued shadow evaluation only. It does
+not permit native skill authorship, a plugin registration, a repository-wide
+conversion or migration. A rejected result stays useful: it records which
+semantic, compression or transfer gate failed without moving the gate after
+observation.

--- a/docs/noema-v1.md
+++ b/docs/noema-v1.md
@@ -1,0 +1,305 @@
+# Noema version 1 shadow-prototype contract
+
+## Contract identity and authority
+
+The contract identity is `noema/v1`. `NOE1` is the canonical-source magic,
+`NT1` the baseline text-projection magic and `noema-result/v1` the CLI result
+shape. A different identity is unsupported input rather than a compatible
+minor version.
+
+This version runs only in shadow mode. Existing repository Markdown is the
+authored authority. Canonical `.noe`, NIR, text projections, slices, renders,
+semantic diffs and evidence records are derived artifacts. A Noema decision is
+data for a caller that already holds separately recorded authority; the runtime
+does not execute an effect and cannot grant repository, publication,
+deployment, security or financial authority.
+
+## Closed semantic domain
+
+Version 1 admits these nominal core types:
+
+```text
+actor artifact action claim command effect event evidence literal operation
+path predicate promise repository rule scope state transition type value
+```
+
+Modules may define nominal subtypes, qualified predicate signatures and pure
+graph macros. They cannot add a core operator, change an operator's arity or
+meaning, shadow a qualified name, introduce ambient state or execute code.
+
+The closed structural operators and their meanings are:
+
+| opcode | arity | result | meaning |
+| --- | ---: | --- | --- |
+| `!` | 1 | directive | require the proposition |
+| `-` | 1 | directive | prohibit the proposition or effect |
+| `+` | 1 | directive | permit; permission never implies requirement |
+| `?` | 2 | directive | apply the directive only when the guard is checked true |
+| `/` | 2 | directive | apply the directive only when the guard is checked false |
+| `@` | 2 | directive | limit the directive to the named scope |
+| `^` | 2 | directive | name the actor with exclusive authority for the effect |
+| `;` | N | directive | apply a finite ordered directive sequence |
+| `&` | N | proposition | finite conjunction |
+| `|` | N | proposition | finite disjunction |
+| `~` | 1 | proposition | three-valued negation |
+| `=` | 2 | proposition | typed equality without coercion |
+| `=>` | 2 | proposition | implication |
+| `<` | 2 | relation | require the left term before the right term |
+| `all` | 3 | proposition | finite typed universal quantification |
+| `any` | 3 | proposition | finite typed existential quantification |
+| `one` | 3 | proposition | exactly one member of a finite typed set |
+| `in` | 2 | proposition | typed membership |
+| `subset` | 2 | proposition | typed finite-set containment |
+| `lt`,`le`,`gt`,`ge` | 2 | proposition | canonical decimal-string comparison |
+| `count` | 1 | value | finite collection cardinality |
+
+Named record forms are rule, import, literal, definition, precedence,
+override, transition, promise, handoff and exception. Their version-1 fields
+are fixed:
+
+```text
+rule       id directive source-binding
+import     module-id module-sha256
+literal    id kind byte-count exact-utf8
+definition qualified-name typed-parameters pure-body
+precedence higher-rule lower-rule authority scope evidence
+override   id authority high-rule low-rule scope evidence
+transition id machine from event guard to ordered-effects
+promise    id subject claim evidence classes boundary grants refuses recovery level
+handoff    id producer consumer subject scope evidence classes time transform gaps
+exception  id authority gate subject scope record expiry recovery
+```
+
+Unknown record forms, keys, types, operators and extra fields refuse. Numeric
+values are canonical unsigned decimal strings: `0` or a non-zero digit followed
+by digits. No float, exponent, sign, whitespace or numeric coercion is admitted.
+
+## Three-valued facts and authority
+
+Established facts are true or false; absent or insufficient evidence is
+unknown. Negation maps true to false, false to true and unknown to unknown.
+Conjunction returns false if any member is false, unknown if none is false and
+one is unknown, and true otherwise. Disjunction is the dual. A guard containing
+unknown blocks its dependent effect unless a rule explicitly handles an
+unknown-valued predicate.
+
+Capability, authority, execution, receipt and verification are separate typed
+relations. None implies another. Consequence-2 and consequence-3 effects
+default deny unless an applicable authority fact and every named gate are
+checked. Permission does not cancel prohibition. Conflicting requirements
+refuse unless one closed override record names the higher rule, authority,
+scope and evidence.
+
+An exception cannot assert absent evidence, strengthen an evidence class,
+change a source binding or operate outside its subject and scope. Missing,
+expired, unattributed, unrecorded or over-broad exceptions refuse.
+
+## Canonical `.noe` and NIR
+
+Canonical `.noe` is UTF-8, line-oriented and ends with one LF. Its first record
+is `NOE1`. Structural opcodes, qualified predicates, stable ids and typed
+literal references are governing syntax; prose is not. Step 2 fixes the exact
+token grammar while preserving the semantic and resource contract here.
+
+Canonicalization is singular: no insignificant alternate whitespace, key
+order, escape, Unicode normalization or integer spelling exists. Parsing must
+complete validation before a graph is returned. Formatting that graph must
+reproduce the exact canonical source bytes. NIR identity is SHA-256 over those
+canonical bytes and the lock identity; an optional binary cache is derived,
+non-authoritative and never base64 prompt input.
+
+Every governed directive has a stable rule id and source binding. An id remains
+stable across a wording-only source change whose reviewed semantics do not
+change. A semantic change updates the affected graph node and appears in a
+semantic diff.
+
+## Modules and lock identity
+
+A module is canonical data containing one module identity, a closed list of
+typed predicate signatures and pure definitions over already admitted
+operators and signatures. Imports bind complete module SHA-256 values. Import
+cycles, definition cycles, absent modules, multiple bytes for one identity and
+ambient lookup refuse.
+
+`noema-lock/v1` binds source, graph, compiler, kernel and projection-profile
+SHA-256 values plus the ordered module id/digest list. Any changed or missing
+component makes the lock stale. A consumer may use no module meaning that the
+lock does not name.
+
+## Typed inert literals
+
+Literal kinds are `id`, `path`, `sha256`, `command`, `number`, `date`, `url`,
+`quote`, `text` and `bytes`. Identity is the pair of kind and exact UTF-8 bytes;
+different kinds with equal bytes remain distinct. Literal bytes cannot parse as
+a record, predicate, alias, module, fact or authority edge. A command, path or
+URL literal still needs a separately authorised typed effect before a caller
+uses it.
+
+Large opaque values may remain content-addressed sidecars. The projection
+exposes a literal only when it is reachable from the selected slice. Base64 is
+not a transport unless the base64 spelling itself is the exact governed value.
+
+## Text projections
+
+A projection is derived text for one exact tokenizer profile. `NT1` identifies
+the version-1 projection grammar. A profile binds its text alphabet, reserved
+opcodes, tokenizer or vocabulary identity, kernel bytes, alias dictionary and
+their SHA-256 values. Raw token ids are forbidden because text APIs and
+tokenizer revisions do not share their meaning.
+
+Aliases are injective across reserved opcodes, qualified predicates, literal
+ids and values visible in the same slice. Arity does not disambiguate an alias.
+A collision refuses. The manifest plus projection must recover the same NIR;
+shorter bytes or tokens never excuse a changed graph.
+
+Prompt-only mode includes the complete kernel, every reachable definition,
+the slice and its reachable literals. All of those bytes and tokens count.
+Runtime mode may keep checked policy evaluation outside model context, but its
+manifest and lock still bind the same graph.
+
+## Source bindings and semantic diff
+
+A source identity is one unique repository-relative path and exact blob
+SHA-256. Each governed UTF-8 byte span maps to one graph node or one explicit
+unsupported remainder. Spans for one physical source cannot overlap. Gaps in a
+declared governed region, stale bytes, aliased source paths and a remainder that
+grants authority refuse.
+
+Source-span coverage is reviewed evidence. It establishes the recorded mapping
+for exact bytes and does not establish that the reviewer captured unexpressed
+intent. An unsupported remainder blocks authority migration and remains visible
+in every evidence record.
+
+A semantic diff has closed entries for added, removed or modified effects,
+gates, authority, scope, evidence classes, literals, transitions, precedence
+and source bindings. A changed semantic digest with no entry, or an entry with
+unchanged before and after identities, refuses.
+
+## Conservative slicing
+
+`select` receives graph and lock identity, operation, state, target, tools,
+authority inputs and checked facts. Roots are the requested operation, its
+possible effects and output type plus every applicable higher-precedence rule.
+Closure retains referenced definitions, literals, promises, handoffs,
+exceptions, prohibitions, authority constraints, ordering, refusal and
+recovery.
+
+A checked-true guard retains its dependent rule. A checked-false guard may omit
+it only when the manifest carries the exact fact and evidence identity. An
+unknown guard retains it. Any rule that can forbid, constrain, order or recover
+a reachable effect remains reachable.
+
+`noema-manifest/v1` commits to the complete graph and lock, compiler, profile,
+kernel, selection inputs, checked facts, included ids, omitted ids with reasons,
+reachable definitions and literals, projection and every digest. Included and
+omitted ids form an exact partition of the full graph's selectable ids.
+
+## Policy runtime
+
+The runtime surface is exactly:
+
+```text
+select(operation,state,target,tools,authority,facts) -> manifest + projection
+check(effect,facts,manifest)                         -> permit | refuse | unknown
+next(machine,state,event,receipts,manifest)          -> transition | stop
+literal(id,manifest)                                 -> kind + exact bytes
+explain(node,manifest)                               -> non-authoritative render
+```
+
+`next` owns no external domain judgment; it evaluates declared state, event,
+guard and ordered effects. `literal` refuses an unreachable id. `explain`
+labels its output and no policy operation may consume that render as evidence.
+The runtime has no operation for subprocess, network, Git, GitHub, file
+mutation, publication or deployment.
+
+## Resource limits
+
+Version 1 applies every limit before returning a partial graph or result:
+
+| resource | maximum |
+| --- | ---: |
+| input file | 1,048,576 bytes |
+| physical line | 65,536 bytes |
+| source records | 16,384 |
+| graph nodes | 16,384 |
+| imports | 64 |
+| nesting depth | 64 |
+| one literal | 65,000 decoded UTF-8 bytes |
+| all decoded literal occurrences | 786,432 bytes |
+| expanded macro graph | 65,536 nodes |
+| one finite quantifier set | 4,096 members |
+| one derived output | 1,048,576 bytes |
+
+The seed archive verifier separately accepts at most 1,048,576 archive bytes,
+64 members, 1,048,576 uncompressed bytes in aggregate, 1,048,576 bytes for one
+member and 512 UTF-8 bytes for one member path. It rejects encryption, unsafe
+paths, links, special files, unsupported compression, duplicate names and any
+inventory mismatch.
+
+## Result and refusal contract
+
+Each command writes at most one `noema-result/v1` JSON line to standard output.
+It names command, deterministic correlation id, verdict, stable code, input and
+output digests and bounded counts that exist for that command. It never carries
+source text, literal payloads, prompts, model output or credentials.
+
+Stable refusal families are:
+
+| family | subject | recovery |
+| --- | --- | --- |
+| `NOE-E-SYNTAX` | malformed or non-canonical source/tape | repair exact bytes and rerun |
+| `NOE-E-TYPE` | unknown type, operator, key, arity or typed value | use the closed version-1 form |
+| `NOE-E-BOUNDS` | a fixed resource limit | reduce input without deleting governed meaning |
+| `NOE-E-REFERENCE` | id, cycle, source span or closure | repair the named reference relation |
+| `NOE-E-DIGEST` | source, graph, module, compiler, kernel or profile mismatch | restore matching bytes or regenerate derived data |
+| `NOE-E-ALIAS` | projection collision or overload | choose one injective mapping and regenerate |
+| `NOE-E-SLICE` | omitted reachable rule or invalid omission proof | restore conservative closure |
+| `NOE-E-AUTHORITY` | missing, conflicting or over-broad authority | supply applicable checked authority or refuse the effect |
+| `NOE-E-PATH` | unsafe, escaping, linked or special path | select a confined regular path |
+| `NOE-E-IO` | read, write, sync or atomic replacement uncertainty | inspect complete old/new state and rerun safely |
+| `NOE-E-EVALUATION` | packet, profile, family, case or answer mismatch | restore the exact isolated cohort and retally |
+| `NOE-E-UNIMPLEMENTED` | operation reserved for a later prototype step | finish and verify its declared step |
+
+A refusal returns no partial graph, tape, slice, decision or evidence file.
+Failure blocks its dependent operation while leaving inspection, repair, rerun
+and safe exit available when their own inputs validate.
+
+## Measurement and family evaluation
+
+Measurement records bytes and real tokenizer counts separately for Markdown
+source, canonical `.noe`, full projection, operation slice, literals, kernel,
+reachable definitions, first use, steady state and corpus amortisation. Source
+and projections use the same exact profile. Missing exact OpenAI, Anthropic,
+Google or open-weight profiles remain `unknown`; heuristic counts do not
+replace them.
+
+The fixed gates are first use at most 70% of relevant Markdown, steady state at
+most 40%, complete canonical Noema at most 55% of the declared source corpus,
+and 100% for critical permission/prohibition, authority, negation,
+unknown-guard, ordering, exact-literal and consequence-3 vectors.
+
+Evaluation emits one answer-free source prompt and one Noema prompt per case,
+one isolated context each. The packet is complete only after its manifest is
+written. Tally requires exact case-set equality, no duplicate id, exact tree,
+source, graph, kernel, projection, profile and model identity, and two genuinely
+different family identities for a cross-family result. A committed run records
+that run; it does not predict a rerun or establish model quality.
+
+External tokenizer or model programs are explicit digest-bound argv lists with
+a minimal environment allowlist, timeout and output cap. New dependencies,
+downloads, credentials, network calls, source disclosure and paid use require
+separate operator authority. Model output is untrusted data and never becomes a
+command, query, path, fact or authority edge.
+
+## Versioning and recovery
+
+Version 1 is closed. An added operator, type, record field or changed meaning
+requires a new contract identity. A new projection profile may be added under
+version 1 only when it recovers the same NIR and binds its own complete bytes.
+
+Canonical source and lock are the recovery root for derived graph caches,
+projections, slices, renders, semantic diffs and evidence. Regenerate derived
+artifacts after verifying source and module identities; never edit a derived
+view to make a stale check pass. During this issue, canonical source itself is
+recoverable from authoritative Markdown and reviewed source bindings because
+Noema remains in shadow mode.

--- a/docs/noema-v1.md
+++ b/docs/noema-v1.md
@@ -234,7 +234,8 @@ The seed archive verifier separately accepts at most 1,048,576 archive bytes,
 64 members, 1,048,576 uncompressed bytes in aggregate, 1,048,576 bytes for one
 member and 512 UTF-8 bytes for one member path. It rejects encryption,
 non-canonical or unsafe paths, links, special files, unsupported compression,
-duplicate names and any inventory mismatch.
+duplicate names and any inventory mismatch. Root and member spellings use the
+exact alphabets published in the seed-inventory schema.
 
 ## Result and refusal contract
 

--- a/docs/noema-v1.md
+++ b/docs/noema-v1.md
@@ -232,9 +232,9 @@ Version 1 applies every limit before returning a partial graph or result:
 
 The seed archive verifier separately accepts at most 1,048,576 archive bytes,
 64 members, 1,048,576 uncompressed bytes in aggregate, 1,048,576 bytes for one
-member and 512 UTF-8 bytes for one member path. It rejects encryption, unsafe
-paths, links, special files, unsupported compression, duplicate names and any
-inventory mismatch.
+member and 512 UTF-8 bytes for one member path. It rejects encryption,
+non-canonical or unsafe paths, links, special files, unsupported compression,
+duplicate names and any inventory mismatch.
 
 ## Result and refusal contract
 

--- a/docs/noema/runbook.md
+++ b/docs/noema/runbook.md
@@ -1,0 +1,438 @@
+# Runbook: prototype Noema as a model-native sliced instruction IR
+
+This runbook derives from `.hexaemeron/study.md` at SHA-256
+`4a7c0e7bdfc3d44535d36d3666b3272436d1662463aabc6c82380bd554e5ffec`.
+It delivers one shadow-mode root prototype in five stacked pull requests.
+Existing Markdown remains authoritative throughout. No step changes a plugin,
+marketplace, router, Promise Machine claim, CI workflow, #909 path or external
+repository. ADR-054 exists on another active ref, so this run reserves ADR-055
+against the refs observed during study; integration must refuse a collision
+rather than overwrite another record.
+
+## Step 1: freeze the Noema contract and verified seed inventory
+
+**Goal.** Commit the receipted specification, shadow-authority decision,
+version-1 public contract, closed schema, safe CLI scaffold and exact inventory
+of the operator-supplied evidence before implementing its semantics.
+
+**Entry.** The clean run branch at
+`7e97b5195d5b0e43146b4200f26cd41b89003413`, with the study receipted at
+SHA-256 `4a7c0e7bdfc3d44535d36d3666b3272436d1662463aabc6c82380bd554e5ffec`,
+this runbook receipted, current-main audit synopses verified, and none of the
+declared Noema product paths present. The exact repository interpreter is
+Python 3.14.6. The public evidence archive is 24,907 bytes with SHA-256
+`1e1eb5e9908551f1337b7ec58a37ae7f37fd97e41d5ac424bc4992eb1d11b540`.
+
+**Exit.** `docs/noema/study.md` and `docs/noema/runbook.md` match the
+receipted artifacts byte for byte. ADR-055 records the decision to evaluate a
+typed sliced IR in shadow mode, the rejected full-codec, prose-summary and
+opaque-carrier options, and the fact that only a later record may reverse
+Markdown authority. `docs/noema-v1.md` fixes the closed core types, operator
+semantics, canonical-source and projection roles, digest rules, resource caps,
+stable refusal families, source-binding boundary, runtime operations,
+evaluation boundary and recovery. The JSON schema parses and fixes the closed
+inventory, lock, manifest, result and evidence shapes used by later steps.
+
+`tests/fixtures/noema-v1/seed-inventory.json` names the archive, public URL,
+all 17 relative paths, sizes and SHA-256 values from #942. `verify-seed` reads a
+caller-supplied archive without extracting or executing it, rejects unsafe or
+unexpected members and prints one bounded digest result. The scaffold exposes
+only `about`, `verify-seed` and help; every unimplemented operation refuses by
+name. No plugin or #909 path changes, and every command below exits zero:
+
+```bash
+python3 -c 'import platform; assert platform.python_version() == "3.14.6"'
+cmp .hexaemeron/study.md docs/noema/study.md
+cmp .hexaemeron/runbook.md docs/noema/runbook.md
+python3 scripts/noema.py verify-seed --archive /private/tmp/noema-v0-evidence.zip --inventory tests/fixtures/noema-v1/seed-inventory.json
+python3 -m unittest tests.test_noema.NoemaScaffoldTests -v
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/noema/study.md
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/noema/runbook.md
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/noema/study.md docs/noema/runbook.md docs/noema-v1.md docs/decisions/ADR-055-evaluate-noema-as-a-sliced-instruction-ir.md
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py scripts tests
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py scripts tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py docs scripts
+python3 scripts/run_checks.py
+python3 plugins/hexaemeron/skills/fiat/scripts/audit_synopsis.py --check .
+python3 plugins/horos/skills/horos/scripts/horos.py check .
+git diff --check
+```
+
+**Files.** Create `docs/noema/study.md`, `docs/noema/runbook.md`,
+`docs/noema-v1.md`,
+`docs/decisions/ADR-055-evaluate-noema-as-a-sliced-instruction-ir.md`,
+`schemas/noema-v1.schema.json`, `scripts/noema.py`, `tests/test_noema.py`,
+`tests/fixtures/noema-v1/README.md` and
+`tests/fixtures/noema-v1/seed-inventory.json`. Permit `.horos/boundary.json`
+only for the deterministic tracked-tree update and the configured Fiat audit
+record plus generated synopsis only in their owning phase. Change no other
+product path without a receipted study amendment.
+
+**Tests.** Add at least 15 `NoemaScaffoldTests` for the two receipted-copy
+digests, exact Python pin, schema JSON and closed top-level keys, version magic,
+CLI help and stable unimplemented refusals, archive and member byte caps,
+duplicate and extra member refusal, traversal, absolute path, link and special
+file refusal, archive digest mismatch, per-file size/digest mismatch and one
+valid inventory verification. The fixture builder uses only synthetic bytes;
+the exit command separately verifies the operator archive. The source-bound
+Elenchus runner for any audit repair is
+`python3 tests/run_tests.py --elenchus-report {report}`; report format
+`unittest-json-v1`; expected schema `elenchus.unittest.v1`; report file
+`.elenchus/fiat-942-step-1.json`. The report path must be fresh, and missing,
+stale, malformed, empty, zero-test or infrastructure-failed output is
+`inconclusive`.
+
+**Disciplines.** phylax: a supplied ZIP crosses a new ingestion boundary, so
+the archive is bounded and inventoried without extraction or execution, and
+the focused suite drives hostile members. ephoros: this is an operator-run CLI
+with no unattended path; one bounded result names archive digest, member count
+and refusal while emitting no member bytes. metron: none, because this step
+freezes budgets but makes no measured compression claim. elenchus: no product
+failure exists at entry; an audit repair must use the exact structured runner
+above and preserve a parent-red guard. hypomnema: ADR-055 is the standing home
+for the cross-repository authority direction and all rejected designs before
+the tracked study ships.
+
+## Step 2: build the canonical graph, module lock and text projection
+
+**Goal.** Implement a bounded standard-library parser, type checker, formatter,
+module registry, semantic diff and reversible tokenizer-profile text projection
+for the closed version-1 graph.
+
+**Entry.** Step 1's pull request is integrated into the run branch; its tracked
+study, runbook, ADR, public contract, schema, inventory, CLI scaffold and tests
+are unchanged and green. The seed reference code remains outside the product
+and has not been executed or copied into `scripts/`.
+
+**Exit.** Canonical `.noe` parses to one closed NIR and formats back to the
+same UTF-8 bytes with LF and final LF. Duplicate ids, unknown operators or
+types, bad arity, unsafe Unicode, unresolved references, type mismatch,
+relation cycles, ambient or cyclic imports, stale module/compiler/profile
+digests, alias collision, unbounded quantification and every exact or
+limit-plus-one resource specimen refuse with stable `NOE-E-*` codes before a
+partial graph is returned. Modules carry qualified signatures and pure graph
+definitions; locks bind complete module, compiler, kernel and profile bytes.
+
+The baseline ASCII projection recovers the same NIR together with its manifest
+and cannot overload an alias by arity or collide with a reserved opcode,
+predicate, literal id or visible value. Typed literals preserve kind and exact
+bytes and remain inert. `semantic-diff` reports every changed effect, gate,
+authority, scope, evidence class, literal, transition and precedence edge in a
+closed machine-readable record. Confined commands read regular files, refuse
+symlinks and special files, and write atomically with a target-independent
+temporary name. `self-test` exercises one complete graph/module/profile round
+trip. Every command below exits zero:
+
+```bash
+python3 scripts/noema.py self-test
+python3 -m unittest tests.test_noema.CanonicalSourceTests tests.test_noema.GraphValidationTests tests.test_noema.ModuleLockTests tests.test_noema.ProjectionTests tests.test_noema.SemanticDiffTests tests.test_noema.PathBoundaryTests -v
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py scripts tests
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py scripts tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py docs scripts
+python3 scripts/run_checks.py
+python3 plugins/hexaemeron/skills/fiat/scripts/audit_synopsis.py --check .
+python3 plugins/horos/skills/horos/scripts/horos.py check .
+git diff --check
+```
+
+**Files.** Change `scripts/noema.py`, `schemas/noema-v1.schema.json`,
+`docs/noema-v1.md`,
+`docs/decisions/ADR-055-evaluate-noema-as-a-sliced-instruction-ir.md` and
+`tests/test_noema.py`. Create bounded valid and invalid samples only below
+`tests/fixtures/noema-v1/codec/`, core module bytes below
+`tests/fixtures/noema-v1/modules/`, and the baseline profile below
+`tests/fixtures/noema-v1/profiles/`. Permit the deterministic Horos boundary
+and configured audit record/synopsis updates. No #909, plugin, dependency,
+toolchain, CI, Promise Machine or marketplace file is in scope.
+
+**Tests.** Extend the focused module to at least 100 total tests. Cover every
+core type and operator, canonical key/record order, LF/final-LF, exact UTF-8
+lengths, every literal kind, type and reference closure, stable rule ids,
+module signature and pure-macro checks, lock identity, projection recovery,
+alias injectivity, semantic-diff field coverage, no-op diffs, source and tape
+idempotence, all item-10 caps at limit and limit-plus-one, very long decimals,
+duplicate JSON keys, path confinement, maximum leaf names, partial writes,
+sync failures, symlinks, directories, FIFOs and no leaked temporary file. For
+an audit repair use `python3 tests/run_tests.py --elenchus-report {report}`;
+format `unittest-json-v1`; schema `elenchus.unittest.v1`; fresh report
+`.elenchus/fiat-942-step-2.json`, with every incomplete or infrastructure
+result classified `inconclusive`.
+
+**Disciplines.** phylax: untrusted source, JSON, tape and paths enter a parser
+and atomic writer, so bounds, duplicate rejection, no shell, no dynamic
+execution, regular-file confinement and hostile fixtures are gates. ephoros:
+the local commands answer digest, count, verdict, controlling node and output
+questions through one bounded `noema-result/v1` line; no daemon, metric or alert
+is introduced. metron: none, because reversible encoding is proved but no
+token saving or speed is claimed. elenchus: each observed codec failure gets
+minimal parent-red bytes and the exact runner above before repair. hypomnema:
+the public contract documents grammar, interface and refusals; ADR-055 records
+only authority and architecture so parser mechanics are not duplicated there.
+
+## Step 3: build conservative slicing and the non-executing policy runtime
+
+**Goal.** Implement dependency-closed operation/state slicing and the five
+bounded policy operations without giving the runtime an external-effect path.
+
+**Entry.** Step 2's pull request is integrated; canonical source, locked
+modules, baseline projection, semantic diff, confined I/O and their focused
+tests pass. One synthetic complete graph is available for runtime fixtures,
+and no source-bound skill specimen has been admitted yet.
+
+**Exit.** `select(operation,state,target,tools,authority,facts)` roots the
+requested operation and possible effects, partially evaluates only checked
+facts, retains unknown guards, closes every reachable definition, literal,
+promise, handoff, authority constraint, prohibition, order edge, exception,
+refusal and recovery, and emits a canonical manifest over the full graph. A
+checked-false guard may omit a rule only with its fact and evidence digest in
+the manifest. Recomputing the same inputs yields identical included/omitted id
+sets, tape and digests; changed facts or graph yield a declared changed result.
+
+`check` returns permit, refuse or unknown and the controlling node. Permission
+never cancels prohibition, conflicting requirements need a typed higher-authority
+override, and consequence-2/3 effects default deny without applicable authority
+and satisfied gates. `next` enables only a transition whose event, state and
+guard are established and keeps authored effect order. `literal` reveals only
+a reachable typed literal. `explain` produces a labelled non-authoritative
+render and no policy input can consume that render. The runtime has no shell,
+network, Git, GitHub, file-mutation or external-effect operation.
+
+The synthetic runtime demonstration covers allowed consequence 0, refused
+consequence 3, unknown guard retention, checked-false omission, ordered next
+transition, reachable literal and non-authoritative explanation. Every command
+below exits zero:
+
+```bash
+python3 scripts/noema.py runtime-self-test
+python3 scripts/noema.py verify --manifest tests/fixtures/noema-v1/runtime/manifest.json
+python3 -m unittest tests.test_noema.SliceTests tests.test_noema.PolicyCheckTests tests.test_noema.TransitionTests tests.test_noema.LiteralTests tests.test_noema.ExplainTests tests.test_noema.RuntimeResultTests -v
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py scripts tests
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py scripts tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py docs scripts
+python3 scripts/run_checks.py
+python3 plugins/hexaemeron/skills/fiat/scripts/audit_synopsis.py --check .
+python3 plugins/horos/skills/horos/scripts/horos.py check .
+git diff --check
+```
+
+**Files.** Change `scripts/noema.py`, `schemas/noema-v1.schema.json`,
+`docs/noema-v1.md`,
+`docs/decisions/ADR-055-evaluate-noema-as-a-sliced-instruction-ir.md` and
+`tests/test_noema.py`. Create the complete synthetic graph, facts, operations,
+locks, expected slices, tapes and result records below
+`tests/fixtures/noema-v1/runtime/`. Permit deterministic Horos and configured
+audit record/synopsis changes. Change no adapter, external-service, plugin,
+#909 or shared authority surface.
+
+**Tests.** Add at least 80 runtime cases while preserving Step 2's focused
+count. Cover true, false and unknown guards; nested unknowns; closure through
+macros, promises, handoffs, exceptions and recovery; included and omitted id
+partition; omission proof mismatch; stale inputs; deterministic manifests;
+prohibition/permission conflict; authority precedence and scope; missing,
+expired and over-broad exceptions; consequence levels 0 through 3; capability,
+authority, done, receipt and verification separation; transition state/event/
+guard/order; unreachable literals; instruction-shaped literal inertness; and
+bounded result redaction. Audit repairs use
+`python3 tests/run_tests.py --elenchus-report {report}`, format
+`unittest-json-v1`, schema `elenchus.unittest.v1` and fresh report
+`.elenchus/fiat-942-step-3.json`; inconclusive reports establish no guard.
+
+**Disciplines.** phylax: facts, manifests and instruction-shaped literals are
+hostile inputs; the runtime validates them and returns data without executing
+model output or an effect. ephoros: each operation emits a correlated bounded
+result answering which graph, facts, slice and rule controlled the outcome;
+there is no unattended service, long-running job or alert. metron: none, since
+closure size is recorded for later measurement but no compression verdict is
+made. elenchus: a dropped constraint, wrong decision or changed manifest is a
+concrete failure and must stay parent-red under the declared runner after its
+cause is fixed. hypomnema: the public contract owns callable arguments,
+returns, stable failures and the non-executing boundary; ADR-055 retains the
+reason for that boundary.
+
+## Step 4: bind the four specimens and hostile mutation corpus
+
+**Goal.** Import the verified seed as inert reference evidence, author reviewed
+Noema mappings for Fiat, Phylax, Sapheneia and full Brevitas, and prove their
+source coverage and critical mutation behavior.
+
+**Entry.** Step 3's pull request is integrated; the complete synthetic runtime
+passes, the public source and runtime contract is fixed, the archive and all 17
+source files still match Step 1's inventory, and the four canonical skill
+sources are read from the current stacked base without modifying them.
+
+**Exit.** All 17 seed files are copied byte-identically below a directory
+labelled non-executable reference evidence, with archive and per-file digests
+rechecked before the copy. No seed Python is imported or run. Each of the three
+bounded tapes and the full Brevitas tape has a separately authored canonical
+`.noe`, lock, full projection, operation slice, literal set, source-span map,
+closed questions and expected policy answers. Source identities bind exact
+repository paths and blob digests. Every governed span maps to one typed node
+or an explicit unsupported remainder; gaps and overlaps refuse; remainders
+grant no authority and keep the specimen in shadow mode.
+
+The manifest declares and executes mutations for dropped negation, permission
+for prohibition, swapped actor, widened scope, changed exact literal, stale
+module, omitted dependency, unknown opcode, alias collision, unknown-guard
+deletion, reordered effects, missing authority and consequence-3 bypass. Each
+mutation refuses or yields its exact declared changed semantic digest, diff and
+answer. Critical permission/prohibition, authority, negation, unknown-guard,
+ordering, exact-literal and consequence-3 vectors pass 100%. The checked
+source, canonical graph, full projection, operation slice, literals, kernel and
+reachable definitions are distinct manifest objects. Every command below exits
+zero:
+
+```bash
+python3 scripts/noema.py verify-seed --archive /private/tmp/noema-v0-evidence.zip --inventory tests/fixtures/noema-v1/seed-inventory.json
+python3 scripts/noema.py verify --manifest tests/fixtures/noema-v1/manifest.json
+python3 scripts/noema.py mutations --manifest tests/fixtures/noema-v1/manifest.json
+python3 -m unittest tests.test_noema.SourceBindingTests tests.test_noema.SpecimenRoundTripTests tests.test_noema.MutationTests tests.test_noema.CriticalVectorTests -v
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py scripts tests
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py scripts tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py docs scripts
+python3 scripts/run_checks.py
+python3 plugins/hexaemeron/skills/fiat/scripts/audit_synopsis.py --check .
+python3 plugins/horos/skills/horos/scripts/horos.py check .
+git diff --check
+```
+
+**Files.** Change `scripts/noema.py`, `schemas/noema-v1.schema.json`,
+`docs/noema-v1.md`,
+`docs/decisions/ADR-055-evaluate-noema-as-a-sliced-instruction-ir.md`,
+`tests/test_noema.py` and `tests/fixtures/noema-v1/manifest.json`. Create
+byte-identical reference files below
+`tests/fixtures/noema-v1/seed-reference/` and specimen-owned source identity,
+canonical `.noe`, locks, full/sliced projections, literals, source-span maps,
+questions, answers and mutations below `tests/fixtures/noema-v1/specimens/`.
+Permit deterministic Horos and configured audit record/synopsis updates. Do
+not edit the four source skills, their plugins, generated copies or #909 paths.
+
+**Tests.** Add at least 60 source, specimen and mutation cases. Test archive
+and imported-byte equality, exact source blob binding, span ordering and full
+governed coverage, unsupported remainder behavior, all four source/graph/source
+and graph/projection/graph round trips, deterministic regeneration, closed
+question and answer sets, every declared hostile mutation, unchanged-digest
+refusal and 100% critical-vector accounting. Preserve malicious strings in
+every literal kind and assert they cannot mint a node, alias or effect. Audit
+repairs use `python3 tests/run_tests.py --elenchus-report {report}`, format
+`unittest-json-v1`, schema `elenchus.unittest.v1` and fresh report
+`.elenchus/fiat-942-step-4.json`; any incomplete comparison is inconclusive.
+
+**Disciplines.** phylax: an external archive and current skill bytes cross the
+fixture boundary, so exact inventory, confined import, non-execution, source
+digests and hostile literal tests are mandatory. ephoros: verification emits
+bounded per-specimen counts, digests and mutation verdicts under one run id;
+no prompt, source body or literal payload enters results. metron: none, because
+this step fixes the comparison corpus and components but leaves all token
+counts to Step 5's same-profile baseline. elenchus: each mutation is a named
+counterexample; an unexpected clean or changed answer becomes the minimal
+parent-red guard before repair. hypomnema: source-span provenance and review
+belong in fixture manifests, public semantics in the contract and the authority
+decision in ADR-055, avoiding a fourth narrative home.
+
+## Step 5: measure, run the family evaluation and decide Noema
+
+**Goal.** Record exact tokenizer/component measurements and isolated
+source-versus-Noema behavior for two authorised model families, then accept,
+narrow or reject the hypothesis in ADR-055.
+
+**Entry.** Step 4's pull request is integrated; all four source-bound
+specimens, critical vectors and hostile mutations pass. Exact OpenAI,
+Anthropic, Google and one open-weight tokenizer profiles can be named or
+recorded unavailable, and two genuinely distinct model-family contexts are
+separately authorised with exact model identity, invocation boundary, public
+input treatment and acquisition digests. If two family runs require an
+unauthorised credential, network call, paid endpoint, model download, new
+dependency or source disclosure, stop at this entry and ask the operator. Do
+not substitute aliases, synthetic answers or two releases of one family.
+
+**Exit.** `measure` establishes the Markdown baseline first and records bytes
+and real-token counts separately for source, canonical `.noe`, full projection,
+operation slice, literals, kernel, reachable definitions, first use, steady
+state and corpus amortisation under each exact profile. Missing exact profiles
+remain explicit unknowns. It applies the unchanged gates: first use at most
+70%, steady state at most 40%, complete canonical Noema at most 55%, plus 100%
+critical vectors. Unlike tokenizer identities are never compared as one
+cohort, and dictionary, alias and kernel cost is never hidden.
+
+`emit-evaluation` writes one answer-free source prompt and one Noema prompt per
+case, one context nonce each, and a manifest written last. `tally-evaluation`
+rejects duplicate, missing, extra, unknown or cross-paired answers; binds exact
+tree, source, graph, kernel, projection, profile, case-set and model-family
+identities; and reports each required decision, refusal and unknown separately.
+At least two genuinely different families complete all critical cases with no
+changed required answer between source and Noema. The record does not claim
+future rerun agreement, model quality or semantic correctness beyond its cases.
+
+ADR-055 states every measured count, gate verdict, family result, unknown and
+failure. It chooses `accepted for continued shadowing`, `narrowed` or
+`rejected`; names the trade against #909's whole-model codec; keeps Markdown
+authoritative; and lists the exact later evidence required before native Noema
+authorship or repository migration could be proposed. A failed threshold or
+behavior case remains in the record and cannot be moved. The complete clean
+demonstration and every command below exit zero:
+
+```bash
+python3 scripts/noema.py measure --manifest tests/fixtures/noema-v1/manifest.json --profiles tests/fixtures/noema-v1/profiles/measurement.json --output tmp/noema-measurement.json
+cmp tmp/noema-measurement.json tests/fixtures/noema-v1/evidence/measurement.json
+python3 scripts/noema.py emit-evaluation --manifest tests/fixtures/noema-v1/manifest.json --output tmp/noema-evaluation-packet
+python3 scripts/noema.py tally-evaluation --packet tmp/noema-evaluation-packet/manifest.json --answers tests/fixtures/noema-v1/evidence/answers.json --output tmp/noema-evaluation.json
+cmp tmp/noema-evaluation.json tests/fixtures/noema-v1/evidence/evaluation.json
+python3 scripts/noema.py verify --manifest tests/fixtures/noema-v1/manifest.json
+python3 scripts/noema.py mutations --manifest tests/fixtures/noema-v1/manifest.json
+python3 -m unittest tests.test_noema -v
+python3 -m unittest discover -s tests
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/noema/study.md
+python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/noema/runbook.md
+python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/noema/study.md docs/noema/runbook.md docs/noema-v1.md docs/decisions/ADR-055-evaluate-noema-as-a-sliced-instruction-ir.md
+python3 plugins/hexaemeron/skills/phylax/scripts/phylax.py scripts tests
+python3 plugins/hexaemeron/skills/ephoros/scripts/ephoros.py scripts tests
+python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py docs scripts
+python3 scripts/run_checks.py
+python3 plugins/hexaemeron/skills/fiat/scripts/audit_synopsis.py --check .
+python3 plugins/horos/skills/horos/scripts/horos.py check .
+git diff --check
+```
+
+**Files.** Change `scripts/noema.py`, `schemas/noema-v1.schema.json`,
+`docs/noema-v1.md`,
+`docs/decisions/ADR-055-evaluate-noema-as-a-sliced-instruction-ir.md`,
+`tests/test_noema.py`, `tests/fixtures/noema-v1/manifest.json` and profile
+records below `tests/fixtures/noema-v1/profiles/`. Create deterministic
+measurement, answer-provenance and evaluation records below
+`tests/fixtures/noema-v1/evidence/`. Permit deterministic Horos and configured
+audit record/synopsis updates. Add no dependency, credential, provider SDK,
+model bytes, raw response transcript, plugin, Promise Machine claim, README
+entry, CI workflow, #909 file or external-repository change.
+
+**Tests.** Add at least 40 measurement and evaluation-adapter cases using fake
+local executables for every failure path, then run the exact authorised live
+profiles only for the committed evidence. Cover component omission, dictionary
+under-counting, changed executable or vocabulary digest, unavailable profile,
+non-integer and negative counts, unlike cohorts, threshold boundaries, packet
+partial writes, prompt answer leakage, one-case context binding, duplicate and
+missing answers, family aliases, stale tree/profile/model ids, unknown answer
+values, timeout, output cap, environment allowlist, secret-shaped output and
+atomic reports. Audit repairs use
+`python3 tests/run_tests.py --elenchus-report {report}`, format
+`unittest-json-v1`, schema `elenchus.unittest.v1` and fresh report
+`.elenchus/fiat-942-step-5.json`; an unavailable or contaminated live run is
+evidence unknown, never a guarded result.
+
+**Disciplines.** phylax: external tokenizer/model programs and model answers
+cross the final boundary, so explicit argv, cleared environment allowlist,
+timeouts, caps, digest-bound identities, no shell, public fixtures and no
+credential in records are gates; live use remains operator-authorised.
+ephoros: packet, measurement and tally records answer which exact context,
+profile, case and digest produced each bounded verdict; this creates no
+production telemetry or alert. metron: the source baseline precedes every
+projection count, the same tokenizer/profile measures both sides, all
+components and variance are retained, and a miss records rejection rather than
+moving the limit. elenchus: any adapter, contamination, count or answer failure
+is reduced under fake executables and guarded before the exact live case is
+rerun. hypomnema: ADR-055 receives the measured choice, rejected alternatives,
+unknowns and authority condition; the public contract and fixtures retain
+interface and evidence details without turning the study into the standing
+record.

--- a/docs/noema/study.md
+++ b/docs/noema/study.md
@@ -1,0 +1,380 @@
+# Prototype Noema as a model-native sliced instruction IR
+
+## 1. Problem statement
+
+Issue [#942](https://github.com/wildcat-finance/skills/issues/942) asks whether
+the governed part of an agent skill can move from repeatedly loaded prose to a
+closed instruction graph, selected by task state and checked by a small policy
+runtime. The existing issue [#909](https://github.com/wildcat-finance/skills/issues/909)
+answers a narrower question: its reviewed model stays derived from authored
+Markdown and its compact `WAI1` bytes encode the whole reviewed model. Noema
+tests typed native authoring, dependency-closed slices and an enforcement
+boundary for consequential effects. It does not supersede #909.
+
+The supplied seed is useful evidence and an unsafe implementation base. Its
+three specimen tapes, full Brevitas tape and subset parser reproduce
+`OK roundtrip=4 structures=6 malformed=3 semantic=7 digest-mutations=4`, but
+the parser has a global handwritten predicate-arity table, no typed module
+bodies, no source-span validator, no module lock, no slice manifest and no
+policy runtime. Importing those bytes unchanged would preserve the questions,
+not answer them.
+
+A working prototype has one repository command that can:
+
+1. parse, type-check, format and recover byte-identical canonical `.noe`;
+2. project and recover the same graph under a digest-bound text profile;
+3. select a conservative operation/state slice with a manifest naming every
+   included and omitted node and the evidence for each omission;
+4. answer `select`, `check`, `next`, `literal` and `explain` without executing
+   an external effect; and
+5. verify four source-bound specimens, hostile mutations, fixed compression
+   gates and separately recorded fresh-context answers.
+
+The deterministic acceptance command will be
+`python3 scripts/noema.py verify --manifest tests/fixtures/noema-v1/manifest.json`.
+Focused proof will be `python3 -m unittest tests.test_noema -v`. Model contexts
+remain outside those commands: an offline `emit-evaluation`/`tally-evaluation`
+pair will bind one fresh context per case and refuse a result that does not name
+two genuinely distinct family identities. The issue is accepted only if the
+verified record meets item 10's fixed gates; a measured rejection is a valid
+design outcome.
+
+## 2. Prior art
+
+The target paths `docs/noema/`, `schemas/noema-v1.schema.json`,
+`scripts/noema.py`, `tests/test_noema.py` and `tests/fixtures/noema-v1/` do not
+exist at the starting ref. `git log --first-parent --merges` over those exact
+paths returns no pull request, so there are no two merged changes to read for
+the new target itself. The last two merged pull requests on the nearest
+model-evaluation boundary are the useful substitutes:
+
+**[#922](https://github.com/wildcat-finance/skills/pull/922)**, merged as
+`a8289d46`, added an offline packet/tally driver for 38 isolated router-selection
+contexts. Its applicable carried items are retained here: prompts contain no
+answers, every context receives one case, duplicate answer ids refuse, the
+manifest is written last, and a committed result records one grading rather
+than a rerun guarantee. Its open tree-binding gap becomes a Noema requirement:
+each evaluation record binds the source tree, graph, projection, kernel,
+profile and case-set digests.
+
+**[#851](https://github.com/wildcat-finance/skills/pull/851)**, merged as
+`d1ca7ba5`, added Homologia and forced the router corpus regrade that #922 later
+made repeatable. It established two limits that carry here. Agreement between
+two implementations is not correctness, and a model result without the tree it
+graded cannot distinguish model variance from changed instructions. Noema's
+graph equality is therefore structural evidence; semantic adequacy still needs
+source-span review and fresh-context cases.
+
+Pull request [#755](https://github.com/wildcat-finance/skills/pull/755) is the
+adjacent provider-boundary precedent. Its job-scoped model proxy keeps
+credentials and provider-native authority out of a worker and treats synthetic
+conformance as component evidence. Noema reuses the separation, not the proxy:
+committed tooling emits and tallies bounded packets offline, and any live
+adapter remains a separately authorised operator surface.
+
+The controlling prior design is still the open #909 stack. Pull request
+[#921](https://github.com/wildcat-finance/skills/pull/921) freezes
+`wildcat-agent-instruction/v1`; pull request
+[#937](https://github.com/wildcat-finance/skills/pull/937) implements its
+bounded canonical codec at audited head `7305e750`. The following lessons are
+content for this run:
+
+- preserve the Promise claim itself, not only its authority fields;
+- count every literal occurrence across direct validation and decoding;
+- enforce per-value and aggregate bounds before numeric conversion;
+- require one physical source path identity so sibling spans cannot evade
+  overlap checks; and
+- derive atomic temporary names independently of the caller's leaf length.
+
+The current-main whole-set audit-synopsis check exited 0. The views read were
+`audit/AUDIT_SYNOPSIS.md` for the root history and
+`audit/rounds/fiat-904-grade-the-router-corpus-from-a-driver-rather.synopsis.md`
+for #922. The #909 record is PR-local, so its synopsis is outside current-main
+currency; both
+`audit/rounds/fiat-909-compact-lossless-agent-instruction-language.md` and its
+synopsis were read directly from audited head `7305e750`. No finding from that
+record is treated as fixed on `main` until its stack lands.
+
+Outside the repository, no format or library is selected. The hypothesis is
+about this corpus and its existing Python pin; adopting a serialization or
+provider SDK before the graph contract exists would choose the dependency
+before the semantics.
+
+## 3. Constraints and non-goals
+
+The starting ref is `7e97b5195d5b0e43146b4200f26cd41b89003413` on
+`main`. At least four other agents are changing the repository, so every step
+uses the dedicated Fiat stack and regenerates shared derived files only when
+its own tracked paths require them. It does not rebase, retarget, close or edit
+#909, #921, #937 or their branches. Compatible ideas may be reimplemented from
+their public contract; unmerged code is not copied across the stack.
+
+The prototype is root tooling, not a plugin or selectable skill. It changes no
+marketplace manifest, runtime router, existing `SKILL.md`, Promise Machine
+claim, CI workflow or external repository. A later accepted design may earn a
+separate registration or migration run.
+
+Python uses the exact `.python-version` interpreter. Canonical validation,
+slicing, policy decisions, packet emission and tallying use the standard
+library. Tokenizer and model-family programs are external, digest-bound
+adapters with explicit argv; adding a dependency, downloading a model, sending
+source to a network, using a credential or incurring paid endpoint use is
+ask-first.
+
+Non-goals for this issue:
+
+- lossless translation of arbitrary English, custom model training or a claim
+  that a reviewed graph captures an author's unexpressed intent;
+- repository-wide conversion, Shoggoth migration or an authority flip for any
+  existing skill;
+- raw tokenizer ids, binary/base64 prompt transport or an opaque substitution
+  cipher whose dictionary cost is omitted;
+- executing repository, publication, deployment, security or financial
+  effects from the Noema runtime; and
+- universal model-family parity, tokenizer stability or safety beyond the
+  exact profiles, cases and records observed.
+
+Source-to-graph review remains a human evidence boundary. Unsupported governed
+meaning blocks migration and appears as an explicit unsupported remainder;
+display prose and rationale may remain source-bound, non-authoritative
+sidecars.
+
+## 4. Design options
+
+**A. Extend the active `wildcat-agent-instruction/v1` stack.** Rejected for
+this run. #909 fixes Markdown as authored authority and compact bytes as a full
+derived view. Noema tests a different authority endpoint plus operation/state
+slicing. Mixing both into the active stack would make #909 review moving
+ground, erase the control design and create avoidable conflicts with #921 and
+#937.
+
+**B. Encode prose as a private binary or token substitution table.** Rejected.
+The seed measured Fiat Markdown at 13,628 `o200k_base` tokens and its
+gzip/base64 and gzip/base85 forms at 19,173 and 19,707. Ten aliases cut one
+Brevitas tape from 479 to 455 tokens, while their 73-token legend raised first
+use to 528. A carrier win without grammar, dictionary and behavioral cost is a
+shell game, plus opaque bytes discard ordinary Git review.
+
+**C. Keep Markdown authoritative and emit task-specific prose summaries.**
+Rejected as the final design. It can save tokens, but authority checks still
+depend on a model interpreting prose and an omitted prohibition has no
+deterministic witness. This remains a useful baseline in the evaluation.
+
+**D. Build a closed typed graph with canonical `.noe`, digest-bound modules,
+provider text projections, a conservative slicer and a non-executing policy
+runtime.** Chosen. Canonical source is a line-oriented, non-English semantic
+program with stable rule ids and typed inert literals. A projection may shorten
+reserved opcodes and qualified predicates only when its manifest recovers the
+same graph and includes its dictionary cost. The runtime computes policy
+answers from the graph and supplied checked facts; models consume slices and
+propose effects but do not decide their own authority.
+
+The trade is a larger trusted computing base: parser, type checker, module
+registry, projector, slicer and policy evaluator all become security-sensitive.
+That cost is accepted only for a bounded shadow prototype. Five stacked steps
+separate contract, codec, slicing/runtime, specimens and evaluation so each
+layer can be rejected without converting a skill or changing authority.
+
+## 5. Risk register seed
+
+```risk-register
+source-omission | governed Markdown spans | every byte span is mapped to one reviewed node or one explicit unsupported remainder; overlap, gap and stale-source checks refuse
+semantic-drift | canonical source, graph and projection | source-to-graph review is recorded, graph round trips are byte-identical, and semantic diff names every changed effect, gate, authority, scope, evidence class, literal and precedence edge
+slice-omission | a rule omitted from one operation/state slice | false guards need recorded facts; unknown guards remain; effect closure retains prohibitions, authority, order, exceptions, refusal and recovery
+authority-confusion | capability, authority, execution, receipt and verification | each is a separate type and no transition infers another; consequence-2/3 checks default deny without applicable authority and satisfied gates
+module-drift | imported predicate or macro meaning | locks bind full module bytes, compiler and profile digests; missing, stale, cyclic or ambient imports refuse
+alias-collision | tokenizer-profile projection | aliases are injective across reserved opcodes, predicates, literal ids and visible values; the projector refuses collision or overload
+literal-injection | instruction-shaped path, quote, text, command, URL or error bytes | literals are length-bound inert nodes and require a separately authorised effect before use
+parser-exhaustion | untrusted `.noe`, manifests, facts and tapes | byte, line, node, depth, import, literal, expansion and output caps apply before allocation or integer conversion; no partial graph escapes a refusal
+profile-mismatch | tokenizer, vocabulary, kernel or projection change | exact executable or vocabulary identity and digests are recorded and reread; unlike profiles are never compared as one cohort
+hidden-overhead | bootstrap, definitions, aliases or cached prefix | reports separate every component and count first use, steady state, full canonical and corpus-amortised totals under the same tokenizer
+evaluation-contamination | fresh-context model comparison | one case per context, answer-free packets, exact case-set equality, distinct family identities and source/tree/profile digests are mandatory
+provider-boundary | external tokenizer or model process | explicit argv, cleared environment allowlist, public synthetic inputs, timeout, output cap and no shell; credentials, network and paid use remain ask-first
+derived-drift | semantic diff, render, tape, manifest or evidence record | deterministic regeneration and digest comparison refuse stale checked-in views; binary caches carry no review authority
+parallel-stack | #909 or current-main movement | no #909 path changes; each step rechecks ancestry and regenerates only its own derived counts against its actual tree
+```
+
+## 6. Glossary seeds
+
+- **NIR.** The closed typed graph recovered from canonical source. Graph
+  identity is a digest of canonical bytes and locked module meanings.
+- **`.noe`.** The canonical line-oriented review and authorship surface. It
+  contains structural opcodes, qualified predicates, stable ids and typed
+  literal references, with no governing prose.
+- **Module.** A finite, digest-bound set of predicate signatures and pure graph
+  definitions. It cannot alter a core opcode.
+- **Projection.** A deterministic text representation for a declared tokenizer
+  profile. It is derived and must recover the same NIR with its manifest.
+- **Slice.** Dependency closure for one operation, state, target, tool set,
+  authority input and fact set.
+- **Slice manifest.** The commitment to the full graph, compiler, inputs,
+  included and omitted ids, omission facts, reachable definitions and literals,
+  emitted projection and every digest.
+- **Policy runtime.** The bounded, non-executing implementation of `select`,
+  `check`, `next`, `literal` and `explain`.
+- **Unsupported remainder.** A source span with no admitted semantics. It is
+  visible evidence that blocks authority migration and grants nothing.
+- **Prompt-only mode.** The fallback that gives a model the complete reachable
+  kernel, dictionary and slice. Every one of those tokens counts.
+- **Shadow mode.** Markdown remains authoritative while Noema output is checked
+  as derived evidence. This issue never leaves shadow mode.
+
+## 7. Sources
+
+- Issue [#942](https://github.com/wildcat-finance/skills/issues/942), including
+  its fixed acceptance gates and public evidence attachment.
+- `noema-v0-evidence.zip`, 24,907 bytes, SHA-256
+  `1e1eb5e9908551f1337b7ec58a37ae7f37fd97e41d5ac424bc4992eb1d11b540`;
+  all 17 listed source files and the clean archive test were read.
+- Issue [#909](https://github.com/wildcat-finance/skills/issues/909), pull
+  requests [#921](https://github.com/wildcat-finance/skills/pull/921) and
+  [#937](https://github.com/wildcat-finance/skills/pull/937), and audited head
+  `7305e750f06c5180f380d0e54af71e825e32587e`.
+- On the #909 head: `docs/agent-instruction-language-v1.md`,
+  `docs/compact-agent-instruction-language/study.md`,
+  `docs/compact-agent-instruction-language/runbook.md`,
+  `docs/decisions/ADR-051-encode-a-closed-agent-instruction-model.md`, and both
+  `audit/rounds/fiat-909-compact-lossless-agent-instruction-language` views.
+- Merged pull requests [#922](https://github.com/wildcat-finance/skills/pull/922),
+  [#851](https://github.com/wildcat-finance/skills/pull/851) and
+  [#755](https://github.com/wildcat-finance/skills/pull/755), plus current-main
+  `audit/AUDIT_SYNOPSIS.md` and #922's current synopsis.
+
+## 8. Signals, and the questions behind them
+
+Every command is operator-run; there is no daemon, unattended scheduler or
+on-call alert. Ephoros's questions still determine the result record. An
+operator needs to know which source, graph, module set, profile, facts and
+operation were read; whether a decision was permit, refuse or unknown; which
+node controlled it; what was omitted and why; what recovery remains; and
+whether output bytes were committed atomically.
+
+Each command emits one bounded
+`noema-result/v1` JSON line carrying command, correlation id, input and output
+digests, counts, verdict or refusal code, controlling node and output path when
+one exists. `select` also writes a manifest; `check` and `next` name the rule or
+transition; `literal` names the typed literal; `explain` labels its render
+non-authoritative. No result contains full source, literal payloads, prompts,
+model output or credentials.
+
+Evaluation records add case id, isolated-context nonce, declared model family
+and exact model/profile identity. The tally reports required-answer agreement,
+refusals and unknowns per family and representation. These are run evidence,
+not telemetry about future prompts. There is no production metric or alert to
+invent for a local prototype.
+
+## 9. Boundaries, per capability
+
+- **Imports the seed.** Only the public archive whose exact size and SHA-256
+  appear in item 7. Extraction rejects absolute paths, traversal, links,
+  special files, unexpected names, duplicate names, excess bytes and any
+  per-file digest mismatch. Imported specimens are reference fixtures; seed
+  Python is never executed or installed.
+- **Reads and writes repository files.** Paths resolve beneath the repository
+  or a declared fixture root, with regular-file, symlink and size checks.
+  Derived output uses a target-independent sibling temporary name, fsync and
+  atomic replacement. No shell interpolation or evaluator consumes source.
+- **Parses and projects instructions.** The grammar, types, opcodes and keys are
+  closed. Validation completes before a graph or tape is returned. Unknown
+  syntax, types, ids, references, modules, profiles and trailing bytes refuse
+  with stable codes.
+- **Selects and checks policy.** The runtime receives checked facts as data,
+  closes a slice and returns a decision. It has no subprocess, network, Git,
+  GitHub or mutation capability. A permit result authorises nothing outside the
+  caller's separately recorded authority; it never performs the effect.
+- **Runs external profiles.** Offline emit/tally is the default. An optional
+  tokenizer or model adapter accepts an explicit digest-bound argv list,
+  minimal environment allowlist, timeout and output cap. New dependencies,
+  model downloads, credentials, network/source disclosure and paid calls need
+  the operator's separate recorded authority before execution.
+
+Human source-span review, model comprehension and the truth of supplied facts
+remain outside deterministic validation. The result record says `checked`,
+`recorded`, `measured` or `unknown` for the relation actually established and
+does not strengthen one into another.
+
+## 10. The budget, or its absence
+
+Compression is the reason for the work, so Metron's baseline/change rule is a
+gate. The seed numbers are prior evidence, not the official baseline. Each
+official run counts the same exact corpus under the same profile before and
+after projection and reports bytes and real tokenizer counts separately for
+Markdown source, canonical `.noe`, full projection, operation slice, literals,
+kernel, reachable definitions and corpus-amortised totals.
+
+The fixed semantic-token gates from #942 are:
+
+- first-use kernel + definitions + slice at most 70% of relevant Markdown;
+- steady-state slice at most 40%; and
+- complete canonical Noema at most 55% of the declared source corpus.
+
+Critical authority, permission/prohibition, negation, unknown-guard, ordering,
+exact-literal and consequence-3 vectors must pass 100%. Results must name
+OpenAI, Anthropic, Google and one open-weight tokenizer profile; an unavailable
+exact tokenizer remains `unknown`. Behavioral evidence needs two genuinely
+different agent families. Aliases, two versions of one family and unrecorded
+endpoints do not satisfy that count.
+
+Resource caps for version 1 are fixed before implementation: 1,048,576 input
+bytes, 65,536 bytes per physical line, 16,384 records, 16,384 graph nodes,
+64 imports, depth 64, 65,000 bytes per literal, 786,432 aggregate decoded
+literal bytes, 65,536 expanded macro nodes, 4,096 members in any finite
+quantifier set and 1,048,576 output bytes. The implementation may lower a cap
+only before Step 1's contract is receipted and with the reason recorded; it may
+not raise or omit one after a hostile fixture reaches it.
+
+No wall-clock performance claim is made. External adapters use explicit
+timeouts for safe operation, while speed is recorded only as diagnostic
+context and cannot rescue a semantic or token-gate failure.
+
+## 11. The fail-closed posture
+
+Stable refusal families cover syntax, canonical form, type, bounds, reference
+closure, source binding, module/profile digest, alias collision, slice closure,
+authority, path/I/O and evaluation binding. A refusal returns no partial graph,
+slice, decision, tape or evidence record. Atomic output keeps the old complete
+file or the new complete file; a durability uncertainty still reports refusal.
+
+Unknown facts stay unknown. A checked-false guard may omit its dependent rule
+only with that fact in the manifest; an unknown guard keeps the rule. Permission
+does not cancel prohibition. Conflicting requirements refuse unless a typed
+override names higher authority, scope and evidence. Consequence-2/3 effects
+default deny without applicable authority even when no explicit prohibition is
+present.
+
+Failure blocks only the dependent output or policy answer. Inspection,
+`explain`, source repair, manifest repair, rerun and safe exit remain available
+when their own inputs validate. The validator never edits a failing source to
+make it pass.
+
+Elenchus governs every defect found after implementation: preserve the exact
+failing bytes, reduce them to the smallest case, make the guard fail against
+the parent, fix the cause, then retain the guard. A changed answer without a
+changed semantic digest is a high-severity evaluation finding; a changed
+semantic digest without a named semantic diff is a high-severity codec finding.
+
+## 12. Decisions and their homes
+
+The expensive decision is the authority direction. This run chooses shadow
+mode: existing Markdown remains authoritative, canonical Noema and every
+projection remain derived, and the policy runtime is non-executing. The final
+ADR at `docs/decisions/ADR-<next>-evaluate-noema-as-a-sliced-instruction-ir.md`
+must choose accept, narrow or reject from the recorded gates. It must reconcile
+#909's full-derived-codec conclusion, state the measured trade, and name the
+separate evidence and run that a later authority reversal would require.
+
+The public grammar, types, bounds, stable refusal codes, module/profile lock,
+slice and runtime interfaces live in `docs/noema-v1.md` and
+`schemas/noema-v1.schema.json`. The implementation lives in
+`scripts/noema.py`; source-bound specimens, manifests, mutations, tokenizer
+profiles and evaluation records live under `tests/fixtures/noema-v1/`; focused
+guards live in `tests/test_noema.py`. The receipted study and runbook are copied
+byte for byte into `docs/noema/` before product implementation.
+
+The five ordered steps are: freeze the contract and verified seed inventory;
+build the canonical graph, module lock and projection; build conservative
+slicing and the policy runtime; bind four specimens plus hostile mutations;
+then measure, run or tally the authorised fresh-context evaluation and write
+the ADR. The last step stops at its entry if two authorised family runs cannot
+be established. A stop records unknown evidence; it does not weaken the gate,
+invent parity or hold earlier shadow-mode tooling out as accepted Noema.

--- a/schemas/noema-v1.schema.json
+++ b/schemas/noema-v1.schema.json
@@ -34,7 +34,7 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 512,
-      "pattern": "^[A-Za-z0-9][A-Za-z0-9._/-]*$"
+      "pattern": "^(?!.*//)(?!.*(?:^|/)\\.{1,2}(?:/|$))[A-Za-z0-9](?:[A-Za-z0-9._/-]*[A-Za-z0-9._-])?$"
     },
     "seedFile": {
       "type": "object",

--- a/schemas/noema-v1.schema.json
+++ b/schemas/noema-v1.schema.json
@@ -1,0 +1,579 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wildcat.finance/schemas/noema-v1.schema.json",
+  "title": "Noema version 1 shadow-prototype records",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/seedInventory"
+    },
+    {
+      "$ref": "#/$defs/lock"
+    },
+    {
+      "$ref": "#/$defs/manifest"
+    },
+    {
+      "$ref": "#/$defs/result"
+    },
+    {
+      "$ref": "#/$defs/evidence"
+    }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "identifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z][A-Za-z0-9_.-]*$"
+    },
+    "relativePath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._/-]*$"
+    },
+    "seedFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "bytes",
+        "sha256"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1048576
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "seedInventory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "archive",
+        "files"
+      ],
+      "properties": {
+        "schema": {
+          "const": "noema-seed-inventory/v1"
+        },
+        "archive": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "url",
+            "bytes",
+            "sha256",
+            "root"
+          ],
+          "properties": {
+            "name": {
+              "const": "noema-v0-evidence.zip"
+            },
+            "url": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 2048,
+              "format": "uri"
+            },
+            "bytes": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1048576
+            },
+            "sha256": {
+              "$ref": "#/$defs/sha256"
+            },
+            "root": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 256,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*/$"
+            }
+          }
+        },
+        "files": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/seedFile"
+          }
+        }
+      }
+    },
+    "moduleLock": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "sha256"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "lock": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "source_sha256",
+        "graph_sha256",
+        "compiler_sha256",
+        "kernel_sha256",
+        "profile_sha256",
+        "modules"
+      ],
+      "properties": {
+        "schema": {
+          "const": "noema-lock/v1"
+        },
+        "source_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "graph_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "compiler_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "kernel_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "profile_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "modules": {
+          "type": "array",
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/moduleLock"
+          }
+        }
+      }
+    },
+    "fact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "value",
+        "evidence_sha256"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "value": {
+          "enum": [
+            "true",
+            "false",
+            "unknown"
+          ]
+        },
+        "evidence_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "omission": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "reason",
+        "fact"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "reason": {
+          "const": "checked-false-guard"
+        },
+        "fact": {
+          "$ref": "#/$defs/identifier"
+        }
+      }
+    },
+    "selection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation",
+        "state",
+        "target",
+        "tools",
+        "authority",
+        "facts"
+      ],
+      "properties": {
+        "operation": {
+          "$ref": "#/$defs/identifier"
+        },
+        "state": {
+          "$ref": "#/$defs/identifier"
+        },
+        "target": {
+          "$ref": "#/$defs/identifier"
+        },
+        "tools": {
+          "type": "array",
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/identifier"
+          }
+        },
+        "authority": {
+          "type": "array",
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/identifier"
+          }
+        },
+        "facts": {
+          "type": "array",
+          "maxItems": 4096,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/fact"
+          }
+        }
+      }
+    },
+    "manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "graph_sha256",
+        "lock_sha256",
+        "compiler_sha256",
+        "kernel_sha256",
+        "profile_sha256",
+        "selection",
+        "included_ids",
+        "omitted",
+        "definitions",
+        "literals",
+        "projection_sha256"
+      ],
+      "properties": {
+        "schema": {
+          "const": "noema-manifest/v1"
+        },
+        "graph_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "lock_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "compiler_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "kernel_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "profile_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "selection": {
+          "$ref": "#/$defs/selection"
+        },
+        "included_ids": {
+          "type": "array",
+          "maxItems": 16384,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/identifier"
+          }
+        },
+        "omitted": {
+          "type": "array",
+          "maxItems": 16384,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/omission"
+          }
+        },
+        "definitions": {
+          "type": "array",
+          "maxItems": 16384,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/identifier"
+          }
+        },
+        "literals": {
+          "type": "array",
+          "maxItems": 16384,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/identifier"
+          }
+        },
+        "projection_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "digestSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "archive": {
+          "$ref": "#/$defs/sha256"
+        },
+        "inventory": {
+          "$ref": "#/$defs/sha256"
+        },
+        "source": {
+          "$ref": "#/$defs/sha256"
+        },
+        "graph": {
+          "$ref": "#/$defs/sha256"
+        },
+        "lock": {
+          "$ref": "#/$defs/sha256"
+        },
+        "profile": {
+          "$ref": "#/$defs/sha256"
+        },
+        "kernel": {
+          "$ref": "#/$defs/sha256"
+        },
+        "projection": {
+          "$ref": "#/$defs/sha256"
+        },
+        "manifest": {
+          "$ref": "#/$defs/sha256"
+        },
+        "output": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "countSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1048576
+        },
+        "members": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 64
+        },
+        "records": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 16384
+        },
+        "nodes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 65536
+        },
+        "included": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 16384
+        },
+        "omitted": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 16384
+        },
+        "cases": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4096
+        }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "command",
+        "correlation_id",
+        "verdict",
+        "code",
+        "digests",
+        "counts"
+      ],
+      "properties": {
+        "schema": {
+          "const": "noema-result/v1"
+        },
+        "command": {
+          "enum": [
+            "about",
+            "verify-seed",
+            "parse",
+            "format",
+            "project",
+            "semantic-diff",
+            "select",
+            "check",
+            "next",
+            "literal",
+            "explain",
+            "verify",
+            "mutations",
+            "measure",
+            "emit-evaluation",
+            "tally-evaluation",
+            "self-test",
+            "runtime-self-test"
+          ]
+        },
+        "correlation_id": {
+          "$ref": "#/$defs/sha256"
+        },
+        "verdict": {
+          "enum": [
+            "ok",
+            "refuse",
+            "unknown"
+          ]
+        },
+        "code": {
+          "type": "string",
+          "pattern": "^NOE-(OK|I-[A-Z0-9_.-]+|E-[A-Z0-9_.-]+)$"
+        },
+        "field": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9_.\u005b\u005d-]+$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        "digests": {
+          "$ref": "#/$defs/digestSet"
+        },
+        "counts": {
+          "$ref": "#/$defs/countSet"
+        }
+      }
+    },
+    "profileEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "family",
+        "identity",
+        "status"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "family": {
+          "enum": [
+            "openai",
+            "anthropic",
+            "google",
+            "open-weight"
+          ]
+        },
+        "identity": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "status": {
+          "enum": [
+            "measured",
+            "recorded",
+            "unknown"
+          ]
+        },
+        "executable_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "vocabulary_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "kind",
+        "tree_sha256",
+        "manifest_sha256",
+        "status",
+        "profiles"
+      ],
+      "properties": {
+        "schema": {
+          "const": "noema-evidence/v1"
+        },
+        "kind": {
+          "enum": [
+            "measurement",
+            "evaluation"
+          ]
+        },
+        "tree_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "status": {
+          "enum": [
+            "measured",
+            "recorded",
+            "unknown"
+          ]
+        },
+        "profiles": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 16,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/profileEvidence"
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/noema.py
+++ b/scripts/noema.py
@@ -203,7 +203,13 @@ def _exact_keys(value: object, expected: set[str], field: str) -> dict[str, obje
 
 
 def _bounded_string(value: object, field: str, limit: int) -> str:
-    if not isinstance(value, str) or not value or len(value.encode("utf-8")) > limit:
+    if not isinstance(value, str) or not value:
+        refuse("NOE-E-TYPE.STRING", field, "expected one bounded non-empty string")
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError:
+        refuse("NOE-E-SYNTAX.UNICODE", field, "string must contain Unicode scalar values")
+    if len(encoded) > limit:
         refuse("NOE-E-TYPE.STRING", field, "expected one bounded non-empty string")
     if unicodedata.normalize("NFC", value) != value:
         refuse("NOE-E-SYNTAX.UNICODE", field, "string must be NFC")
@@ -399,6 +405,7 @@ def verify_seed(archive_path: Path, inventory_path: Path) -> dict[str, object]:
     except (
         OSError,
         RuntimeError,
+        UnicodeError,
         zipfile.BadZipFile,
         zipfile.LargeZipFile,
         zlib.error,

--- a/scripts/noema.py
+++ b/scripts/noema.py
@@ -30,6 +30,11 @@ MAX_PATH_BYTES = 512
 MAX_JSON_BYTES = 1_048_576
 
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+SEED_RELATIVE_PATH_RE = re.compile(
+    r"^(?!.*//)(?!.*(?:^|/)\.{1,2}(?:/|$))[A-Za-z0-9]"
+    r"(?:[A-Za-z0-9._/-]*[A-Za-z0-9._-])?$"
+)
+SEED_ROOT_PATH_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/$")
 UNIMPLEMENTED = (
     "parse",
     "format",
@@ -216,6 +221,8 @@ def _relative_path(value: object, field: str) -> str:
         refuse("NOE-E-PATH.TRAVERSAL", field, "path must stay below the archive root")
     if path.as_posix() != text:
         refuse("NOE-E-PATH.RELATIVE", field, "archive member path must be canonical POSIX")
+    if SEED_RELATIVE_PATH_RE.fullmatch(text) is None:
+        refuse("NOE-E-PATH.RELATIVE", field, "archive member path is outside the seed alphabet")
     return text
 
 
@@ -229,6 +236,7 @@ def _root_path(value: object, field: str) -> str:
         len(path.parts) != 1
         or path.parts[0] in {"", ".", ".."}
         or path.as_posix() != root
+        or SEED_ROOT_PATH_RE.fullmatch(text) is None
     ):
         refuse("NOE-E-PATH.ROOT", field, "archive root must be one relative directory")
     return text

--- a/scripts/noema.py
+++ b/scripts/noema.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Bounded entrypoint for the Noema version 1 shadow prototype."""
+
+from __future__ import annotations
+
+import argparse
+from hashlib import sha256
+import io
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import stat
+import sys
+import unicodedata
+import zipfile
+
+
+CONTRACT = "noema/v1"
+SOURCE_MAGIC = "NOE1"
+PROJECTION_MAGIC = "NT1"
+RESULT_SCHEMA = "noema-result/v1"
+INVENTORY_SCHEMA = "noema-seed-inventory/v1"
+
+MAX_ARCHIVE_BYTES = 1_048_576
+MAX_MEMBERS = 64
+MAX_MEMBER_BYTES = 1_048_576
+MAX_TOTAL_MEMBER_BYTES = 1_048_576
+MAX_PATH_BYTES = 512
+MAX_JSON_BYTES = 1_048_576
+
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+UNIMPLEMENTED = (
+    "parse",
+    "format",
+    "project",
+    "semantic-diff",
+    "select",
+    "check",
+    "next",
+    "literal",
+    "explain",
+    "verify",
+    "mutations",
+    "measure",
+    "emit-evaluation",
+    "tally-evaluation",
+    "self-test",
+    "runtime-self-test",
+)
+ALLOWED_COMPRESSION = {zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED}
+
+
+class Refusal(ValueError):
+    """One stable, bounded refusal without untrusted payload bytes."""
+
+    def __init__(self, code: str, field: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.field = field
+        self.message = message
+
+
+def refuse(code: str, field: str, message: str) -> None:
+    raise Refusal(code, field, message)
+
+
+def _correlation(command: str, *values: str) -> str:
+    digest = sha256()
+    digest.update(b"noema-result/v1\x00")
+    for value in (command, *values):
+        encoded = value.encode("utf-8")
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+    return digest.hexdigest()
+
+
+def _result(
+    command: str,
+    verdict: str,
+    code: str,
+    *,
+    correlation_values: tuple[str, ...] = (),
+    field: str | None = None,
+    message: str | None = None,
+    digests: dict[str, str] | None = None,
+    counts: dict[str, int] | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema": RESULT_SCHEMA,
+        "command": command,
+        "correlation_id": _correlation(command, *correlation_values),
+        "verdict": verdict,
+        "code": code,
+        "digests": digests or {},
+        "counts": counts or {},
+    }
+    if field is not None:
+        payload["field"] = field
+    if message is not None:
+        payload["message"] = message
+    return payload
+
+
+def emit(payload: dict[str, object]) -> None:
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+
+
+def _object_without_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            refuse("NOE-E-SYNTAX.DUPLICATE_KEY", "inventory", "duplicate JSON key")
+        result[key] = value
+    return result
+
+
+def _read_regular(path: Path, field: str, limit: int) -> bytes:
+    if not hasattr(os, "O_NOFOLLOW"):
+        refuse("NOE-E-PATH.PLATFORM", field, "no-follow file reads are unavailable")
+    try:
+        before_path = path.lstat()
+    except OSError:
+        refuse("NOE-E-IO.READ", field, "regular input cannot be inspected")
+    if not stat.S_ISREG(before_path.st_mode):
+        refuse("NOE-E-PATH.REGULAR", field, "input must be a regular file")
+    if before_path.st_size > limit:
+        refuse("NOE-E-BOUNDS.FILE", field, "input exceeds its byte limit")
+
+    flags = os.O_RDONLY | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        refuse("NOE-E-IO.READ", field, "regular input cannot be opened")
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            refuse("NOE-E-PATH.REGULAR", field, "opened input is not a regular file")
+        if (before.st_dev, before.st_ino) != (before_path.st_dev, before_path.st_ino):
+            refuse("NOE-E-PATH.IDENTITY", field, "input identity changed before read")
+        if before.st_size > limit:
+            refuse("NOE-E-BOUNDS.FILE", field, "input exceeds its byte limit")
+
+        chunks: list[bytes] = []
+        total = 0
+        while True:
+            chunk = os.read(descriptor, min(65_536, limit + 1 - total))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > limit:
+                refuse("NOE-E-BOUNDS.FILE", field, "input exceeds its byte limit")
+        after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+
+    before_identity = (
+        before.st_dev,
+        before.st_ino,
+        before.st_size,
+        before.st_mtime_ns,
+        before.st_ctime_ns,
+    )
+    after_identity = (
+        after.st_dev,
+        after.st_ino,
+        after.st_size,
+        after.st_mtime_ns,
+        after.st_ctime_ns,
+    )
+    if before_identity != after_identity or total != after.st_size:
+        refuse("NOE-E-IO.CHANGED", field, "input changed during read")
+    return b"".join(chunks)
+
+
+def _exact_keys(value: object, expected: set[str], field: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        refuse("NOE-E-TYPE.OBJECT", field, "expected an object")
+    actual = set(value)
+    if actual != expected:
+        refuse("NOE-E-TYPE.KEYS", field, "object keys do not match the closed shape")
+    return value
+
+
+def _bounded_string(value: object, field: str, limit: int) -> str:
+    if not isinstance(value, str) or not value or len(value.encode("utf-8")) > limit:
+        refuse("NOE-E-TYPE.STRING", field, "expected one bounded non-empty string")
+    if unicodedata.normalize("NFC", value) != value:
+        refuse("NOE-E-SYNTAX.UNICODE", field, "string must be NFC")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        refuse("NOE-E-SYNTAX.CONTROL", field, "control characters are forbidden")
+    return value
+
+
+def _bounded_integer(value: object, field: str, maximum: int, *, minimum: int = 0) -> int:
+    if type(value) is not int or value < minimum or value > maximum:
+        refuse("NOE-E-BOUNDS.INTEGER", field, "integer is outside its closed range")
+    return value
+
+
+def _digest(value: object, field: str) -> str:
+    if not isinstance(value, str) or SHA256_RE.fullmatch(value) is None:
+        refuse("NOE-E-TYPE.SHA256", field, "expected one lowercase SHA-256 value")
+    return value
+
+
+def _relative_path(value: object, field: str) -> str:
+    text = _bounded_string(value, field, MAX_PATH_BYTES)
+    if "\\" in text or text.startswith("/") or text.endswith("/"):
+        refuse("NOE-E-PATH.RELATIVE", field, "expected one file path below the archive root")
+    path = PurePosixPath(text)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        refuse("NOE-E-PATH.TRAVERSAL", field, "path must stay below the archive root")
+    return text
+
+
+def _root_path(value: object, field: str) -> str:
+    text = _bounded_string(value, field, 256)
+    if "\\" in text or not text.endswith("/") or text.startswith("/"):
+        refuse("NOE-E-PATH.ROOT", field, "archive root must be one relative directory")
+    path = PurePosixPath(text[:-1])
+    if len(path.parts) != 1 or path.parts[0] in {"", ".", ".."}:
+        refuse("NOE-E-PATH.ROOT", field, "archive root must be one relative directory")
+    return text
+
+
+def load_inventory(path: Path) -> tuple[dict[str, object], bytes]:
+    raw = _read_regular(path, "inventory", MAX_JSON_BYTES)
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        refuse("NOE-E-SYNTAX.UTF8", "inventory", "inventory must be UTF-8")
+    if text.startswith("\ufeff"):
+        refuse("NOE-E-SYNTAX.BOM", "inventory", "inventory must not carry a BOM")
+    try:
+        value = json.loads(text, object_pairs_hook=_object_without_duplicates)
+    except Refusal:
+        raise
+    except (ValueError, RecursionError):
+        refuse("NOE-E-SYNTAX.JSON", "inventory", "inventory is not bounded JSON")
+
+    inventory = _exact_keys(value, {"schema", "archive", "files"}, "inventory")
+    if inventory["schema"] != INVENTORY_SCHEMA:
+        refuse("NOE-E-TYPE.VERSION", "inventory.schema", "unsupported inventory schema")
+
+    archive = _exact_keys(
+        inventory["archive"],
+        {"name", "url", "bytes", "sha256", "root"},
+        "inventory.archive",
+    )
+    if _bounded_string(archive["name"], "inventory.archive.name", 256) != "noema-v0-evidence.zip":
+        refuse("NOE-E-TYPE.ARCHIVE_NAME", "inventory.archive.name", "unexpected archive name")
+    url = _bounded_string(archive["url"], "inventory.archive.url", 2048)
+    if not url.startswith("https://"):
+        refuse("NOE-E-TYPE.URL", "inventory.archive.url", "archive URL must use HTTPS")
+    _bounded_integer(archive["bytes"], "inventory.archive.bytes", MAX_ARCHIVE_BYTES, minimum=1)
+    _digest(archive["sha256"], "inventory.archive.sha256")
+    _root_path(archive["root"], "inventory.archive.root")
+
+    files = inventory["files"]
+    if not isinstance(files, list) or not files or len(files) > MAX_MEMBERS:
+        refuse("NOE-E-BOUNDS.MEMBERS", "inventory.files", "file inventory count is outside its limit")
+    paths: list[str] = []
+    total = 0
+    for index, item in enumerate(files):
+        entry = _exact_keys(item, {"path", "bytes", "sha256"}, f"inventory.files[{index}]")
+        paths.append(_relative_path(entry["path"], f"inventory.files[{index}].path"))
+        total += _bounded_integer(
+            entry["bytes"],
+            f"inventory.files[{index}].bytes",
+            MAX_MEMBER_BYTES,
+        )
+        _digest(entry["sha256"], f"inventory.files[{index}].sha256")
+    if paths != sorted(paths) or len(paths) != len(set(paths)):
+        refuse("NOE-E-REFERENCE.FILE_ORDER", "inventory.files", "file paths must be unique and sorted")
+    if total > MAX_TOTAL_MEMBER_BYTES:
+        refuse("NOE-E-BOUNDS.TOTAL", "inventory.files", "inventoried bytes exceed the aggregate limit")
+    return inventory, raw
+
+
+def _member_kind(info: zipfile.ZipInfo) -> str:
+    mode = (info.external_attr >> 16) & 0xFFFF
+    kind = stat.S_IFMT(mode)
+    if info.is_dir():
+        return "directory" if kind in {0, stat.S_IFDIR} else "special"
+    return "file" if kind in {0, stat.S_IFREG} else "special"
+
+
+def verify_seed(archive_path: Path, inventory_path: Path) -> dict[str, object]:
+    inventory, inventory_raw = load_inventory(inventory_path)
+    archive_record = inventory["archive"]
+    assert isinstance(archive_record, dict)
+    archive_raw = _read_regular(archive_path, "archive", MAX_ARCHIVE_BYTES)
+    archive_digest = sha256(archive_raw).hexdigest()
+    expected_archive_digest = archive_record["sha256"]
+    if len(archive_raw) != archive_record["bytes"]:
+        refuse("NOE-E-DIGEST.ARCHIVE_SIZE", "archive", "archive size does not match inventory")
+    if archive_digest != expected_archive_digest:
+        refuse("NOE-E-DIGEST.ARCHIVE", "archive", "archive digest does not match inventory")
+
+    files = inventory["files"]
+    assert isinstance(files, list)
+    expected = {entry["path"]: entry for entry in files}
+    root = archive_record["root"]
+    assert isinstance(root, str)
+    seen_names: set[str] = set()
+    seen_files: set[str] = set()
+    seen_offsets: set[int] = set()
+    total = 0
+    saw_root = False
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(archive_raw), "r") as archive:
+            members = archive.infolist()
+            if not members or len(members) > MAX_MEMBERS:
+                refuse("NOE-E-BOUNDS.MEMBERS", "archive", "archive member count is outside its limit")
+            for index, info in enumerate(members):
+                field = f"archive.member[{index}]"
+                if info.orig_filename != info.filename or "\x00" in info.filename:
+                    refuse("NOE-E-PATH.NAME", field, "archive member name is ambiguous")
+                if info.filename in seen_names:
+                    refuse("NOE-E-REFERENCE.DUPLICATE_MEMBER", field, "archive member name is duplicated")
+                seen_names.add(info.filename)
+                if info.header_offset < 0 or info.header_offset >= len(archive_raw):
+                    refuse("NOE-E-SYNTAX.ZIP_OFFSET", field, "archive member offset is invalid")
+                if info.header_offset in seen_offsets:
+                    refuse("NOE-E-SYNTAX.ZIP_OFFSET", field, "archive members share one header offset")
+                seen_offsets.add(info.header_offset)
+                if info.flag_bits & 0x1:
+                    refuse("NOE-E-SYNTAX.ENCRYPTED", field, "encrypted archive members are unsupported")
+                if info.compress_type not in ALLOWED_COMPRESSION:
+                    refuse("NOE-E-SYNTAX.COMPRESSION", field, "archive compression method is unsupported")
+                if _member_kind(info) == "special":
+                    refuse("NOE-E-PATH.SPECIAL", field, "links and special archive members are forbidden")
+
+                if info.is_dir():
+                    if info.filename != root:
+                        refuse("NOE-E-PATH.DIRECTORY", field, "only the declared root directory is allowed")
+                    saw_root = True
+                    continue
+
+                if not info.filename.startswith(root):
+                    refuse("NOE-E-PATH.ROOT", field, "archive member is outside the declared root")
+                relative = _relative_path(info.filename[len(root):], field)
+                if relative not in expected:
+                    refuse("NOE-E-REFERENCE.EXTRA_MEMBER", field, "archive contains an unlisted file")
+                if relative in seen_files:
+                    refuse("NOE-E-REFERENCE.DUPLICATE_MEMBER", field, "archive file is duplicated")
+                record = expected[relative]
+                if info.file_size > MAX_MEMBER_BYTES:
+                    refuse("NOE-E-BOUNDS.MEMBER", field, "archive member exceeds its byte limit")
+                if info.file_size != record["bytes"]:
+                    refuse("NOE-E-DIGEST.MEMBER_SIZE", field, "archive member size does not match inventory")
+                total += info.file_size
+                if total > MAX_TOTAL_MEMBER_BYTES:
+                    refuse("NOE-E-BOUNDS.TOTAL", "archive", "archive members exceed the aggregate limit")
+                with archive.open(info, "r") as source:
+                    payload = source.read(MAX_MEMBER_BYTES + 1)
+                    remainder = source.read(1)
+                if len(payload) > MAX_MEMBER_BYTES or remainder:
+                    refuse("NOE-E-BOUNDS.MEMBER", field, "archive member exceeds its byte limit")
+                if len(payload) != record["bytes"]:
+                    refuse("NOE-E-DIGEST.MEMBER_SIZE", field, "decoded member size does not match inventory")
+                if sha256(payload).hexdigest() != record["sha256"]:
+                    refuse("NOE-E-DIGEST.MEMBER", field, "archive member digest does not match inventory")
+                seen_files.add(relative)
+    except Refusal:
+        raise
+    except (OSError, RuntimeError, zipfile.BadZipFile, zipfile.LargeZipFile):
+        refuse("NOE-E-SYNTAX.ZIP", "archive", "archive is malformed or failed integrity checking")
+
+    if not saw_root:
+        refuse("NOE-E-REFERENCE.ROOT", "archive", "declared archive root entry is missing")
+    missing = set(expected) - seen_files
+    if missing:
+        refuse("NOE-E-REFERENCE.MISSING_MEMBER", "archive", "archive is missing an inventoried file")
+    if total != sum(entry["bytes"] for entry in files):
+        refuse("NOE-E-DIGEST.TOTAL", "archive", "archive decoded-byte total does not match inventory")
+
+    inventory_digest = sha256(inventory_raw).hexdigest()
+    return _result(
+        "verify-seed",
+        "ok",
+        "NOE-OK",
+        correlation_values=(archive_digest, inventory_digest),
+        message="seed inventory matched exact archive bytes",
+        digests={"archive": archive_digest, "inventory": inventory_digest},
+        counts={"bytes": len(archive_raw), "members": len(seen_files)},
+    )
+
+
+def about() -> dict[str, object]:
+    return _result(
+        "about",
+        "ok",
+        "NOE-I-ABOUT",
+        correlation_values=(CONTRACT, SOURCE_MAGIC, PROJECTION_MAGIC),
+        message=f"{CONTRACT} shadow prototype; source={SOURCE_MAGIC}; projection={PROJECTION_MAGIC}",
+    )
+
+
+def unimplemented(command: str) -> dict[str, object]:
+    refuse(
+        "NOE-E-UNIMPLEMENTED",
+        "command",
+        f"{command} is reserved for a later receipted prototype step",
+    )
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    subparsers = root.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("about", help="print the bounded contract identity")
+    seed = subparsers.add_parser("verify-seed", help="verify an archive against its exact inventory")
+    seed.add_argument("--archive", required=True, type=Path)
+    seed.add_argument("--inventory", required=True, type=Path)
+    for command in UNIMPLEMENTED:
+        subparsers.add_parser(command, help="reserved by the receipted runbook")
+    return root
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = parser().parse_args(argv)
+    command = arguments.command
+    try:
+        if command == "about":
+            payload = about()
+        elif command == "verify-seed":
+            payload = verify_seed(arguments.archive, arguments.inventory)
+        else:
+            payload = unimplemented(command)
+    except Refusal as error:
+        payload = _result(
+            command,
+            "refuse",
+            error.code,
+            correlation_values=(error.code, error.field),
+            field=error.field,
+            message=error.message,
+        )
+        emit(payload)
+        return 2
+    emit(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/noema.py
+++ b/scripts/noema.py
@@ -139,6 +139,7 @@ def _read_regular(path: Path, field: str, limit: int) -> bytes:
         descriptor = os.open(path, flags)
     except OSError:
         refuse("NOE-E-IO.READ", field, "regular input cannot be opened")
+    close_failed = False
     try:
         before = os.fstat(descriptor)
         if not stat.S_ISREG(before.st_mode):
@@ -159,8 +160,18 @@ def _read_regular(path: Path, field: str, limit: int) -> bytes:
             if total > limit:
                 refuse("NOE-E-BOUNDS.FILE", field, "input exceeds its byte limit")
         after = os.fstat(descriptor)
+    except Refusal:
+        raise
+    except OSError:
+        refuse("NOE-E-IO.READ", field, "regular input failed during descriptor read")
     finally:
-        os.close(descriptor)
+        try:
+            os.close(descriptor)
+        except OSError:
+            close_failed = True
+
+    if close_failed:
+        refuse("NOE-E-IO.READ", field, "regular input descriptor could not be closed")
 
     before_identity = (
         before.st_dev,

--- a/scripts/noema.py
+++ b/scripts/noema.py
@@ -214,6 +214,8 @@ def _relative_path(value: object, field: str) -> str:
     path = PurePosixPath(text)
     if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
         refuse("NOE-E-PATH.TRAVERSAL", field, "path must stay below the archive root")
+    if path.as_posix() != text:
+        refuse("NOE-E-PATH.RELATIVE", field, "archive member path must be canonical POSIX")
     return text
 
 
@@ -221,8 +223,13 @@ def _root_path(value: object, field: str) -> str:
     text = _bounded_string(value, field, 256)
     if "\\" in text or not text.endswith("/") or text.startswith("/"):
         refuse("NOE-E-PATH.ROOT", field, "archive root must be one relative directory")
-    path = PurePosixPath(text[:-1])
-    if len(path.parts) != 1 or path.parts[0] in {"", ".", ".."}:
+    root = text[:-1]
+    path = PurePosixPath(root)
+    if (
+        len(path.parts) != 1
+        or path.parts[0] in {"", ".", ".."}
+        or path.as_posix() != root
+    ):
         refuse("NOE-E-PATH.ROOT", field, "archive root must be one relative directory")
     return text
 

--- a/scripts/noema.py
+++ b/scripts/noema.py
@@ -14,6 +14,7 @@ import stat
 import sys
 import unicodedata
 import zipfile
+import zlib
 
 
 CONTRACT = "noema/v1"
@@ -395,7 +396,13 @@ def verify_seed(archive_path: Path, inventory_path: Path) -> dict[str, object]:
                 seen_files.add(relative)
     except Refusal:
         raise
-    except (OSError, RuntimeError, zipfile.BadZipFile, zipfile.LargeZipFile):
+    except (
+        OSError,
+        RuntimeError,
+        zipfile.BadZipFile,
+        zipfile.LargeZipFile,
+        zlib.error,
+    ):
         refuse("NOE-E-SYNTAX.ZIP", "archive", "archive is malformed or failed integrity checking")
 
     if not saw_root:

--- a/tests/fixtures/noema-v1/README.md
+++ b/tests/fixtures/noema-v1/README.md
@@ -1,0 +1,22 @@
+# Noema version 1 fixtures
+
+This tree holds the shadow prototype's bounded evidence. None of it is a
+selectable skill or authority source.
+
+`seed-inventory.json` binds the public #942 attachment before any reference
+file is imported. Step 1 verifies the ZIP in place and does not extract or
+execute it. Later steps add canonical codec fixtures, runtime fixtures,
+byte-identical non-executable seed references, reviewed source bindings,
+mutations, profiles and evidence under their named directories.
+
+Run the current boundary with:
+
+```bash
+python3 scripts/noema.py verify-seed \
+  --archive /private/tmp/noema-v0-evidence.zip \
+  --inventory tests/fixtures/noema-v1/seed-inventory.json
+```
+
+The local path is operator state. The public attachment URL and every expected
+digest live in the inventory, so another operator can download the exact bytes
+and verify them without trusting this checkout's temporary directory.

--- a/tests/fixtures/noema-v1/seed-inventory.json
+++ b/tests/fixtures/noema-v1/seed-inventory.json
@@ -1,0 +1,97 @@
+{
+  "schema": "noema-seed-inventory/v1",
+  "archive": {
+    "name": "noema-v0-evidence.zip",
+    "url": "https://github.com/user-attachments/files/31608611/noema-v0-evidence.zip",
+    "bytes": 24907,
+    "sha256": "1e1eb5e9908551f1337b7ec58a37ae7f37fd97e41d5ac424bc4992eb1d11b540",
+    "root": "noema-v0.28VEy4/"
+  },
+  "files": [
+    {
+      "path": "bootstrap.txt",
+      "bytes": 1776,
+      "sha256": "e8a56f59a9b3a97180362e839ef33140db6651c4d293a7d540924b60c9a8a5bf"
+    },
+    {
+      "path": "brevitas-answer-literals.txt",
+      "bytes": 413,
+      "sha256": "ee82614410094ddd7fbaaf7a623bb160a030d764d2dcc054049a8ba1aa051f14"
+    },
+    {
+      "path": "brevitas-answer.nt",
+      "bytes": 2105,
+      "sha256": "bbfb62267630c3de24ce8e9b7e78a2d6deb4fae75b7c73b99b95dd129a1652ed"
+    },
+    {
+      "path": "brevitas-coverage.md",
+      "bytes": 2812,
+      "sha256": "72fb20d1f0c9b267b74638e9100846061edba1ddc25cdd9eda828692d3a63ab3"
+    },
+    {
+      "path": "brevitas-full.nt",
+      "bytes": 3729,
+      "sha256": "65b5199bd84dd6c5ef2be8183aa784188624af8ba0c692e66ef80e56fe2ee3f5"
+    },
+    {
+      "path": "brevitas-literals.txt",
+      "bytes": 713,
+      "sha256": "e3bfb6b7eae7bb399cbbb4e57b1e87accc6239c93e46043f9fc85078d292a4a9"
+    },
+    {
+      "path": "comprehension-vectors.md",
+      "bytes": 1933,
+      "sha256": "4d03569f9e7c638c9bd95ca4e1f223b52256852bd1819d578a8cf5a79b73c886"
+    },
+    {
+      "path": "coverage.md",
+      "bytes": 2196,
+      "sha256": "fa659edef7339a001ef85405164790e65d4fca2c65a33dd6796bba316ba2e585"
+    },
+    {
+      "path": "criteria.md",
+      "bytes": 2372,
+      "sha256": "4cdbdb438a0ee0774070e3b4a05700fd0219b304ad79b41acb155c947c0aac62"
+    },
+    {
+      "path": "demo-fiat-hard.nt",
+      "bytes": 1010,
+      "sha256": "0ebda824a20b1f1c6978b8746393c9d4acad761e29fe694a3415b24fa548caa6"
+    },
+    {
+      "path": "demo-phylax.nt",
+      "bytes": 833,
+      "sha256": "e3118a3ae613bd42649bd9b9e0abe5c0fee5a1c2b2576e2871c03bb6d7ef6e10"
+    },
+    {
+      "path": "demo-sapheneia.nt",
+      "bytes": 753,
+      "sha256": "63e86276c5ac5bdaf90cd98905c0a60c0e78c35a10f7d573bdb2e4e7571e1923"
+    },
+    {
+      "path": "kernel.nk",
+      "bytes": 828,
+      "sha256": "7da37c32a8e56cd5b119da2556bff61d076ab63ca6937c0d56714ac485d357d2"
+    },
+    {
+      "path": "noema-v0.md",
+      "bytes": 16892,
+      "sha256": "535d767f11163fec5187ac664cb4d13e0f84fd08af3b281d27120fc206bb33ed"
+    },
+    {
+      "path": "reachable-defs.nt",
+      "bytes": 509,
+      "sha256": "5f0bff8b78d0c69682eab8bf75efe6ca8fffd4d5d10205af4a5097b225214fce"
+    },
+    {
+      "path": "test_noema.py",
+      "bytes": 4228,
+      "sha256": "7509c5b0addc96c7d3b966697afcacd1a710b3586fe41a15d8afdc76699b1df8"
+    },
+    {
+      "path": "validate.py",
+      "bytes": 9974,
+      "sha256": "acb3f30aec3c9aba686caf770d7a7ce07a45a97354b639cb54ec89f10faedb52"
+    }
+  ]
+}

--- a/tests/test_noema.py
+++ b/tests/test_noema.py
@@ -7,6 +7,7 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import re
 import stat
 import subprocess
 import sys
@@ -159,6 +160,13 @@ class NoemaScaffoldTests(unittest.TestCase):
         )
         for name in ("seedInventory", "lock", "manifest", "result", "evidence"):
             self.assertFalse(schema["$defs"][name]["additionalProperties"])
+
+    def test_schema_rejects_noncanonical_archive_member_paths(self):
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        pattern = schema["$defs"]["relativePath"]["pattern"]
+        for path in ("a/./b", "a//b", "a/"):
+            with self.subTest(path=path):
+                self.assertIsNone(re.fullmatch(pattern, path))
 
     def test_contract_magic_and_about_result_are_fixed(self):
         self.assertEqual((noema.CONTRACT, noema.SOURCE_MAGIC, noema.PROJECTION_MAGIC),
@@ -329,6 +337,23 @@ class NoemaScaffoldTests(unittest.TestCase):
             )
             error = refusal(archive_path, inventory_path)
             self.assertEqual(error.code, "NOE-E-PATH.RELATIVE")
+
+    def test_noncanonical_archive_member_path_refuses(self):
+        for name in ("a/./b", "a//b"):
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as temporary:
+                files = [(name, b"alpha")]
+                archive_path, inventory_path = write_case(Path(temporary), files)
+                error = refusal(archive_path, inventory_path)
+                self.assertEqual(error.code, "NOE-E-PATH.RELATIVE")
+
+    def test_noncanonical_archive_root_refuses(self):
+        files = [("a.txt", b"alpha")]
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), files, root="seed//"
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-PATH.ROOT")
 
     def test_symbolic_link_archive_member_refuses(self):
         expected = [("link", b"target")]

--- a/tests/test_noema.py
+++ b/tests/test_noema.py
@@ -457,6 +457,29 @@ class NoemaScaffoldTests(unittest.TestCase):
             error = refusal(archive_path, inventory_path)
             self.assertEqual(error.code, "NOE-E-SYNTAX.COMPRESSION")
 
+    def test_corrupt_deflate_member_refuses(self):
+        import io
+
+        files = [("a.txt", b"alpha" * 8)]
+        payload = bytearray(archive_bytes(files))
+        with zipfile.ZipFile(io.BytesIO(payload), "r") as archive:
+            info = archive.getinfo("seed/a.txt")
+            compressed_start = (
+                info.header_offset
+                + 30
+                + len(info.filename.encode("utf-8"))
+                + len(info.extra)
+            )
+        payload[compressed_start] ^= 0x55
+        corrupted = bytes(payload)
+        record = inventory_for(corrupted, files)
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), files, payload=corrupted, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-SYNTAX.ZIP")
+
     def test_archive_digest_mismatch_refuses_before_member_read(self):
         files = [("a.txt", b"alpha")]
         payload = archive_bytes(files)

--- a/tests/test_noema.py
+++ b/tests/test_noema.py
@@ -551,6 +551,39 @@ class NoemaScaffoldTests(unittest.TestCase):
             error = refusal(archive_path, inventory_path)
             self.assertEqual(error.code, "NOE-E-TYPE.KEYS")
 
+    def test_lone_surrogate_inventory_string_refuses(self):
+        files = [("a.txt", b"alpha")]
+        payload = archive_bytes(files)
+        record = inventory_for(payload, files)
+        record["archive"]["url"] = "https://example.invalid/\ud800"
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), files, payload=payload, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-SYNTAX.UNICODE")
+
+    def test_invalid_utf8_archive_name_refuses(self):
+        files = [("a.txt", b"alpha")]
+        payload = bytearray(archive_bytes(files))
+        local = payload.index(b"PK\x03\x04")
+        central = payload.index(b"PK\x01\x02")
+        for header, flag_offset, name_offset in (
+            (local, 6, 30),
+            (central, 8, 46),
+        ):
+            flags = int.from_bytes(payload[header + flag_offset:header + flag_offset + 2], "little")
+            payload[header + flag_offset:header + flag_offset + 2] = (flags | 0x800).to_bytes(2, "little")
+            payload[header + name_offset] = 0xFF
+        malformed = bytes(payload)
+        record = inventory_for(malformed, files)
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), files, payload=malformed, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-SYNTAX.ZIP")
+
     @unittest.skipUnless(hasattr(os, "symlink"), "symbolic links are unavailable")
     def test_symbolic_link_archive_path_refuses(self):
         files = [("a.txt", b"alpha")]

--- a/tests/test_noema.py
+++ b/tests/test_noema.py
@@ -1,0 +1,452 @@
+"""Scaffold and hostile-boundary tests for the Noema shadow prototype."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+import importlib.util
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+import warnings
+import zipfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "noema.py"
+SCHEMA = ROOT / "schemas" / "noema-v1.schema.json"
+INVENTORY = ROOT / "tests" / "fixtures" / "noema-v1" / "seed-inventory.json"
+STUDY = ROOT / "docs" / "noema" / "study.md"
+RUNBOOK = ROOT / "docs" / "noema" / "runbook.md"
+
+
+def load_noema():
+    """Load the repository entrypoint without relying on import-path state."""
+    spec = importlib.util.spec_from_file_location("noema_v1", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+noema = load_noema()
+
+
+def write_bytes(path: Path, payload: bytes) -> None:
+    """Write one test-owned file below its disposable directory."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+
+
+def zip_info(name: str, kind: int = stat.S_IFREG, compression: int = zipfile.ZIP_DEFLATED):
+    """Return one Unix-attributed ZipInfo for a hostile fixture."""
+    info = zipfile.ZipInfo(name)
+    info.create_system = 3
+    info.compress_type = compression
+    permissions = 0o755 if kind == stat.S_IFDIR else 0o644
+    info.external_attr = (kind | permissions) << 16
+    if kind == stat.S_IFDIR:
+        info.external_attr |= 0x10
+    return info
+
+
+def archive_bytes(
+    files: list[tuple[str, bytes]],
+    *,
+    root: str = "seed/",
+    include_root: bool = True,
+    special: tuple[str, int, bytes] | None = None,
+    compression: int = zipfile.ZIP_DEFLATED,
+) -> bytes:
+    """Build one bounded archive entirely in memory."""
+    import io
+
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w") as archive:
+        if include_root:
+            archive.writestr(zip_info(root, stat.S_IFDIR, compression), b"")
+        for name, payload in files:
+            archive.writestr(zip_info(root + name, stat.S_IFREG, compression), payload)
+        if special is not None:
+            name, kind, payload = special
+            archive.writestr(zip_info(root + name, kind, compression), payload)
+    return output.getvalue()
+
+
+def inventory_for(payload: bytes, files: list[tuple[str, bytes]], *, root: str = "seed/"):
+    """Return the exact closed inventory for one synthetic archive."""
+    return {
+        "schema": noema.INVENTORY_SCHEMA,
+        "archive": {
+            "name": "noema-v0-evidence.zip",
+            "url": "https://example.invalid/noema-v0-evidence.zip",
+            "bytes": len(payload),
+            "sha256": sha256(payload).hexdigest(),
+            "root": root,
+        },
+        "files": [
+            {
+                "path": name,
+                "bytes": len(content),
+                "sha256": sha256(content).hexdigest(),
+            }
+            for name, content in sorted(files)
+        ],
+    }
+
+
+def write_case(
+    directory: Path,
+    files: list[tuple[str, bytes]],
+    *,
+    payload: bytes | None = None,
+    inventory: dict[str, object] | None = None,
+    **archive_options,
+) -> tuple[Path, Path]:
+    """Write one archive/inventory pair and return both paths."""
+    encoded = payload if payload is not None else archive_bytes(files, **archive_options)
+    record = inventory if inventory is not None else inventory_for(
+        encoded, files, root=archive_options.get("root", "seed/")
+    )
+    archive_path = directory / "seed.zip"
+    inventory_path = directory / "inventory.json"
+    write_bytes(archive_path, encoded)
+    write_bytes(
+        inventory_path,
+        (json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n").encode(),
+    )
+    return archive_path, inventory_path
+
+
+def refusal(archive_path: Path, inventory_path: Path) -> noema.Refusal:
+    """Return the stable refusal for one invalid pair."""
+    with unittest.TestCase().assertRaises(noema.Refusal) as raised:
+        noema.verify_seed(archive_path, inventory_path)
+    return raised.exception
+
+
+class NoemaScaffoldTests(unittest.TestCase):
+    def test_receipted_study_copy_is_exact(self):
+        self.assertEqual(
+            sha256(STUDY.read_bytes()).hexdigest(),
+            "4a7c0e7bdfc3d44535d36d3666b3272436d1662463aabc6c82380bd554e5ffec",
+        )
+
+    def test_receipted_runbook_copy_is_exact(self):
+        self.assertEqual(
+            sha256(RUNBOOK.read_bytes()).hexdigest(),
+            "29a63b93e77f4022d145520d2b29cfd52dbff55ff2d97a6568e8285d7ce67acc",
+        )
+
+    def test_repository_python_pin_is_exact(self):
+        self.assertEqual((ROOT / ".python-version").read_text().strip(), "3.14.6")
+
+    def test_schema_is_closed_and_names_all_record_families(self):
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        self.assertEqual(
+            set(schema), {"$schema", "$id", "title", "oneOf", "$defs"}
+        )
+        self.assertEqual(
+            {"seedInventory", "lock", "manifest", "result", "evidence"},
+            {
+                reference["$ref"].rsplit("/", 1)[-1]
+                for reference in schema["oneOf"]
+            },
+        )
+        for name in ("seedInventory", "lock", "manifest", "result", "evidence"):
+            self.assertFalse(schema["$defs"][name]["additionalProperties"])
+
+    def test_contract_magic_and_about_result_are_fixed(self):
+        self.assertEqual((noema.CONTRACT, noema.SOURCE_MAGIC, noema.PROJECTION_MAGIC),
+                         ("noema/v1", "NOE1", "NT1"))
+        result = noema.about()
+        self.assertEqual(result["schema"], "noema-result/v1")
+        self.assertEqual(result["code"], "NOE-I-ABOUT")
+        self.assertEqual(result["verdict"], "ok")
+        self.assertRegex(result["correlation_id"], r"^[0-9a-f]{64}$")
+
+    def test_cli_help_names_only_scaffold_and_reserved_operations(self):
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT), "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0)
+        self.assertIn("verify-seed", completed.stdout)
+        for command in noema.UNIMPLEMENTED:
+            self.assertIn(command, completed.stdout)
+
+    def test_every_reserved_operation_refuses_with_one_json_line(self):
+        for command in noema.UNIMPLEMENTED:
+            with self.subTest(command=command):
+                completed = subprocess.run(
+                    [sys.executable, str(SCRIPT), command],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(completed.returncode, 2)
+                self.assertEqual(completed.stderr, "")
+                self.assertEqual(len(completed.stdout.splitlines()), 1)
+                result = json.loads(completed.stdout)
+                self.assertEqual(result["code"], "NOE-E-UNIMPLEMENTED")
+                self.assertEqual(result["command"], command)
+                self.assertEqual(result["verdict"], "refuse")
+
+    def test_committed_seed_inventory_has_exact_public_shape(self):
+        inventory, raw = noema.load_inventory(INVENTORY)
+        self.assertEqual(len(inventory["files"]), 17)
+        self.assertEqual(inventory["archive"]["bytes"], 24_907)
+        self.assertEqual(
+            inventory["archive"]["sha256"],
+            "1e1eb5e9908551f1337b7ec58a37ae7f37fd97e41d5ac424bc4992eb1d11b540",
+        )
+        self.assertEqual(sha256(raw).hexdigest(), sha256(INVENTORY.read_bytes()).hexdigest())
+
+    def test_valid_synthetic_archive_verifies_without_extraction(self):
+        files = [("a.txt", b"alpha\n"), ("nested.json", b"{}\n")]
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(Path(temporary), files)
+            before = set(Path(temporary).iterdir())
+            result = noema.verify_seed(archive_path, inventory_path)
+            self.assertEqual(result["code"], "NOE-OK")
+            self.assertEqual(result["counts"]["members"], 2)
+            self.assertEqual(set(Path(temporary).iterdir()), before)
+
+    def test_archive_byte_cap_refuses_before_zip_parsing(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            archive_path = directory / "oversized.zip"
+            write_bytes(archive_path, b"z" * (noema.MAX_ARCHIVE_BYTES + 1))
+            _, inventory_path = write_case(directory / "record", [("a", b"a")])
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-BOUNDS.FILE")
+
+    def test_member_count_cap_includes_the_root_directory(self):
+        files = [(f"f{index:02}.txt", b"x") for index in range(noema.MAX_MEMBERS)]
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(Path(temporary), files)
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-BOUNDS.MEMBERS")
+
+    def test_inventory_rejects_one_member_above_its_byte_cap(self):
+        files = [("a.txt", b"a")]
+        payload = archive_bytes(files)
+        record = inventory_for(payload, files)
+        record["files"][0]["bytes"] = noema.MAX_MEMBER_BYTES + 1
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), files, payload=payload, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-BOUNDS.INTEGER")
+
+    def test_inventory_rejects_aggregate_member_bytes_above_cap(self):
+        files = [("a", b"a"), ("b", b"b")]
+        payload = archive_bytes(files)
+        record = inventory_for(payload, files)
+        record["files"][0]["bytes"] = 600_000
+        record["files"][1]["bytes"] = 600_000
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), files, payload=payload, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-BOUNDS.TOTAL")
+
+    def test_duplicate_archive_member_refuses(self):
+        files = [("a.txt", b"alpha")]
+        import io
+
+        output = io.BytesIO()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            with zipfile.ZipFile(output, "w") as archive:
+                archive.writestr(zip_info("seed/", stat.S_IFDIR), b"")
+                archive.writestr(zip_info("seed/a.txt"), b"alpha")
+                archive.writestr(zip_info("seed/a.txt"), b"alpha")
+        payload = output.getvalue()
+        record = inventory_for(payload, files)
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), files, payload=payload, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-REFERENCE.DUPLICATE_MEMBER")
+
+    def test_extra_archive_member_refuses(self):
+        expected = [("a.txt", b"alpha")]
+        payload = archive_bytes(expected + [("extra.txt", b"extra")])
+        record = inventory_for(payload, expected)
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), expected, payload=payload, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-REFERENCE.EXTRA_MEMBER")
+
+    def test_traversal_archive_member_refuses(self):
+        expected = [("a.txt", b"alpha")]
+        payload = archive_bytes([("../escape", b"alpha")])
+        record = inventory_for(payload, expected)
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), expected, payload=payload, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-PATH.TRAVERSAL")
+
+    def test_absolute_archive_member_refuses(self):
+        expected = [("a.txt", b"alpha")]
+        payload = archive_bytes([], include_root=True)
+        import io
+
+        output = io.BytesIO()
+        with zipfile.ZipFile(output, "w") as archive:
+            archive.writestr(zip_info("seed/", stat.S_IFDIR), b"")
+            archive.writestr(zip_info("/absolute.txt"), b"alpha")
+        payload = output.getvalue()
+        record = inventory_for(payload, expected)
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), expected, payload=payload, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-PATH.ROOT")
+
+    def test_backslash_archive_member_refuses(self):
+        expected = [("a.txt", b"alpha")]
+        payload = archive_bytes([("bad\\name", b"alpha")])
+        record = inventory_for(payload, expected)
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), expected, payload=payload, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-PATH.RELATIVE")
+
+    def test_symbolic_link_archive_member_refuses(self):
+        expected = [("link", b"target")]
+        payload = archive_bytes([], special=("link", stat.S_IFLNK, b"target"))
+        record = inventory_for(payload, expected)
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), expected, payload=payload, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-PATH.SPECIAL")
+
+    def test_fifo_archive_member_refuses(self):
+        expected = [("pipe", b"")]
+        payload = archive_bytes([], special=("pipe", stat.S_IFIFO, b""))
+        record = inventory_for(payload, expected)
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), expected, payload=payload, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-PATH.SPECIAL")
+
+    def test_unsupported_archive_compression_refuses(self):
+        if not hasattr(zipfile, "ZIP_BZIP2"):
+            self.skipTest("BZIP2 Zip support is unavailable")
+        files = [("a.txt", b"alpha")]
+        payload = archive_bytes(files, compression=zipfile.ZIP_BZIP2)
+        record = inventory_for(payload, files)
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), files, payload=payload, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-SYNTAX.COMPRESSION")
+
+    def test_archive_digest_mismatch_refuses_before_member_read(self):
+        files = [("a.txt", b"alpha")]
+        payload = archive_bytes(files)
+        record = inventory_for(payload, files)
+        record["archive"]["sha256"] = "0" * 64
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), files, payload=payload, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-DIGEST.ARCHIVE")
+
+    def test_member_size_mismatch_refuses(self):
+        files = [("a.txt", b"alpha")]
+        payload = archive_bytes(files)
+        record = inventory_for(payload, files)
+        record["files"][0]["bytes"] = 4
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), files, payload=payload, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-DIGEST.MEMBER_SIZE")
+
+    def test_member_digest_mismatch_refuses(self):
+        files = [("a.txt", b"alpha")]
+        payload = archive_bytes(files)
+        record = inventory_for(payload, files)
+        record["files"][0]["sha256"] = "0" * 64
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), files, payload=payload, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-DIGEST.MEMBER")
+
+    def test_missing_root_directory_entry_refuses(self):
+        files = [("a.txt", b"alpha")]
+        payload = archive_bytes(files, include_root=False)
+        record = inventory_for(payload, files)
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), files, payload=payload, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-REFERENCE.ROOT")
+
+    def test_duplicate_inventory_key_refuses(self):
+        text = (
+            '{"schema":"noema-seed-inventory/v1",'
+            '"schema":"noema-seed-inventory/v1","archive":{},"files":[]}'
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "inventory.json"
+            write_bytes(path, text.encode())
+            with self.assertRaises(noema.Refusal) as raised:
+                noema.load_inventory(path)
+            self.assertEqual(raised.exception.code, "NOE-E-SYNTAX.DUPLICATE_KEY")
+
+    def test_inventory_extra_key_refuses(self):
+        files = [("a.txt", b"alpha")]
+        payload = archive_bytes(files)
+        record = inventory_for(payload, files)
+        record["extra"] = True
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path, inventory_path = write_case(
+                Path(temporary), files, payload=payload, inventory=record
+            )
+            error = refusal(archive_path, inventory_path)
+            self.assertEqual(error.code, "NOE-E-TYPE.KEYS")
+
+    @unittest.skipUnless(hasattr(os, "symlink"), "symbolic links are unavailable")
+    def test_symbolic_link_archive_path_refuses(self):
+        files = [("a.txt", b"alpha")]
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            archive_path, inventory_path = write_case(directory, files)
+            linked = directory / "linked.zip"
+            linked.symlink_to(archive_path)
+            error = refusal(linked, inventory_path)
+            self.assertEqual(error.code, "NOE-E-PATH.REGULAR")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_noema.py
+++ b/tests/test_noema.py
@@ -168,6 +168,18 @@ class NoemaScaffoldTests(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertIsNone(re.fullmatch(pattern, path))
 
+    def test_runtime_path_alphabets_match_the_published_schema(self):
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        self.assertEqual(
+            noema.SEED_RELATIVE_PATH_RE.pattern,
+            schema["$defs"]["relativePath"]["pattern"],
+        )
+        self.assertEqual(
+            noema.SEED_ROOT_PATH_RE.pattern,
+            schema["$defs"]["seedInventory"]["properties"]["archive"]
+            ["properties"]["root"]["pattern"],
+        )
+
     def test_contract_magic_and_about_result_are_fixed(self):
         self.assertEqual((noema.CONTRACT, noema.SOURCE_MAGIC, noema.PROJECTION_MAGIC),
                          ("noema/v1", "NOE1", "NT1"))
@@ -354,6 +366,24 @@ class NoemaScaffoldTests(unittest.TestCase):
             )
             error = refusal(archive_path, inventory_path)
             self.assertEqual(error.code, "NOE-E-PATH.ROOT")
+
+    def test_schema_invalid_archive_member_path_refuses(self):
+        for name in ("a b", "C:policy"):
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as temporary:
+                files = [(name, b"alpha")]
+                archive_path, inventory_path = write_case(Path(temporary), files)
+                error = refusal(archive_path, inventory_path)
+                self.assertEqual(error.code, "NOE-E-PATH.RELATIVE")
+
+    def test_schema_invalid_archive_root_refuses(self):
+        files = [("a.txt", b"alpha")]
+        for root in ("seed space/", "C:seed/"):
+            with self.subTest(root=root), tempfile.TemporaryDirectory() as temporary:
+                archive_path, inventory_path = write_case(
+                    Path(temporary), files, root=root
+                )
+                error = refusal(archive_path, inventory_path)
+                self.assertEqual(error.code, "NOE-E-PATH.ROOT")
 
     def test_symbolic_link_archive_member_refuses(self):
         expected = [("link", b"target")]

--- a/tests/test_noema.py
+++ b/tests/test_noema.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 import warnings
 import zipfile
 
@@ -384,6 +385,42 @@ class NoemaScaffoldTests(unittest.TestCase):
                 )
                 error = refusal(archive_path, inventory_path)
                 self.assertEqual(error.code, "NOE-E-PATH.ROOT")
+
+    def test_descriptor_read_failure_refuses(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "input"
+            write_bytes(path, b"alpha")
+            with mock.patch.object(
+                noema.os, "read", side_effect=OSError("injected read fault")
+            ), self.assertRaises(noema.Refusal) as raised:
+                noema._read_regular(path, "archive", 16)
+            self.assertEqual(raised.exception.code, "NOE-E-IO.READ")
+
+    def test_descriptor_inspection_failure_refuses(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "input"
+            write_bytes(path, b"alpha")
+            with mock.patch.object(
+                noema.os, "fstat", side_effect=OSError("injected fstat fault")
+            ), self.assertRaises(noema.Refusal) as raised:
+                noema._read_regular(path, "archive", 16)
+            self.assertEqual(raised.exception.code, "NOE-E-IO.READ")
+
+    def test_descriptor_close_failure_refuses(self):
+        real_close = os.close
+
+        def close_then_fail(descriptor):
+            real_close(descriptor)
+            raise OSError("injected close fault")
+
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "input"
+            write_bytes(path, b"alpha")
+            with mock.patch.object(
+                noema.os, "close", side_effect=close_then_fail
+            ), self.assertRaises(noema.Refusal) as raised:
+                noema._read_regular(path, "archive", 16)
+            self.assertEqual(raised.exception.code, "NOE-E-IO.READ")
 
     def test_symbolic_link_archive_member_refuses(self):
         expected = [("link", b"target")]


### PR DESCRIPTION
## What changed

Define `noema/v1`, its closed semantic domain, shadow-authority boundary,
canonical source and projection roles, resource limits, stable refusal
families, runtime surface, measurement contract, and evaluation boundary.
ADR-055 records why the prototype uses a typed sliced IR while existing
Markdown remains authoritative.

Add a closed JSON schema and a bounded `verify-seed` command. The command
checks the exact 24,907-byte evidence archive and its 17-file inventory without
extracting or executing member content. It refuses linked, special, encrypted,
unsupported, malformed, non-canonical, over-limit, extra, missing, duplicate,
or digest-mismatched inputs with one bounded result.

This is Step 1 of the issue #942 prototype. It freezes the contract and seed
boundary only. It does not make Noema authoritative, replace repository
Markdown, execute policy effects, or integrate the prototype into the skills
framework.

## Audit

- Record: `audit/rounds/fiat-942-prototype-noema-as-a-model-native-sliced-ins.md`
- Stacked audit PR: https://github.com/wildcat-finance/skills/pull/956
- Task issue: https://github.com/wildcat-finance/skills/issues/942
- Stacks on: `fiat/942-prototype-noema-as-a-model-native-sliced-ins`

Six rounds fixed six low findings across canonical archive paths, schema and
runtime path parity, descriptor failures, corrupt deflate streams, and malformed
Unicode. Round 6 found no new issue. The audit excluded the later parser,
module, projection, slicer, policy-runtime, source-binding, measurement, and
provider-adapter work, plus hosted CI and integration.

## Proof

```bash
python3 scripts/noema.py verify-seed --archive /private/tmp/noema-v0-evidence.zip --inventory tests/fixtures/noema-v1/seed-inventory.json
python3 -m unittest tests.test_noema.NoemaScaffoldTests -v
python3 tests/run_tests.py --elenchus-report .elenchus/fiat-942-step-1.json
python3 scripts/run_checks.py
python3 plugins/hexaemeron/skills/fiat/scripts/audit_synopsis.py --check .
python3 plugins/horos/skills/horos/scripts/horos.py check .
```

<!-- wildcat-origin: shoggoth -->
