### PR TITLE
Measure what an explicit budget buys on the standard runner

### DIFF
--- a/.github/workflows/plugin-gate-measurement.yml
+++ b/.github/workflows/plugin-gate-measurement.yml
@@ -1,0 +1,108 @@
+name: plugin-gate-measurement
+
+# Temporary. It measures what an explicit budget override buys on the standard
+# four-core runner, so wildcat-finance/skills#992 can decide about a paid larger
+# runner against a number rather than an estimate.
+#
+# The `plugins` gate runs the Hexaemeron suite at `--jobs 1`. Nothing chooses
+# that: `run_checks.py` derives budget 2 from four cores, `_allocation_for`
+# hands a nested coordinator `max(2, budget // 2)` slots when more than one
+# check runs, and the coordinator keeps one of them. Every arm below runs the
+# same `hexaemeron` scope on the same runner and differs only in that budget,
+# so the arm durations are the scaling curve on the hardware that actually
+# gates a pull request.
+#
+# Arm budgets map to suite workers as `max(2, budget // 2) - 1`:
+# control 1, 6 -> 2, 8 -> 3, 10 -> 4.
+#
+# Delete this file once #992 records the measurement.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".python-version"
+      - "pyproject.toml"
+      - ".github/workflows/plugin-gate-measurement.yml"
+  pull_request:
+    paths:
+      - ".python-version"
+      - "pyproject.toml"
+      - ".github/workflows/plugin-gate-measurement.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  arm:
+    strategy:
+      fail-fast: false
+      matrix:
+        budget:
+          - 0
+          - 6
+          - 8
+          - 10
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+          cache: pip
+          cache-dependency-path: plugins/lazarus/requirements.lock
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "26.6.0"
+      - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.7.1
+      - name: Install locked Lazarus dependencies
+        run: python3 -m pip install --requirement plugins/lazarus/requirements.lock
+      - name: Import pinned historical verification key
+        env:
+          EXPECTED_GPG_FINGERPRINT: 636EC19DE45DF10F3CE6206F57742DA1ABED6F46
+        run: |
+          key_path=plugins/hexaemeron/tests/fixtures/signing-keys/shoggoth-636ec19d.asc
+          actual_fingerprint="$(
+            gpg --batch --with-colons --import-options show-only --import "$key_path" |
+              awk -F: '$1 == "fpr" {print $10; exit}'
+          )"
+          test "$actual_fingerprint" = "$EXPECTED_GPG_FINGERPRINT"
+          gpg --batch --import "$key_path"
+      - name: Report the runner's own capacity
+        run: nproc
+      - name: Hexaemeron scope at this budget
+        env:
+          BUDGET: ${{ matrix.budget }}
+        run: |
+          set -eu
+          case "$BUDGET" in
+            "" | *[!0-9]*)
+              echo "budget must be a whole number"
+              exit 1
+              ;;
+          esac
+          if [ "$BUDGET" -eq 0 ]; then
+            python3 scripts/run_checks.py \
+              --scope hexaemeron \
+              --report tmp/checks/hexaemeron.json
+          else
+            python3 scripts/run_checks.py \
+              --scope hexaemeron \
+              --jobs "$BUDGET" \
+              --report tmp/checks/hexaemeron.json
+          fi
+      - name: Preserve the bounded check report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gate-measurement-budget-${{ matrix.budget }}
+          path: tmp/checks/hexaemeron.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/plugin-gate-measurement.yml
+++ b/.github/workflows/plugin-gate-measurement.yml
@@ -12,8 +12,12 @@ name: plugin-gate-measurement
 # so the arm durations are the scaling curve on the hardware that actually
 # gates a pull request.
 #
-# Arm budgets map to suite workers as `max(2, budget // 2) - 1`:
-# control 1, 6 -> 2, 8 -> 3, 10 -> 4.
+# Arm budgets map to suite workers as `max(2, budget // 2) - 1`.
+#
+# Run 33438750597 measured the first four arms and is not repeated here.
+# Control, at one worker, did not finish: `run_checks.py` killed it on its
+# 1800-second per-check timeout. The rest passed, at 1083s for two workers,
+# 954s for three and 830s for four. This round looks for the knee above four.
 #
 # Delete this file once #992 records the measurement.
 
@@ -41,10 +45,9 @@ jobs:
       fail-fast: false
       matrix:
         budget:
-          - 0
-          - 6
-          - 8
-          - 10
+          - 12
+          - 14
+          - 16
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 2283
+    "files_walked": 2284
   },
   "entries": [
     {

--- a/tests/test_python_contract.py
+++ b/tests/test_python_contract.py
@@ -37,6 +37,7 @@ PYTHON_WORKFLOWS = {
     "janus.yml",
     "lazarus.yml",
     "pandects.yml",
+    "plugin-gate-measurement.yml",
     "plugins.yml",
     "repo.yml",
     "synkrisis.yml",


### PR DESCRIPTION
Temporary measurement for #992, which is deciding whether to buy a larger hosted runner for the two half-hour shards.

## What this found first

The `plugins` gate does not run the Hexaemeron suite in parallel. It runs it at `--jobs 1`. From the check report of run 33336955590:

```
argv = ['python3', 'plugins/hexaemeron/tests/run_tests.py', '--jobs', '1']
slots = 2, coordinator_slots = 1, nested_allocation = 1, duration = 1604.9s
```

Nothing selects that number. `run_checks.py` derives budget 2 from the runner's four cores at [`:1011`](https://github.com/wildcat-finance/skills/blob/main/scripts/run_checks.py#L1011), `_allocation_for` hands a nested coordinator `max(2, budget // 2)` slots when more than one check runs at [`:2136`](https://github.com/wildcat-finance/skills/blob/main/scripts/run_checks.py#L2136), and the coordinator keeps one of them at [`:2169`](https://github.com/wildcat-finance/skills/blob/main/scripts/run_checks.py#L2169).

Two consequences for #992's route 1:

- An eight-core runner buys nothing. Budget 5 still grants 2 and still leaves one worker. The first size that changes anything is sixteen cores, at four workers.
- `scope (promise-machine)` spends its 29 minutes on the same `hexaemeron-suite` check, at 1606.3s and also `--jobs 1`. The gate pays for that suite twice.

The suite itself parallelises: 1812 fixture domains over 2131 tests, no class fixture on any of the four heaviest classes, and a 23.0s longest single test. There is no structural floor in the range that matters. #992's claim that a split leaving `test_hexctl` whole floors at about eight CI minutes does not hold, because `test_hexctl` carries 32 classes and no module fixture, so the scheduler already splits it.

## What this measures

Four arms over the `hexaemeron` scope on the same `ubuntu-latest` runner, differing only in the budget handed to `run_checks.py`. An explicit `--jobs` sets reserve to zero and takes the number as given, so the arms are the scaling curve on the hardware that actually gates a pull request.

| arm | suite workers |
| --- | --- |
| control | 1 |
| `--jobs 6` | 2 |
| `--jobs 8` | 3 |
| `--jobs 10` | 4 |

## Boundary

- `plugins.yml` is unchanged. The budget worth committing is whichever arm wins, and no number has been measured yet.
- `plugins` stays `disabled_manually`. This workflow does not re-enable it.
- The four arms run on free standard runners.
- Delete `.github/workflows/plugin-gate-measurement.yml` once #992 records the numbers.

`tests/test_python_contract.py` registers the new workflow, and `.horos/boundary.json` moves `files_walked` from 2283 to 2284. Both are the repository's own contracts reacting to one added file.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
