### PR TITLE
fix(ci): enforce base-owned commit identity

### DIFF
--- a/.dead-code/baseline.json
+++ b/.dead-code/baseline.json
@@ -2787,6 +2787,13 @@
     },
     {
       "analyser_id": "python",
+      "id": "sha256:1b083d7ec048e9621e899cc804e9b5498a5dcb9d81aacd1b1122914f5e2ff7ab",
+      "path": "scripts/check_commit_identity.py",
+      "suppressed": false,
+      "symbol": "annotations@4"
+    },
+    {
+      "analyser_id": "python",
       "id": "sha256:d85dcde843934c95ea913c74a246952be827e64b9b7efbcc3c3b7259fae4fd41",
       "path": "scripts/contributors.py",
       "suppressed": false,
@@ -2941,6 +2948,13 @@
     },
     {
       "analyser_id": "python",
+      "id": "sha256:4f0b837327d1ff85c5c33532f506a53ddbc8b483744987f9d8f6feac3727ca2e",
+      "path": "tests/test_commit_identity.py",
+      "suppressed": false,
+      "symbol": "annotations@3"
+    },
+    {
+      "analyser_id": "python",
       "id": "sha256:1c5f40729f5a24f8fe9c7c44a5b2445ed2953a8d41ce840149b897c57575b942",
       "path": "tests/test_contributors.py",
       "suppressed": false,
@@ -3083,10 +3097,10 @@
     "version": "1"
   },
   "tree": {
-    "commit": "88b451634849ff9200ca93a0dd2dc7e446f5b920",
-    "git_tree": "908dcca8d69c08265a97018e46eb75b9f3ccfd88"
+    "commit": "1b678576500fb35d784cc55e4f85c2c6b90800b8",
+    "git_tree": "44f68dfeac4a2778fea84870574f38acf3cccae8"
   },
   "universe": {
-    "id": "sha256:f1bfbd9a745407c6fb8907d0bae27c370f68d0c3c325dd0af81d1050bb031da6"
+    "id": "sha256:ef6a4570c20f3d8c7739b881cba14accb06a3129407974693a7b481805637a69"
   }
 }

--- a/.dead-code/baseline.json
+++ b/.dead-code/baseline.json
@@ -3097,10 +3097,10 @@
     "version": "1"
   },
   "tree": {
-    "commit": "1b678576500fb35d784cc55e4f85c2c6b90800b8",
-    "git_tree": "44f68dfeac4a2778fea84870574f38acf3cccae8"
+    "commit": "370c09bbb5308809b95e7838e52e30673f81aab7",
+    "git_tree": "efab2267a510f73803db4b799146890590099ee9"
   },
   "universe": {
-    "id": "sha256:ef6a4570c20f3d8c7739b881cba14accb06a3129407974693a7b481805637a69"
+    "id": "sha256:89ad1c35e1e088eda757efaab45d3f40b684c46af2659b4cab8b568c035a1ba7"
   }
 }

