### PR TITLE
chore: clear the dead-code report's high-confidence unused bindings

### DIFF
--- a/plugins/alexandria/tests/test_interval.py
+++ b/plugins/alexandria/tests/test_interval.py
@@ -2,7 +2,6 @@
 
 from copy import deepcopy
 import json
-import os
 from pathlib import Path
 import socket
 import sys
@@ -713,7 +712,7 @@ class EpochDiscoveryTests(unittest.TestCase):
 
     def test_two_different_bodies_for_one_implementation_refuse(self):
         evidence = epoch_evidence()
-        first = "0x1b0e765f6224c21223aea2af16c1c46e38885a40"
+        _first = "0x1b0e765f6224c21223aea2af16c1c46e38885a40"
         evidence["code_reads"]["0x1B0E765F6224C21223AEA2AF16C1C46E38885A40"] = "0xdeadbeef"
         with self.assertRaisesRegex(AlexandriaError, "two different bodies"):
             discover_epochs(**evidence)

--- a/plugins/alexandria/tests/test_release.py
+++ b/plugins/alexandria/tests/test_release.py
@@ -1,7 +1,6 @@
 """Raw release ingestion and hostile offline verification cases."""
 
 from copy import deepcopy
-import hashlib
 import json
 import os
 from pathlib import Path

--- a/plugins/anamnesis/tests/test_s1_admission.py
+++ b/plugins/anamnesis/tests/test_s1_admission.py
@@ -10,7 +10,6 @@ import importlib.util
 import json
 import os
 from pathlib import Path
-import sys
 import tempfile
 import unittest
 

--- a/plugins/anamnesis/tests/test_s5_boundary.py
+++ b/plugins/anamnesis/tests/test_s5_boundary.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import copy
 import importlib.util
-import json
 from pathlib import Path
 import unittest
 

--- a/plugins/ariadne/tests/test_capture_dataset.py
+++ b/plugins/ariadne/tests/test_capture_dataset.py
@@ -9,7 +9,7 @@ from unittest import mock
 
 from . import support  # noqa: F401  (sets sys.path)
 
-from ariadne_lib import envelope, registry, statement, verify  # noqa: E402
+from ariadne_lib import envelope, registry, verify  # noqa: E402
 import ariadne_lib.predicates  # noqa: F401,E402  (registers the shipped predicates)
 from ariadne_lib.capture import dataset as capture  # noqa: E402
 

--- a/plugins/berean/scripts/berean_lib/jsonio.py
+++ b/plugins/berean/scripts/berean_lib/jsonio.py
@@ -9,7 +9,6 @@ import json
 import os
 
 from . import BereanError
-from . import digests
 
 MAX_JSON_BYTES = 4 * 1024 * 1024
 MAX_DEPTH = 32

--- a/plugins/berean/tests/test_evals.py
+++ b/plugins/berean/tests/test_evals.py
@@ -9,7 +9,6 @@ import unittest
 from tests.support import SCRIPTS, SCHEMAS, FIXTURES  # noqa: F401
 
 from berean_lib import BereanError, canonical, digests, evals, release
-from tests import release_fixture
 
 PASS_RELEASE = FIXTURES / "conformance" / "pass-release"
 

--- a/plugins/berean/tests/test_examples.py
+++ b/plugins/berean/tests/test_examples.py
@@ -9,7 +9,7 @@ import unittest
 
 from tests.support import PLUGIN_ROOT, REPO_ROOT, SCRIPTS  # noqa: F401
 
-from berean_lib import evals, jsonio, promote, release
+from berean_lib import evals, jsonio, release
 from tests.test_corpus import failures
 
 EXAMPLE = PLUGIN_ROOT / "examples" / "goldfinch-demo-v0"

--- a/plugins/berean/tests/test_release.py
+++ b/plugins/berean/tests/test_release.py
@@ -34,7 +34,7 @@ class BuildTests(unittest.TestCase):
             set(release.IDENTITY_FIELDS) | {"release_digest"}, set(release.FIELDS)
         )
         with tempfile.TemporaryDirectory() as holder:
-            directory, document = build_temp_release(holder)
+            _directory, document = build_temp_release(holder)
             for field in release.IDENTITY_FIELDS:
                 mutated = json.loads(json.dumps(document))
                 if field == "retention":
@@ -176,7 +176,6 @@ class AllowlistWalkTests(unittest.TestCase):
     def test_a_nested_unallowlisted_address_fails_the_gate(self):
         import shutil as _shutil
 
