### PR TITLE
The published package loses every executable bit

### DIFF
--- a/scripts/portable_promise_machine.py
+++ b/scripts/portable_promise_machine.py
@@ -550,22 +550,37 @@ Changes belong upstream. Open issues and pull requests against
     return text.encode("utf-8")
 
 
-def _package_bytes(root: Path, commit: str) -> dict[str, bytes]:
-    """Return every path the published package carries, keyed relative to it."""
+def _package_bytes(root: Path, commit: str) -> tuple[dict[str, bytes], dict[str, int]]:
+    """Return every path the published package carries, keyed relative to it.
+
+    The second mapping carries the permission bits of the entries that come
+    from a file in `root`, keyed the same way.  A package key is not a source
+    path -- the payload is republished under a prefix -- so a caller holding
+    only the key cannot find the origin to read its mode from.  Both paths are
+    in hand here, which is the only place the pairing can be recorded.
+    """
     payload, manifest = expected_files(root)
     files: dict[str, bytes] = {}
+    modes: dict[str, int] = {}
     for relative in PACKAGE_AUTHORED:
         source = root / relative
         if source.is_symlink() or not source.is_file():
             raise PackageError(f"authored package file is absent: {relative}")
         files[relative.as_posix()] = source.read_bytes()
+        modes[relative.as_posix()] = source.stat().st_mode & 0o777
     runtime = PACKAGE_ROOT / "runtime"
     for relative, data in payload.items():
-        files[(runtime / relative).as_posix()] = data
+        key = (runtime / relative).as_posix()
+        files[key] = data
+        # A payload key is a path in `root`, except for the boundary this
+        # generator renders itself; that one keeps the default mode.
+        origin = root / relative
+        if origin.is_file() and not origin.is_symlink():
+            modes[key] = origin.stat().st_mode & 0o777
     files[(runtime / "MANIFEST.json").as_posix()] = manifest
     files[SKILLS_CONFIG.as_posix()] = _package_config()
     files["README.md"] = _package_readme(commit)
-    return files
+    return files, modes
 
 
 # A directory this generator wrote carries its manifest at this path. Anything
@@ -600,7 +615,7 @@ def _checked_output(raw: str) -> Path:
 def package(root: Path, raw_out: str, commit: str | None) -> Path:
     """Write a complete installable package into a named directory."""
     out = _checked_output(raw_out)
-    files = _package_bytes(root, commit or source_commit(root))
+    files, modes = _package_bytes(root, commit or source_commit(root))
     for relative in files:
         pure = PurePosixPath(relative)
         if pure.is_absolute() or ".." in pure.parts:
@@ -612,9 +627,9 @@ def package(root: Path, raw_out: str, commit: str | None) -> Path:
             destination = candidate / relative
             destination.parent.mkdir(parents=True, exist_ok=True)
             destination.write_bytes(data)
-            origin = root / relative
-            if origin.is_file() and not origin.is_symlink():
-                destination.chmod(origin.stat().st_mode & 0o777)
+            mode = modes.get(relative)
+            if mode is not None:
+                destination.chmod(mode)
         if out.exists():
             shutil.rmtree(out)
         candidate.replace(out)

--- a/tests/test_skills_sh_package.py
+++ b/tests/test_skills_sh_package.py
@@ -335,6 +335,41 @@ class SkillsShPackageTests(unittest.TestCase):
         ):
             self.assertTrue((GENERATED / relative).is_file(), relative)
 
+    def test_package_preserves_the_executable_bit(self):
+        """A script executable in the source is still executable once published.
+
+        The package republishes the payload under a prefix, so a package key is
+        not a source path.  Reading the origin mode back through the package key
+        found nothing at all and left the whole tree at 0644, which breaks the
+        entries that are run as ./name rather than through an interpreter.
+        """
+        listing = subprocess.run(  # phylax: allow subprocess: fixed local git argv
+            ["git", "-C", str(ROOT), "ls-tree", "-r", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        executable = [
+            line.partition("\t")[2]
+            for line in listing.splitlines()
+            if line.split(maxsplit=1)[0] == "100755"
+        ]
+        self.assertTrue(executable, "the source tracks no executable file")
+        # The payload omits most tests and every repository script, so an
+        # executable source file need not appear here; one that does must keep
+        # the bit.
+        checked = 0
+        for relative in executable:
+            published = RUNTIME / relative
+            if not published.is_file():
+                continue
+            self.assertTrue(
+                os.access(published, os.X_OK),
+                f"{relative} is executable in the source but not in the package",
+            )
+            checked += 1
+        self.assertGreater(checked, 0, "no executable source file reached the package")
+
     def test_generated_package_verifies_itself_offline(self):
         verifier = PACKAGE / "scripts" / "verify_runtime.py"
         result = subprocess.run(  # phylax: allow subprocess: fixed local verifier argv


### PR DESCRIPTION
<!-- wildcat-origin: shoggoth -->

The generator dropped the executable bit from every file it published. The
source tracks 26 files at mode 100755; the package carried none of them.

`_package_bytes` keys the payload under `.agents/skills/promise-machine/runtime/`,
and `package()` then tried to recover each file's mode by treating that key as a
path in the source:

```python
origin = root / relative   # .agents/skills/promise-machine/runtime/plugins/...
if origin.is_file() and not origin.is_symlink():
    destination.chmod(origin.stat().st_mode & 0o777)
```

Nothing lives at that path in the source, so `is_file()` was false on every
entry and the tree landed wholly at 0644. `sync()` does the same thing correctly
because its payload keys are runtime-relative, which is why the bug only showed
once `package` actually published: `wildcat-finance/skills-runtime@fefb05c6`
carries `mode change 100755 => 100644` across the payload.

Two of the affected entries carry no extension and can only be run as `./name`,
so they arrived broken for anyone who installed the package:

- `plugins/lemma/solc-container`
- `plugins/lemma/baseline/regenerate`

## The change

`_package_bytes` now returns the modes beside the bytes, recorded at the one
point where both the package key and its origin are still in hand, and
`package()` applies them. Recovering the origin downstream from the key cannot
work, so the pairing is written where it is known rather than re-derived.

## Evidence

Generating locally now yields 21 executable files where it produced 0. The other
five of the source's 26 are tests and `scripts/run_checks.py`, which the payload
omits by design.

`test_package_preserves_the_executable_bit` reads the 100755 set from
`git ls-tree` rather than a hardcoded list, so it follows whatever the source
marks executable. Against the old generator it fails:

```
AssertionError: False is not true : plugins/anamnesis/skills/anamnesis/scripts/anamnesis.py
is executable in the source but not in the package
```

No manifest change, so no digest moves: modes are not recorded there. That is
also the gap this does not close -- `verify_runtime.py` compares bytes and never
checks a mode, which is why both the pre-publish step and the offline verifier
reported success throughout. Filed separately.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