--- a/.github/workflows/identity.yml
+++ b/.github/workflows/identity.yml
@@ -1,0 +1,128 @@
+name: identity
+
+# The candidate supplies Git objects only. Policy and Python imports come from
+# the exact protected base; no pull-request tree is checked out or executed.
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  identity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Mark exact head pending
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "identity: event head object identifier is malformed" >&2
+            exit 2
+          fi
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          gh api --method POST \
+            "repos/wildcat-finance/skills/statuses/$HEAD_SHA" \
+            -f state=pending \
+            -f context=identity \
+            -f description="Base-owned identity policy is evaluating this head" \
+            -f target_url="$run_url" \
+            >/dev/null
+
+      - name: Check out exact base policy
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Check candidate commit identities with base policy
+        id: evaluate
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$PR_NUMBER" in
+            ""|*[!0-9]*)
+              echo "identity: pull-request number is malformed" >&2
+              exit 2
+              ;;
+          esac
+          if [[ ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+             [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "identity: event object identifier is malformed" >&2
+            exit 2
+          fi
+
+          candidate_repository="$RUNNER_TEMP/identity-candidate.git"
+          test ! -e "$candidate_repository"
+          git init --bare "$candidate_repository"
+          git --git-dir="$candidate_repository" remote add origin \
+            https://github.com/wildcat-finance/skills.git
+          git --git-dir="$candidate_repository" fetch \
+            --no-tags \
+            --no-write-fetch-head \
+            --filter=blob:none \
+            origin \
+            +refs/heads/main:refs/remotes/origin/main \
+            "+refs/pull/${PR_NUMBER}/head:refs/pull/request/head"
+
+          fetched_head="$(
+            git --git-dir="$candidate_repository" rev-parse refs/pull/request/head
+          )"
+          test "$fetched_head" = "$HEAD_SHA"
+
+          python3 scripts/check_commit_identity.py \
+            --repository "$candidate_repository" \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --pull-request-login "$PR_LOGIN"
+
+      - name: Publish exact-head result
+        if: ${{ always() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVALUATION_OUTCOME: ${{ steps.evaluate.outcome }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "identity: event head object identifier is malformed" >&2
+            exit 2
+          fi
+          state=failure
+          description="Base-owned identity policy refused or could not evaluate this head"
+          if [ "$EVALUATION_OUTCOME" = "success" ]; then
+            state=success
+            description="Base-owned identity policy accepted this head"
+          fi
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          gh api --method POST \
+            "repos/wildcat-finance/skills/statuses/$HEAD_SHA" \
+            -f state="$state" \
+            -f context=identity \
+            -f description="$description" \
+            -f target_url="$run_url" \
+            >/dev/null

--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 2112
+    "files_walked": 2118
   },
   "entries": [
     {

--- a/docs/decisions/ADR-058-require-base-owned-identity-and-human-review.md
+++ b/docs/decisions/ADR-058-require-base-owned-identity-and-human-review.md
@@ -1,0 +1,93 @@
+# ADR-058: Require base-owned identity checks and human review
+
+## Status
+
+Accepted, 2026-08-30. Extends
+[ADR-016](ADR-016-attribute-governed-agent-work-to-shoggoth.md) and
+[ADR-052](ADR-052-separate-governed-authorship-from-publication.md).
+
+## Context
+
+GitHub's signed-commit rule verifies a signature without deciding whether the
+author or committer fields name the contributing actor. A cloud host can sign
+with an environment-managed key, put its own identity in both fields, and
+receive a green badge. Fiat rejects that attribution inside its own runs, but
+the protected branch does not require contributors to use Fiat. The branch
+also requires no approving review, so the pull-request author can be the sole
+party to the merge.
+
+A normal pull-request workflow is not sufficient policy authority: the
+candidate merge tree can change the workflow or script that judges it. A
+`pull_request_target` workflow receives trusted base bytes but becomes unsafe
+if it checks out and executes the candidate.
+
+## Decision
+
+Run one unconditional base-context Actions job named `identity` for every pull
+request to `main`. Check out the exact base SHA as policy, fetch the proposed
+history into a separate bare object database, and execute only the base-owned
+identity script. Never check out, import, build, or install candidate bytes in
+that privileged job. Keep contents read-only and grant only the additional
+commit-status write permission needed to publish the result against the
+validated event head. Pass event values through environment variables rather
+than shell interpolation.
+
+The script checks every commit outside the exact base. It refuses a known
+runtime host as author, committer, co-author, generated-by attribution, or
+pull-request login; malformed or unreadable identity data also refuses. It
+reuses the host classification already shared by Fiat and the contributor
+pipeline. Shoggoth authorship must use the exact canonical identity and
+provenance trailers. Human authors remain allowed and are not reauthored as
+Shoggoth.
+
+`pull_request_target` attaches its native job to the base branch SHA, while a
+required check must pass on the latest pull-request SHA. The job therefore
+posts `identity` pending against the validated event head before fallible work,
+then posts success only when the evaluation step succeeds. A failure posts
+failure where possible; cancellation or publication failure leaves pending.
+
+Merge the base-owned workflow before requiring its context. Then use a signed
+canary to prove that GitHub Actions publishes `identity` on the exact
+pull-request head under integration `15368`. Only after that proof may the live
+required-CI ruleset add `identity` alongside strict `invariants` and `plugins`.
+
+Separately, raise the protected branch's required approving review count from
+zero to one. One approving review is required. Preserve every other rule and
+add no bypass actor. Approval does
+not prove authorship; it prevents one party from being the only party to the
+merge.
+
+## Alternatives
+
+- Treat any verified signature as authorship evidence. This repeats the false
+  inference demonstrated by issue #893.
+- Keep the check only inside Fiat. This leaves direct pull requests outside the
+  controller unguarded.
+- Execute the candidate's copy of the identity script. The proposed change can
+  make its own policy return success.
+- Check out the candidate under `pull_request_target`. The privileged workflow
+  would expose the repository to candidate-controlled hooks, imports, builds,
+  or dependencies.
+- Require an explicit account allowlist. The repository accepts external human
+  contributors, and the present evidence supports rejecting known hosts rather
+  than declaring a closed list of authorised people.
+- Require two reviews or code-owner review. No evidence in this issue justifies
+  that broader governance change.
+
+## Consequences
+
+Signed commits and authorship become separate required signals. A pull request
+cannot pass when any inspected identity surface names a known runtime host, and
+the candidate cannot rewrite the deciding policy. An independent approving
+review is required before merge.
+
+The policy remains prospective. An unfamiliar future host name is not silently
+reclassified as a known runtime; the mechanical set must be extended when
+evidence identifies it. A green result establishes only that the bounded
+known-host checks passed on the stated commits. It does not prove publication
+authority, contributor intent, or the correctness of the change.
+
+Bootstrap requires one signed workflow pull request and one signed canary
+before live enforcement. If the explicit status is absent from the exact
+canary head, comes from the wrong source, or lacks its Actions run link, the
+required-check update stops.

--- a/docs/pr-identity-gate/runbook.md
+++ b/docs/pr-identity-gate/runbook.md
@@ -1,0 +1,155 @@
+# Pull-request identity gate runbook
+
+## Step 1: Build and test the base-owned identity policy
+
+### Scope and exit
+
+**Goal.** Reject known runtime-host attribution across every identity surface
+without executing candidate code.
+
+**Entry.** `main` equals the signed #891 head
+`b3f7de8742f4e69a61a7ae969e23b73d728e9473`, and the study in this directory
+is accepted.
+
+**Exit.** `scripts/check_commit_identity.py` validates the pull-request login,
+reads every commit in `base..head` from a non-shallow repository, and rejects a
+known host author, committer, co-author, generated-by line, malformed identity,
+or malformed Shoggoth provenance. Git config, replacement objects, command
+time, command output, commit count, object size, and total bytes are bounded.
+Focused tests cover each refusal, a human-authored commit, the authorised
+Shoggoth-author/Laurence-publisher split, an offending middle commit, base
+exclusion, malformed objects, and every ceiling.
+
+### Files and tests
+
+**Files.** `scripts/check_commit_identity.py`,
+`tests/test_commit_identity.py`, this study and runbook, and ADR-058.
+
+**Tests.** First show a fixture with `Claude <noreply@anthropic.com>` passes the
+signed-only premise and fails the new identity predicate. Run the complete
+focused module, the existing contributor and Fiat attribution modules, root
+invariants, policy lints, and `git diff --check`.
+
+### Discipline routing
+
+**Disciplines.** phylax: hostile Git objects, path identity, fixed subprocesses,
+and byte/time ceilings. ephoros: bounded JSON success and role-specific
+refusals. metron: no performance claim. elenchus: one red fixture for every
+accepted role and boundary. hypomnema: ADR-058 owns the repository decision;
+the script owns mechanics.
+
+## Step 2: Bootstrap the immutable hosted context
+
+### Scope and exit
+
+**Goal.** Publish one stable GitHub Actions job without giving candidate bytes
+execution authority.
+
+**Entry.** Step 1 is green and the branch is current with protected `main`.
+
+**Exit.** `.github/workflows/identity.yml` runs unconditionally for pull
+requests to `main`, has a job and status context named `identity`, read-only
+contents permission, only commit-status write permission, no repository secret,
+no cache, no persisted checkout credential, and a five-minute timeout. It marks
+the validated event head pending before fallible work. It checks out the exact
+base SHA as the workspace, fetches `main` and the decimal-validated pull ref
+from the fixed public URL into a fresh bare repository, verifies the fetched
+head, invokes only the base script, and publishes success only for a successful
+evaluation step. Tests prove no candidate checkout, import, dependency, event
+interpolation, or path filter exists. The signed pull request is hosted-green
+for existing required checks and fast-forwards `main` without rewriting its
+commits.
+
+### Files and tests
+
+**Files.** `.github/workflows/identity.yml` and its root contract tests.
+
+**Tests.** Mutate each protected workflow clause and show the contract test
+fails. Run the root suite, complete plugin graph, Promise Machine checks,
+Protasis, Imprimatur, Vulgate comparison, Brevitas, Phylax, Ephoros,
+Hypomnema, Horos, and local signature verification before push. Do not add
+`identity` to a ruleset in this step.
+
+### Discipline routing
+
+**Disciplines.** phylax: base-owned execution, bare candidate objects,
+read-only token, fixed remote and argv, and no untrusted interpolation.
+ephoros: stable job name plus exact base, head, count and refusal logs. metron:
+no claim. elenchus: workflow contract mutations. hypomnema: workflow procedure
+and ADR-058.
+
+## Step 3: Prove the exact-head context with a signed canary
+
+### Scope and exit
+
+**Goal.** Establish that the base-owned workflow publishes `identity` where the
+required-check rule will look for it.
+
+**Entry.** Step 2 is on `main`; the live required-check set is still
+`invariants` and `plugins`.
+
+**Exit.** A separate public canary pull request carries one machine-key-signed
+Shoggoth-authored commit, uses `laurenceday` as publisher, and receives a green
+`identity` status. The commit-status API names `identity`, the GitHub Actions
+creator and integration `15368`, the linked workflow run, and the canary's exact
+current head SHA. A deliberately forbidden local fixture remains red. The
+canary may be closed unmerged after this evidence; its commit, status, and run
+URL remain inspectable.
+
+If the explicit status is absent from the exact head, comes from another
+source, lacks the run link, or is not green, stop. Do not create the required
+context or raise the review count; repair and re-review publication first.
+
+### Files and tests
+
+**Files.** No protected repository bytes are required. The canary branch may
+carry a temporary documentation specimen that is never merged.
+
+**Tests.** Query the pull request, exact head, combined status, context, creator,
+integration ID, target run, workflow event, and anonymous visibility. Verify
+the canary commit locally and through GitHub before its first push.
+
+### Discipline routing
+
+**Disciplines.** phylax: the base-owned token writes only commit statuses to the
+validated event head. ephoros: exact status and run-URL receipt. metron: none.
+elenchus: forbidden fixture stays red. hypomnema: external run and status
+objects are the receipt.
+
+## Step 4: Require identity and one independent approval
+
+### Scope and exit
+
+**Goal.** Make the observed identity check and a human review mandatory for
+`main`.
+
+**Entry.** Step 3 proves `identity` on the exact canary head. Fresh reads show
+ruleset `21830871` still requires strict `invariants` and `plugins`, ruleset
+`16257211` still requires zero approvals with no bypass, and signed-commit
+rules remain active.
+
+**Exit.** Ruleset `21830871` requires exactly `identity`, `invariants`, and
+`plugins` from GitHub Actions integration `15368`, retains strict current-base
+policy, its conditions and enforcement, and has no bypass. Ruleset
+`16257211` requires one approving review while preserving signatures,
+deletion, non-fast-forward, merge methods, unattributed-change handling, all
+other pull-request fields, and no bypass. Immediate full readbacks match. Issue
+#893 is closed only after both documents agree and all public objects return
+anonymous HTTP 200.
+
+### Files and tests
+
+**Files.** No repository file change in this step.
+
+**Tests.** Read, minimally transform, update, and read back each full ruleset.
+Query current `main`, the bootstrap pull request, canary status, issue state,
+signatures, and anonymous visibility. Any changed field outside the declared
+contexts or approval count is a stop.
+
+### Discipline routing
+
+**Disciplines.** phylax: authenticated writes derive from fresh full reads and
+preserve every unowned field. ephoros: post-write rule documents and public
+objects. metron: none. elenchus: absent context, wrong integration, lost
+strictness, wrong approval count, or bypass is red. hypomnema: ADR-058 explains
+the choice; GitHub rulesets own enforcement.

--- a/docs/pr-identity-gate/study.md
+++ b/docs/pr-identity-gate/study.md
@@ -1,0 +1,220 @@
+# Pull-request identity gate study
+
+Assuming, unless corrected:
+
+1. Issue #893 authorises the repository workflow, required-check, and review
+   rules needed to reject governed work attributed to a runtime host.
+2. This branch starts from the signed head of pull request #964 at
+   `b3f7de8742f4e69a61a7ae969e23b73d728e9473`. Nothing from this study may be
+   published until `main` equals that commit.
+3. Ruleset `21830871` requires the current-base `invariants` and `plugins`
+   contexts. Organization ruleset `16257211` requires a pull request but no
+   approval. Ruleset `16257446` requires signatures and does not classify the
+   author or committer.
+4. The host sets in Fiat and `scripts/contributors.py` are the current
+   executable interpretation of ADR-016. They are a known-host refusal set,
+   not a claim that every future host name is already known.
+5. Publication is by `laurenceday`; governed commits remain authored by
+   Shoggoth and are signed with `B83B60AE16F5DD1A`.
+
+## 1. Problem statement
+
+GitHub's signed-commit rule establishes that GitHub accepts a signature on a
+commit. It does not establish that the author or committer fields name the
+contributing actor. Issue #893 carries the concrete counterexample: commit
+`a597c21` was signed by a cloud-managed key and reported as verified while both
+identity fields named Claude. With no required review, the same runtime host
+can open and merge the pull request that carries it.
+
+Success has two separately visible parts. Every pull request to `main` receives
+one stable `identity` result produced by policy bytes from the protected base.
+That result is green only when the pull-request login and every commit outside
+the exact base reject no known host author, committer, co-author, or generated
+byline. After that context is proved on an exact canary head, the repository
+rules require it alongside `invariants` and `plugins`. The pull-request rule
+then requires one approving review.
+
+## 2. Prior art
+
+ADR-016 classifies runtime hosts as execution metadata rather than authors.
+ADR-052 separates the Shoggoth author from an explicitly authorised human
+publisher, signer, and repository account. Fiat enforces both rules inside a
+receipted run, and `scripts/contributors.py` carries the same three host sets
+for repository-wide contributor classification. Tests already refuse drift
+between those copies.
+
+That controller gate is not a branch gate. A contributor can bypass Fiat, and
+GitHub does not inspect the identity fields as part of `required_signatures`.
+The new check therefore reuses the existing host-set semantics but runs at the
+protected repository boundary.
+
+GitHub documents `pull_request_target` as privileged base-context execution,
+with `GITHUB_SHA` set to the last commit on the default branch, and warns
+against checking out and executing untrusted pull-request code. It separately
+requires a required status to succeed on the latest pull-request head. The
+base-owned job therefore publishes one commit status to the event's validated
+head SHA. The context is not added to the live ruleset until a canary proves
+that exact association and source.
+
+## 3. Constraints and non-goals
+
+The workflow is unconditional for pull requests to `main` and has no path
+filter. Its job and future required context are both named `identity`. It runs
+with `contents: read` and the single additional `statuses: write` permission
+needed to mark the validated event head pending, then success or failure. It
+persists no checkout credential, references no repository secret, and has a
+short timeout. Candidate commits are fetched from the fixed public repository
+URL into a bare repository under the runner's temporary directory. The
+pull-request tree is never checked out. Python imports and the executable
+script come only from the exact base SHA checked out as the workflow workspace.
+
+The workflow passes event values through environment variables rather than
+interpolating them into shell source. The pull-request number is checked as
+decimal before it enters the fixed `refs/pull/<number>/head` fetch. The policy
+script validates full object identifiers, refuses a shallow object database,
+disables replacement objects and inherited Git configuration, bounds the
+commit count, each commit object's bytes, total bytes, command time, and output,
+and reads commit objects only. It never runs a hook, build, dependency, or file
+from the candidate.
+
+The gate refuses known host names, addresses, GitHub logins, co-author trailers,
+and generated-by lines using the same policy as Fiat. A Shoggoth author must be
+the exact `Shoggoth <shoggoth@wildcat.finance>` identity and must carry exactly
+one canonical co-author trailer and one `Wildcat-Origin: shoggoth` trailer. A
+non-host human author is allowed without those Shoggoth trailers. The gate does
+not infer whether a human publisher had authority, prove that an unfamiliar
+future model name is human, or turn a signature into authorship evidence.
+Those claims remain outside the available evidence.
+
+Always: test the policy against every role and every commit in a range; prove
+the workflow never executes candidate bytes; run the root suite, complete
+plugin graph, policy lints, Promise Machine checks, Horos, and signature
+verification; read each live ruleset before and after mutation. Ask first:
+adding a bypass actor, weakening the host set, accepting an unknown payload
+shape, or reducing the approval count after enforcement. Never: run candidate
+code under `pull_request_target`, make a path-filtered required job, add the
+required context before a head-bound canary, or treat the approval as proof of
+authorship.
+
+## 4. Design options
+
+**A. Extend the signed-commit rule.** GitHub's rule has no author-policy input.
+It cannot express ADR-016. Rejected.
+
+**B. Run a normal `pull_request` workflow from the candidate merge ref.** This
+attaches naturally to the pull request, but the pull request can alter the
+workflow or script that decides whether it passes. Read-only credentials do
+not make self-modifying policy trustworthy. Rejected.
+
+**C. Run `pull_request_target`, check out the candidate, and execute its policy
+script.** The workflow definition comes from the base, but the deciding code
+does not. This is the unsafe checkout-and-execute shape GitHub warns about.
+Rejected.
+
+**D. Run base-owned policy over candidate commit objects in a bare repository.**
+Chosen. The candidate supplies data only. No candidate tree becomes a working
+directory or Python import root, and the script has fixed, bounded Git reads.
+Because the native job belongs to the base SHA, the job uses `statuses: write`
+only to publish `identity` against the validated event head. It posts pending
+before any fallible checkout or fetch and resolves the status to success only
+when the evaluation step succeeded; cancellation or publication failure leaves
+the head pending. The trade is a two-stage bootstrap: merge the workflow before
+it can run, then prove its exact-head status with a signed canary before changing
+the ruleset.
+
+## 5. Risk register seed
+
+```risk-register
+self-modified-policy | the pull request changes the gate that judges it | workflow and script are checked out from the exact base SHA as the workspace
+candidate-execution | a hook import build or dependency runs from the pull request | candidate exists only as bounded commit objects in a bare repository
+script-injection | event text enters shell source | expressions populate environment values and the only ref component is decimal-validated
+partial-range | a shallow fetch hides an earlier host-authored commit | policy refuses shallow repositories and checks every commit in base..head under a count cap
+replacement-object | Git replacement refs change the object inspected | policy sets GIT_NO_REPLACE_OBJECTS and uses a fresh bare repository
+oversized-commit | attacker-controlled messages exhaust runner memory or logs | per-object total-byte commit-count output and timeout ceilings refuse first
+policy-drift | Fiat contributors and the branch gate classify different hosts | root tests compare every host set and shared regex with the canonical controller
+unknown-host | a future runtime name is not in the known set | no universal claim is made and policy extension remains fail-closed maintenance
+missing-context | the base workflow cannot publish against the PR head | status is posted to the validated event head and a signed canary must prove it before ruleset mutation
+false-green | an earlier step fails before the result is published | pending is posted first and only the evaluation step's success outcome selects success
+publication-authority | candidate input redirects the writable status request | repository endpoint and context are fixed by base bytes and the head is full-lowercase-SHA validated
+context-wedge | the ruleset requires a check that cannot run | bootstrap merges first and canary evidence gates the ruleset write
+sole-party-merge | the author opens and merges the same pull request | organization pull-request rule requires one approving review after bootstrap
+ruleset-drift | a narrow live edit drops signatures checks or conditions | mutate fresh full documents preserve every other field and read back immediately
+```
+
+## 6. Glossary seeds
+
+Base-owned policy: workflow and script bytes read from the protected target
+branch rather than from the proposed change.
+
+Candidate object database: a bare Git repository that holds commit data for
+inspection and has no checked-out candidate files.
+
+Host identity: a name, address, login, co-author, or generated-by attribution
+that the repository's ADR-016 policy classifies as a runtime rather than a
+contributing actor.
+
+Exact-head canary: a signed, public pull request used only to prove that the
+`identity` context is produced by GitHub Actions for that pull request's current
+head SHA before the context becomes required.
+
+## 7. Sources
+
+- Issue [#893](https://github.com/wildcat-finance/skills/issues/893).
+- `SHOGGOTH.md`, ADR-016, ADR-018, and ADR-052.
+- `plugins/hexaemeron/skills/fiat/scripts/hexctl.py` and
+  `scripts/contributors.py`.
+- Live rulesets `16257211`, `16257446`, and `21830871`, read before design.
+- GitHub's [secure `pull_request_target` guidance](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target),
+  [workflow event reference](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows),
+  [commit-status API reference](https://docs.github.com/en/rest/commits/statuses),
+  and [required-check troubleshooting](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/troubleshooting-required-status-checks).
+
+## 8. Signals, and the questions behind them
+
+Ephoros applies. A green run prints the schema, exact base and head, validated
+pull-request login, and commit count without printing addresses. A refusal
+names the commit and identity role that failed. The explicit status links the
+immutable Actions run and records pending, success, or failure. The canary
+record must show the context name, GitHub Actions creator, and exact head SHA.
+Post-write ruleset reads answer which
+contexts, strictness, approval count, merge methods, and bypass actors now
+control `main`.
+
+## 9. Boundaries, per capability
+
+Phylax applies. The GitHub event and candidate Git objects are hostile inputs.
+The workflow has no write permission beyond commit statuses, no repository
+secret, cache, candidate checkout, or candidate dependency installation. Its
+status endpoint, context, remote URL, ref prefixes, argv, policy path, and
+Python version source are fixed by base-owned bytes. The status target is a
+full lowercase SHA from the event. The script reads only commit objects under
+explicit shape and size limits. The candidate cannot alter an import because
+the bare repository is never on `sys.path`.
+
+## 10. The budget, or its absence
+
+No performance improvement is claimed. The gate reads commit metadata rather
+than trees or blobs and refuses more than 1,024 commits, more than 128 KiB in
+one commit object, or more than 8 MiB across the range. Each Git command has a
+ten-second timeout and the Actions job has a five-minute timeout. The normal
+case is a handful of commit objects and should finish before the existing root
+or plugin checks.
+
+## 11. The fail-closed posture
+
+Elenchus applies. A malformed identity, invalid UTF-8, absent object, shallow
+history, host role, oversized range, command failure, timeout, mismatched event
+head, missing status, wrong status creator, or ruleset readback mismatch is red
+or blocks the next transition. The workflow does not downgrade an unreadable
+identity to unknown. A canary whose context cannot be proved against its exact
+head leaves the live required-check set unchanged.
+
+## 12. Decisions and their homes
+
+Hypomnema places the durable choice in
+`docs/decisions/ADR-058-require-base-owned-identity-and-human-review.md`.
+`scripts/check_commit_identity.py` owns the bounded commit-object policy,
+`.github/workflows/identity.yml` owns hosted execution, and root tests own
+policy parity plus workflow immutability. This study and the runbook remain in
+`docs/pr-identity-gate/`. GitHub owns commit statuses and rulesets; exact API
+readbacks are their receipts rather than a second repository configuration.

--- a/scripts/check_commit_identity.py
+++ b/scripts/check_commit_identity.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Reject runtime-host attribution in one bounded pull-request commit range."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+
+import contributors
+
+
+SCHEMA = "wildcat-commit-identity-check/v1"
+SHA_RE = re.compile(r"\A(?:[0-9a-f]{40}|[0-9a-f]{64})\Z")
+GITHUB_LOGIN_RE = re.compile(
+    r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})(?:\[bot\])?$"
+)
+IDENT_LINE_RE = re.compile(
+    r"\A(?P<name>[^<>\x00-\x1f\x7f]{1,256}) "
+    r"<(?P<email>[^<>\x00-\x20\x7f]{1,320})> "
+    r"(?P<timestamp>-?[0-9]+) (?P<timezone>[+-][0-9]{4})\Z"
+)
+COAUTHOR_RE = re.compile(
+    r"^Co-authored-by:\s*(?P<name>.+?)\s*<(?P<email>[^<>]+)>$",
+    re.IGNORECASE,
+)
+HOST_BYLINE_RE = re.compile(
+    r"(?:generated\s+(?:by|with)|(?:co-)?authored\s+by)\s+"
+    r"(?:\[(?:claude(?: code)?|codex|chatgpt|copilot|gemini(?: code assist)?)\]"
+    r"\([^\)]+\)|claude(?: code)?|codex|chatgpt|copilot|gemini(?: code assist)?)",
+    re.IGNORECASE,
+)
+
+SHOGGOTH_NAME = "Shoggoth"
+SHOGGOTH_EMAIL = "shoggoth@wildcat.finance"
+COAUTHOR_TRAILER = "Co-authored-by: Shoggoth <shoggoth@wildcat.finance>"
+ORIGIN_TRAILER = "Wildcat-Origin: shoggoth"
+
+COMMIT_COUNT_MAX = 1024
+COMMIT_BYTES_MAX = 128 * 1024
+COMMIT_TOTAL_BYTES_MAX = 8 * 1024 * 1024
+GIT_OUTPUT_MAX = 256 * 1024
+GIT_TIMEOUT_SECONDS = 10
+COAUTHOR_COUNT_MAX = 32
+
+
+class Refusal(Exception):
+    """An identity result that must keep the required check red."""
+
+
+def _repository_path(value: str) -> Path:
+    """Accept one real, non-symlinked bare object database."""
+    handed = os.path.abspath(value)
+    resolved = os.path.realpath(handed)
+    if handed != resolved:
+        raise Refusal("candidate repository path contains a symlink")
+    path = Path(resolved)
+    try:
+        mode = path.stat(follow_symlinks=False).st_mode
+    except OSError as error:
+        raise Refusal("candidate repository path cannot be read") from error
+    if not stat.S_ISDIR(mode):
+        raise Refusal("candidate repository path is not a directory")
+    if (path / ".git").exists():
+        raise Refusal("candidate repository is not bare")
+    return path
+
+
+def _git_environment() -> dict[str, str]:
+    environment = {
+        key: value for key, value in os.environ.items() if not key.startswith("GIT_")
+    }
+    environment.update(
+        {
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_NO_REPLACE_OBJECTS": "1",
+            "GIT_OPTIONAL_LOCKS": "0",
+            "LC_ALL": "C",
+        }
+    )
+    return environment
+
+
+def _git(
+    repository: Path,
+    arguments: list[str],
+    label: str,
+    *,
+    output_max: int = GIT_OUTPUT_MAX,
+    allowed_exits: frozenset[int] = frozenset({0}),
+) -> tuple[int, bytes]:
+    """Run one fixed, bounded metadata read against the bare repository."""
+    try:
+        completed = subprocess.run(
+            ["git", f"--git-dir={repository}", *arguments],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=GIT_TIMEOUT_SECONDS,
+            check=False,
+            env=_git_environment(),
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise Refusal(f"{label} could not complete") from error
+    if len(completed.stdout) > output_max or len(completed.stderr) > GIT_OUTPUT_MAX:
+        raise Refusal(f"{label} exceeded its output ceiling")
+    if completed.returncode not in allowed_exits:
+        raise Refusal(f"{label} failed with exit {completed.returncode}")
+    return completed.returncode, completed.stdout
+
+
+def _one_line(repository: Path, arguments: list[str], label: str) -> str:
+    _, raw = _git(repository, arguments, label, output_max=256)
+    try:
+        text = raw.decode("ascii")
+    except UnicodeDecodeError as error:
+        raise Refusal(f"{label} returned non-ASCII output") from error
+    value = text.rstrip("\n")
+    if not value or "\n" in value or "\r" in value:
+        raise Refusal(f"{label} returned a malformed value")
+    return value
+
+
+def _full_sha(value: str, label: str, object_format: str) -> str:
+    if SHA_RE.fullmatch(value) is None:
+        raise Refusal(f"{label} is not a full lowercase object identifier")
+    expected = 40 if object_format == "sha1" else 64
+    if len(value) != expected:
+        raise Refusal(f"{label} does not match repository object format {object_format}")
+    return value
+
+
+def _commit_range(repository: Path, base: str, head: str) -> list[str]:
+    exit_code, _ = _git(
+        repository,
+        ["merge-base", "--is-ancestor", base, head],
+        "base ancestry check",
+        output_max=0,
+        allowed_exits=frozenset({0, 1}),
+    )
+    if exit_code != 0:
+        raise Refusal("pull-request head does not contain the exact base commit")
+    _, raw = _git(
+        repository,
+        [
+            "rev-list",
+            "--reverse",
+            "--topo-order",
+            f"--max-count={COMMIT_COUNT_MAX + 1}",
+            f"{base}..{head}",
+        ],
+        "commit range read",
+        output_max=(COMMIT_COUNT_MAX + 1) * 65,
+    )
+    try:
+        lines = raw.decode("ascii").splitlines()
+    except UnicodeDecodeError as error:
+        raise Refusal("commit range returned non-ASCII output") from error
+    if not lines:
+        raise Refusal("pull-request range contains no commit")
+    if len(lines) > COMMIT_COUNT_MAX:
+        raise Refusal(f"pull-request range exceeds {COMMIT_COUNT_MAX} commits")
+    if len(lines) != len(set(lines)) or any(SHA_RE.fullmatch(line) is None for line in lines):
+        raise Refusal("commit range returned malformed or duplicate object identifiers")
+    return lines
+
+
+def _commit_bytes(repository: Path, commit_sha: str) -> bytes:
+    object_type = _one_line(
+        repository, ["cat-file", "-t", commit_sha], f"commit {commit_sha} type"
+    )
+    if object_type != "commit":
+        raise Refusal(f"object {commit_sha} is not a commit")
+    size_text = _one_line(
+        repository, ["cat-file", "-s", commit_sha], f"commit {commit_sha} size"
+    )
+    if re.fullmatch(r"(?:0|[1-9][0-9]*)", size_text) is None:
+        raise Refusal(f"commit {commit_sha} size is malformed")
+    size = int(size_text)
+    if size > COMMIT_BYTES_MAX:
+        raise Refusal(f"commit {commit_sha} exceeds {COMMIT_BYTES_MAX} bytes")
+    _, data = _git(
+        repository,
+        ["cat-file", "commit", commit_sha],
+        f"commit {commit_sha} read",
+        output_max=COMMIT_BYTES_MAX,
+    )
+    if len(data) != size:
+        raise Refusal(f"commit {commit_sha} changed during its bounded read")
+    return data
+
+
+def _identity(line: str, commit_sha: str, role: str) -> tuple[str, str]:
+    match = IDENT_LINE_RE.fullmatch(line)
+    if match is None:
+        raise Refusal(f"commit {commit_sha} has malformed {role} identity")
+    name = match.group("name").strip()
+    email = match.group("email")
+    if not name or name != match.group("name"):
+        raise Refusal(f"commit {commit_sha} has malformed {role} identity")
+    exact_shoggoth = name == SHOGGOTH_NAME and email == SHOGGOTH_EMAIL
+    partial_shoggoth = (
+        name.casefold() == SHOGGOTH_NAME.casefold()
+        or email.casefold() == SHOGGOTH_EMAIL.casefold()
+    )
+    if partial_shoggoth and not exact_shoggoth:
+        raise Refusal(f"commit {commit_sha} has ambiguous Shoggoth {role} identity")
+    if contributors.is_host_identity(name, email):
+        raise Refusal(f"commit {commit_sha} names a runtime host as {role}")
+    return name, email
+
+
+def _parsed_commit(data: bytes, commit_sha: str) -> tuple[tuple[str, str], tuple[str, str], str]:
+    if b"\x00" in data or b"\r" in data:
+        raise Refusal(f"commit {commit_sha} contains unsupported control bytes")
+    try:
+        header_bytes, message_bytes = data.split(b"\n\n", 1)
+    except ValueError as error:
+        raise Refusal(f"commit {commit_sha} has no header-message boundary") from error
+    try:
+        headers = header_bytes.decode("utf-8").splitlines()
+        message = message_bytes.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise Refusal(f"commit {commit_sha} identity or message is not UTF-8") from error
+    authors = [line[7:] for line in headers if line.startswith("author ")]
+    committers = [line[10:] for line in headers if line.startswith("committer ")]
+    if len(authors) != 1 or len(committers) != 1:
+        raise Refusal(f"commit {commit_sha} does not carry one author and one committer")
+    return (
+        _identity(authors[0], commit_sha, "author"),
+        _identity(committers[0], commit_sha, "committer"),
+        message,
+    )
+
+
+def _message_policy(message: str, commit_sha: str, author: tuple[str, str]) -> None:
+    if HOST_BYLINE_RE.search(message):
+        raise Refusal(f"commit {commit_sha} carries a runtime-host generated-by byline")
+    coauthor_count = 0
+    for line in message.splitlines():
+        match = COAUTHOR_RE.fullmatch(line)
+        if match is None:
+            continue
+        coauthor_count += 1
+        if coauthor_count > COAUTHOR_COUNT_MAX:
+            raise Refusal(
+                f"commit {commit_sha} exceeds {COAUTHOR_COUNT_MAX} co-author trailers"
+            )
+        name, email = match.group("name"), match.group("email")
+        if len(name) > 256 or len(email) > 320:
+            raise Refusal(f"commit {commit_sha} has malformed co-author identity")
+        if contributors.is_host_identity(name, email):
+            raise Refusal(f"commit {commit_sha} names a runtime host as co-author")
+        partial_shoggoth = (
+            name.strip().casefold() == SHOGGOTH_NAME.casefold()
+            or email.strip().casefold() == SHOGGOTH_EMAIL.casefold()
+        )
+        if partial_shoggoth and line != COAUTHOR_TRAILER:
+            raise Refusal(f"commit {commit_sha} has ambiguous Shoggoth co-author identity")
+    if author == (SHOGGOTH_NAME, SHOGGOTH_EMAIL):
+        lines = message.splitlines()
+        if lines.count(COAUTHOR_TRAILER) != 1:
+            raise Refusal(
+                f"commit {commit_sha} does not carry one exact Shoggoth co-author trailer"
+            )
+        if lines.count(ORIGIN_TRAILER) != 1:
+            raise Refusal(
+                f"commit {commit_sha} does not carry one exact Wildcat-Origin trailer"
+            )
+
+
+def evaluate(repository_value: str, base_value: str, head_value: str, login: str) -> dict:
+    """Return one bounded success record or raise ``Refusal``."""
+    repository = _repository_path(repository_value)
+    bare = _one_line(
+        repository,
+        ["rev-parse", "--is-bare-repository"],
+        "bare repository check",
+    )
+    if bare != "true":
+        raise Refusal("candidate repository is not bare")
+    shallow = _one_line(
+        repository,
+        ["rev-parse", "--is-shallow-repository"],
+        "shallow repository check",
+    )
+    if shallow != "false":
+        raise Refusal("candidate repository is shallow")
+    object_format = _one_line(
+        repository,
+        ["rev-parse", "--show-object-format"],
+        "object format read",
+    )
+    if object_format not in {"sha1", "sha256"}:
+        raise Refusal("candidate repository uses an unsupported object format")
+    base = _full_sha(base_value, "base SHA", object_format)
+    head = _full_sha(head_value, "head SHA", object_format)
+    if not isinstance(login, str):
+        raise Refusal("pull-request login is malformed")
+    if contributors.is_host_login(login):
+        raise Refusal("pull request was opened by a runtime-host account")
+    if GITHUB_LOGIN_RE.fullmatch(login) is None:
+        raise Refusal("pull-request login is malformed")
+
+    commits = _commit_range(repository, base, head)
+    total_bytes = 0
+    shoggoth_authors = 0
+    for commit_sha in commits:
+        data = _commit_bytes(repository, commit_sha)
+        total_bytes += len(data)
+        if total_bytes > COMMIT_TOTAL_BYTES_MAX:
+            raise Refusal(
+                f"pull-request commit objects exceed {COMMIT_TOTAL_BYTES_MAX} bytes"
+            )
+        author, _committer, message = _parsed_commit(data, commit_sha)
+        _message_policy(message, commit_sha, author)
+        if author == (SHOGGOTH_NAME, SHOGGOTH_EMAIL):
+            shoggoth_authors += 1
+    return {
+        "schema": SCHEMA,
+        "status": "passed",
+        "base": base,
+        "head": head,
+        "pull_request_login": login,
+        "commit_count": len(commits),
+        "shoggoth_author_count": shoggoth_authors,
+        "human_author_count": len(commits) - shoggoth_authors,
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    command = argparse.ArgumentParser(
+        description="Reject runtime-host attribution in a pull-request commit range."
+    )
+    command.add_argument("--repository", required=True, help="bare Git object database")
+    command.add_argument("--base", required=True, help="exact protected base SHA")
+    command.add_argument("--head", required=True, help="exact pull-request head SHA")
+    command.add_argument(
+        "--pull-request-login", required=True, help="GitHub pull-request author login"
+    )
+    return command
+
+
+def main(arguments: list[str] | None = None) -> int:
+    options = parser().parse_args(arguments)
+    try:
+        result = evaluate(
+            options.repository,
+            options.base,
+            options.head,
+            options.pull_request_login,
+        )
+    except Refusal as error:
+        print(f"identity: {error}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_commit_identity.py
+++ b/tests/test_commit_identity.py
@@ -1,0 +1,466 @@
+"""Contract tests for the base-owned pull-request identity gate."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager, redirect_stdout
+import importlib.util
+from io import StringIO
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+POLICY_PATH = SCRIPTS / "check_commit_identity.py"
+HEXCTL_PATH = (
+    ROOT / "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
+)
+WORKFLOW = ROOT / ".github/workflows/identity.yml"
+STUDY = ROOT / "docs/pr-identity-gate/study.md"
+RUNBOOK = ROOT / "docs/pr-identity-gate/runbook.md"
+ADR = ROOT / "docs/decisions/ADR-058-require-base-owned-identity-and-human-review.md"
+
+
+def load_module(name: str, path: Path):
+    scripts = str(SCRIPTS)
+    sys.path.insert(0, scripts)
+    try:
+        spec = importlib.util.spec_from_file_location(name, path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(scripts)
+
+
+def workflow_run_blocks(text: str) -> list[str]:
+    """Return only literal shell bodies, excluding surrounding expressions."""
+    lines = text.splitlines(keepends=True)
+    blocks = []
+    index = 0
+    while index < len(lines):
+        if lines[index] != "        run: |\n":
+            index += 1
+            continue
+        index += 1
+        body = []
+        while index < len(lines):
+            line = lines[index]
+            if line.strip() and not line.startswith("          "):
+                break
+            body.append(line)
+            index += 1
+        blocks.append("".join(body))
+    return blocks
+
+
+policy = load_module("commit_identity_under_test", POLICY_PATH)
+contributors = load_module("contributors_under_test", SCRIPTS / "contributors.py")
+hexctl = load_module("hexctl_identity_policy_under_test", HEXCTL_PATH)
+
+
+def run(*arguments: str, cwd: Path, input_bytes: bytes | None = None) -> str:
+    completed = subprocess.run(
+        list(arguments),
+        cwd=cwd,
+        input=input_bytes,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        env={**os.environ, "LC_ALL": "C"},
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"{arguments!r} failed with {completed.returncode}: "
+            f"{completed.stderr.decode(errors='replace')}"
+        )
+    return completed.stdout.decode().strip()
+
+
+def commit(
+    source: Path,
+    *,
+    author_name: str,
+    author_email: str,
+    committer_name: str,
+    committer_email: str,
+    message: str,
+) -> str:
+    environment = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": author_name,
+        "GIT_AUTHOR_EMAIL": author_email,
+        "GIT_COMMITTER_NAME": committer_name,
+        "GIT_COMMITTER_EMAIL": committer_email,
+        "LC_ALL": "C",
+    }
+    completed = subprocess.run(
+        [
+            "git",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "--allow-empty",
+            "-m",
+            message,
+        ],
+        cwd=source,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        env=environment,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(completed.stderr.decode(errors="replace"))
+    return run("git", "rev-parse", "HEAD", cwd=source)
+
+
+HUMAN = {
+    "author_name": "A Human",
+    "author_email": "human@example.com",
+    "committer_name": "A Human",
+    "committer_email": "human@example.com",
+    "message": "human change",
+}
+SHOGGOTH = {
+    "author_name": "Shoggoth",
+    "author_email": "shoggoth@wildcat.finance",
+    "committer_name": "Laurence Day",
+    "committer_email": "laurence@wildcat.finance",
+    "message": (
+        "governed change\n\n"
+        "Co-authored-by: Shoggoth <shoggoth@wildcat.finance>\n"
+        "Wildcat-Origin: shoggoth"
+    ),
+}
+
+
+@contextmanager
+def candidate_repository(changes=(), *, base_change=None, shallow=False):
+    temporary_root = Path(tempfile.gettempdir()).resolve()
+    with tempfile.TemporaryDirectory(dir=temporary_root) as directory:
+        root = Path(directory)
+        source = root / "source"
+        bare = root / "candidate.git"
+        source.mkdir()
+        run("git", "init", "-b", "main", cwd=source)
+        base = commit(source, **dict(HUMAN if base_change is None else base_change))
+        head = base
+        for change in changes:
+            head = commit(source, **dict(change))
+        clone_arguments = ["git", "clone", "--bare"]
+        if shallow:
+            clone_arguments.extend(["--depth", "1", source.as_uri()])
+        else:
+            clone_arguments.append(str(source))
+        clone_arguments.append(str(bare))
+        run(*clone_arguments, cwd=root)
+        yield source, bare, base, head
+
+
+class AcceptedIdentityTests(unittest.TestCase):
+    def test_authorised_shoggoth_author_and_human_publisher_pass(self):
+        with candidate_repository([SHOGGOTH]) as (_source, bare, base, head):
+            result = policy.evaluate(str(bare), base, head, "laurenceday")
+        self.assertEqual(result["status"], "passed")
+        self.assertEqual(result["commit_count"], 1)
+        self.assertEqual(result["shoggoth_author_count"], 1)
+        self.assertEqual(result["human_author_count"], 0)
+
+    def test_a_human_contributor_needs_no_shoggoth_trailer(self):
+        with candidate_repository([HUMAN]) as (_source, bare, base, head):
+            result = policy.evaluate(str(bare), base, head, "radup1337")
+        self.assertEqual(result["human_author_count"], 1)
+        self.assertEqual(result["shoggoth_author_count"], 0)
+
+    def test_the_base_commit_is_not_reclassified_as_pull_request_work(self):
+        base_host = dict(
+            HUMAN,
+            author_name="Claude",
+            author_email="noreply@anthropic.com",
+            committer_name="Claude",
+            committer_email="noreply@anthropic.com",
+        )
+        with candidate_repository([HUMAN], base_change=base_host) as (
+            _source,
+            bare,
+            base,
+            head,
+        ):
+            result = policy.evaluate(str(bare), base, head, "radup1337")
+        self.assertEqual(result["commit_count"], 1)
+
+    def test_success_output_contains_no_address(self):
+        with candidate_repository([SHOGGOTH]) as (_source, bare, base, head):
+            output = StringIO()
+            with redirect_stdout(output):
+                exit_code = policy.main(
+                    [
+                        "--repository",
+                        str(bare),
+                        "--base",
+                        base,
+                        "--head",
+                        head,
+                        "--pull-request-login",
+                        "laurenceday",
+                    ]
+                )
+        self.assertEqual(exit_code, 0)
+        self.assertNotIn("@", output.getvalue())
+        self.assertIn('"schema":"wildcat-commit-identity-check/v1"', output.getvalue())
+
+
+class RefusedIdentityTests(unittest.TestCase):
+    def refusal(self, change, *, login="laurenceday", patch=None):
+        with candidate_repository([change]) as (_source, bare, base, head):
+            context = patch if patch is not None else mock.patch.object(
+                policy, "COMMIT_COUNT_MAX", policy.COMMIT_COUNT_MAX
+            )
+            with context, self.assertRaises(policy.Refusal) as stopped:
+                policy.evaluate(str(bare), base, head, login)
+        return str(stopped.exception)
+
+    def test_known_host_author_name_or_address_refuses(self):
+        cases = (
+            dict(HUMAN, author_name="Claude"),
+            dict(HUMAN, author_email="noreply@anthropic.com"),
+            dict(HUMAN, author_name="Codex"),
+        )
+        for change in cases:
+            with self.subTest(change=change):
+                self.assertIn("runtime host as author", self.refusal(change))
+
+    def test_known_host_committer_refuses(self):
+        change = dict(
+            HUMAN,
+            committer_name="Codex",
+            committer_email="noreply@openai.com",
+        )
+        self.assertIn("runtime host as committer", self.refusal(change))
+
+    def test_known_host_coauthor_refuses(self):
+        change = dict(
+            HUMAN,
+            message=(
+                "change\n\nCo-authored-by: Claude <noreply@anthropic.com>"
+            ),
+        )
+        self.assertIn("runtime host as co-author", self.refusal(change))
+
+    def test_known_host_generated_by_byline_refuses(self):
+        change = dict(HUMAN, message="change\n\nGenerated with Claude Code")
+        self.assertIn("generated-by byline", self.refusal(change))
+
+    def test_known_host_pull_request_login_refuses(self):
+        for login in sorted(
+            policy.contributors.HOST_PR_LOGINS
+            | policy.contributors.HOST_IDENTITY_NAMES
+        ):
+            with self.subTest(login=login):
+                self.assertIn(
+                    "runtime-host account", self.refusal(HUMAN, login=login)
+                )
+
+    def test_ambiguous_shoggoth_identity_refuses(self):
+        change = dict(SHOGGOTH, author_email="other@example.com")
+        self.assertIn("ambiguous Shoggoth author", self.refusal(change))
+
+    def test_shoggoth_author_requires_each_exact_trailer_once(self):
+        missing = dict(SHOGGOTH, message="governed change")
+        duplicate = dict(
+            SHOGGOTH,
+            message=SHOGGOTH["message"] + "\nWildcat-Origin: shoggoth",
+        )
+        self.assertIn("co-author trailer", self.refusal(missing))
+        self.assertIn("Wildcat-Origin trailer", self.refusal(duplicate))
+
+    def test_an_offending_middle_commit_cannot_hide_behind_a_clean_head(self):
+        host = dict(
+            HUMAN,
+            author_name="Claude",
+            author_email="noreply@anthropic.com",
+        )
+        with candidate_repository([HUMAN, host, SHOGGOTH]) as (
+            _source,
+            bare,
+            base,
+            head,
+        ):
+            with self.assertRaisesRegex(policy.Refusal, "runtime host as author"):
+                policy.evaluate(str(bare), base, head, "laurenceday")
+
+    def test_a_head_that_does_not_contain_the_exact_base_refuses(self):
+        with candidate_repository([HUMAN]) as (source, bare, base, head):
+            run("git", "checkout", "--orphan", "unrelated", cwd=source)
+            unrelated = commit(source, **dict(HUMAN, message="unrelated root"))
+            run("git", f"--git-dir={bare}", "fetch", str(source), unrelated, cwd=source)
+            with self.assertRaisesRegex(policy.Refusal, "does not contain the exact base"):
+                policy.evaluate(str(bare), base, unrelated, "radup1337")
+            self.assertNotEqual(head, unrelated)
+
+    def test_a_shallow_candidate_repository_refuses(self):
+        with candidate_repository([HUMAN], shallow=True) as (_source, bare, base, head):
+            with self.assertRaisesRegex(policy.Refusal, "repository is shallow"):
+                policy.evaluate(str(bare), base, head, "radup1337")
+
+    def test_a_non_bare_repository_refuses(self):
+        with candidate_repository([HUMAN]) as (source, _bare, base, head):
+            with self.assertRaisesRegex(policy.Refusal, "repository is not bare"):
+                policy.evaluate(str(source), base, head, "radup1337")
+
+    def test_a_symlinked_repository_path_refuses(self):
+        with candidate_repository([HUMAN]) as (source, bare, base, head):
+            link = source.parent / "candidate-link"
+            link.symlink_to(bare, target_is_directory=True)
+            with self.assertRaisesRegex(policy.Refusal, "path contains a symlink"):
+                policy.evaluate(str(link), base, head, "radup1337")
+
+    def test_commit_count_object_and_total_byte_ceilings_refuse(self):
+        with candidate_repository([HUMAN, HUMAN]) as (_source, bare, base, head):
+            with mock.patch.object(policy, "COMMIT_COUNT_MAX", 1):
+                with self.assertRaisesRegex(policy.Refusal, "exceeds 1 commits"):
+                    policy.evaluate(str(bare), base, head, "radup1337")
+        with candidate_repository([HUMAN]) as (_source, bare, base, head):
+            with mock.patch.object(policy, "COMMIT_BYTES_MAX", 1):
+                with self.assertRaisesRegex(policy.Refusal, "exceeds 1 bytes"):
+                    policy.evaluate(str(bare), base, head, "radup1337")
+            with mock.patch.object(policy, "COMMIT_TOTAL_BYTES_MAX", 1):
+                with self.assertRaisesRegex(policy.Refusal, "objects exceed 1 bytes"):
+                    policy.evaluate(str(bare), base, head, "radup1337")
+
+    def test_a_malformed_author_object_refuses(self):
+        with candidate_repository([]) as (source, _bare, base, _head):
+            tree = run("git", "show", "-s", "--format=%T", base, cwd=source)
+            raw = (
+                f"tree {tree}\n"
+                f"parent {base}\n"
+                "author malformed\n"
+                "committer A Human <human@example.com> 1 +0000\n\n"
+                "malformed identity\n"
+            ).encode()
+            malformed = run(
+                "git", "hash-object", "-t", "commit", "-w", "--stdin", "--literally",
+                cwd=source,
+                input_bytes=raw,
+            )
+            run("git", "update-ref", "refs/heads/main", malformed, cwd=source)
+            bare = source.parent / "malformed.git"
+            run("git", "clone", "--bare", str(source), str(bare), cwd=source.parent)
+            with self.assertRaisesRegex(policy.Refusal, "malformed author identity"):
+                policy.evaluate(str(bare), base, malformed, "radup1337")
+
+
+class PolicyParityTests(unittest.TestCase):
+    def test_host_sets_are_the_existing_fiat_and_contributor_sets(self):
+        for name in (
+            "HOST_IDENTITY_NAMES",
+            "HOST_IDENTITY_EMAILS",
+            "HOST_PR_LOGINS",
+        ):
+            self.assertEqual(
+                getattr(policy.contributors, name), getattr(contributors, name)
+            )
+            self.assertEqual(
+                getattr(policy.contributors, name), getattr(hexctl, name)
+            )
+
+    def test_message_and_login_grammars_match_fiat(self):
+        self.assertEqual(policy.COAUTHOR_RE.pattern, hexctl.COAUTHOR_RE.pattern)
+        self.assertEqual(policy.COAUTHOR_RE.flags, hexctl.COAUTHOR_RE.flags)
+        self.assertEqual(policy.HOST_BYLINE_RE.pattern, hexctl.HOST_BYLINE_RE.pattern)
+        self.assertEqual(policy.HOST_BYLINE_RE.flags, hexctl.HOST_BYLINE_RE.flags)
+        self.assertEqual(policy.GITHUB_LOGIN_RE.pattern, hexctl.GITHUB_LOGIN_RE.pattern)
+        self.assertEqual(policy.GITHUB_LOGIN_RE.flags, hexctl.GITHUB_LOGIN_RE.flags)
+
+    def test_provenance_trailers_match_fiat(self):
+        self.assertEqual(policy.COAUTHOR_TRAILER, hexctl.COAUTHOR_TRAILER)
+        self.assertEqual(policy.ORIGIN_TRAILER, hexctl.ORIGIN_TRAILER)
+
+
+class WorkflowContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = WORKFLOW.read_text(encoding="utf-8")
+        cls.run_blocks = workflow_run_blocks(cls.text)
+        cls.run_block = "".join(cls.run_blocks)
+
+    def test_job_and_trigger_are_unconditional_and_stable(self):
+        self.assertIn("name: identity\n", self.text)
+        self.assertRegex(self.text, r"(?m)^  pull_request_target:$")
+        self.assertNotRegex(self.text, r"(?m)^  pull_request:$")
+        self.assertNotIn("paths:", self.text)
+        self.assertRegex(self.text, r"(?m)^  identity:$")
+        self.assertIn("timeout-minutes: 5", self.text)
+
+    def test_only_exact_head_status_publication_is_writable(self):
+        permission_block = self.text.split("permissions:\n", 1)[1].split("\njobs:\n", 1)[0]
+        self.assertEqual(
+            permission_block.strip(),
+            "contents: read\n  statuses: write",
+        )
+        self.assertEqual(permission_block.casefold().count(": write"), 1)
+        self.assertNotIn("secrets.", self.text)
+        self.assertNotIn("actions/cache", self.text)
+        self.assertIn("persist-credentials: false", self.text)
+
+    def test_exact_head_status_is_pending_then_resolved_fail_closed(self):
+        endpoint = '"repos/wildcat-finance/skills/statuses/$HEAD_SHA"'
+        self.assertEqual(self.run_block.count(endpoint), 2)
+        self.assertEqual(self.run_block.count("-f context=identity"), 2)
+        self.assertIn("-f state=pending", self.run_block)
+        self.assertIn("state=failure", self.run_block)
+        self.assertIn('[ "$EVALUATION_OUTCOME" = "success" ]', self.run_block)
+        self.assertIn("if: ${{ always() }}", self.text)
+        self.assertIn(
+            "EVALUATION_OUTCOME: ${{ steps.evaluate.outcome }}",
+            self.text,
+        )
+        self.assertNotIn("continue-on-error", self.text)
+
+    def test_only_the_exact_base_policy_is_checked_out(self):
+        self.assertEqual(self.text.count("uses: actions/checkout@v4"), 1)
+        self.assertIn("ref: ${{ github.event.pull_request.base.sha }}", self.text)
+        self.assertNotIn("path:", self.text)
+        self.assertNotIn("github.event.pull_request.head.sha }}\n          path:", self.text)
+
+    def test_candidate_is_bare_and_only_base_policy_executes(self):
+        self.assertIn('git init --bare "$candidate_repository"', self.run_block)
+        self.assertIn("https://github.com/wildcat-finance/skills.git", self.run_block)
+        self.assertIn("refs/pull/${PR_NUMBER}/head", self.run_block)
+        self.assertIn("python3 scripts/check_commit_identity.py", self.run_block)
+        for forbidden in ("git checkout", "pip install", "npm ", "make ", "source "):
+            self.assertNotIn(forbidden, self.run_block)
+
+    def test_event_values_do_not_enter_shell_source(self):
+        for block in self.run_blocks:
+            self.assertNotIn("${{", block)
+        for value in ("BASE_SHA", "HEAD_SHA", "PR_LOGIN", "PR_NUMBER"):
+            self.assertIn(f"{value}: ${{{{ github.event.pull_request.", self.text)
+        self.assertIn('""|*[!0-9]*)', self.run_block)
+        self.assertIn('test "$fetched_head" = "$HEAD_SHA"', self.run_block)
+
+
+class DurableRecordTests(unittest.TestCase):
+    def test_study_runbook_and_decision_name_the_bootstrap_boundary(self):
+        study = STUDY.read_text(encoding="utf-8")
+        runbook = RUNBOOK.read_text(encoding="utf-8")
+        decision = ADR.read_text(encoding="utf-8")
+        for text in (study, runbook, decision):
+            self.assertIn("base", text.casefold())
+            self.assertIn("canary", text.casefold())
+            self.assertIn("one approving review", text.casefold())
+        self.assertIn(
+            "Do not add `identity` to a ruleset in this step",
+            " ".join(runbook.split()),
+        )
+        self.assertIn("candidate cannot rewrite the deciding policy", decision)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_commit_identity.py
+++ b/tests/test_commit_identity.py
@@ -59,6 +59,13 @@ def workflow_run_blocks(text: str) -> list[str]:
     return blocks
 
 
+def scratch_directory(prefix: str = "commit-identity-"):
+    """Keep fixture churn under the repository's ignored scratch anchor."""
+    scratch = ROOT / "tmp"
+    scratch.mkdir(exist_ok=True)
+    return tempfile.TemporaryDirectory(dir=scratch, prefix=prefix)
+
+
 policy = load_module("commit_identity_under_test", POLICY_PATH)
 contributors = load_module("contributors_under_test", SCRIPTS / "contributors.py")
 hexctl = load_module("hexctl_identity_policy_under_test", HEXCTL_PATH)
@@ -142,8 +149,7 @@ SHOGGOTH = {
 
 @contextmanager
 def candidate_repository(changes=(), *, base_change=None, shallow=False):
-    temporary_root = Path(tempfile.gettempdir()).resolve()
-    with tempfile.TemporaryDirectory(dir=temporary_root) as directory:
+    with scratch_directory() as directory:
         root = Path(directory)
         source = root / "source"
         bare = root / "candidate.git"

--- a/tests/test_python_contract.py
+++ b/tests/test_python_contract.py
@@ -33,6 +33,7 @@ EXACT_VERSION = "3.14.6"
 PYTHON_WORKFLOWS = {
     "contributors.yml",
     "dead-code.yml",
+    "identity.yml",
     "janus.yml",
     "lazarus.yml",
     "pandects.yml",
@@ -40,7 +41,7 @@ PYTHON_WORKFLOWS = {
     "repo.yml",
     "synkrisis.yml",
 }
-PULL_REQUEST_WORKFLOWS = PYTHON_WORKFLOWS - {"contributors.yml"}
+PULL_REQUEST_WORKFLOWS = PYTHON_WORKFLOWS - {"contributors.yml", "identity.yml"}
 # Required gates carry no path filter, so they have no filter to inspect.
 UNFILTERED_GATES = {"plugins.yml", "repo.yml"}
 PATH_FILTERED_PULL_REQUEST_WORKFLOWS = PULL_REQUEST_WORKFLOWS - UNFILTERED_GATES


### PR DESCRIPTION
## What changed

- add an unconditional base-owned `pull_request_target` identity policy for pull requests to `main`
- inspect every commit in the exact `base..head` range without checking out or executing candidate bytes
- reject known runtime-host authors, committers, co-authors, generated-by lines, and pull-request accounts
- require exact Shoggoth identity and provenance trailers when Shoggoth is the author
- publish a fail-closed `identity` commit status to the validated pull-request head
- record the decision, bootstrap boundary, live-enforcement runbook, and contract tests

The workflow checks out the exact protected base as its policy workspace. Candidate Git objects exist only in a fresh bare repository. It has read-only contents access and the single additional `statuses: write` permission needed to mark the fixed `identity` context pending, then success or failure. Success is selected only from the evaluation step's successful outcome.

The [study](https://github.com/wildcat-finance/skills/blob/3b9a67f765be7256fa79a28fdfd4d4c33aeb7bad/docs/pr-identity-gate/study.md), [runbook](https://github.com/wildcat-finance/skills/blob/3b9a67f765be7256fa79a28fdfd4d4c33aeb7bad/docs/pr-identity-gate/runbook.md), and [ADR-058](https://github.com/wildcat-finance/skills/blob/3b9a67f765be7256fa79a28fdfd4d4c33aeb7bad/docs/decisions/ADR-058-require-base-owned-identity-and-human-review.md) name the evidence boundary and the two-stage bootstrap.

## Evidence

- `TMPDIR=/private/tmp python3 scripts/run_checks.py --full`: all 25 declared checks passed
- root suite: 781 tests passed
- Hexaemeron suite: 2,022 tests passed
- dead-code baseline matches product commit `370c09bbb5308809b95e7838e52e30673f81aab7`
- `git verify-commit HEAD~3 HEAD~2 HEAD~1 HEAD`: all four commits have valid signatures from `B83B60AE16F5DD1A`
- every commit is authored by `Shoggoth <shoggoth@wildcat.finance>`, committed by `Laurence Day <laurence@wildcat.finance>`, and carries each required provenance trailer exactly once

## Bootstrap hold

This pull request intentionally leaves the live required-check and review rules unchanged. After its exact signed head reaches `main`, a separate signed canary must prove that `identity` is green on the canary's exact head, links the base-owned Actions run, and comes from GitHub Actions integration `15368`. Only then may the live required-CI ruleset add `identity` and the protected-branch rule require one approving review.

Refs #893.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: https://github.com/wildcat-finance/skills/issues/893
Root-Issue-Successor: none-recorded
Root-Issue-Fiat-Required: 1
Root-Issue-Route: fiat-required
Root-Issue-Classification-Source: live-contract
<!-- root-issue-analytics:v1:end -->
