### PR TITLE
Shard the plugin gate across the declared scopes

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1,8 +1,11 @@
 name: plugins
 
-# This is the required aggregate plugin gate. It has no path filter because a
-# required context must exist on every pull request, and the declared full graph
-# itself decides what complete coverage means.
+# This is the required aggregate plugin gate. The shard matrix has no path
+# filter because a required context must exist on every pull request, and the
+# declared full graph itself decides what complete coverage means. One shard per
+# declared scope runs the committed graph for that scope, so the graph remains
+# the only definition of a check and no command is copied into this file. The
+# `plugins` job below aggregates every shard and is the stable required context.
 
 on:
   push:
@@ -15,9 +18,37 @@ permissions:
   contents: read
 
 jobs:
-  plugins:
+  scope:
+    strategy:
+      fail-fast: false
+      matrix:
+        scope:
+          - alexandria
+          - ariadne
+          - berean
+          - brevitas
+          - ci
+          - dead-code
+          - docs
+          - hermes
+          - hexaemeron
+          - homologia
+          - horos
+          - janus
+          - lazarus
+          - lemma
+          - marketplace
+          - pandects
+          - probitas
+          - promise-machine
+          - repo-lints
+          - root
+          - sapheneia
+          - schemas
+          - synkrisis
+          - tabularium
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -46,13 +77,29 @@ jobs:
           )"
           test "$actual_fingerprint" = "$EXPECTED_GPG_FINGERPRINT"
           gpg --batch --import "$key_path"
-      - name: Complete declared check graph
-        run: python3 scripts/run_checks.py --full --report tmp/checks/plugins.json
+      - name: Declared checks for this scope
+        run: >-
+          python3 scripts/run_checks.py
+          --scope ${{ matrix.scope }}
+          --report tmp/checks/${{ matrix.scope }}.json
       - name: Preserve the bounded check report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: plugin-check-report
-          path: tmp/checks/plugins.json
+          name: plugin-check-report-${{ matrix.scope }}
+          path: tmp/checks/${{ matrix.scope }}.json
           if-no-files-found: error
           retention-days: 14
+
+  plugins:
+    needs: scope
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Every declared scope reached terminal success
+        env:
+          SHARDS: ${{ needs.scope.result }}
+        run: |
+          echo "shard result: $SHARDS"
+          test "$SHARDS" = success

--- a/plugins/lazarus/tests/test_scaffold.py
+++ b/plugins/lazarus/tests/test_scaffold.py
@@ -338,7 +338,15 @@ class ScaffoldTests(unittest.TestCase):
         for event in ("push", "pull_request"):
             with self.subTest(aggregate_event=event):
                 self.assertIsNone(event_paths(plugins_workflow, event, required=False))
-        self.assertIn("python3 scripts/run_checks.py --full", plugins_workflow)
+        # The aggregate gate shards the declared graph, one job per scope, so
+        # Lazarus is covered by its own shard rather than by a single --full
+        # invocation. What matters here is unchanged: the gate carries no path
+        # filter, so its context reaches every pull request.
+        self.assertIn(
+            "python3 scripts/run_checks.py\n          --scope ${{ matrix.scope }}",
+            plugins_workflow,
+        )
+        self.assertIn("          - lazarus\n", plugins_workflow)
 
         self.assertIn('python-version-file: ".python-version"', workflow)
         self.assertNotIn("matrix.python-version", workflow)

--- a/tests/test_python_contract.py
+++ b/tests/test_python_contract.py
@@ -313,7 +313,7 @@ class PythonRuntimeContractTests(unittest.TestCase):
                     with self.assertRaises(ValueError):
                         workflow_event_paths(text, event)
 
-    def test_complete_plugin_gate_runs_the_one_full_graph(self):
+    def test_complete_plugin_gate_shards_the_one_declared_graph(self):
         workflow = WORKFLOWS / "plugins.yml"
         self.assertTrue(workflow.is_file(), "the complete plugin workflow is missing")
         text = workflow.read_text(encoding="utf-8")
