### PR TITLE
chore: ignore the plugin test runner's timing cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,17 @@ plugins/*/harness/cache/
 # a plugin that wants its own tmp/ still decides for itself.
 /tmp/
 
+# The timing cache from plugins/hexaemeron/tests/run_tests.py, whose path is
+# `<cwd>/tmp/check-runner/timings-v1.json` because its run root is the working
+# directory. Run the plugin suite from the repository root, as AGENTS.md:276
+# does, and the rule above already covers it; run it from the plugin directory
+# the way plugins/hexaemeron/README.md:333 shows, or from the tests directory,
+# and the cache lands on a path nothing ignores. The rule names check-runner/
+# rather than tmp/ so a plugin still decides its own tmp/, per the note above.
+# It also covers the `.timings-v1.json.<pid>.<ns>.tmp` a hard-killed run leaves
+# beside the cache.
+**/tmp/check-runner/
+
 # Demo output. The Synkrisis example commands write their cohort here; the
 # committed expected copies live under the plugin's examples tree.
 /build/


### PR DESCRIPTION
## What this fixes

`plugins/hexaemeron/tests/run_tests.py` writes a timing cache at
`<cwd>/tmp/check-runner/timings-v1.json`, because its run root is
`Path.cwd().resolve(strict=True)` rather than the script's own directory. The
existing `/tmp/` rule is anchored to the repository root, so only one of the
documented invocations was covered:

| Invocation | Cache lands at | Ignored before |
| --- | --- | --- |
| repo root, `AGENTS.md:276` | `tmp/check-runner/` | yes, by `/tmp/` |
| plugin directory, `plugins/hexaemeron/README.md:333` | `plugins/hexaemeron/tmp/check-runner/` | no |
| tests directory | `plugins/hexaemeron/tests/tmp/check-runner/` | no |

The two uncovered cases leave an untracked, unignored generated file that a
stray `git add -A` commits. It came up twice while preparing #1151, which is
what prompted this.

## Why the rule is shaped this way

`**/tmp/check-runner/` names `check-runner/` rather than `tmp/`, so the promise
in the note above `/tmp/` still holds: a plugin that wants its own `tmp/` still
decides for itself. Only this runner's cache directory is claimed.

It also covers the `.timings-v1.json.<pid>.<ns>.tmp` that a hard-killed run
leaves beside the cache, which is the same failure mode the
`.CONTRIBUTORS.md.*` rule further down already guards against.

## Evidence

`git check-ignore -v` resolves all three to `.gitignore:49`:

- `plugins/hexaemeron/tests/tmp/check-runner/timings-v1.json`
- `plugins/hexaemeron/tests/tmp/check-runner/.timings-v1.json.999.123.tmp`
- `plugins/hexaemeron/tmp/check-runner/timings-v1.json`

The 11 tracked fixtures under `plugins/hexaemeron/tests/fixtures/check-runner/`
are not matched — they have no `tmp/` parent — and `git check-ignore` exits 1
for them.

`python3 tests/run_tests.py` passes 1116/1116. `horos.py scan . --write` writes
no diff, so `files_walked` stays at 2471 and no boundary refresh rides along.

## What this does not do

It does not change where the runner writes, and it does not make the cache a
tracked artefact. If the right fix is for the runner to root its cache at the
repository rather than the working directory, this rule becomes redundant
rather than wrong.
