### PR TITLE
chore(dead-code): republish the baseline at the corrected analyser and sources

### DIFF
--- a/.dead-code/baseline.json
+++ b/.dead-code/baseline.json
@@ -148,45 +148,10 @@
     },
     {
       "analyser_id": "python",
-      "id": "sha256:d4dffabb31d9223d70594b0ab494ee63d541d9230cbf9e845227164dd528dfcf",
-      "path": "plugins/alexandria/tests/test_interval.py",
-      "suppressed": false,
-      "symbol": "os@5"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:8044d4db39bdcc62a7eda9f63ce506b19f9e163b6c980d612b7383849f1d40b3",
-      "path": "plugins/alexandria/tests/test_interval.py",
-      "suppressed": false,
-      "symbol": "test_two_different_bodies_for_one_implementation_refuse.first@716"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:60c7ac00850f42419ab00cd046c61fb2441f672029dc4bacfbce7164c79c2d06",
-      "path": "plugins/alexandria/tests/test_release.py",
-      "suppressed": false,
-      "symbol": "hashlib@4"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:0e5226f502a98f32ba28642fb0cf627a7e7db0476a1b0c61cc9655a9372ed1ed",
-      "path": "plugins/anamnesis/tests/test_s1_admission.py",
-      "suppressed": false,
-      "symbol": "sys@13"
-    },
-    {
-      "analyser_id": "python",
       "id": "sha256:4e6917b4387b9adc7e22f2587431db969e19d9ef96f5cca00e2c1172ff984b0a",
       "path": "plugins/anamnesis/tests/test_s3_consumers.py",
       "suppressed": false,
       "symbol": "copy@5"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:95424ab0e4a57b3f5d4ace15a80c22c81885a3aa73a148d0f4eac1663fa88b1b",
-      "path": "plugins/anamnesis/tests/test_s5_boundary.py",
-      "suppressed": false,
-      "symbol": "json@12"
     },
     {
       "analyser_id": "python",
@@ -330,13 +295,6 @@
     },
     {
       "analyser_id": "python",
-      "id": "sha256:bd0326d944619e07a862d2ce875aede75afe8861107c782e171b46db19b53ee4",
-      "path": "plugins/ariadne/tests/test_capture_dataset.py",
-      "suppressed": false,
-      "symbol": "statement@12"
-    },
-    {
-      "analyser_id": "python",
       "id": "sha256:e4cb3ee718ea65c03c244dfdc8e7fd5790bafdb26e75adb1e8f1949310cb95ba",
       "path": "plugins/berean/scripts/berean_lib/answers.py",
       "suppressed": false,
@@ -386,13 +344,6 @@
     },
     {
       "analyser_id": "python",
-      "id": "sha256:05049c94b154cae5ba42d7e57789a97718a7c870b26f640bd05bfb43e58f0b36",
-      "path": "plugins/berean/scripts/berean_lib/jsonio.py",
-      "suppressed": false,
-      "symbol": "digests@12"
-    },
-    {
-      "analyser_id": "python",
       "id": "sha256:541fa7863227706825c73040390107f997922dd0a6fd54bd50e0ba551b26a995",
       "path": "plugins/berean/scripts/berean_lib/paths.py",
       "suppressed": false,
@@ -432,34 +383,6 @@
       "path": "plugins/berean/tests/support.py",
       "suppressed": false,
       "symbol": "<module>"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:cb78c8312c17428e4ddd5ceda5c43a287edcf053e4ff3729f1ddb9fa16f82cbc",
-      "path": "plugins/berean/tests/test_evals.py",
-      "suppressed": false,
-      "symbol": "release_fixture@12"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:fc10abb6bca72659222bf9e4116d1c8fdc6acd5e64ac38d6cbff21a68f95d154",
-      "path": "plugins/berean/tests/test_examples.py",
-      "suppressed": false,
-      "symbol": "promote@12"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:194a61dc3f0e41f27ee59fd09f1f751d0d4d122d886b76892adfb8d6283ad2d1",
-      "path": "plugins/berean/tests/test_release.py",
-      "suppressed": false,
-      "symbol": "jsonio_lib@179"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:9c21984a40423ea4c6f1698885b9870bfa5d563fdb4e3f408aab23ea6cdf54df",
-      "path": "plugins/berean/tests/test_release.py",
-      "suppressed": false,
-      "symbol": "test_the_digest_covers_every_identity_field.directory@37"
     },
     {
       "analyser_id": "python",
@@ -565,27 +488,6 @@
       "path": "plugins/dokimasia/tests/fixtures/workbooks/build.py",
       "suppressed": false,
       "symbol": "<module>"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:1c41bcf7de5b7b23ca2675e5c76d61424aa86f79cba40ca0027ff6434bccbbc7",
-      "path": "plugins/dokimasia/tests/test_propose.py",
-      "suppressed": false,
-      "symbol": "test_a_confirmed_entry_survives_byte_for_byte.counts@133"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:73f0c18a487e06a78ee8b2516706969d512eb55fc009219eb6b2bf8511158b0a",
-      "path": "plugins/dokimasia/tests/test_propose.py",
-      "suppressed": false,
-      "symbol": "test_untouched_drafts_are_replaced_and_counted.again@152"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:c54486cfb4c1694604a59956d4f138c38e08251cecd108d60fda02fd8672921a",
-      "path": "plugins/dokimasia/tests/test_propose.py",
-      "suppressed": false,
-      "symbol": "test_untouched_drafts_are_replaced_and_counted.record@151"
     },
     {
       "analyser_id": "python",
@@ -820,13 +722,6 @@
     },
     {
       "analyser_id": "python",
-      "id": "sha256:7c92b835718083b80594f41321f1b3305b978f0b55aeef122e77c446857ed479",
-      "path": "plugins/hexaemeron/tests/fixtures/xray-reuse/run_demo.py",
-      "suppressed": false,
-      "symbol": "execute.source_paths@152"
-    },
-    {
-      "analyser_id": "python",
       "id": "sha256:4e2226062d4b20bdecfcebc10733208687f52880af52d797a35432419d44de57",
       "path": "plugins/hexaemeron/tests/hexctl_harness.py",
       "suppressed": false,
@@ -894,34 +789,6 @@
       "path": "plugins/hexaemeron/tests/test_audit_log_path.py",
       "suppressed": false,
       "symbol": "<module>"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:f3a88ee82a272a6e8dd751fc23b1895e03b33fb1cdac7509854f7b0af86f2a96",
-      "path": "plugins/hexaemeron/tests/test_audit_log_path.py",
-      "suppressed": false,
-      "symbol": "unittest@13"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:f60b5957e7b6511be7d11965333eab627775dcd05a2b5e9df249eee92bba633c",
-      "path": "plugins/hexaemeron/tests/test_early_step_merge.py",
-      "suppressed": false,
-      "symbol": "copy@23"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:2cc0c23292d67fff507016ef983b52e5cd5863f5327328941fa370d24d451308",
-      "path": "plugins/hexaemeron/tests/test_early_step_merge.py",
-      "suppressed": false,
-      "symbol": "json@26"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:655a17b032cc163abc2bd4f8d5eff769a15e29e4c77a45ac212824d865f22e2a",
-      "path": "plugins/hexaemeron/tests/test_early_step_merge.py",
-      "suppressed": false,
-      "symbol": "test_a_head_that_moved_still_refuses_when_the_pull_request_merged.branch@200"
     },
     {
       "analyser_id": "python",
@@ -1051,20 +918,6 @@
     },
     {
       "analyser_id": "python",
-      "id": "sha256:364ff99160c64dfedbc27fce37f3c14f5f5552a87c32f1b759c9dcdd5461feb7",
-      "path": "plugins/hexaemeron/tests/test_hexctl_frontier_receipt.py",
-      "suppressed": false,
-      "symbol": "re@24"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:035f33ab0eeeeb66e7d6022a5c40c0014fda87e3f812441305a00fab935a411a",
-      "path": "plugins/hexaemeron/tests/test_hexctl_frontier_receipt.py",
-      "suppressed": false,
-      "symbol": "test_the_reader_and_the_writer_share_one_key.module@300"
-    },
-    {
-      "analyser_id": "python",
       "id": "sha256:2ac3adbbf0391e871f25c9cf5cc3fc58b6c6612393b37fd9bd4dd81466ed1b2f",
       "path": "plugins/hexaemeron/tests/test_hexctl_generator_aggregates.py",
       "suppressed": false,
@@ -1114,13 +967,6 @@
     },
     {
       "analyser_id": "python",
-      "id": "sha256:58639b44c82cb99715e7ea42ef86fbcd67d31f67ff86a641685ed0db13ded597",
-      "path": "plugins/horos/skills/horos/scripts/languages/cpp/cpp.py",
-      "suppressed": false,
-      "symbol": "_scan_raw.n@179"
-    },
-    {
-      "analyser_id": "python",
       "id": "sha256:d69734ac8ad1246161113527e6be705b8121df6b4af75212bf826a780aa8e141",
       "path": "plugins/horos/skills/horos/scripts/languages/go/go.py",
       "suppressed": false,
@@ -1153,13 +999,6 @@
       "path": "plugins/horos/tests/test_scoped_entry.py",
       "suppressed": false,
       "symbol": "json@17"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:d7f4642796a15426b3d20055656f974be467c36fdb70c4b4e9bb8b35c2a705ab",
-      "path": "plugins/horos/tests/test_ts_lexer.py",
-      "suppressed": false,
-      "symbol": "test_the_newline_guard_reclassifies_a_false_regex.spans@68"
     },
     {
       "analyser_id": "python",
@@ -1359,20 +1198,6 @@
     },
     {
       "analyser_id": "python",
-      "id": "sha256:f49eb722b84a42525292b617c4d51718fb1d31c63fcc31fde71a879e6e54f43b",
-      "path": "plugins/lemma/chunkers/markdown.py",
-      "suppressed": false,
-      "symbol": "fnmatch@34"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:f9ca73a9c82ae718c8b1943a034416d3ca7d6c6b765b986ca605220733a4540b",
-      "path": "plugins/lemma/chunkers/solidity.py",
-      "suppressed": false,
-      "symbol": "resolve_inheritance.cid@653"
-    },
-    {
-      "analyser_id": "python",
       "id": "sha256:49ff33f890f71909191aea4a52a1bfc799aef768da1f0cef3f84356801f5904c",
       "path": "plugins/lemma/schema.py",
       "suppressed": false,
@@ -1412,13 +1237,6 @@
       "path": "plugins/pandects/scripts/pandects_lib/safejson.py",
       "suppressed": false,
       "symbol": "<module>"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:bbea83bd9c2f96de19050f68df92d0e228f4ab480dc05f925fcca53099b4f3b5",
-      "path": "plugins/pandects/tests/test_checker.py",
-      "suppressed": false,
-      "symbol": "json@9"
     },
     {
       "analyser_id": "python",
@@ -1527,20 +1345,6 @@
     },
     {
       "analyser_id": "python",
-      "id": "sha256:67c65416627e1aab2d3d71d007b0e9c9f9124502defd3fac33681b9a7713d046",
-      "path": "plugins/probitas/tests/test_registry.py",
-      "suppressed": false,
-      "symbol": "test_record_count_comes_from_the_records.records@92"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:881a4bb5c800ccf885b76b5f42893db9a3c16ccd8fb0ea50d0d7499dfeb651a3",
-      "path": "plugins/probitas/tests/test_statement.py",
-      "suppressed": false,
-      "symbol": "os@7"
-    },
-    {
-      "analyser_id": "python",
       "id": "sha256:5a09da913fd9ba1e5b8252ab06c167ae5fe301c017d3559204136d546230d8f5",
       "path": "plugins/synkrisis/tests/support.py",
       "suppressed": false,
@@ -1615,13 +1419,6 @@
       "path": "plugins/tabularium/scripts/tabularium_lib/release.py",
       "suppressed": false,
       "symbol": "<module>"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:ca0787c3a75ae105a635ec962ab0e9d7df36355ff919bb3e6886a578dcef715d",
-      "path": "plugins/tabularium/scripts/tabularium_lib/release.py",
-      "suppressed": false,
-      "symbol": "MAX_SAFE_INTEGER@7"
     },
     {
       "analyser_id": "python",
@@ -1737,27 +1534,6 @@
     },
     {
       "analyser_id": "python",
-      "id": "sha256:4eadaa74c4d401eb9d498552290352aca37d2fe50d6cab2ab4814aefeb045753",
-      "path": "tests/test_run_observation_capture.py",
-      "suppressed": false,
-      "symbol": "io@7"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:d5fbafe6f3b6c588e1602e8a76cd0b769847f14c9a4f36420a47bad7ba20b053",
-      "path": "tests/test_run_observation_capture.py",
-      "suppressed": false,
-      "symbol": "os@9"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:eef4b07c0c2131d21c848d905e60483bcd3655715c53b1f38af5d20e175db981",
-      "path": "tests/test_run_observation_capture.py",
-      "suppressed": false,
-      "symbol": "redirect_stdout@16"
-    },
-    {
-      "analyser_id": "python",
       "id": "sha256:c61c4e334cb137b497347bd227dd468c3d0a9fabb557b4164eda1326b960fe01",
       "path": "tests/test_run_observation_inoculation.py",
       "suppressed": false,
@@ -1769,27 +1545,6 @@
       "path": "tests/test_run_observation_inoculation.py",
       "suppressed": false,
       "symbol": "tempfile@14"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:4ff383839cd1062d18b5f41916495922c2c1ded462e8f6695a372c91f512da54",
-      "path": "tests/test_unique_identifiers.py",
-      "suppressed": false,
-      "symbol": "bound_promise_ids.key@82"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:cf7ec627fc8a0e36e3610de93559641cd586a3d99ef21976876a33992cab314d",
-      "path": "tests/test_unique_identifiers.py",
-      "suppressed": false,
-      "symbol": "test_no_two_coverage_entries_share_an_id.key@124"
-    },
-    {
-      "analyser_id": "python",
-      "id": "sha256:c458d2bbb31f6d5890824d2dda586820aca71e0a7ab82dfe2e60c4170ef34789",
-      "path": "tests/test_version_propagation.py",
-      "suppressed": false,
-      "symbol": "test_the_three_manifests_agree.directory@101"
     }
   ],
   "schema": "dead-code-baseline/v1",
