### PR TITLE
Exempt the generated SOURCES.md citation from the outside-link rule

### DIFF
--- a/plugins/ariadne/tests/test_docs.py
+++ b/plugins/ariadne/tests/test_docs.py
@@ -40,14 +40,23 @@ DOCUMENTED = (
 EXAMPLES = os.path.join(PLUGIN, "examples")
 
 POLICY_CITATION = re.compile(r"(?m)^Policy: \[[^\]]+\]\([^)]+\)$")
-"""The one link a ledger has to point outside the plugin.
+"""The first of two links a ledger has to point outside the plugin.
 
 `tests/test_evolution_contract.py` at the repository root requires every
 governed ledger to cite `plugins/hexaemeron/skills/VERSIONING.md` by a relative
 path that resolves to that file. The versioning contract is shared by twelve
 plugins and is not copied into each, so that citation cannot both satisfy the
-repository contract and stay inside this plugin. The exemption is this one line;
-every other link in the ledger is held to the rule below.
+repository contract and stay inside this plugin.
+"""
+
+SOURCES_CITATION = re.compile(r"(?m)^- Sources: \[[^\]]+\]\([^)]+\)$")
+"""The second, on the same terms as the policy citation above.
+
+`SOURCES.md` at the repository root is the generated coverage manifest that
+replaced `VENUES.json`. Its generator writes and repairs this line in all 27
+governed ledgers, so it is no more copyable into one plugin than the versioning
+contract is. The exemption is these two lines; every other link in the ledger is
+held to the rule below.
 """
 
 
@@ -230,6 +239,7 @@ class ContractTests(unittest.TestCase):
                 text = read(path)
                 if name == "EVOLUTION.md":
                     text = POLICY_CITATION.sub("", text)
+                    text = SOURCES_CITATION.sub("", text)
                 for link in re.findall(r"\]\((\.[^)]+)\)", text):
                     target = os.path.normpath(os.path.join(directory, link))
                     with self.subTest(document=os.path.relpath(path, PLUGIN)):

--- a/plugins/tabularium/tests/test_scaffold.py
+++ b/plugins/tabularium/tests/test_scaffold.py
@@ -77,6 +77,10 @@ class TabulariumPackagingTests(unittest.TestCase):
         shared_versioning = (
             REPO_ROOT / "plugins" / "hexaemeron" / "skills" / "VERSIONING.md"
         ).resolve()
+        # SOURCES.md at the repository root is the generated coverage manifest
+        # whose generator writes this citation into all 27 governed ledgers. Like
+        # the versioning contract, it is shared and not copied into any plugin.
+        shared_sources = (REPO_ROOT / "SOURCES.md").resolve()
         for path in PLUGIN_ROOT.rglob("*.md"):
             if "__pycache__" in path.parts:
                 continue
@@ -85,7 +89,7 @@ class TabulariumPackagingTests(unittest.TestCase):
                     continue
                 target = (path.parent / link.split("#", 1)[0]).resolve()
                 with self.subTest(document=path.relative_to(PLUGIN_ROOT), link=link):
-                    if target == shared_versioning:
+                    if target in (shared_versioning, shared_sources):
                         self.assertTrue(target.is_file())
                         continue
                     self.assertIn(PLUGIN_ROOT, target.parents)


### PR DESCRIPTION
`main` has been red since `64e251d7` ("data: swap VENUES.json for the generated
SOURCES.md and wire its refresh"). Two plugin suites fail on the default branch:

```
plugins/ariadne/tests/test_docs.py::test_no_shipped_document_links_outside_the_plugin
plugins/tabularium/tests/test_scaffold.py::test_public_document_links_resolve_inside_the_plugin
```

## Cause

`64e251d7` had its generator write a `- Sources: [../../../../SOURCES.md](...)`
line into all 27 governed `EVOLUTION.md` files, and states that the generator
repairs that line at every refresh. Ariadne and Tabularium are the only two
plugins that assert a shipped document never links outside its own directory.

Both already carve out the shared versioning contract, on the grounds that
`plugins/hexaemeron/skills/VERSIONING.md` is cited by twelve plugins and cannot
be copied into each. Ariadne's `POLICY_CITATION` docstring says so directly:
"The exemption is this one line." The new `Sources:` citation has exactly the
same character — a shared, generated, repository-root document that no plugin
can hold a private copy of — and got no such carve-out.

So this is an omission from `64e251d7`, not a disagreement about whether the
link belongs.

## Change

Each plugin keeps its own idiom rather than being converted to a shared helper:

- **Ariadne** strips the line by regex, beside the policy line it already
  strips. `POLICY_CITATION`'s docstring is amended from "the one link" to "the
  first of two", and a `SOURCES_CITATION` pattern is added with its own reason.
- **Tabularium** compares against a resolved repository-root path, beside the
  `shared_versioning` path it already compares.

## Evidence

- `plugins/ariadne/tests` — 881 tests, OK.
- `plugins/tabularium/tests` — 134 tests, OK.
- Both failures reproduced first in a clean `git archive` extract of `main` at
  `66b6cfd6` with no worktree or controller state present, so the red is not a
  local artefact.
- The exemption is narrow, not a disabled check: with an extra
  `- Bogus: [../../../../README.md](../../../../README.md)` line injected into
  each ledger, **both suites still fail**. The ledgers were restored
  byte-identically afterwards.

`scripts/run_checks.py --full` was not completed locally — it sat at 0% CPU for
27 minutes against two other Fiat runs on the same machine and was killed, so it
is reported here as inconclusive rather than green. CI runs the full graph.

<!-- wildcat-origin: shoggoth -->

<!-- root-issue-analytics:v1:start -->
## Root issue analytics

Root-Issue: none-recorded
Root-Issue-Successor: not-applicable
Root-Issue-Fiat-Required: not-applicable
Root-Issue-Route: not-applicable
Root-Issue-Classification-Source: none-recorded
<!-- root-issue-analytics:v1:end -->