@@ -348,18 +348,39 @@ class PythonRuntimeContractTests(unittest.TestCase):
             "gpg --batch --import \"$key_path\"",
             text,
         )
+        # One shard per declared scope, each running the committed graph for
+        # that scope alone. The graph stays the only definition of a check, and
+        # no command is copied into the workflow.
         self.assertEqual(
             text.count(
-                "run: python3 scripts/run_checks.py --full "
-                "--report tmp/checks/plugins.json"
+                "python3 scripts/run_checks.py\n"
+                "          --scope ${{ matrix.scope }}\n"
+                "          --report tmp/checks/${{ matrix.scope }}.json"
             ),
             1,
         )
+        declared = set(
+            json.loads((ROOT / "tests" / "check-map-v1.json").read_text())["scopes"]
+        )
+        block = text[text.index("        scope:\n") : text.index("    runs-on:")]
+        sharded = set(re.findall(r"^\s+- ([a-z][a-z-]*)$", block, re.MULTILINE))
+        self.assertEqual(
+            sharded,
+            declared,
+            "every declared scope needs exactly one shard, and no shard may "
+            "name a scope the graph does not declare",
+        )
+        # The aggregate job is the required context and is green only when
+        # every shard reached terminal success.
+        self.assertIn("    needs: scope\n", text)
+        self.assertIn('test "$SHARDS" = success', text)
+        self.assertIn("fail-fast: false", text)
         self.assertIn("if: always()", text)
         self.assertIn("uses: actions/upload-artifact@v4", text)
-        self.assertIn("path: tmp/checks/plugins.json", text)
+        self.assertIn("path: tmp/checks/${{ matrix.scope }}.json", text)
         self.assertNotIn("continue-on-error", text)
         self.assertNotIn("github.event.pull_request", text)
+        self.assertNotIn("--full", text)
 
     def test_complete_graph_has_one_owned_suite_scope_for_every_plugin(self):
         graph = json.loads((ROOT / "tests" / "check-map-v1.json").read_text())


### PR DESCRIPTION
The `plugins` gate ran `scripts/run_checks.py --full` in a single job, so all twenty-four declared scopes executed serially on one runner.

Measured on `main` and on live branches:

| started | finished | elapsed |
| --- | --- | --- |
| 16:48:47 | 17:12:30 | 23m43s |
| 16:36:42 | 17:07:50 | 31m08s |
| 16:32:59 | 17:05:30 | 32m31s |
| 15:59:04 | 16:32:33 | 33m29s |

All four passed. The job works; it is the wall time that is the problem, and `ADR-056` made the context required without recording a duration. Every pull request into `main` now waits about half an hour at its final gate.

## What changes

One shard per declared scope, twenty-four of them, each running the committed graph for its own scope. `tests/check-map-v1.json` stays the only definition of a check and no command is copied into the workflow, which is the property `ADR-056` was protecting.

The matrix carries no path filter, so every pull request still produces every shard. A new aggregate job named `plugins` collects them with `needs: scope` and `if: always()`, and passes only when the shard result is `success`. The required context keeps both its name and its meaning: green only when every declared scope reached terminal success.

`fail-fast: false`, so one failing scope no longer hides the rest. Each shard uploads its own bounded report instead of one combined artefact.

## What does not change

Coverage, the graph, the toolchain pins, the fingerprint-checked key import, and the required-context name. `ADR-056`'s Consequences section reserved exactly this:

> A later performance change must measure the cost and preserve the same coverage and required-context availability.

Both are preserved. The cost becomes the slowest single scope rather than the sum of all of them.

## Checked before opening

The shard list matches the twenty-four declared scopes exactly, with none missing and none extra, compared against `tests/check-map-v1.json`. A single scope runs standalone: `run_checks.py --scope horos` selects its own closure and passes.

## Not addressed here

The root suite still runs twice, once as `invariants` and once inside the `root` shard. `ADR-056` accepted that duplication deliberately for a safe migration and it is left alone.

Scope closures overlap, so some suites run in more than one shard. That trades runner minutes for wall time, which is the intended direction, and this repository is public so Actions minutes are free.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
