### PR TITLE
Name the boundary rescan command in both currency failures

### DIFF
--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 2329
+    "files_walked": 2330
   },
   "entries": [
     {

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -110,7 +110,7 @@
     ],
     "tests": {
       "path": "tests/test_agent_instruction.py",
-      "sha256": "bc731ed721f937917b02ad51e3e0ea439fbe1a722651b3aee02d873a46e144f3",
+      "sha256": "c74b1081ee9a0323121b90b752f708494129011159fccb9014abfeb0d6e111c8",
       "selectors": [
         "test_root_promise_has_complete_exact_field_inventory",
         "test_specialised_coverage_binds_promise_and_contract",

--- a/tests/test_agent_instruction.py
+++ b/tests/test_agent_instruction.py
@@ -111,9 +111,9 @@ class AgentInstructionScaffoldTests(unittest.TestCase):
         self.assertEqual(entries, FIXTURE_IDS)
 
     def test_horos_boundary_is_current_for_the_scaffold(self):
-        from tests.test_boundary_currency import drifted_paths
+        from tests.test_boundary_currency import REFRESH, drifted_paths
 
-        self.assertEqual(drifted_paths(ROOT), [])
+        self.assertEqual(drifted_paths(ROOT), [], REFRESH)
 
     def test_existing_repository_licence_is_apache_2(self):
         text = (ROOT / "LICENSE").read_text(encoding="utf-8")


### PR DESCRIPTION
Two root tests compare `.horos/boundary.json` against a fresh scan and go red after ordinary edits, and the remedy only arrives if somebody remembers it. `test_boundary_currency` already names the exact command in its failure message; the scaffold copy in `test_agent_instruction` asserted bare. Both now fail with the same line:

    regenerate with: python3 plugins/horos/skills/horos/scripts/horos.py scan . --write

Of the two remedies the issue weighs, this is the one that does not depend on anyone following instructions: the failure carries its own fix. Running the scan from a step's exit checks would be more process prose, and process prose is what failed twice.

Two consequences are included:

- Editing the test file re-pins its digest in `tests/promise_machine_coverage.json`.
- The refreshed boundary heals drift this branch inherited: #1080 added `VENUES.json` without a rescan, so the committed count read 2329 against a tracked tree of 2330. The root suite is red on main today for exactly the reason the issue describes.

Full root suite after the change: 1110 tests, 0 failures.

Closes wildcat-finance/skills#1063

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: https://github.com/wildcat-finance/skills/issues/1063
Root-Issue-Successor: none-recorded
Root-Issue-Fiat-Required: 0
Root-Issue-Route: pr-only
Root-Issue-Classification-Source: live-contract
<!-- root-issue-analytics:v1:end -->
