### PR TITLE
fix: drop the no-op conjunct in the ADR collision test

### DIFF
--- a/tests/test_decision_records.py
+++ b/tests/test_decision_records.py
@@ -140,7 +140,7 @@ class DecisionRecordNumbering(unittest.TestCase):
             if number not in theirs:
                 continue
             added = names - theirs[number]
-            if added and True:
+            if added:
                 if len(names | theirs[number]) > 1:
                     collisions.append(
                         f"ADR-{number}: this branch adds {sorted(added)} while the "


### PR DESCRIPTION
## What changed

One line in `tests/test_decision_records.py`, inside
`test_no_number_collides_with_one_already_on_the_default_branch`:

```diff
-            if added and True:
+            if added:
```

No other file is touched.

## Why the conjunct was deleted rather than completed

The line read as though a second condition had been intended and then lost, so
history was checked before removing it.

`git log -L 130,145:tests/test_decision_records.py` returns exactly one commit
over that range: `71a5961b` (2026-08-24, "fix: close the three gaps that let a
delivery corrupt its own evidence"), the file's initial add. The line arrived as
`if added and True:` in that commit and has never been modified since. No
condition was ever removed, so there is nothing to restore.

## Behaviour

Unchanged. `x and True` is truthy exactly when `x` is, so the guard admits the
same set of values as before.

## Evidence

`python3 -m unittest tests.test_decision_records`

```
.....
----------------------------------------------------------------------
Ran 5 tests in 0.023s

OK
```

5 tests, 0 skips. No skips means the local `origin/main` ref was present, so
`test_no_number_collides_with_one_already_on_the_default_branch` ran rather
than short-circuiting on a missing default-branch ref.

Not established: whether the body under `if added:` was entered on that run.
That needs an ADR number present on both this branch and the default branch,
which the current tree may not supply. It does not affect the change, which is
a pure no-op removal either way.

## Provenance

Spotted during a Fiat audit round on an unrelated documents-only delivery, and
explicitly out of that run's scope, so it is carried here on its own branch.

Co-authored-by: Shoggoth <shoggoth@wildcat.finance>
Wildcat-Origin: shoggoth