### PR TITLE
docs: repoint the checkpoint programme issues at their successors

### DIFF
--- a/docs/hexaemeron-checkpoint-programme-runbook.md
+++ b/docs/hexaemeron-checkpoint-programme-runbook.md
@@ -6,6 +6,13 @@
 > replaces it with same-ledger checkpoint continuation at two explicit
 > boundaries.
 
+> **Issue renumbering, 31 August 2026.** The epic and component issues were
+> re-filed under new numbers, and the links below point at the successors:
+> #558 to #859, #560 to #860, #561 to #861, #563 to #862, #564 to #863, #565
+> to #864, #566 to #865, #567 to #866, and #568 to #867. The `decision-chain`
+> packet #559 has no successor. Those originals and #530, #539, and #562 no
+> longer resolve on GitHub.
+
 Derived from `docs/hexaemeron-checkpoint-programme-study.md`. The chosen design
 is cumulative green-boundary archives, an independent locked authority, a
 signed external-run publication fence, and explicit DAG resolution.
@@ -42,9 +49,9 @@ decisions on a signed review branch while binding every component issue.
 `5d6fc67bb6c861f2be631eef2d7bef3c01c73e84`, after reading merged PR #562
 and merged PR #539; accepted ADR-022 on `main`; milestone
 [Wave Delta](https://github.com/wildcat-finance/skills/milestone/64); epic
-[#558](https://github.com/wildcat-finance/skills/issues/558); component issues
-#559, #560, #561, and #563 through #568; ADR-028 through ADR-032
-collision-free.
+[#859](https://github.com/wildcat-finance/skills/issues/859); component issues
+#559 (retired, no successor), #860, #861, and #862 through #867; ADR-028
+through ADR-032 collision-free.
 
 **Exit.** The study and this runbook pass Protasis; ADR-028 through ADR-032
 each pass Hypomnema with `Status: Proposed`; Imprimatur and Brevitas pass every
@@ -75,7 +82,7 @@ shows that one of these files earns a classified entry.
 
 **Tests.** No executable checkpoint test exists in this planning packet. The
 existing root decision/link/currency suites and the structural/prose commands
-above guard the shipped document surface. Read back milestone #64, epic #558,
+above guard the shipped document surface. Read back milestone #64, epic #859,
 and every component issue through GitHub before push.
 
 **Disciplines.** phylax: none, this step adds no executable or input path;
@@ -86,7 +93,7 @@ proposed records and no issue body masquerades as accepted policy.
 
 ## Step 2: Fix run, snapshot, transport, and receipt identities
 
-**Goal.** Deliver issue [#560](https://github.com/wildcat-finance/skills/issues/560)
+**Goal.** Deliver issue [#860](https://github.com/wildcat-finance/skills/issues/860)
 so two clean machines derive the same checkpoint identity while `main` moves.
 
 **Entry.** Step 1's PR is merged or its proposed ADR-028 and ADR-032 outcomes
@@ -127,7 +134,7 @@ accepted results of ADR-028 and ADR-032 without changing their scope silently.
 
 ## Step 3: Export, inspect, and restore one cumulative archive
 
-**Goal.** Deliver issue [#561](https://github.com/wildcat-finance/skills/issues/561)
+**Goal.** Deliver issue [#861](https://github.com/wildcat-finance/skills/issues/861)
 with deterministic bytes and an offline clean-directory restore.
 
 **Entry.** Step 2 is merged and released; #435 and #436 have landed safe,
@@ -171,7 +178,7 @@ lives in ADR-028 and this step must implement it rather than broaden it.
 
 ## Step 4: Build quarantine, validation, and immutable publication
 
-**Goal.** Deliver issue [#563](https://github.com/wildcat-finance/skills/issues/563)
+**Goal.** Deliver issue [#862](https://github.com/wildcat-finance/skills/issues/862)
 in one explicitly authorised service repository.
 
 **Entry.** Step 3 is released; the Creator has approved the exact service
@@ -210,7 +217,7 @@ and hands the attestation predicate/signature profile to Ariadne's boundary.
 
 ## Step 5: Deploy and prove the locked authority
 
-**Goal.** Deliver issue [#564](https://github.com/wildcat-finance/skills/issues/564)
+**Goal.** Deliver issue [#863](https://github.com/wildcat-finance/skills/issues/863)
 so accepted state outlives its DigitalOcean compute and mutable index.
 
 **Entry.** Step 4 is merged with non-production deployment support; exact
@@ -250,7 +257,7 @@ not change its authority split through an operator shortcut.
 
 ## Step 6: Enforce the external-run publication fence
 
-**Goal.** Deliver issue [#565](https://github.com/wildcat-finance/skills/issues/565)
+**Goal.** Deliver issue [#864](https://github.com/wildcat-finance/skills/issues/864)
 so one externally completed transition is not complete until its signed
 acceptance statement verifies locally.
 
@@ -294,7 +301,7 @@ the accepted execution classes without a new decision.
 
 ## Step 7: Preserve siblings and require signed resolution
 
-**Goal.** Deliver issue [#566](https://github.com/wildcat-finance/skills/issues/566)
+**Goal.** Deliver issue [#865](https://github.com/wildcat-finance/skills/issues/865)
 so concurrent useful checkpoints remain visible and preference is explicit.
 
 **Entry.** Step 6 publishes valid siblings; the service target and resolver
@@ -329,7 +336,7 @@ policy decision separate from a service index update.
 
 ## Step 8: Break and recover the complete authority path
 
-**Goal.** Deliver issue [#567](https://github.com/wildcat-finance/skills/issues/567)
+**Goal.** Deliver issue [#866](https://github.com/wildcat-finance/skills/issues/866)
 with preserved adversarial fixtures and measured recovery evidence.
 
 **Entry.** Steps 3 through 7 are pinned by signed releases/commits in a
@@ -350,7 +357,7 @@ and recovery harnesses, measurement records, recurring-drill schedules, all
 incident runbooks, and stable Make targets. Defects in other repositories are
 filed separately and remain outside this step's write boundary.
 
-**Tests.** The complete matrix from #567: canonicalisation, ZIP/Git/state,
+**Tests.** The complete matrix from #866: canonicalisation, ZIP/Git/state,
 identity/signatures, retries, siblings/resolutions, revocation/salvage,
 database/Droplet/primary/replica/KMS/certificate failures, index tampering,
 key transition, exact-version break glass, output redaction, alert delivery,
@@ -365,7 +372,7 @@ recovery authority earns a new record rather than an edited incident report.
 
 ## Step 9: Add Atlas resume, redraw, and start routing
 
-**Goal.** Deliver issue [#568](https://github.com/wildcat-finance/skills/issues/568)
+**Goal.** Deliver issue [#867](https://github.com/wildcat-finance/skills/issues/867)
 without making Atlas an archive or resolution authority.
 
 **Entry.** Step 8 proves the service and recovery path; issues #505 and #530
@@ -404,7 +411,7 @@ client under ADR-029 and cannot absorb checkpoint authority through convenience.
 ## Step 10: Demonstrate the programme and close the epic last
 
 **Goal.** Run the study's full two-machine, moving-main, fork, reconciliation,
-revocation, and recovery demonstration before closing #558.
+revocation, and recovery demonstration before closing #859.
 
 **Entry.** Steps 1 through 9 are merged/deployed where authorised, every child
 issue is still open or has its exit evidence linked, exact production/staging
@@ -418,12 +425,12 @@ siblings, accepts an authorised reconciliation, revokes one exact poisoned
 version, refuses its descendants, salvages from a clean ancestor, destroys and
 rebuilds replaceable service state, and restores through the replica path. All
 identities, signatures, object versions, source states, alerts, and durations
-are attached to #558. Component issues close only after their own criteria;
-#558 closes last. No evidence gap is replaced with a summary claim.
+are attached to #859. Component issues close only after their own criteria;
+#859 closes last. No evidence gap is replaced with a summary claim.
 
 **Files.** No product file is changed by programme closure. Store bounded
 demonstration scripts and non-secret fixtures in the repository that owns them;
-attach or link immutable evidence from #558 and update issue checklists without
+attach or link immutable evidence from #859 and update issue checklists without
 rewriting earlier records.
 
 **Tests.** Re-run every component's released check/demo target at its pinned

--- a/docs/hexaemeron-checkpoint-programme-study.md
+++ b/docs/hexaemeron-checkpoint-programme-study.md
@@ -6,6 +6,13 @@
 > permits checkpoint continuation only at a successful end of step or an
 > exhausted audit, on the same controller ledger.
 
+> **Issue renumbering, 31 August 2026.** The Wave Delta epic and its component
+> issues were re-filed under new numbers, and the links below point at the
+> successors: #558 to #859, #560 to #860, #561 to #861, #563 to #862, #564 to
+> #863, #565 to #864, #566 to #865, #567 to #866, and #568 to #867. The
+> `decision-chain` packet #559 has no successor. Those originals and #530,
+> #539, #547, #549, #550, and #562 no longer resolve on GitHub.
+
 Assuming, unless corrected:
 
 1. This delivery records the programme, its proposed decisions, and its issue
@@ -33,7 +40,7 @@ Assuming, unless corrected:
    `wildcat-finance/fiat-checkpoints` repository. That repository does not
    exist by authority of this study; exact owner, name, visibility, actor, and
    cloud targets are ask-first entry gates in issue
-   [#563](https://github.com/wildcat-finance/skills/issues/563).
+   [#862](https://github.com/wildcat-finance/skills/issues/862).
 8. The proposed first deployment uses replaceable DigitalOcean compute and
    Managed PostgreSQL in `LON1`, while locked S3 object versions and KMS-signed
    receipts in separate AWS accounts carry authority. PostgreSQL and the
@@ -73,15 +80,15 @@ contributor routing can fail and ship separately:
 
 | Module id | Responsibility | Issue | Target | Depends on |
 | --- | --- | --- | --- | --- |
-| `decision-chain` | Replace stale checkpoint prior art with the current contract and proposed records | [#559](https://github.com/wildcat-finance/skills/issues/559) | `wildcat-finance/skills` | #439, #434 |
-| `checkpoint-identity` | Fix run anchors, semantic identity, transport identity, parents, stage, and receipt sidecars | [#560](https://github.com/wildcat-finance/skills/issues/560) | `wildcat-finance/skills` | `decision-chain` |
-| `archive-core` | Export, inspect, and restore one cumulative deterministic archive | [#561](https://github.com/wildcat-finance/skills/issues/561) | `wildcat-finance/skills` | `checkpoint-identity`, #435, #436 |
-| `checkpoint-service` | Quarantine hostile uploads, validate, publish immutably, and index accepted state | [#563](https://github.com/wildcat-finance/skills/issues/563) | future service repository | `archive-core` |
-| `storage-authority` | Deploy locked primary and replica objects plus the receipt signer behind replaceable compute | [#564](https://github.com/wildcat-finance/skills/issues/564) | future service repository | `checkpoint-service` |
-| `publication-fence` | Require a verified acceptance receipt before an external transition advances | [#565](https://github.com/wildcat-finance/skills/issues/565) | `wildcat-finance/skills` | `archive-core`, `checkpoint-service`, `storage-authority` |
-| `lineage-resolution` | Preserve siblings, advisory claims, signed resolution, reconciliation, and salvage | [#566](https://github.com/wildcat-finance/skills/issues/566) | future service repository | `checkpoint-identity`, `publication-fence` |
-| `recovery-proof` | Break hostile, concurrent, revoked, and lost-infrastructure paths and measure recovery | [#567](https://github.com/wildcat-finance/skills/issues/567) | future service repository | every service/controller module |
-| `resume-routing` | Let Atlas offer resume, redraw, or start from redacted current state | [#568](https://github.com/wildcat-finance/skills/issues/568) | `wildcat-finance/shoggoth-wave-atlas` | #505, #530, `recovery-proof` |
+| `decision-chain` | Replace stale checkpoint prior art with the current contract and proposed records | #559 (retired, no successor) | `wildcat-finance/skills` | #439, #434 |
+| `checkpoint-identity` | Fix run anchors, semantic identity, transport identity, parents, stage, and receipt sidecars | [#860](https://github.com/wildcat-finance/skills/issues/860) | `wildcat-finance/skills` | `decision-chain` |
+| `archive-core` | Export, inspect, and restore one cumulative deterministic archive | [#861](https://github.com/wildcat-finance/skills/issues/861) | `wildcat-finance/skills` | `checkpoint-identity`, #435, #436 |
+| `checkpoint-service` | Quarantine hostile uploads, validate, publish immutably, and index accepted state | [#862](https://github.com/wildcat-finance/skills/issues/862) | future service repository | `archive-core` |
+| `storage-authority` | Deploy locked primary and replica objects plus the receipt signer behind replaceable compute | [#863](https://github.com/wildcat-finance/skills/issues/863) | future service repository | `checkpoint-service` |
+| `publication-fence` | Require a verified acceptance receipt before an external transition advances | [#864](https://github.com/wildcat-finance/skills/issues/864) | `wildcat-finance/skills` | `archive-core`, `checkpoint-service`, `storage-authority` |
+| `lineage-resolution` | Preserve siblings, advisory claims, signed resolution, reconciliation, and salvage | [#865](https://github.com/wildcat-finance/skills/issues/865) | future service repository | `checkpoint-identity`, `publication-fence` |
+| `recovery-proof` | Break hostile, concurrent, revoked, and lost-infrastructure paths and measure recovery | [#866](https://github.com/wildcat-finance/skills/issues/866) | future service repository | every service/controller module |
+| `resume-routing` | Let Atlas offer resume, redraw, or start from redacted current state | [#867](https://github.com/wildcat-finance/skills/issues/867) | `wildcat-finance/shoggoth-wave-atlas` | #505, #530, `recovery-proof` |
 
 Build order follows the table. Each row is a separate delivery with its own
 study, runbook, clean worktree, audit loop, receipts, and pull request. The
@@ -103,12 +110,12 @@ A working programme means this demonstration succeeds from two clean machines:
    until a signed resolution authorises a reconciliation checkpoint.
 6. The service loses its Droplet and PostgreSQL index and rebuilds the same
    accepted graph from locked records, with replica-only read/verify/restore
-   available inside the objective recorded in #567.
+   available inside the objective recorded in #866.
 
 The exact released commands are fixed by the component studies. The final
 demonstration records every command, SHA-256, snapshot id, object version,
 receipt signature, source freshness value, and recovery duration on
-[epic #558](https://github.com/wildcat-finance/skills/issues/558).
+[epic #859](https://github.com/wildcat-finance/skills/issues/859).
 
 ## 2. Prior art
 
@@ -349,16 +356,16 @@ and preserves the bytes.
 
 ## 7. Sources
 
-- [Wave Delta epic #558](https://github.com/wildcat-finance/skills/issues/558)
-  and component issues [#559](https://github.com/wildcat-finance/skills/issues/559),
-  [#560](https://github.com/wildcat-finance/skills/issues/560),
-  [#561](https://github.com/wildcat-finance/skills/issues/561),
-  [#563](https://github.com/wildcat-finance/skills/issues/563),
-  [#564](https://github.com/wildcat-finance/skills/issues/564),
-  [#565](https://github.com/wildcat-finance/skills/issues/565),
-  [#566](https://github.com/wildcat-finance/skills/issues/566),
-  [#567](https://github.com/wildcat-finance/skills/issues/567), and
-  [#568](https://github.com/wildcat-finance/skills/issues/568).
+- [Wave Delta epic #859](https://github.com/wildcat-finance/skills/issues/859)
+  and component issues #559 (retired, no successor),
+  [#860](https://github.com/wildcat-finance/skills/issues/860),
+  [#861](https://github.com/wildcat-finance/skills/issues/861),
+  [#862](https://github.com/wildcat-finance/skills/issues/862),
+  [#863](https://github.com/wildcat-finance/skills/issues/863),
+  [#864](https://github.com/wildcat-finance/skills/issues/864),
+  [#865](https://github.com/wildcat-finance/skills/issues/865),
+  [#866](https://github.com/wildcat-finance/skills/issues/866), and
+  [#867](https://github.com/wildcat-finance/skills/issues/867).
 - `plugins/hexaemeron/skills/fiat/SKILL.md` version `5.19.1` and
   `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`; PRs
   [#549](https://github.com/wildcat-finance/skills/pull/549) and
@@ -466,7 +473,7 @@ still gates the implementation packets: CP-3 records archive size, expanded
 size, export/inspect/restore time, and peak memory on a fixed corpus before any
 optimisation; CP-4 records route/dependency p95 and p99 plus validation queue
 age under a fixed workload; CP-8 measures the 60-minute read-only and four-hour
-full-recovery objectives from #567. Each target study must name the exact
+full-recovery objectives from #866. Each target study must name the exact
 measurement command and environment before code is kept. ZIP size and ratio
 ceilings are security limits, not claims that the service is fast.
 


### PR DESCRIPTION
The Wave Delta epic and its component packets were re-filed under the `shoggoth-wildcat-labs` App on 29 August 2026 and carry the same CP-N bodies in milestone 64. The originals no longer resolve: the Shoggoth account that filed them returns 404 from the users API, which also hides merged pull requests whose merge commits are still in this history.

Two planning documents linked the old numbers. This maps them onto the successors:

| Old | New | Packet |
| --- | --- | --- |
| #558 | #859 | epic |
| #559 | — | `decision-chain` / CP-1, no successor |
| #560 | #860 | CP-2 checkpoint-identity |
| #561 | #861 | CP-3 archive-core |
| #563–#568 | #862–#867 | CP-4 through CP-9 |

`#559` keeps its number without a link. Both documents gain a dated note recording the mapping and naming the references that still do not resolve.

**Left alone.** `docs/fiat-controller-checkpoint-study.md` carries the same dead links to #558, #560, and #561. It is a receipted run artefact pinned by digest in `tests/test_fiat_checkpoint_decision_record.py`; repointing it by hand breaks the binding to the bytes the run produced, so it needs the controller's amendment path or a correction recorded elsewhere.

**Checked.** Every issue and pull-request number linked in the two edited files was queried against the API: all nine successors resolve. Still dead and left alone because they have no successor: #530, #539, #547, #549, #550, #562 — each is named in the note of the file that cites it.

**Not covered.** No test resolves documentation links against GitHub, so this rot is unguarded and will recur. The same files in `wildcat-finance/skills-marketplace` still carry the old numbers.

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: https://github.com/wildcat-finance/skills/issues/560
Root-Issue-Successor: https://github.com/wildcat-finance/skills/issues/860
Root-Issue-Fiat-Required: 1
Root-Issue-Route: fiat-required
Root-Issue-Classification-Source: successor-contract
<!-- root-issue-analytics:v1:end -->