-        from berean_lib import jsonio as jsonio_lib
         from berean_lib import reads as reads_lib
 
         with tempfile.TemporaryDirectory() as holder:

--- a/plugins/dokimasia/tests/test_propose.py
+++ b/plugins/dokimasia/tests/test_propose.py
@@ -130,7 +130,7 @@ class Regeneration(ProposeCase):
     def test_a_confirmed_entry_survives_byte_for_byte(self):
         _, edited = self._edited()
         before = json.dumps(edited["dispositions"][0], sort_keys=True)
-        again, counts = self.draft(edited)
+        again, _counts = self.draft(edited)
         after = next(
             e for e in again["dispositions"]
             if e["item"] == edited["dispositions"][0]["item"]
@@ -148,8 +148,8 @@ class Regeneration(ProposeCase):
         self.assertEqual(json.dumps(after, sort_keys=True), before)
 
     def test_untouched_drafts_are_replaced_and_counted(self):
-        record, edited = self._edited()
-        again, counts = self.draft(edited)
+        _record, edited = self._edited()
+        _again, counts = self.draft(edited)
         self.assertEqual(counts["preserved"], 2)
         self.assertEqual(counts["replaced"], counts["scoped"] - 2)
         self.assertEqual(counts["added"], 0)

--- a/plugins/hexaemeron/tests/fixtures/xray-reuse/run_demo.py
+++ b/plugins/hexaemeron/tests/fixtures/xray-reuse/run_demo.py
@@ -149,7 +149,7 @@ def execute(
     duration = time.perf_counter_ns() - started if started is not None else None
     if promoted["outputs"] != manifest["outputs"]:
         raise RuntimeError("promoted output digests differ from the bound manifest")
-    source_paths = [source["path"] for source in plan["sources"]]
+    _source_paths = [source["path"] for source in plan["sources"]]
     stale_removed = sorted(
         set(plan["removed"]) & set(candidate["synthesis"]["source_inventory"])
     )

--- a/plugins/hexaemeron/tests/test_audit_log_path.py
+++ b/plugins/hexaemeron/tests/test_audit_log_path.py
@@ -10,7 +10,6 @@ import json
 import os
 import shutil
 import tempfile
-import unittest
 
 import sys
 

--- a/plugins/hexaemeron/tests/test_early_step_merge.py
+++ b/plugins/hexaemeron/tests/test_early_step_merge.py
@@ -20,10 +20,8 @@ controller actually writes it.
 
 from __future__ import annotations
 
-import copy
 import hashlib
 import importlib.util
-import json
 import subprocess
 import sys
 import tempfile
@@ -197,7 +195,7 @@ class EarlyMergeAdoptionCase(AdoptionHarness):
     def test_a_head_that_moved_still_refuses_when_the_pull_request_merged(self):
         """The rewrite case the original refusal existed for."""
         self._to_push(1)
-        url, head, branch = self._pull_request(1, merge_sha="e" * 40)
+        url, head, _branch = self._pull_request(1, merge_sha="e" * 40)
         self.fake_prs[url]["head"]["sha"] = "9" * 40
         result = self._push(1, url, head, expect=2)
         self.assertIn("head", result.stderr)

--- a/plugins/hexaemeron/tests/test_hexctl_frontier_receipt.py
+++ b/plugins/hexaemeron/tests/test_hexctl_frontier_receipt.py
@@ -21,7 +21,6 @@ on the refusal itself, the rest on the missing shared constant.
 
 import json
 import os
-import re
 import shutil
 import subprocess
 
@@ -297,7 +296,7 @@ class FrontierReceiptCase(HexctlCase):
         The constant is pinned by value, the reader is pinned to consume the
         constant, and the dead literal is pinned absent.
         """
-        module = hexctl_module()
+        _module = hexctl_module()
         self.assertEqual(self.sync_base_head_key(), "base_head")
         with open(HEXCTL, encoding="utf-8") as handle:
             source = handle.read()

--- a/plugins/horos/skills/horos/scripts/languages/cpp/cpp.py
+++ b/plugins/horos/skills/horos/scripts/languages/cpp/cpp.py
@@ -176,7 +176,7 @@ def _raw_prefix(source, quote_index):
 
 def _scan_raw(source, start):
     """From the opening quote of R"delim( past )delim"; None if unclosed."""
-    n = len(source)
+    _n = len(source)
     open_paren = source.find("(", start + 1)
     if open_paren == -1 or open_paren - start - 1 > 16:
         return None

--- a/plugins/horos/tests/test_ts_lexer.py
+++ b/plugins/horos/tests/test_ts_lexer.py
@@ -65,7 +65,7 @@ class LexerTests(unittest.TestCase):
 
     def test_the_newline_guard_reclassifies_a_false_regex(self):
         source = "const a = x /\n  y;\nconst s = 'safe';\n"
-        spans, errors = ts.lex(source)
+        _spans, errors = ts.lex(source)
         self.assertEqual(errors, [])
         self.assertEqual(only(source, "regex"), [])
         self.assertEqual(only(source, "string"), ["'safe'"])

--- a/plugins/lemma/chunkers/markdown.py
+++ b/plugins/lemma/chunkers/markdown.py
@@ -31,7 +31,6 @@ same way a quoted byte range is.
 from __future__ import annotations
 
 import argparse
-import fnmatch
 import hashlib
 import html
 import importlib.util

--- a/plugins/lemma/chunkers/solidity.py
+++ b/plugins/lemma/chunkers/solidity.py
@@ -650,7 +650,7 @@ def resolve_inheritance(out: dict, chunks: list[Chunk]) -> list[Chunk]:
     exposure: dict[tuple[str, str], list[str]] = {}
     overridden: set[tuple[str, str]] = set()
 
-    for cid, contract in by_id.items():
+    for _cid, contract in by_id.items():
         if contract.get("contractKind") != "contract" or contract.get("abstract"):
             continue                      # only concrete contracts have a surface
         seen: set[tuple[str, str]] = set()

--- a/plugins/pandects/tests/test_checker.py
+++ b/plugins/pandects/tests/test_checker.py
@@ -6,7 +6,6 @@ for the wrong reason, which is the same discipline the corpus asks of a
 specimen.
 """
 
-import json
 import os
 import shutil
 import tempfile

--- a/plugins/probitas/tests/test_registry.py
+++ b/plugins/probitas/tests/test_registry.py
@@ -89,7 +89,7 @@ class TestAdapterFailures(unittest.TestCase):
         def quiet(addresses, config):
             return [], Coverage("wildcat", "empty")
 
-        records, coverage = run_adapter("wildcat", quiet, {}, {})
+        _records, coverage = run_adapter("wildcat", quiet, {}, {})
         self.assertEqual(coverage.records, 0)
         self.assertEqual(coverage.status, "empty")
 

--- a/plugins/probitas/tests/test_statement.py
+++ b/plugins/probitas/tests/test_statement.py
@@ -4,7 +4,6 @@ import contextlib
 import hashlib
 import io
 import json
-import os
 from pathlib import Path
 import runpy
 import subprocess

--- a/plugins/tabularium/scripts/tabularium_lib/release.py
+++ b/plugins/tabularium/scripts/tabularium_lib/release.py
@@ -4,7 +4,7 @@ import re
 
 from . import ADAPTER_VERSION, EVENT_SCHEMA_VERSION
 from .adapters.goldfinch import CHAIN, MAPPINGS
-from .core import MAX_SAFE_INTEGER, TabulariumError, safe_integer, sha256_bytes
+from .core import TabulariumError, safe_integer, sha256_bytes
 
 
 MANIFEST_SCHEMA_VERSION = 1

--- a/tests/test_run_observation_capture.py
+++ b/tests/test_run_observation_capture.py
@@ -4,16 +4,13 @@ from __future__ import annotations
 
 import hashlib
 import importlib.util
-import io
 import json
-import os
 import re
 import shutil
 import subprocess
 import sys
 import tempfile
 import unittest
-from contextlib import redirect_stdout
 from pathlib import Path
 from unittest import mock
 

--- a/tests/test_unique_identifiers.py
+++ b/tests/test_unique_identifiers.py
@@ -79,7 +79,7 @@ def coverage_document():
 def bound_promise_ids(document):
     """Every promise id the coverage file binds, from rows and capability keys."""
     bound = {row["promise_id"] for row in document.get("rows", [])}
-    for key, value in document.items():
+    for _key, value in document.items():
         if isinstance(value, dict) and "promise_id" in value:
             bound.add(value["promise_id"])
     return bound
@@ -121,7 +121,7 @@ class PromiseIdentifiers(unittest.TestCase):
     def test_no_two_coverage_entries_share_an_id(self):
         document = coverage_document()
         ids = [row["promise_id"] for row in document["rows"]]
-        for key, value in document.items():
+        for _key, value in document.items():
             if isinstance(value, dict) and "promise_id" in value:
                 ids.append(value["promise_id"])
         duplicates = sorted(k for k, n in collections.Counter(ids).items() if n > 1)

--- a/tests/test_version_propagation.py
+++ b/tests/test_version_propagation.py
@@ -98,7 +98,7 @@ class PluginVersionPropagationTests(unittest.TestCase):
                 )
 
     def test_the_three_manifests_agree(self):
-        for name, directory in plugin_dirs():
+        for name, _directory in plugin_dirs():
             with self.subTest(plugin=name):
                 assert_version_agreement(self, name)
 


### PR DESCRIPTION
Removes the 35 dead-code findings that survive a manual filter of the report-only analyser's high-confidence set. No behaviour changes.

Rebased onto `main` at `bacb34c0`.

## Where the number comes from

`python3 scripts/dead_code.py report --json --analyser python,repository` returns **514 findings**, all from the `python` analyser — the `repository` analyser reported `state: degraded` and contributed none.

| Slice | Count | Kept or removed |
|---|---:|---|
| `low` confidence | 321 | kept |
| `high`, symbol `annotations` or `<module>` | 107 | kept |
| `high`, deliberate side-effect imports | 42 | kept |
| `high`, `constant-true` conditions | 9 | kept |
| **`high`, genuine** | **35** | **removed** |

## Why 51 high-confidence findings were left alone

**42 waived side-effect imports.** Each waives the unused-import code on the finding's own line, e.g. `plugins/ariadne/tests/test_dataset.py:6`:

```python
from . import support  # noqa: F401  (sets sys.path)
```

Deleting those breaks the test import path.

**9 `constant-true` conditions.** Every one is a literal `while True:`. The analyser's own `false_positive_boundary` field admits the case: "the syntax may be an intentional feature flag or type-checking guard".

## What changed

- **18 unused imports deleted** across alexandria, anamnesis, ariadne, berean, hexaemeron, lemma, pandects, probitas and the root tests.
- **2 multi-name imports narrowed** rather than deleted — only the unused name goes:
  - `plugins/berean/tests/test_examples.py:12` drops `promote`, keeps `evals, jsonio, release`
  - `plugins/tabularium/scripts/tabularium_lib/release.py:7` drops `MAX_SAFE_INTEGER`, keeps the other three
- **15 unused unpack and loop targets take an underscore prefix.** This is the sanctioned fix, not a cosmetic rename: `_unused_bindings` already skips `_`-prefixed bindings for both imports and locals.

### One deletion worth naming

```diff
-from ariadne_lib import envelope, registry, statement, verify  # noqa: E402
+from ariadne_lib import envelope, registry, verify  # noqa: E402
```

`E402` is a placement waiver. It says nothing about an unused binding, so `statement` was dead behind a marker that reads like an exemption at a glance. `envelope`, `registry` and `verify` each have a real use in that file; `statement` appears only in docstrings. Only a waiver naming the unused-import code declares a side effect.

Two other deletions were checked beyond the static claim: `berean_lib/jsonio.py:12 from . import digests` is not a re-export (zero `jsonio.digests` references across the plugin), and `test_audit_log_path.py:13 import unittest` is unused because the file's cases inherit `HexctlCase` rather than `unittest.TestCase`.

## Evidence

**Findings fall 514 → 479**, exactly −35, measured on the clean rebased tree.

**Full check map green** — all 28 checks, including `root-suite` (116.8s), `dead-code-suppressions-check` (43.6s), `hexaemeron-suite` and `lazarus-suite`. `outcome green`.

An earlier run against the dirty working tree went red on two checks, neither a defect in this diff: `dead-code-suppressions-check` hit the tool's clean-tree precondition (*"commit or stash before analysing"*), and `root-suite` failed once under 12-slot parallel load with `HTTPError 403: rate limit exceeded` and `429: too many requests` in its captured output, then passed on every subsequent run.

## Not in scope

`.dead-code/baseline.json` is untouched here. Per [ADR-053](../blob/main/docs/decisions/ADR-053-keep-dead-code-discovery-report-only.md) the analyser stays report-only — it deletes nothing and no finding count gates a check. Every deletion was a human decision against the report, not an automated sweep.

The three false-positive classes this PR works around are fixed in a separate branch, which cuts the report from 480 to 253 and its high-confidence tier to exactly the set removed here.