### PR TITLE
Tell a frontier run to read controller state one field at a time

### DIFF
--- a/plugins/hexaemeron/skills/VERSIONING.md
+++ b/plugins/hexaemeron/skills/VERSIONING.md
@@ -85,6 +85,35 @@ receipt. A failed or unavailable check changes nothing and is not mentioned.
 This clause lives here for the same reason as the one above: the obligation
 belongs to the frontier run, not to any one held job's text.
 
+A frontier run reads controller state one field at a time and keeps the audit
+brief out of its own transcript. Where it needs a single value, use
+`hexctl status --field <path>` rather than `hexctl status --json`, which prints
+every step, receipt and audit round recorded so far and grows for the whole
+run: `--field phase` on resume, `--field observation_run_id` for a companion
+observation receipt. Where it delegates an audit round, pass
+`hexctl next --brief-out <path>` and hand the subagent that path, so the step
+markdown, risk register and design evidence reach the Warden without being
+printed into the controller's context first. An unknown field path is refused
+rather than answered, so a wrong path fails visibly instead of reading as
+absent.
+
+This clause lives here for a different reason from the two above. The
+instructions that would otherwise carry it are inside
+[fiat/SKILL.md](fiat/SKILL.md), which
+`tests/fixtures/agent-instruction-v1/manifest.json` binds by whole-file
+SHA-256; editing it invalidates a bound measurement record that only
+`scripts/agent_instruction.py measure` can reissue, and that measurement has no
+machine to run on. Both flags landed on `main` and are available now, so the
+saving is reachable from here while the bound document waits. Ordinary
+non-frontier runs still read whatever `fiat/SKILL.md` says and still pay for
+it; this is not a substitute for that edit, and it does not settle
+[skills#1066](https://github.com/wildcat-finance/skills/issues/1066)'s
+acceptance checks, which name the controller's transcript rather than a
+frontier run's conduct. See
+[skills#1030](https://github.com/wildcat-finance/skills/issues/1030) and
+[skills#1098](https://github.com/wildcat-finance/skills/issues/1098) for the
+reconciliation this defers.
+
 A mature frontier can reopen only when a maintainer supplies a new external
 failure, requirement, dependency change, or other evidence that invalidates
 the closure. Record that compatibility boundary as an epoch entry, with the


### PR DESCRIPTION
## Result

A frontier run is now told to read controller state one field at a time and to keep the audit brief out of its own transcript. The `status --field` and `next --brief-out` flags landed in #1125; nothing told a run to use them, and the document that would have is bound by digest.

The clause goes in `plugins/hexaemeron/skills/VERSIONING.md` under "What every frontier run owes", beside the two obligations already there. It names three call sites — `--field phase` on resume, `--field observation_run_id` for a companion observation receipt, `--brief-out` for an audit round — and records that an unknown field path is refused rather than answered, so a wrong path fails visibly instead of reading as absent.

## Why not `fiat/SKILL.md`

That is where these instructions belong, and the edit cannot pass. `tests/fixtures/agent-instruction-v1/manifest.json` binds `fiat/SKILL.md` by whole-file SHA-256, and the manifest also binds `evidence/measurement.json`, whose `corpus_sha256` covers that document. Editing the prose and re-pinning every derived artefact by hand still leaves:

```text
{"code":"WAI-E-DIGEST.CORPUS","node_path":"$.evidence.measurement_record","outcome":"refused"}
```

Only `scripts/agent_instruction.py measure` can reissue that record, against the pinned `ollama-loopback-generate/v1` profile — `/usr/bin/curl`, `127.0.0.1:11434`, `gpt-oss:120b`. That measurement has no machine available, so this is not an inconvenience to work around; the edit cannot go green. See #1030 and #1098.

`VERSIONING.md` is bound by nothing: no file in the checkout records its digest. `fiat/SKILL.md`'s frontier maturity gate already sends a run to read it, so the obligation is reachable from an unbound surface.

## What this does not do

The clause states both limits itself rather than leaving them to be discovered.

- **It reaches frontier runs only.** The delegation sits at step 1 of the frontier maturity gate, so an ordinary product run never reads it and still pays for `status --json`.
- **It does not satisfy #1066's acceptance checks.** Those name the controller's transcript for one `audit-round` directive, not a frontier run's conduct. #1066 stays open on items 1 and 2 of its check list.

This is a partial saving on an unbound surface while the bound document waits, and the commit message and the clause both say so.

## Evidence

`scripts/run_checks.py --scope hexaemeron` selected eight checks across the changed scope and its consumers. All eight passed:

```text
dead-code-suite                passed    38.9s
dead-code-suppressions-check   passed    39.0s
hexaemeron-suite               passed   484.2s
imprimatur-suite               passed     1.0s
lint-ephoros                   passed     2.6s
lint-hypomnema                 passed     1.2s
lint-phylax                    passed     3.9s
root-suite                     passed   101.0s
outcome  green
```

`agent_instruction.py check` remains accepted with the manifest digest unchanged at `c7f0bea5…`, and `git status` shows one modified file, so no bound document moved. Imprimatur scores 100/100 with 0 defects on the changed file.

An earlier run at `--jobs 2` reported the Hexaemeron suite red at 1800.4s with `exit -15` and empty output: that is `run_checks.py`'s 30-minute cap killing a suite forced down to one worker, not a test failure.

Refs #1066
