### PR TITLE
perf(fiat): keep one Warden across a step's audit rounds

### DIFF
--- a/plugins/hexaemeron/agents/warden.md
+++ b/plugins/hexaemeron/agents/warden.md
@@ -33,8 +33,9 @@ color: red
 ---
 
 You are Warden, the independent audit worker. You run exactly one audit round
-on one step's branch. Fiat owns the receipt and the decision to continue or
-close the loop.
+per brief. Fiat may hand you the later rounds of the same step, so a second
+brief carrying the same `step_branch` continues work you already have in
+context. Fiat owns the receipt and the decision to continue or close the loop.
 
 The controller gives you one `brief` object with exactly `step_branch`,
 `stacked_branch`, `security_suite`, `plugin_root`, `audit_log_path`, `round`,
@@ -52,7 +53,12 @@ digest preconditions before reading or following
 `<plugin-root>/skills/x-ray/SKILL.md`, then read
 `<plugin-root>/skills/solidity-auditor/SKILL.md`, and follow each in that
 order against the step's full diff and every contract it touches -- not a
-summary. Use the first-party adapter as an X-Ray preparation layer only. Build
+summary. Read those three documents once per context. If this brief is a
+later round of a step you already audited, they are still in front of you
+and reading them again buys nothing. If you do not have them, read them now,
+whatever `round` says. A round number above 1 is not evidence that you read
+anything; only your own context is. Use the first-party adapter as an X-Ray
+preparation layer only. Build
 the full logical scope from the current tree; read and digest every current
 source as the pinned X-Ray operation requires. Reuse replaces only
 preparation-fact regeneration. Accept only a closed, complete, validated

--- a/plugins/hexaemeron/skills/fiat/references/audit-loop.md
+++ b/plugins/hexaemeron/skills/fiat/references/audit-loop.md
@@ -6,6 +6,21 @@ step's branch, logs everything, fixes on a stacked branch, and repeats
 until a round comes back clean or the remaining leads are judged not worth
 another pass.
 
+## One warden per step
+
+Delegate a step's first round to a new Warden, and every later round of the
+same step to that same agent. The suite documents Warden reads in round 1 come
+to 164,611 bytes; a fresh agent reads all of them again from nothing. Keeping
+the agent is the only thing that avoids that. A round number cannot, because an
+agent that has not read a document has not read it, and telling it otherwise
+would put a false claim in its context.
+
+Start a new Warden when the step changes, when the host cannot keep an agent
+alive between rounds, or when its context was lost. A new Warden reads the
+suite documents in full. Nothing about the evidence changes either way: one
+round still produces one `audit-round` receipt, and the round is still the unit
+Fiat records.
+
 ## One round
 
 1. Before selecting X-Ray, read the
@@ -15,7 +30,9 @@ another pass.
    `x-ray` pass first, then `solidity-auditor`. Both are vendored under
    `$PLUGIN_ROOT/skills/<name>/` (as defined in the entry skill) -- read
    each SKILL.md and follow
-   it. Give each the step's full diff and the contracts it touches, not a
+   it, unless this same agent already read them for an earlier round of
+   this step. Give each the step's full diff and the contracts it touches,
+   not a
    summary. Its adapter is a preparation layer only: build the full logical
    scope from the current tree, read and digest every current source, and
    preserve every pinned X-Ray source-read and verification call. Reuse


### PR DESCRIPTION
Closes the first finding of #1066.

## What this changes

Warden is delegated fresh on every `audit-round` directive, so each round re-reads the same 164,611 bytes of suite documentation before it reads one line of the target repository:

| File | Bytes |
| --- | --- |
| `plugins/hexaemeron/agents/warden.md` | 7,418 |
| `plugins/hexaemeron/skills/fiat/references/xray-reuse.md` | 4,355 |
| `plugins/hexaemeron/skills/x-ray/SKILL.md` | 41,327 |
| `plugins/hexaemeron/skills/x-ray/references/threats.md` | 48,186 |
| `plugins/hexaemeron/skills/x-ray/references/templates.md` | 46,695 |
| `plugins/hexaemeron/skills/solidity-auditor/SKILL.md` | 16,630 |

`threats.md` and `templates.md` are Step 1 loads: `x-ray/SKILL.md:342` and `x-ray/SKILL.md:348` both say "already loaded in Step 1". `max_rounds` defaults to 8 at `hexctl.py:131`. At four steps and two or three rounds each that is ten identical re-reads of text that did not change.

`audit-loop.md` gains a `One warden per step` section: a step's first round goes to a new Warden, and its later rounds go to that same agent. Round 1 then pays for the suite documents once per step rather than once per round.

## Why the saving is stated as agent persistence rather than a round number

A fresh agent has not read anything, so telling it that round 3 need not re-read would put a false claim in its context. Both files say to read in full whenever the documents are not already there, and `warden.md` says a round number above 1 is not evidence of a read. Starting a new Warden stays correct where a host cannot keep one alive between rounds, and a new Warden reads everything.

## What does not change

No receipt shape, refusal, or ledger behaviour. One round still produces one `audit-round` receipt, and the round is still the unit Fiat records. No code changes: the diff is two Markdown files.

## Why this is split out

The other three findings in #1066 are finished as code but each needs one sentence added to `plugins/hexaemeron/skills/fiat/SKILL.md`, which is digest-bound by the agent-instruction fixture and cannot be reconciled away from one machine. That constraint is filed as #1098. Neither file in this pull request is digest-bound, so this finding is separable and lands on its own.

## Testing

Run on this branch and on unmodified `809554c2`:

```text
python3 -m unittest discover -s tests -v
```

Both produce an identical set of 3 failures and 6 errors, and the difference between the two sets is empty. All nine come from this container running CPython 3.11.15 against the 3.14.6 in `.python-version`: six `sys.monitoring` errors in `test_dead_code`, the interpreter check in `test_python_contract`, and two others. CI reads `python-version-file`, so it runs the pinned interpreter.

Green on this branch:

- `tests/test_shipped_prose_lints.py`
- `tests/test_shipped_tree_lints.py`
- `plugins/hexaemeron/tests/test_fiat_skill.py`
- `plugins/hexaemeron/tests/test_xray_reuse.py`
- `plugins/hexaemeron/tests/test_hexctl.py`, 284 tests, run on the same two files before this branch was split out

Imprimatur reports 0 defects at 100.0 on both changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQT9hnrH2BexNU9z99EPrD)_

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
