### PR TITLE
Scan the Horos boundary from a clean checkout

### DIFF
--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -2,21 +2,13 @@
   "counts": {
     "bytes_binary": 43942223,
     "bytes_content_addressed": 7844971,
-    "bytes_generated": 103765,
+    "bytes_generated": 67070,
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
     "files_walked": 2286
   },
   "entries": [
-    {
-      "bytes": 36695,
-      "category": "generated",
-      "evidence": "linguist-generated for '.agents/skills/promise-machine/runtime/**' in .gitattributes",
-      "files": 1,
-      "grade": "hard",
-      "path": ".agents/skills/promise-machine/runtime/"
-    },
     {
       "bytes": 1485,
       "category": "generated",


### PR DESCRIPTION
Repairs the `repo` workflow failure on `main` introduced by #725.

The Horos boundary in that pull request was scanned on a machine where the generated portable runtime existed on disk, so the committed boundary listed `.agents/skills/promise-machine/runtime/`. A fresh checkout does not have that directory, and the fresh scan in `test_the_committed_boundary_matches_a_fresh_scan` disagreed. This regenerates the boundary from a clean checkout with `python3 plugins/horos/skills/horos/scripts/horos.py scan . --write`; one file changes.

Run on this branch: `tests.test_boundary_currency`, `tests.test_agent_instruction`, and `tests.test_skills_sh_package` pass.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
