### PR TITLE
Authorise a delimited status block in issue bodies

### DIFF
--- a/docs/decisions/ADR-014-reallocate-the-live-wave-atlas-from-a-complete-census.md
+++ b/docs/decisions/ADR-014-reallocate-the-live-wave-atlas-from-a-complete-census.md
@@ -57,6 +57,48 @@ Apply these rules:
 Milestone descriptions hold the score and concise ordering reason for every
 current member. They are the durable ranking record for this allocation.
 
+## Amendment: Authorise a delimited status block in issue bodies (2026-08-31)
+
+The alternatives below reject writing Wave metadata into issue bodies, because
+that creates a second source of truth and changes issue content. That reasoning
+holds for Wave assignment and is unchanged here. The milestone field stays the
+only Wave assignment, and nothing may write a Wave into a body.
+
+It does not extend to an issue's current requirement. A Wave has a canonical
+GitHub field, so writing it into prose duplicates a value that already exists.
+Requirement drift has no such field. When an open issue is narrowed by work that
+landed, subsumed by a later issue, or invalidated by a change to `main`, the only
+surfaces available are the body and the comment thread.
+
+The comment thread is the weaker of the two, and the difference is measured.
+Issue #838 read 213 issues and 583 closed pull requests and found 436
+carried-forward items across pull-request bodies and issue closing comments, of
+which 344 name no issue or pull request and 245 have no register anywhere. A
+correction that arrives as the fourteenth comment is not read by a census that
+reads bodies.
+
+This amendment authorises one further mutation, bounded as follows.
+
+1. An open issue's body may be edited to record current status, supersession, or
+   a changed requirement. The edit is confined to a single block at the top of
+   the body, delimited by `<!-- status:start -->` and `<!-- status:end -->`.
+2. Wave assignment remains milestone-only. No Wave, score, or ordering value may
+   be written into a body.
+3. Filing prose outside the delimited block is not rewritten. Where a filing is
+   wrong rather than stale, the block says so and the original text stays, which
+   keeps the append-only amendment discipline that governs documents.
+4. The Atlas dependency extractor must ignore the delimited block. It parses
+   bodies for dependency declarations, and issue #497 records it reading a
+   `depends on` line as a declaration about the issue that contained it. A status
+   block naming other issues would otherwise change eligibility.
+5. Titles, labels, assignees, comments, and project membership stay outside the
+   authorised mutation, as the Context section states.
+
+This amendment does not address issue #894, which records that this document
+misstates what happened to the superseded alpha, beta, and Handover milestones.
+That correction needs its own amendment and a decision about whether closed
+issues should carry a Wave at all.
+
 ## Alternatives
 
 - **Patch only the issues added since the previous census.** This would be


### PR DESCRIPTION
ADR-014 states that issue bodies "were outside the authorised mutation", and
rejects writing metadata into them on the ground that it "creates a second source
of truth and changes issue content".

That reasoning holds for Wave assignment. A Wave has a canonical GitHub milestone
field, so writing it into prose duplicates a value that already exists. It does not
extend to an issue's current requirement, which has no field at all. When an open
issue is narrowed by work that landed, subsumed by a later issue, or invalidated by
a change to `main`, the only surfaces available are the body and the comment thread.

The comment thread is the weaker of the two, and #838 measured the difference: 436
carried-forward items across pull-request bodies and issue closing comments, of
which 344 name no issue or pull request and 245 have no register anywhere.

## What this authorises

One bounded write, appended as an amendment rather than corrected in place:

1. An open issue's body may carry a single status block at the top, delimited by
   `<!-- status:start -->` and `<!-- status:end -->`, recording current status,
   supersession, or a changed requirement.
2. Wave assignment stays milestone-only. No Wave, score, or ordering value may be
   written into a body.
3. Filing prose outside the block is not rewritten. Where a filing is wrong rather
   than stale, the block says so and the original text stays.
4. The Atlas dependency extractor must skip the block. It parses bodies for
   dependency declarations, and #497 records it reading a `depends on` line as a
   declaration about the issue that contained it.
5. Titles, labels, assignees, comments, and project membership stay outside the
   authorised mutation.

## Boundary

This does not address #894, which records that the same document misstates what
happened to the superseded alpha, beta, and Handover milestones. That correction
needs its own amendment and a decision about whether closed issues should carry a
Wave at all.

No convention is enforced by this change and no checker is added. The convention
and the staleness check belong to the observation filed alongside it.

## Evidence

`docs/**` declares no checks in `tests/check-map-v1.json` and is excluded from the
shipped-prose lint at `tests/test_shipped_prose_lints.py:66`, so this change carries
no scope-owned gate. Imprimatur 2.3.0 scores the amendment 100.0/100 with 0 defects.

The root suite was run before and after the edit on the same tree: 1110 tests, one
failure in both runs, `test_python_contract.test_current_runtime_prose_points_to_the_pin`.
That failure is the #897 pathology and is caused by a sibling Fiat worktree under
`.claude/worktrees/` being walked by `ROOT.rglob("*.md")`. It is present on an
unmodified checkout of `51fb586e` and is unrelated to this change.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