@@ -1802,10 +1557,10 @@
     "version": "1"
   },
   "tree": {
-    "commit": "53310c63ea409fef85385c11f7c36220e891dd42",
-    "git_tree": "ae073f9266e708dbeef616343e13ceeb9c9befbe"
+    "commit": "73355fef57c03096f310e606493839bcbb426773",
+    "git_tree": "7a4e2c3f41e743163a690d29134d8be30a22bf65"
   },
   "universe": {
-    "id": "sha256:fe9ba97a634bdd47a8e14b1dea00b65769097033c8922c6d91e722b435d748bd"
+    "id": "sha256:5f783d447521efb9340c8ce6b423ce58c0724bbd13fa7477dfb53a751bca7c5d"
   }
 }


### PR DESCRIPTION
Brings `.dead-code/baseline.json` up to the tree a reader actually has. **Only that file changes.**

## Why it was stale

The record was published at `53310c63` in #1160. #1159 then changed 25 tracked paths, so `baseline --check` on `main` read:

```
findings  253 candidate(s), 253 active, 0 suppressed; report-only
currency  stale; 25 path(s) changed after publication: ... and 20 more
status    matched
```

Nothing was broken — [ADR-059](../blob/main/docs/decisions/ADR-059-report-baseline-currency-without-failing-the-check.md) reports currency without failing, the exit code was 0 and the `dead-code` scope stayed green. But the record described a tree nobody has.

## After

Republished from `73355fef` following the two-commit publication in [dead-code-v1.md](../blob/main/docs/promise-machine/dead-code-v1.md):

```
source    73355fef57c03096f310e606493839bcbb426773
published db31d80961379b8b19cb8e310fdced4072390cbb
findings  218 candidate(s), 218 active, 0 suppressed; report-only
changes   added=0 resolved=0 stale_suppressions=0
currency  current; no tracked path changed after publication
status    matched; candidate count did not gate this command
```

**218 candidates, none high confidence.** For comparison, the record it replaces held 437 from commit `2ecc1c83`, and the report against `main` this morning returned 514 with 159 high confidence and not one of them naming a binding a reader could remove.

What remains is the set the report is honest about not resolving: 148 whole-module `<module>` entries plus 70 other dynamic-boundary cases, all `low`. Zero `annotations`, zero `constant-true`, zero suppressions.

## Evidence

- `baseline --check` from the new clean commit: `currency current`, `status matched`, exit 0.
- `run_checks.py --scope dead-code`: green, all 5 checks.
- `python3 -m unittest discover -s tests`: 1126 tests, OK.

No source, schema, command surface or suppression change. The report stays advisory under ADR-053.