### PR TITLE
fix(agent-instruction): say which machine a pinned adapter needs

### DIFF
--- a/scripts/agent_instruction.py
+++ b/scripts/agent_instruction.py
@@ -208,14 +208,21 @@ EVIDENCE_CLASSES = (
 class CodecError(ValueError):
     """A bounded refusal carrying a stable code and model-node path."""
 
-    def __init__(self, code: str, node_path: str = "$") -> None:
+    def __init__(
+        self, code: str, node_path: str = "$", detail: str | None = None
+    ) -> None:
         super().__init__(code)
         self.code = code
         self.node_path = node_path[:512]
+        # Operator guidance for a refusal whose code and node path do not
+        # tell a reader what to do. It never enters an emitted record: the
+        # record stays byte-identical and `main` writes this to stderr,
+        # which these commands otherwise leave empty.
+        self.detail = detail[:1024] if detail is not None else None
 
 
-def refuse(code: str, path: str = "$") -> NoReturn:
-    raise CodecError(code, path)
+def refuse(code: str, path: str = "$", detail: str | None = None) -> NoReturn:
+    raise CodecError(code, path, detail)
 
 
 def _scalar(value: str, path: str) -> None:
@@ -1420,13 +1427,41 @@ def _run_bounded(
                 stream.close()
 
 
+def _adapter_identity_detail(profile: Mapping[str, Any], which: str) -> str:
+    """Name the tokenizer and the machine a pinned adapter needs.
+
+    `WAI-E-ADAPTER.EXECUTABLE_CHANGED` at a digest node tells a reader that a
+    hash differed, not that this profile is bound to one machine's build. The
+    codes stay bounded, so the sentence a contributor can act on rides on
+    stderr instead. See skills#1098.
+    """
+    return (
+        f"adapter refused: the recorded {which} is not the one on this machine. "
+        f"This profile pins tokenizer {profile.get('id', 'unrecorded')}, run as "
+        f"{profile.get('runtime_executable', 'an unrecorded runtime')} "
+        f"through {profile.get('executable', 'an unrecorded client')}. "
+        "measure and parity regenerate token counts through that exact build, "
+        "so they cannot run anywhere it is absent, including CI. Run them on "
+        "the machine that recorded the profile, or re-record the profile where "
+        "you are."
+    )
+
+
 def _verify_profile_identity(profile: Mapping[str, Any], path: str = "$.profile") -> None:
     executable = _absolute_executable(profile["executable"], f"{path}.executable")
     if _hash_executable(executable, f"{path}.executable") != profile["executable_sha256"]:
-        refuse("WAI-E-ADAPTER.EXECUTABLE_CHANGED", f"{path}.executable_sha256")
+        refuse(
+            "WAI-E-ADAPTER.EXECUTABLE_CHANGED",
+            f"{path}.executable_sha256",
+            _adapter_identity_detail(profile, "client executable"),
+        )
     runtime = _absolute_executable(profile["runtime_executable"], f"{path}.runtime_executable")
     if _hash_executable(runtime, f"{path}.runtime_executable") != profile["runtime_executable_sha256"]:
-        refuse("WAI-E-ADAPTER.EXECUTABLE_CHANGED", f"{path}.runtime_executable_sha256")
+        refuse(
+            "WAI-E-ADAPTER.EXECUTABLE_CHANGED",
+            f"{path}.runtime_executable_sha256",
+            _adapter_identity_detail(profile, "runtime executable"),
+        )
     environment = _adapter_environment(profile, path)
     timeout = _small_decimal(profile["timeout_seconds"], f"{path}.timeout_seconds", 600)
     stdout_cap = _small_decimal(profile["max_stdout_bytes"], f"{path}.max_stdout_bytes", MAX_ADAPTER_OUTPUT_BYTES)
@@ -1622,7 +1657,11 @@ def _ollama_generate(
     body = json.dumps(request, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
     executable = _absolute_executable(profile["executable"], f"{path}.executable")
     if _hash_executable(executable, f"{path}.executable") != profile["executable_sha256"]:
-        refuse("WAI-E-ADAPTER.EXECUTABLE_CHANGED", f"{path}.executable_sha256")
+        refuse(
+            "WAI-E-ADAPTER.EXECUTABLE_CHANGED",
+            f"{path}.executable_sha256",
+            _adapter_identity_detail(profile, "client executable"),
+        )
     stdout, _ = _run_bounded(
         executable,
         _adapter_argv(
@@ -3767,6 +3806,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         _emit(_result("accepted", "WAI-OK", "$", input_bytes, model_bytes, compact_bytes, event="roundtrip"))
         return 0
     except CodecError as error:
+        # The record on stdout is the contract and does not change. A
+        # refusal a reader cannot act on from its code alone also says so
+        # here, where nothing parses.
+        if error.detail is not None:
+            print(f"agent_instruction: {error.detail}", file=sys.stderr)
         if arguments.command in ("check", "measure", "parity"):
             record = {
                 "schema": CHECK_RECORD_SCHEMA,

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -4,7 +4,7 @@
     "promise_id": "promise-machine-agent-instruction-prototype",
     "checker": {
       "path": "scripts/agent_instruction.py",
-      "sha256": "0cb16f881aa250ff830449c22dd98cb32d3f2cb432c7a62f74051f71dfc84759"
+      "sha256": "62b88c034915def8676556380674d63fe41ea048055ee50dc9c9f6e188cde289"
     },
     "manifest": {
       "path": "tests/fixtures/agent-instruction-v1/manifest.json",
@@ -110,7 +110,7 @@
     ],
     "tests": {
       "path": "tests/test_agent_instruction.py",
-      "sha256": "c74b1081ee9a0323121b90b752f708494129011159fccb9014abfeb0d6e111c8",
+      "sha256": "483c9b119e8081f6937c607ac8ae89eb28d6cc717654a2d2e97456a05d504769",
       "selectors": [
         "test_root_promise_has_complete_exact_field_inventory",
         "test_specialised_coverage_binds_promise_and_contract",

--- a/tests/test_agent_instruction.py
+++ b/tests/test_agent_instruction.py
@@ -2324,6 +2324,30 @@ class MeasurementTests(AdapterFixtureTests, unittest.TestCase):
         profile["executable_sha256"] = "0" * 64
         self.assertRefusal("WAI-E-ADAPTER.EXECUTABLE_CHANGED", AI._verify_profile_identity, profile)
 
+    def test_changed_executable_refusal_names_the_tokenizer_and_the_machine(self):
+        """skills#1098: the code and node path alone do not say what to do."""
+        profile = self.profile()
+        profile["executable_sha256"] = "0" * 64
+        with self.assertRaises(AI.CodecError) as raised:
+            AI._verify_profile_identity(profile)
+        detail = raised.exception.detail
+        self.assertIsNotNone(detail)
+        self.assertIn(profile["id"], detail)
+        self.assertIn(profile["runtime_executable"], detail)
+        self.assertIn(profile["executable"], detail)
+        self.assertIn("re-record", detail)
+
+    def test_refusal_detail_never_reaches_the_emitted_record(self):
+        error = AI.CodecError("WAI-E-ADAPTER.EXECUTABLE_CHANGED", "$.profile", "guidance")
+        self.assertEqual(error.code, "WAI-E-ADAPTER.EXECUTABLE_CHANGED")
+        self.assertEqual(error.node_path, "$.profile")
+        self.assertEqual(error.detail, "guidance")
+        self.assertNotIn("detail", AI._result("refused", error.code, error.node_path, b""))
+
+    def test_refusal_detail_is_optional_and_bounded(self):
+        self.assertIsNone(AI.CodecError("WAI-E-SHAPE.OBJECT", "$").detail)
+        self.assertEqual(len(AI.CodecError("WAI-E-SHAPE.OBJECT", "$", "x" * 4096).detail), 1024)
+
     def test_changed_vocabulary_digest_refuses(self):
         profile = self.profile()
         profile["model_blobs_sha256"] = ["b" * 64]


### PR DESCRIPTION
Takes the conservative route on #1098.

## The problem

`measure` and `parity` regenerate token counts by calling a local Ollama over a loopback adapter, and check the SHA-256 of both the client and the runtime binary before running. Off the machine that recorded the profile, the check refuses and says only:

```text
"code": "WAI-E-ADAPTER.EXECUTABLE_CHANGED"
"node_path": "$.profile.executable_sha256"
```

A digest node does not tell a contributor that the profile is bound to one machine's build. Three source documents are digest-bound, so by the time the fixture refuses, the edit is already made.

## The change

The refusal now also names the tokenizer, the runtime it is recorded against, the client it is called through, and the two ways out:

```text
agent_instruction: adapter refused: the recorded client executable is not the
one on this machine. This profile pins tokenizer gptoss-120b-ollama-0.32.15,
run as /Applications/Ollama.app/Contents/Resources/ollama through /usr/bin/curl.
measure and parity regenerate token counts through that exact build, so they
cannot run anywhere it is absent, including CI. Run them on the machine that
recorded the profile, or re-record the profile where you are.
```

The codes stay bounded, so the sentence rides on stderr, which these commands otherwise leave empty. `CodecError` gains an optional `detail` that never enters an emitted record.

## What does not change

The record on stdout is byte-identical, verified by running `measure` against the fixture on this branch and on `main` and diffing the output. The exit code is unchanged. A refusal carrying no operator guidance still prints nothing to stderr. No schema, no refusal code, and no record field is added.

## Scope

This is the conservative one of the four routes #1098 sets out: it stops the wasted edit without touching what the measurement means. Replacing the pinned tokenizer, excluding the embedded digest from the measured corpus, and publishing the runtime all remain open, and #1098 says that choice is Protasis's.

Acceptance checks met: the first, in its "refused at the first pass" branch, and the second. The third regresses reconciliation behaviour, which only exists under one of the other three routes, so it is left with them. The fourth holds by construction — a refusal writes no output file, confirmed on both branches.

## Testing

`tests/test_agent_instruction.py`: 310 tests, `OK`, three new:

```text
test_changed_executable_refusal_names_the_tokenizer_and_the_machine
test_refusal_detail_never_reaches_the_emitted_record
test_refusal_detail_is_optional_and_bounded
```

The full gate, `python3 -m unittest discover -s tests`, run on this branch and on a clean `origin/main` worktree in parallel: both give an identical 3 failures and 6 errors, and the set difference is empty. All nine come from this container running CPython 3.11.15 against the 3.14.6 in `.python-version`; CI reads `python-version-file`.

`tests/promise_machine_coverage.json` binds the digest of both edited files. Both are updated, two lines.

## This will land red on `identity`, and that is expected

The commit is authored and committed by a runtime host, which `scripts/check_commit_identity.py` refuses in both roles. The agent that wrote it cannot set a non-host committer. The fix is the same amend applied to #1099: author `Shoggoth <shoggoth@wildcat.finance>`, committer a human, plus

```text
Co-authored-by: Shoggoth <shoggoth@wildcat.finance>
Wildcat-Origin: shoggoth
```

Every other check should pass. Opened red deliberately so the work is reviewable while that amend is pending.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQT9hnrH2BexNU9z99EPrD)_

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: https://github.com/wildcat-finance/skills/issues/1098
Root-Issue-Successor: none-recorded
Root-Issue-Fiat-Required: 1
Root-Issue-Route: fiat-required
Root-Issue-Classification-Source: live-contract
<!-- root-issue-analytics:v1:end -->
