### PR TITLE
Report which test files and methods add no coverage of their own

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -60,6 +60,7 @@ jobs:
           - root
           - sapheneia
           - schemas
+          - suite-redundancy
           - synkrisis
           - tabularium
     runs-on: ubuntu-latest

--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 2491
+    "files_walked": 2494
   },
   "entries": [
     {

--- a/docs/decisions/ADR-075-keep-suite-redundancy-discovery-report-only.md
+++ b/docs/decisions/ADR-075-keep-suite-redundancy-discovery-report-only.md
@@ -1,0 +1,122 @@
+# ADR-075: Keep suite-redundancy discovery report-only
+
+## Status
+
+Accepted, 2026-09-04.
+
+## Context
+
+The repository carries 236 test files and 7,341 test methods across 20 Python
+checks. Nothing said which of them still earn their place. A test can be
+obsoleted by the code it was written against, superseded by a later test, or
+duplicated outright, and none of those states announces itself: an obsolete
+test usually still passes.
+
+A first sweep answered the mechanical part of that question. Attributing
+covered source lines to the test that executed them, then asking which files
+cover a line nothing else covers, established that 171 of 236 files each
+reach a line no other test file reaches, and that no test file in the
+repository is unreachable from `tests/check-map-v1.json`. It also produced 25 files with no
+unique coverage, of which 9 were an artefact of near-identical scaffold tests
+in separate plugins running one shared helper over different data.
+
+The remaining 16 were then put through mutation. Four killed a mutant no other
+file killed and are therefore irreplaceable. Twelve did not, under budgets
+ranging from 528 mutants down to 3.
+
+That spread is the decision this record exists to fix in place. Line coverage
+is insensitive to assertions: `plugins/ariadne/tests/test_schema_agreement.py`
+covers 1,718 lines and none of them uniquely, and its docstring records three
+drift findings it caught that nothing else did. A candidate count cannot
+authorise a deletion, and neither can an unproven mutation verdict, which is
+absence of evidence rather than evidence of absence.
+
+[ADR-053](ADR-053-keep-dead-code-discovery-report-only.md) already settled the
+same question for source: dead-code discovery reports, and never deletes.
+
+## Decision
+
+Provide one report-only command, `scripts/suite_redundancy.py`, that attributes
+covered lines to test files and test methods and classifies them. Its universe
+is the repository source outside any test tree, excluding the analyser itself.
+Findings are candidates for review. No count fails the command, blocks a merge
+or authorises removing a test.
+
+The report separates three states rather than two. A file that uniquely covers
+a line cannot be removed without losing that line, and the report says so; that
+negative result is the half a reader can rely on. A file that covers lines but none uniquely is a review
+candidate. A file that covers no measured line at all is neither, because the
+tracer runs in-process and cannot see a subject driven through a subprocess or
+a subject that is prose, a schema or a fixture.
+
+A method-level pass names two tests only when they share both a covered-line
+set and a hash of their normalised body. Coverage identity alone groups 1,796
+methods and means nothing; the intersection named 2 pairs.
+
+The `suite-redundancy` scope owns the command, its tests and this record. The
+checked runner continues to own scope selection and process budgets.
+
+## Alternatives
+
+Run the suite once per test file and diff coverage. Rejected because it is
+236 suite runs for an answer one traced run already contains: removing a file
+removes exactly the lines its own tests executed.
+
+Gate CI on the candidate count. Rejected for the reason ADR-053 gives and one
+more of its own. Twelve of the sixteen strongest candidates survived mutation
+without being shown redundant, and seven of those twelve had fewer than 50
+mutants to survive.
+
+Ship the mutation harness alongside the analyser. Rejected for now. It must
+mutate source to work, so it needs a copy of the tree and a per-candidate
+budget, and against the hexaemeron suite it spent 2,040 seconds to produce 54
+mutants. It is a deliberate manual investigation, not a check.
+
+Report a method as removable when its covered-line set matches another's.
+Rejected because table-driven cases share a set by construction: 26 methods in
+`tests/test_agent_instruction.py` cover the same 48 lines with different
+inputs.
+
+## Consequences
+
+Contributors get one deterministic report over any set of traced suites,
+naming what is irreplaceable before what is doubtful. The analyser adds no
+dependency: it uses `sys.monitoring`, claims a free tool identity so a run
+under another tracer does not collide, and edits nothing it measures.
+
+Tracing costs 1.2 to 1.5 times an untraced run, so the full sweep is a command
+a contributor runs, not a check CI carries. Only the analyser's own tests run
+in CI.
+
+One duplicate found by the first sweep is removed with this record:
+`test_scan_without_the_flag_is_byte_for_byte_unchanged` in
+`plugins/horos/tests/test_census.py` was byte-identical, over the same fixture,
+to `test_the_cli_json_output_matches_the_committed_boundary` in
+`plugins/horos/tests/test_discipline.py`. No scenario made one fail while the
+other passed. The boundary file keeps the assertion.
+
+Two limits are worth stating before somebody reads a verdict as more than it
+is.
+
+A vacuous assertion is invisible here, and this report will rank it highest.
+`plugins/lazarus/tests/fake_rpc.py` answered every `eth_getProof` with
+`proof_records[0]` whatever address was asked for, so a test asserting one
+account's proof was asserting against another account's record and passing.
+Those tests covered lines nothing else covered, so this analyser would have
+reported them as the only tests reaching those lines for as long as the fixture
+stayed wrong. #1183 made
+the fixture address-aware. The general shape survives the fix: a unique-coverage
+verdict says a line would go uncovered without this test, never that the test
+proves anything about it.
+
+Reachability is not execution. This report establishes that every test file is
+reached by some check in `tests/check-map-v1.json`, which is a claim about the
+map and not about what ran. A class whose `setUpClass` aborts takes its tests
+out of a run while its file stays reachable, and #1183 found the hexaemeron
+shard doing exactly that. `plugins/hexaemeron/tests/run_tests.py` is that
+suite's only correct entry point; `unittest discover` raises an ImportError on
+that tree and reports a clean suite. Neither state is a redundancy question,
+and neither is answered here. A per-suite expected test count answers both.
+
+Twelve files stay unresolved. A later decision may gate on them; it will need
+assertion-level evidence this record does not claim to have.

--- a/plugins/horos/tests/test_census.py
+++ b/plugins/horos/tests/test_census.py
@@ -96,13 +96,6 @@ class CensusTests(unittest.TestCase):
         rows = self.census()["rows"]
         self.assertEqual(rows[0]["suffix"], ".bin")
 
-    def test_scan_without_the_flag_is_byte_for_byte_unchanged(self):
-        committed = (FIXTURE / horos.BOUNDARY_RELPATH).read_text(encoding="utf-8")
-        with mock.patch.object(sys, "stdout", new=io.StringIO()) as stdout:
-            code = horos.main(["scan", str(FIXTURE), "--json"])
-        self.assertEqual(code, 0)
-        self.assertEqual(stdout.getvalue(), committed)
-
     def test_the_committed_fixture_census_matches_a_fresh_run(self):
         committed = (FIXTURE / horos.CENSUS_RELPATH).read_text(encoding="utf-8")
         fresh = horos.render(

--- a/scripts/suite_redundancy.py
+++ b/scripts/suite_redundancy.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Report which test files and test methods add no coverage of their own.
+
+A test file's contribution to line coverage is exactly the set of source lines
+its own tests executed, so removing the file removes exactly that set.  Per-test
+attribution from one traced run therefore answers the same question as running
+the suite once per file, at one run per suite rather than one per file.
+
+The report is advisory.  Line coverage is insensitive to assertions: two tests
+may execute identical lines and prove different properties, so a file that
+covers nothing uniquely is a candidate for review and never a deletion.  The
+converse is sound in the other direction - a file that uniquely covers a line
+cannot be removed without losing that line - and that negative result is the
+part of this report a reader can rely on.
+
+Two states are reported separately from redundancy.  A test that drives its
+subject through a subprocess registers no lines here, because the tracer is
+in-process; so does a test whose subject is prose, a schema or a fixture rather
+than Python.  Neither is evidence about the test.
+
+    python3 scripts/suite_redundancy.py attribute --start tests --top . \
+        --out reports/root.json
+    python3 scripts/suite_redundancy.py report --attribution reports
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import glob
+import json
+import os
+import sys
+import unittest
+
+MONITOR_IDS = (3, 4)
+SCHEMA = "wildcat.suite-attribution.v1"
+SELF = os.path.realpath(__file__)
+
+
+def measured(root, filename, cache):
+    """Return one repository-relative source path, or False to ignore it."""
+    verdict = cache.get(filename)
+    if verdict is None:
+        real = os.path.realpath(filename) if filename else ""
+        verdict = False
+        if real != SELF and real.startswith(root) and real.endswith(".py"):
+            relative = real[len(root):]
+            parts = relative.split(os.sep)
+            verdict = (
+                "tests" not in parts
+                and not parts[0].startswith(".")
+                and not parts[-1].startswith("test_")
+            )
+            if verdict:
+                verdict = relative
+        cache[filename] = verdict
+    return verdict
+
+
+class Attributor:
+    """Record, per running test, the source lines executed under it."""
+
+    def __init__(self, root):
+        self.root = os.path.realpath(root) + os.sep
+        self.current = None
+        self.monitor = sys.monitoring
+        self.cache = {}
+        self.tool = None
+
+    def line(self, code, lineno):
+        """Record one executed line and disable that location for this test."""
+        target = self.current
+        if target is not None:
+            relative = measured(self.root, code.co_filename, self.cache)
+            if relative:
+                target.add(f"{relative}:{lineno}")
+        return self.monitor.DISABLE
+
+    def start(self):
+        """Claim a free monitoring identity so a nested run cannot collide."""
+        for candidate in MONITOR_IDS:
+            if self.monitor.get_tool(candidate) is None:
+                self.tool = candidate
+                break
+        if self.tool is None:
+            raise RuntimeError("no free sys.monitoring tool identity")
+        self.monitor.use_tool_id(self.tool, "suite-redundancy")
+        self.monitor.register_callback(self.tool, self.monitor.events.LINE, self.line)
+        self.monitor.set_events(self.tool, self.monitor.events.LINE)
+
+    def stop(self):
+        """Release the tool identity, leaving monitoring as it was found."""
+        self.monitor.set_events(self.tool, 0)
+        self.monitor.register_callback(self.tool, self.monitor.events.LINE, None)
+        self.monitor.free_tool_id(self.tool)
+        self.tool = None
+
+
+class AttributingResult(unittest.TextTestResult):
+    """Swap the attribution target at each test boundary."""
+
+    attributor = None
+    collected = None
+    root = ""
+
+    def owning_file(self, test):
+        """Return the repository-relative path of the file declaring one test."""
+        module = sys.modules.get(test.__class__.__module__)
+        path = getattr(module, "__file__", None)
+        if not path:
+            return "<unknown>"
+        real = os.path.realpath(path)
+        prefix = self.root + os.sep
+        return real[len(prefix):] if real.startswith(prefix) else real
+
+    def startTest(self, test):
+        """Give this test a fresh set and re-enable every disabled location."""
+        super().startTest(test)
+        self.attributor.current = set()
+        self.attributor.monitor.restart_events()
+
+    def stopTest(self, test):
+        """Close this test's set and record it against its declaring file."""
+        covered = self.attributor.current or set()
+        self.attributor.current = None
+        self.collected.append((self.owning_file(test), test.id(), covered))
+        super().stopTest(test)
+
+
+def signature(covered):
+    """Hash one covered-line set stably, so separate suites can be compared."""
+    if not covered:
+        return ""
+    digest = hashlib.sha256()
+    for key in sorted(covered):
+        digest.update(key.encode())
+        digest.update(b"\n")
+    return digest.hexdigest()[:16]
+
+
+def attribute(start, top, root, methods):
+    """Run one suite under the tracer and return its attribution payload."""
+    sys.path.insert(0, os.path.realpath(top))
+    suite = unittest.defaultTestLoader.discover(start, pattern="test_*.py",
+                                                top_level_dir=top)
+    attributor = Attributor(root)
+    AttributingResult.attributor = attributor
+    AttributingResult.collected = []
+    AttributingResult.root = os.path.realpath(root)
+    with open(os.devnull, "w", encoding="utf-8") as sink:
+        runner = unittest.TextTestRunner(verbosity=0, resultclass=AttributingResult,
+                                         stream=sink)
+        attributor.start()
+        try:
+            result = runner.run(suite)
+        finally:
+            attributor.stop()
+
+    payload = {"schema": SCHEMA, "start": start, "tests_run": result.testsRun,
+               "failures": len(result.failures) + len(result.errors)}
+    if methods:
+        seen = {}
+        for _, _, covered in AttributingResult.collected:
+            for line in covered:
+                seen[line] = seen.get(line, 0) + 1
+        payload["methods"] = [
+            {"file": source, "id": identifier, "covered": len(covered),
+             "signature": signature(covered),
+             "suite_unique": sorted(line for line in covered if seen[line] == 1)}
+            for source, identifier, covered in AttributingResult.collected
+        ]
+    else:
+        files = {}
+        counts = {}
+        for source, _, covered in AttributingResult.collected:
+            files.setdefault(source, set()).update(covered)
+            counts[source] = counts.get(source, 0) + 1
+        payload["files"] = {
+            source: {"tests": counts[source], "lines": sorted(lines)}
+            for source, lines in files.items()
+        }
+    return payload
+
+
+def load(directory):
+    """Merge every attribution payload in one directory."""
+    files = {}
+    tests = {}
+    methods = []
+    for path in sorted(glob.glob(os.path.join(directory, "*.json"))):
+        with open(path, encoding="utf-8") as handle:
+            payload = json.load(handle)
+        if payload.get("schema") != SCHEMA:
+            continue
+        for source, record in payload.get("files", {}).items():
+            files.setdefault(source, set()).update(record["lines"])
+            tests[source] = tests.get(source, 0) + record["tests"]
+        methods.extend(payload.get("methods", []))
+    return files, tests, methods
+
+
+def classify(files, tests):
+    """Sort test files into no-measured-source, no-unique and unique coverage."""
+    owners = {}
+    for source, lines in files.items():
+        for line in lines:
+            owners.setdefault(line, set()).add(source)
+
+    rows = []
+    for source, lines in sorted(files.items()):
+        unique = {line for line in lines if owners[line] == {source}}
+        if not lines:
+            category = "no-measured-source"
+        elif not unique:
+            category = "no-unique-coverage"
+        else:
+            category = "unique-coverage"
+        overlap = {}
+        if category == "no-unique-coverage":
+            for line in lines:
+                for other in owners[line]:
+                    if other != source:
+                        overlap[other] = overlap.get(other, 0) + 1
+        rows.append({"file": source, "tests": tests.get(source, 0),
+                     "covered": len(lines), "unique": len(unique),
+                     "category": category,
+                     "covered_also_by": sorted(overlap.items(),
+                                               key=lambda item: -item[1])[:3]})
+    return rows, owners
+
+
+def method_bodies(path):
+    """Hash each function body in one file, ignoring its docstring."""
+    shapes = {}
+    try:
+        with open(path, encoding="utf-8") as handle:
+            tree = ast.parse(handle.read())
+    except (OSError, SyntaxError, ValueError):
+        return shapes
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        statements = list(node.body)
+        first = statements[0] if statements else None
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant) \
+                and isinstance(first.value.value, str):
+            statements = statements[1:]
+        shape = "".join(ast.dump(statement, include_attributes=False)
+                        for statement in statements)
+        shapes[node.name] = hashlib.sha256(shape.encode()).hexdigest()[:16]
+    return shapes
+
+
+def duplicates(methods, owners):
+    """Group test methods that cover the same lines and share a body shape."""
+    shapes = {}
+    for record in methods:
+        if record["file"] not in shapes:
+            shapes[record["file"]] = method_bodies(record["file"])
+        record["body"] = shapes[record["file"]].get(record["id"].rsplit(".", 1)[-1], "")
+        record["sole_coverage"] = sum(
+            1 for line in record["suite_unique"]
+            if owners.get(line, set()) == {record["file"]}
+        )
+
+    grouped = {}
+    for record in methods:
+        if record["signature"] and record["body"]:
+            grouped.setdefault((record["signature"], record["body"]), []).append(record)
+    return [rows for rows in grouped.values() if len(rows) > 1]
+
+
+def render(rows, methods, groups, stream):
+    """Print the report a reader acts on, counts before candidate lists."""
+    counts = {}
+    for row in rows:
+        counts[row["category"]] = counts.get(row["category"], 0) + 1
+    print(f"test files          {len(rows)}", file=stream)
+    for key in sorted(counts):
+        print(f"  {key:20} {counts[key]}", file=stream)
+    if methods:
+        empty = sum(1 for record in methods if record["covered"] == 0)
+        sole = sum(1 for record in methods if record["sole_coverage"] > 0)
+        print(f"test methods        {len(methods)}", file=stream)
+        print(f"  no measured source   {empty}", file=stream)
+        print(f"  sole coverer         {sole}", file=stream)
+        print(f"  duplicate groups     {len(groups)}", file=stream)
+
+    print("\nfiles with no unique coverage; review, do not delete on this alone",
+          file=stream)
+    for row in rows:
+        if row["category"] != "no-unique-coverage":
+            continue
+        also = ", ".join(f"{os.path.basename(name)}({count})"
+                         for name, count in row["covered_also_by"])
+        print(f"  {row['tests']:4d} tests {row['covered']:6d} lines  {row['file']}",
+              file=stream)
+        print(f"       also covered by: {also}", file=stream)
+
+    if groups:
+        print("\nmethods sharing both a covered-line set and a body shape",
+              file=stream)
+        for rows_in_group in sorted(groups, key=lambda group: -len(group)):
+            print(f"  {len(rows_in_group)}x {rows_in_group[0]['id']}", file=stream)
+            for record in rows_in_group[1:]:
+                print(f"      == {record['id']}", file=stream)
+
+
+def parse(argv):
+    """Parse one attribute or report invocation."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    run = commands.add_parser("attribute", help="trace one suite")
+    run.add_argument("--start", required=True, help="discovery start directory")
+    run.add_argument("--top", required=True, help="discovery top-level directory")
+    run.add_argument("--out", required=True, help="attribution payload to write")
+    run.add_argument("--root", default=os.getcwd(), help="repository root")
+    run.add_argument("--methods", action="store_true",
+                     help="attribute per test method rather than per file")
+
+    read = commands.add_parser("report", help="classify traced attributions")
+    read.add_argument("--attribution", required=True,
+                      help="directory of attribution payloads")
+    read.add_argument("--json", dest="json_out", help="write the rows as JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    """Run one subcommand and return its exit status."""
+    arguments = parse(sys.argv[1:] if argv is None else argv)
+
+    if arguments.command == "attribute":
+        payload = attribute(arguments.start, arguments.top, arguments.root,
+                            arguments.methods)
+        with open(arguments.out, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle)
+        print(f"{arguments.start}: {payload['tests_run']} tests, "
+              f"{payload['failures']} failed")
+        return 1 if payload["failures"] else 0
+
+    files, tests, methods = load(arguments.attribution)
+    if not files and not methods:
+        print("no attribution payloads found", file=sys.stderr)
+        return 2
+    rows, owners = classify(files, tests)
+    groups = duplicates(methods, owners)
+    render(rows, methods, groups, sys.stdout)
+    if arguments.json_out:
+        with open(arguments.json_out, "w", encoding="utf-8") as handle:
+            json.dump({"files": rows, "methods": methods}, handle, indent=1)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/check-map-v1.json
+++ b/tests/check-map-v1.json
@@ -24,6 +24,13 @@
       "kind": "command",
       "script": "scripts/dead_code.py"
     },
+    "suite-redundancy-suite": {
+      "title": "Report-only suite-redundancy analyser suite",
+      "argv": ["python3", "-m", "unittest", "tests.test_suite_redundancy", "-v"],
+      "cwd": ".",
+      "kind": "suite",
+      "script": "tests/test_suite_redundancy.py"
+    },
     "alexandria-suite": {
       "title": "Alexandria suite",
       "argv": ["python3", "-m", "unittest", "discover", "-s", "plugins/alexandria/tests", "-t", "plugins/alexandria"],
@@ -220,6 +227,10 @@
       "title": "Report-only dead-code discovery",
       "checks": ["dead-code-suite", "dead-code-suppressions-check"]
     },
+    "suite-redundancy": {
+      "title": "Report-only test-suite redundancy discovery",
+      "checks": ["suite-redundancy-suite"]
+    },
     "repo-lints": {
       "title": "Repository-wide tree lints",
       "checks": ["lint-phylax", "lint-ephoros", "lint-hypomnema"]
@@ -266,6 +277,7 @@
   "dependencies": {
     "root": ["repo-lints", "dead-code"],
     "dead-code": ["repo-lints"],
+    "suite-redundancy": ["repo-lints"],
     "docs": ["root", "repo-lints"],
     "schemas": ["root"],
     "promise-machine": ["root", "hexaemeron"],
@@ -319,6 +331,7 @@
     {"path": "docs/dead-code", "scope": "dead-code"},
     {"path": "docs/dead-code-checkout-suppressions", "scope": "dead-code"},
     {"path": "docs/decisions/ADR-053-keep-dead-code-discovery-report-only.md", "scope": "dead-code"},
+    {"path": "docs/decisions/ADR-075-keep-suite-redundancy-discovery-report-only.md", "scope": "suite-redundancy"},
     {"path": "docs/decisions/ADR-063-separate-live-worktree-reports-from-baselines.md", "scope": "dead-code"},
     {"path": "docs/decisions/ADR-064-check-current-dead-code-suppressions-separately.md", "scope": "dead-code"},
     {"path": "docs/promise-machine/dead-code-v1.md", "scope": "dead-code"},
@@ -330,11 +343,13 @@
     {"path": "schemas/dead-code-suppressions-v1.schema.json", "scope": "dead-code"},
     {"path": "scripts", "scope": "root"},
     {"path": "scripts/dead_code.py", "scope": "dead-code"},
+    {"path": "scripts/suite_redundancy.py", "scope": "suite-redundancy"},
     {"path": "scripts/dead_code_monitoring", "scope": "dead-code"},
     {"path": "scripts/promise_machine.py", "scope": "promise-machine"},
     {"path": "tests", "scope": "root"},
     {"path": "tests/emit_dead_code_report.py", "scope": "dead-code"},
     {"path": "tests/test_dead_code.py", "scope": "dead-code"},
+    {"path": "tests/test_suite_redundancy.py", "scope": "suite-redundancy"},
     {"path": "tests/check-map-v1.json", "scope": "root"},
     {"path": "tests/promise_machine_coverage.json", "scope": "promise-machine"},
     {"path": "plugins/alexandria", "scope": "alexandria"},

--- a/tests/test_suite_redundancy.py
+++ b/tests/test_suite_redundancy.py
@@ -1,0 +1,317 @@
+"""The suite-redundancy report classifies coverage without claiming authority.
+
+The report's value is its negative half: a file that uniquely covers a line
+cannot be removed without losing that line.  These tests hold the classifier to
+that reading, and hold the duplicate finder to needing both an identical
+covered-line set and an identical body before it names two methods the same.
+"""
+
+from pathlib import Path
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import suite_redundancy  # noqa: E402
+
+
+class MeasuredUniverseTests(unittest.TestCase):
+    """Only repository source outside a test tree enters the universe."""
+
+    def setUp(self):
+        self.root = os.path.realpath("/repo") + os.sep
+
+    def measured(self, path):
+        return suite_redundancy.measured(self.root, path, {})
+
+    def test_a_source_file_under_the_root_is_measured(self):
+        self.assertEqual(self.measured("/repo/scripts/thing.py"), "scripts/thing.py")
+
+    def test_a_file_outside_the_root_is_ignored(self):
+        self.assertFalse(self.measured("/elsewhere/thing.py"))
+
+    def test_a_file_inside_a_tests_directory_is_ignored(self):
+        self.assertFalse(self.measured("/repo/plugins/p/tests/helper.py"))
+
+    def test_a_test_module_is_ignored_wherever_it_sits(self):
+        self.assertFalse(self.measured("/repo/scripts/test_thing.py"))
+
+    def test_a_dot_directory_is_ignored(self):
+        self.assertFalse(self.measured("/repo/.venv/lib/thing.py"))
+
+    def test_a_non_python_file_is_ignored(self):
+        self.assertFalse(self.measured("/repo/scripts/thing.json"))
+
+    def test_the_analyser_never_measures_itself(self):
+        self.assertFalse(
+            suite_redundancy.measured(
+                os.path.realpath(suite_redundancy.SELF).rsplit(os.sep, 3)[0] + os.sep,
+                suite_redundancy.SELF, {})
+        )
+
+    def test_a_verdict_is_cached_rather_than_recomputed(self):
+        cache = {}
+        suite_redundancy.measured(self.root, "/repo/scripts/thing.py", cache)
+        self.assertEqual(cache["/repo/scripts/thing.py"], "scripts/thing.py")
+
+
+class SignatureTests(unittest.TestCase):
+    """A covered-line set hashes the same wherever it was collected."""
+
+    def test_an_empty_set_has_no_signature(self):
+        self.assertEqual(suite_redundancy.signature(set()), "")
+
+    def test_the_signature_ignores_insertion_order(self):
+        first = suite_redundancy.signature({"a.py:1", "a.py:2"})
+        second = suite_redundancy.signature({"a.py:2", "a.py:1"})
+        self.assertEqual(first, second)
+
+    def test_a_different_set_has_a_different_signature(self):
+        self.assertNotEqual(suite_redundancy.signature({"a.py:1"}),
+                            suite_redundancy.signature({"a.py:2"}))
+
+
+class ClassifyTests(unittest.TestCase):
+    """Three categories, and only one of them is a review candidate."""
+
+    def setUp(self):
+        self.files = {
+            "tests/test_alone.py": {"a.py:1", "a.py:2"},
+            "tests/test_shared.py": {"a.py:1"},
+            "tests/test_prose.py": set(),
+        }
+        self.tests = {"tests/test_alone.py": 3, "tests/test_shared.py": 2,
+                      "tests/test_prose.py": 1}
+
+    def rows(self):
+        rows, _ = suite_redundancy.classify(self.files, self.tests)
+        return {row["file"]: row for row in rows}
+
+    def test_a_file_covering_a_line_alone_has_unique_coverage(self):
+        row = self.rows()["tests/test_alone.py"]
+        self.assertEqual(row["category"], "unique-coverage")
+        self.assertEqual(row["unique"], 1)
+
+    def test_a_file_whose_lines_are_all_shared_has_no_unique_coverage(self):
+        row = self.rows()["tests/test_shared.py"]
+        self.assertEqual(row["category"], "no-unique-coverage")
+        self.assertEqual(row["unique"], 0)
+
+    def test_a_file_covering_nothing_is_reported_separately(self):
+        self.assertEqual(self.rows()["tests/test_prose.py"]["category"],
+                         "no-measured-source")
+
+    def test_a_shared_file_names_what_else_covers_its_lines(self):
+        row = self.rows()["tests/test_shared.py"]
+        self.assertEqual(row["covered_also_by"], [("tests/test_alone.py", 1)])
+
+    def test_the_owner_map_records_every_file_covering_a_line(self):
+        _, owners = suite_redundancy.classify(self.files, self.tests)
+        self.assertEqual(owners["a.py:1"],
+                         {"tests/test_alone.py", "tests/test_shared.py"})
+
+    def test_the_test_count_is_carried_through(self):
+        self.assertEqual(self.rows()["tests/test_alone.py"]["tests"], 3)
+
+
+class MethodBodyTests(unittest.TestCase):
+    """A body shape ignores the docstring and nothing else."""
+
+    def write(self, text):
+        handle = tempfile.NamedTemporaryFile("w", suffix=".py", delete=False)
+        self.addCleanup(os.unlink, handle.name)
+        handle.write(text)
+        handle.close()
+        return handle.name
+
+    def test_two_bodies_differing_only_by_docstring_hash_alike(self):
+        first = self.write("def a():\n    'one'\n    return 1\n")
+        second = self.write("def a():\n    'another'\n    return 1\n")
+        self.assertEqual(suite_redundancy.method_bodies(first)["a"],
+                         suite_redundancy.method_bodies(second)["a"])
+
+    def test_a_different_statement_changes_the_shape(self):
+        first = self.write("def a():\n    return 1\n")
+        second = self.write("def a():\n    return 2\n")
+        self.assertNotEqual(suite_redundancy.method_bodies(first)["a"],
+                            suite_redundancy.method_bodies(second)["a"])
+
+    def test_an_unreadable_file_yields_no_shapes(self):
+        self.assertEqual(suite_redundancy.method_bodies("/no/such/file.py"), {})
+
+    def test_a_file_that_does_not_parse_yields_no_shapes(self):
+        self.assertEqual(suite_redundancy.method_bodies(self.write("def (\n")), {})
+
+
+class DuplicateTests(unittest.TestCase):
+    """Both the covered lines and the body must match before a pair is named."""
+
+    def setUp(self):
+        self.source = tempfile.NamedTemporaryFile("w", suffix=".py", delete=False)
+        self.addCleanup(os.unlink, self.source.name)
+        self.source.write(
+            "class T:\n"
+            "    def test_one(self):\n        return 1\n"
+            "    def test_two(self):\n        return 1\n"
+            "    def test_three(self):\n        return 9\n"
+        )
+        self.source.close()
+
+    def method(self, name, lines):
+        return {"file": self.source.name, "id": f"m.T.{name}",
+                "covered": len(lines), "signature": suite_redundancy.signature(lines),
+                "suite_unique": sorted(lines)}
+
+    def test_identical_coverage_and_body_group_together(self):
+        groups = suite_redundancy.duplicates(
+            [self.method("test_one", {"a.py:1"}), self.method("test_two", {"a.py:1"})],
+            {})
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(len(groups[0]), 2)
+
+    def test_identical_coverage_with_a_different_body_is_not_a_duplicate(self):
+        groups = suite_redundancy.duplicates(
+            [self.method("test_one", {"a.py:1"}),
+             self.method("test_three", {"a.py:1"})], {})
+        self.assertEqual(groups, [])
+
+    def test_an_identical_body_over_different_lines_is_not_a_duplicate(self):
+        groups = suite_redundancy.duplicates(
+            [self.method("test_one", {"a.py:1"}), self.method("test_two", {"a.py:2"})],
+            {})
+        self.assertEqual(groups, [])
+
+    def test_a_method_covering_nothing_never_groups(self):
+        groups = suite_redundancy.duplicates(
+            [self.method("test_one", set()), self.method("test_two", set())], {})
+        self.assertEqual(groups, [])
+
+    def test_sole_coverage_counts_only_lines_no_other_file_covers(self):
+        records = [self.method("test_one", {"a.py:1", "a.py:2"})]
+        suite_redundancy.duplicates(
+            records, {"a.py:1": {self.source.name}, "a.py:2": {"other.py", self.source.name}})
+        self.assertEqual(records[0]["sole_coverage"], 1)
+
+
+class LoadTests(unittest.TestCase):
+    """Only payloads carrying this schema are merged."""
+
+    def setUp(self):
+        self.directory = tempfile.mkdtemp()
+
+    def write(self, name, payload):
+        path = os.path.join(self.directory, name)
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle)
+
+    def test_two_payloads_merge_their_line_sets(self):
+        self.write("a.json", {"schema": suite_redundancy.SCHEMA,
+                              "files": {"t.py": {"tests": 1, "lines": ["a.py:1"]}}})
+        self.write("b.json", {"schema": suite_redundancy.SCHEMA,
+                              "files": {"t.py": {"tests": 2, "lines": ["a.py:2"]}}})
+        files, tests, _ = suite_redundancy.load(self.directory)
+        self.assertEqual(files["t.py"], {"a.py:1", "a.py:2"})
+        self.assertEqual(tests["t.py"], 3)
+
+    def test_a_foreign_payload_is_skipped(self):
+        self.write("c.json", {"schema": "something-else",
+                              "files": {"t.py": {"tests": 1, "lines": ["a.py:1"]}}})
+        files, _, _ = suite_redundancy.load(self.directory)
+        self.assertEqual(files, {})
+
+    def test_method_payloads_accumulate(self):
+        self.write("d.json", {"schema": suite_redundancy.SCHEMA,
+                              "methods": [{"file": "t.py", "id": "x", "covered": 0,
+                                           "signature": "", "suite_unique": []}]})
+        _, _, methods = suite_redundancy.load(self.directory)
+        self.assertEqual(len(methods), 1)
+
+
+class AttributeTests(unittest.TestCase):
+    """One traced run attributes executed lines to the test that ran them."""
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.path = list(sys.path)
+        self.modules = set(sys.modules)
+        os.makedirs(os.path.join(self.root, "pkg"))
+        os.makedirs(os.path.join(self.root, "suite"))
+        self.write("pkg/__init__.py", "")
+        self.write("pkg/thing.py", "def widen(value):\n    if value:\n        return 1\n    return 0\n")
+        self.write("suite/__init__.py", "")
+        self.write("suite/test_thing.py",
+                   "import unittest\nfrom pkg.thing import widen\n\n\n"
+                   "class T(unittest.TestCase):\n"
+                   "    def test_true(self):\n        self.assertEqual(widen(1), 1)\n"
+                   "    def test_prose(self):\n        self.assertEqual('a', 'a')\n")
+
+    def tearDown(self):
+        sys.path[:] = self.path
+        for name in set(sys.modules) - self.modules:
+            del sys.modules[name]
+
+    def write(self, relative, text):
+        with open(os.path.join(self.root, relative), "w", encoding="utf-8") as handle:
+            handle.write(text)
+
+    def test_a_file_level_run_records_the_lines_its_tests_executed(self):
+        payload = suite_redundancy.attribute(
+            os.path.join(self.root, "suite"), self.root, self.root, False)
+        self.assertEqual(payload["tests_run"], 2)
+        self.assertEqual(payload["failures"], 0)
+        record = payload["files"]["suite/test_thing.py"]
+        self.assertEqual(record["tests"], 2)
+        self.assertIn("pkg/thing.py:3", record["lines"])
+
+    def test_a_method_level_run_separates_a_test_that_executes_nothing(self):
+        payload = suite_redundancy.attribute(
+            os.path.join(self.root, "suite"), self.root, self.root, True)
+        covered = {record["id"].rsplit(".", 1)[-1]: record["covered"]
+                   for record in payload["methods"]}
+        self.assertGreater(covered["test_true"], 0)
+        self.assertEqual(covered["test_prose"], 0)
+
+    def test_the_payload_names_its_schema(self):
+        payload = suite_redundancy.attribute(
+            os.path.join(self.root, "suite"), self.root, self.root, False)
+        self.assertEqual(payload["schema"], suite_redundancy.SCHEMA)
+
+
+class RenderTests(unittest.TestCase):
+    """The report leads with counts and marks candidates as review, not deletion."""
+
+    def test_the_header_counts_every_category(self):
+        stream = io.StringIO()
+        rows, _ = suite_redundancy.classify(
+            {"t.py": {"a.py:1"}, "u.py": set()}, {"t.py": 1, "u.py": 1})
+        suite_redundancy.render(rows, [], [], stream)
+        text = stream.getvalue()
+        self.assertIn("test files          2", text)
+        self.assertIn("no-measured-source   1", text)
+
+    def test_a_candidate_line_says_it_is_not_a_deletion(self):
+        stream = io.StringIO()
+        rows, _ = suite_redundancy.classify(
+            {"t.py": {"a.py:1"}, "u.py": {"a.py:1"}}, {"t.py": 1, "u.py": 1})
+        suite_redundancy.render(rows, [], [], stream)
+        self.assertIn("review, do not delete on this alone", stream.getvalue())
+
+
+class MainTests(unittest.TestCase):
+    """The command refuses an empty attribution directory rather than passing."""
+
+    def test_a_directory_with_no_payload_exits_two(self):
+        directory = tempfile.mkdtemp()
+        with contextlib.redirect_stderr(io.StringIO()) as captured:
+            status = suite_redundancy.main(["report", "--attribution", directory])
+        self.assertEqual(status, 2)
+        self.assertIn("no attribution payloads found", captured.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds one report-only command that says which test files and test methods add no
coverage of their own, and removes the one duplicate it found that survives
scrutiny. **One script, its tests, one decision record, the check-map and
plugin-gate wiring, and a seven-line deletion in the Horos census suite.**

## Why

The repository carries 238 test files and 7,392 test methods across 20 Python
checks, and nothing said which of them still earn their place. An obsolete test
does not announce itself, because it usually still passes.

## What the sweep found

A test file's contribution to line coverage is exactly the set of source lines
its own tests executed, so removing it removes exactly that set. Per-test
attribution from one traced run therefore answers the same question as running
the suite once per file, at 20 runs rather than 238.

| Category | Files |
|---|---|
| Reaches a line no other test file reaches | 169 |
| Covers lines, none of them uniquely | 25 |
| Executes no measured source line | 44 |

**Zero orphans.** Every test file on disk is reached by some check in
`tests/check-map-v1.json`. That is a claim about the map, not about what ran;
ADR-075 says so and names the failure mode it does not catch.

Nine of the 25 are unique within their own plugin and only look redundant
because a near-identical `test_scaffold.py` in another plugin runs one shared
helper over different data. The other 16 went through mutation against the
pre-#1183 tree: mutants generated in the lines each file covers, offered to
every other file covering that line, stopping at the first mutant the candidate
alone kills.

Four proved irreplaceable that coverage alone could not justify keeping:
`berean/test_examples.py`, `lazarus/test_text.py` (13 other files cover that
line and none of them notices `or` becoming `and`),
`tabularium/test_builder_cli.py` and `ariadne/test_schema_drift.py`. Twelve did
not, under budgets from 528 mutants down to 3. None of the twelve is proposed
for removal: an unproven verdict is absence of evidence, and for seven of them
there was barely any evidence to have.

## What it does not claim

Line coverage is insensitive to assertions.
`plugins/ariadne/tests/test_schema_agreement.py` covers 1,718 lines, none of
them uniquely, and its docstring records three schema drift findings it caught
that nothing else did.

Worse, a vacuous assertion is invisible here and ranks *highest*. Before #1183,
`plugins/lazarus/tests/fake_rpc.py` answered every `eth_getProof` with
`proof_records[0]` whatever address was asked for. Those tests covered lines
nothing else covered, so this analyser would have reported them as the only
tests reaching those lines for as long as the fixture stayed wrong. ADR-075 carries both limits.

At method level, an identical covered-line set alone groups 1,796 methods and
means nothing, since 26 methods in `tests/test_agent_instruction.py` cover the same
48 lines with different inputs. Intersecting coverage identity with a hash of
the normalised body cut that to 13 groups, 11 of which are one inherited class
(`FrontierGateCompactTests` extends `FrontierGateTests` and overrides only
`setUp`), leaving 2 real pairs.

## The deletion

`test_scan_without_the_flag_is_byte_for_byte_unchanged` in
`plugins/horos/tests/test_census.py` was byte-identical, over the same `FIXTURE`
constant, to `test_the_cli_json_output_matches_the_committed_boundary` in
`plugins/horos/tests/test_discipline.py`. No scenario made one fail while the
other passed. The boundary suite keeps the assertion; the census suite drops its
copy. `io`, `sys` and `mock` remain used in that file. The report now finds 12
duplicate groups where it found 13.

The second pair is left alone: `pandects/tests/test_checker.py` runs
`self.assertEqual(self.findings(), [])` twice under different class names, and
the second's docstring names a distinct claim, so removing it would drop
documentation rather than a duplicate.

## Evidence

```
python3 -m unittest tests.test_suite_redundancy      35 tests, OK
python3 -m unittest discover -s plugins/horos/tests  235 tests, OK (was 236)
python3 scripts/run_checks.py --scope suite-redundancy --scope horos \
  --scope root --scope repo-lints --scope dead-code --scope ci
```

The analyser adds no dependency. It uses `sys.monitoring`, claims a free tool
identity so a run under another tracer does not collide, excludes itself from
the universe it measures, and edits nothing. Tracing costs 1.2 to 1.5 times an
untraced run, so only its own tests run in CI; the full sweep stays a command a
contributor runs.

The new `suite-redundancy` scope earns its shard in the plugin gate, and
`.horos/boundary.json` is refreshed for the files this adds.

[ADR-075](../blob/main/docs/decisions/ADR-075-keep-suite-redundancy-discovery-report-only.md)
holds the reasoning, the four rejected alternatives, the two limits above, and
the twelve files this does not resolve.
