### PR TITLE
Scaffold the harness roster: one schema, its tests, and the decision record

### DIFF
--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 2492
+    "files_walked": 2497
   },
   "entries": [
     {

--- a/docs/atlas-harness-handoff/runbook.md
+++ b/docs/atlas-harness-handoff/runbook.md
@@ -1,0 +1,255 @@
+# Runbook: test the remaining Atlas hand-offs before adding README buttons
+
+Derived from `.hexaemeron/study.md` for issue
+[#856](https://github.com/wildcat-finance/skills/issues/856). Base ref
+`8dc3aca54adeca49387a2bdfc174cf6e72d02a11` on `main`, run branch
+`fiat/856-framework-13-test-the-remaining-atlas-hand-o`.
+
+The study's open question was put to the user, who chose the outcome rather than
+a reading of the boundary: no account is enrolled in any Copilot plan, and
+GitHub Copilot is classified `manual route` with its blocker recorded. The
+choice costs nothing either way here, because every client is absent from this
+host. No step attempts a harness client run, and no step creates an Atlas route.
+
+## Where the pending gates land
+
+Three conformance gates were left pending in the design record. Fiat runs the
+design checker at a `step:N` transition before opening that step, so the work
+that produces each report sits in the step before its stop point.
+
+- `killed-probe-recovery` blocks `step:3`. Step 2 builds the probe's atomic
+  write and the guard test that proves it, so the report exists before step 3
+  runs the probe for real.
+- `roster-single-source` and `wording-regen-budget` block `step:4`. Step 3
+  generates the three wording surfaces from the manifest and measures the
+  regeneration, so both reports exist before step 4 binds the surfaces to the
+  repository suite.
+
+The study calls step 4 the step that makes the surfaces generated. Step 4 is
+where generated surfaces become the shipped, suite-bound state; step 3 is where
+they are first produced, because that is what makes the declared stop point
+real. This reading is recorded here rather than resolved silently.
+
+## The runner contract every step shares
+
+Test command `python3 tests/run_tests.py --elenchus-report {report}`, report
+format `elenchus.unittest.v1`, report file `.elenchus/fiat-856-step-<N>.json`.
+Warden receives those three inputs and may not substitute a nearby suite.
+
+Every step's exit runs the root suite, `python3 scripts/run_checks.py --full`,
+at exit zero, against a committed tree. Three lints passing is not the suite.
+
+Two known false reds, from the study's constraints. A `run_checks.py` failure
+reported as `WAI-E-ADAPTER.TIMEOUT` is parallel load, not a defect; rerun with
+`--jobs 1`. A Python pin check that comes back one short is usually a stale
+sibling under `.claude/worktrees/`, not the diff. The dead-code check needs a
+clean tree, so each step commits before running the suite.
+
+No step edits any file under `audit/`. Those bytes are pinned.
+
+```design-lock
+schema | protasis-design-evidence/v1
+sha256 | dc945d47bd56ee1ef71051fb86fd93d8a63242806bf9a8a41d1bbc5d193552fe
+candidate | probe-manifest
+```
+
+## Step 1: Scaffold the harness record and commit the run documents
+
+**Goal.** Put the study, this runbook, the decision record and the manifest
+schema in the repository so every later step has a fixed home to write into.
+
+**Entry.** `main` at `8dc3aca54adeca49387a2bdfc174cf6e72d02a11`, clean tree.
+
+**Exit.** `docs/atlas-harness-handoff/study.md` and
+`docs/atlas-harness-handoff/runbook.md` are byte-identical copies of the two
+`.hexaemeron/` artefacts. `schemas/harness-classification-v1.json` validates the
+four classification names and the per-harness observation fields.
+`docs/decisions/ADR-074-generate-the-harness-roster-from-one-probed-manifest.md`
+records the schema, the four names and the acceptance-condition-2 reading.
+`tests/test_harness_manifest.py` exists and its schema cases pass. Proved by
+`python3 scripts/run_checks.py --full` at exit zero on the committed tree.
+
+**Files.** `docs/atlas-harness-handoff/study.md`,
+`docs/atlas-harness-handoff/runbook.md`,
+`schemas/harness-classification-v1.json`,
+`docs/decisions/ADR-074-generate-the-harness-roster-from-one-probed-manifest.md`,
+`tests/test_harness_manifest.py`, and the check-map entry that binds the new
+paths to a declared scope.
+
+**Tests.** `tests/test_harness_manifest.py` gains `SchemaTests`: the four
+classification names are exactly `Atlas launcher`, `tested local route`,
+`manual route` and `unsupported`; an unknown name is refused; each of the six
+harness entries requires `client_present`, `client_version`, `auth_configured`,
+`launcher_contract` and `blocker`; a missing field is refused; a null
+`client_version` is admitted only when `client_present` is false. Expect eight
+cases. Step audit runner contract is test command
+`python3 tests/run_tests.py --elenchus-report {report}`, report format
+`elenchus.unittest.v1`, report file `.elenchus/fiat-856-step-1.json`.
+
+**Disciplines.** phylax: none, this step adds no input path and spawns nothing.
+ephoros: none, nothing here runs unattended. metron: none, no performance claim
+is made. elenchus: none, no failure is in hand. hypomnema: the schema and the
+four classification names are costly to reverse once prose is generated from
+them, so ADR-074 is their home.
+
+## Step 2: Build the probe and prove it cannot lie or half-write
+
+**Goal.** Write the probe that observes this host, and the guards that stop it
+awarding a class it did not earn or leaving a torn manifest behind.
+
+**Entry.** Step 1's exit state.
+
+**Exit.** `scripts/probe_harnesses.py --out <path>` writes a manifest that
+validates against the step 1 schema, using a fixed argv per client, no shell,
+and a bounded timeout. The classifier cannot return `Atlas launcher` or
+`tested local route` from any input that carries no recorded client run. The
+manifest write is atomic: a temporary file in the destination directory
+followed by a rename. `killed-probe-recovery` is resolved by
+`python3 -m unittest tests.test_harness_manifest.KilledProbeTests`, writing
+`.hexaemeron/reports/probe-manifest-killed-probe-recovery.json`. Proved by
+`python3 scripts/run_checks.py --full` at exit zero on the committed tree.
+
+**Files.** `scripts/probe_harnesses.py`, `tests/test_harness_manifest.py`.
+
+**Tests.** `ClassifierTests`: every input shape that lacks a recorded client run
+returns `manual route` or `unsupported`, and no input returns a tested class;
+absence from the host and a failed authentication produce different records and
+never collapse. `SubprocessTests`: argv is a fixed list, no shell is used, no
+probe argument is read from a manifest, and a client that does not answer inside
+the timeout is recorded as unread with its reason rather than as absent.
+`CredentialTests`: a pattern sweep over the manifest and the probe log finds no
+token, key, cookie or session shape, using a client output fixture that contains
+one. `KilledProbeTests`: a probe killed mid-write leaves the previous manifest
+intact, or nothing when there was none, and never a partial file the renderer
+would accept. Expect around eighteen cases. Step audit runner contract is test
+command `python3 tests/run_tests.py --elenchus-report {report}`, report format
+`elenchus.unittest.v1`, report file `.elenchus/fiat-856-step-2.json`.
+
+**Disciplines.** phylax: this step spawns client binaries and reads what they
+print, so the fixed argv, the bounded timeout and the credential sweep all
+apply. ephoros: the manifest carries the probe command and result per harness,
+which is the signal answering why a harness got its class. metron: none, the
+probe's cost is dominated by client startup this repository does not control.
+elenchus: the killed-write guard is a cause-level test that fails without the
+atomic rename. hypomnema: none, ADR-074 already holds the decision this step
+implements.
+
+## Step 3: Record this host and generate the three wording surfaces
+
+**Goal.** Run the probe for real, land the checked-in record for all six
+harnesses, and produce the README block, the guide table and the PDF harness
+page from it.
+
+**Entry.** Step 2's exit state, with the `step:3` design transition recorded.
+
+**Exit.** `docs/harness-classification.json` exists and carries all six
+harnesses, each with its observation fields and, where it could not be run, its
+exact blocker: Copilot no seat and an unconfigured organisation policy, Cursor
+and Gemini CLI and Cline absent and unauthenticated, Windsurf absent and now
+published as Cascade inside Devin Desktop, Roo Code sunset and archived.
+`scripts/render_harness_roster.py` writes the three surfaces from that manifest
+and `--check` exits non-zero on drift. `roster-single-source` is resolved by
+`python3 .hexaemeron/design/count_roster_copies.py --report
+.hexaemeron/reports/probe-manifest-roster-single-source.json` at a count of one.
+`wording-regen-budget` is resolved by `python3
+.hexaemeron/design/time_wording_regen.py --report
+.hexaemeron/reports/probe-manifest-wording-regen-budget.json` inside 60000
+milliseconds. Proved by `python3 scripts/run_checks.py --full` at exit zero on
+the committed tree.
+
+**Files.** `docs/harness-classification.json`,
+`scripts/render_harness_roster.py`, `README.md`,
+`docs/how-to-help-shoggoth.md`, `scripts/build_contributor_guide.py`,
+`docs/pdf/how-to-help-shoggoth.pdf`,
+`.hexaemeron/design/count_roster_copies.py`,
+`.hexaemeron/design/time_wording_regen.py`, `tests/test_harness_manifest.py`.
+
+**Tests.** `RecordTests`: the landed manifest validates, names all six
+harnesses, carries no tested class, and every entry whose `testable_here` is
+false carries a non-empty blocker. `RenderTests`: the renderer is deterministic
+across two runs; `--check` passes on freshly written surfaces and fails when one
+character of any surface is changed; the PDF comparison reads the harness page's
+text rather than the whole file, so a timestamp does not fail it. Expect around
+twelve new cases. Step audit runner contract is test command
+`python3 tests/run_tests.py --elenchus-report {report}`, report format
+`elenchus.unittest.v1`, report file `.elenchus/fiat-856-step-3.json`.
+
+**Disciplines.** phylax: the probe runs here for real, so the credential sweep
+and the unread-contract rule are exercised rather than only tested. ephoros: the
+manifest's recorded host, date and base ref are the staleness signal the
+renderer later checks against. metron: the regeneration budget is measured here
+and the 60000-millisecond ceiling either holds or the gate fails. elenchus:
+none, no failure is in hand at this step. hypomnema: none, the per-harness
+classifications belong in the regenerated manifest and not in a decision record.
+
+## Step 4: Bind the surfaces to the suite and correct the Atlas claim
+
+**Goal.** Make roster drift a normal test failure, and stop the guide claiming
+Atlas route tests that do not exist.
+
+**Entry.** Step 3's exit state, with the `step:4` design transition recorded.
+
+**Exit.** `scripts/render_harness_roster.py --check` runs inside the repository
+suite through a declared scope, so a drifted surface reddens an ordinary run.
+The guide sentence claiming the two web routes are covered by Atlas launcher
+tests is replaced by what the Atlas repository holds at
+`ce866e3d7e8b489fcb8b70c608f7af72d9b7a673`, which is six test files and no route
+test. Proved by `python3 scripts/run_checks.py --full` at exit zero on the
+committed tree, with a deliberate one-character edit to a generated surface
+shown to redden it and then reverted.
+
+**Files.** `docs/how-to-help-shoggoth.md`, `scripts/build_contributor_guide.py`,
+`docs/pdf/how-to-help-shoggoth.pdf`, the check map, `tests/test_harness_manifest.py`.
+
+**Tests.** `DriftTests`: the check mode is reachable from the repository suite,
+fails on a changed surface, fails on a missing manifest, and fails when the
+manifest's recorded run does not match the surfaces being checked.
+`AtlasClaimTests`: neither the README nor the guide asserts that a route test
+covers `/go/chatgpt` or `/go/claude`. Expect around six new cases. Step audit
+runner contract is test command
+`python3 tests/run_tests.py --elenchus-report {report}`, report format
+`elenchus.unittest.v1`, report file `.elenchus/fiat-856-step-4.json`.
+
+**Disciplines.** phylax: none, this step opens no boundary the earlier steps did
+not already close. ephoros: the drift check is the on-call signal answering
+whether the published roster is still true, and this step is where it starts
+firing. metron: none, the budget was measured and gated at step 3. elenchus: the
+deliberate-edit demonstration is the guard proving the check fails without the
+binding. hypomnema: none, no new costly decision is taken here.
+
+## Step 5: Demonstrate the record end to end
+
+**Goal.** Run the study's demo path on a clean checkout and show the four
+commands producing the record, the surfaces and a green suite.
+
+**Entry.** Step 4's exit state.
+
+**Exit.** These four commands run in order at exit zero, and the tree is clean
+afterwards:
+
+```bash
+python3 scripts/probe_harnesses.py --out docs/harness-classification.json
+python3 scripts/render_harness_roster.py --check
+python3 scripts/build_contributor_guide.py
+python3 -m unittest tests.test_harness_manifest -v
+```
+
+The run transcript, the six per-harness verdicts and the five named blockers are
+recorded in the pull-request body. Proved by
+`python3 scripts/run_checks.py --full` at exit zero on the committed tree.
+
+**Files.** `docs/atlas-harness-handoff/demonstration.md`, and any regenerated
+surface the demo run produces.
+
+**Tests.** No new test module. The demonstration re-runs
+`tests/test_harness_manifest` in full and the root suite behind it. Step audit
+runner contract is test command
+`python3 tests/run_tests.py --elenchus-report {report}`, report format
+`elenchus.unittest.v1`, report file `.elenchus/fiat-856-step-5.json`.
+
+**Disciplines.** phylax: the probe spawns clients again on a clean checkout, so
+the credential sweep runs once more against real output. ephoros: the
+demonstration is where the two recorded questions get their answers read back.
+metron: none, step 3 holds the budget evidence. elenchus: none, no failure is in
+hand. hypomnema: none, the demonstration record is evidence rather than a
+decision.

--- a/docs/atlas-harness-handoff/study.md
+++ b/docs/atlas-harness-handoff/study.md
@@ -1,0 +1,536 @@
+# Study: test the remaining Atlas hand-offs before adding README buttons
+
+Issue [#856](https://github.com/wildcat-finance/skills/issues/856), framework-13.
+Run branch `fiat/856-framework-13-test-the-remaining-atlas-hand-o`, cut from
+`main` at `8dc3aca54adeca49387a2bdfc174cf6e72d02a11`.
+
+## Assumptions
+
+Proceeding on these unless corrected:
+
+1. The issue's `Current review: 26 August 2026` header is the instruction. The
+   `Original filing` block is evidence of what was true on 24 August 2026, and
+   its client versions, measurements and host attribution are not instructions.
+2. The target is `wildcat-finance/skills` at the base ref above. Changes to
+   `wildcat-finance/shoggoth-wave-atlas` are out of this run's reach; the study
+   reads that repository and records what it found, and any route work there is
+   a separate delivery.
+3. The prose surfaces the issue calls "README and PDF" are three files:
+   `README.md`, `docs/how-to-help-shoggoth.md`, and the PDF that
+   `scripts/build_contributor_guide.py` draws at
+   `docs/pdf/how-to-help-shoggoth.pdf`. There is no PDF of `README.md`.
+4. The six harnesses in scope are GitHub Copilot, Cursor, Gemini CLI, Windsurf,
+   Cline and Roo Code. Codex and Claude Code keep the native-package status the
+   24 August checks gave them, and `/go/chatgpt` and `/go/claude` keep theirs.
+5. Python is the interpreter pinned in `.python-version`, with the standard
+   library `unittest`. The repository suite is `python3 scripts/run_checks.py`.
+6. No harness account, licence or seat will be created for this run. That
+   assumption picks the design; if it is wrong, section 4 changes.
+
+## 1. Problem statement
+
+The repository tells contributors which AI coding harness can pick up an Atlas
+job and how. Two web routes are described as checked, six local harnesses are
+described in a table, and none of those six descriptions rests on a recorded
+client run. The issue asks for the run first and the button second.
+
+Built for: the maintainer who decides whether a harness earns a launch button,
+and the external contributor who reads the roster and picks one.
+
+A working prototype here is a repository that can state, per harness, what was
+observed and by which command, and whose reader-facing wording is produced from
+that record rather than typed next to it. It does not require that any harness
+pass. It requires that the roster cannot say a harness passed unless a run is
+recorded, and that a stale roster becomes visible instead of staying quiet.
+
+Demo path, run from the repository root:
+
+```bash
+python3 scripts/probe_harnesses.py --out docs/harness-classification.json
+python3 scripts/render_harness_roster.py --check
+python3 scripts/build_contributor_guide.py
+python3 -m unittest tests.test_harness_manifest -v
+```
+
+The first command re-establishes the record on the host it runs on. The second
+fails when any of the three wording surfaces has drifted from the record. The
+fourth is the binding suite. Success is those four commands at exit zero with
+the tree clean afterwards.
+
+## 2. Prior art
+
+### In this repository
+
+The harness roster exists three times, hand-written, with nothing binding the
+copies to each other.
+
+- `README.md` lines 313 to 324, inside `## Contribute`. Three shields.io badges:
+  `/go/chatgpt`, `/go/claude`, and `/api/job` as a manual prompt. No table. Of
+  the six harnesses in scope, `README.md` names none. Codex appears at line 273
+  as an install pointer, not a launcher.
+- `docs/how-to-help-shoggoth.md` lines 126 to 139, heading `### Local
+  harnesses`. A three-column table, `Harness | Supported route | Checked limit`,
+  with six rows: Codex, Claude Code, GitHub Copilot, Cursor, Gemini CLI,
+  Windsurf. Every one of the six carries the identical `Checked limit` value,
+  `No checked one-click Atlas launcher`, so the column separates nothing. Cline
+  and Roo Code have no row and appear only in the exclusion sentence at lines
+  137 to 139.
+- `scripts/build_contributor_guide.py` lines 333 to 399. The two bootstrap
+  buttons are hardcoded, and the manual harnesses are one hand-typed string,
+  `"GitHub Copilot  /  Cursor  /  Gemini CLI  /  Windsurf"`, under a `Manual
+  only` label.
+
+No test reads any of it. `tests/test_marketplace_prose.py` line 323 opens
+`README.md` and the guide but asserts only on identity wording.
+`plugins/hexaemeron/tests/test_fiat_skill.py` class `HostGuidanceTests` reads
+harness names out of the guide's byline paragraph, not the roster table. There
+is no test for the badge URLs, the table rows, the generator, or either PDF.
+
+The strings `go/copilot` and `tested local route` appear nowhere in the tree.
+
+### The two merged pull requests that changed this subject
+
+`docs/overhaul external contribution path`, commit `b7fc2cb9`, merged by
+`6c98a728` as pull request #528 on 24 August 2026, introduced the badge block,
+the harness table and the sentence separating checked web routes from manual
+local ones. It also added `scripts/build_contributor_guide.py`. The pull request
+itself returns HTTP 404 from the API; its merge commit message and diff are the
+record that remains readable.
+
+`docs: rewrite Shoggoth as a contributor-ready crypto R&D collective`, commit
+`daa64e5f`, merged as pull request #1003 on 31 August 2026, rewrote the same
+prose. Its body records boundaries and verification and carries no unfinished
+work forward on this subject: `Root-Issue: none-recorded`. Nothing from either
+pull request is left open here except the roster duplication itself, which
+neither one closed and which this study answers in section 4.
+
+That change also removed the PR #479 link from the contributor prose.
+`tests/test_marketplace_prose.py` lines 331 and 332 now assert that `pull/479`
+and `PR #479` are absent from `README.md` and the guide. Acceptance condition 2
+asks the hand-off to retain "the link to PR #479"; a live test forbids that link
+in the two documents. Reading chosen: condition 2 means the launcher must
+preserve `job.prompt` byte for byte, and the enumerated items are checked
+against the prompt's current content rather than against the August wording.
+The current prompt carries the issue number and the checkpoint sentence and
+carries no reference to pull request 479.
+
+### Audit records
+
+`python3 plugins/hexaemeron/skills/fiat/scripts/audit_synopsis.py --check .` ran
+from the target root and exited zero, with all 62 records reporting
+`budget=pass` and `committed=match`. The synopsis is therefore the admitted
+reading view, and it was the view read for the 55 per-run records under
+`audit/rounds/` and for the six plugin-local records. Three sources were read
+directly rather than through a synopsis, because a search had to reach text the
+condensed view drops: `audit/AUDIT.md`, `audit/rounds/fiat-859-reinstate-the-wave-delta-distributed-checkpo.md`,
+and `audit/rounds/fiat-1057-record-an-open-issue-s-status-where-the-cen.md`.
+
+No audit round in this repository has ever reached a verdict on an Atlas
+hand-off, a launcher, or a per-harness route. The standing position is recorded
+absence, not a pass:
+
+- `audit/rounds/fiat-1057-...:7` reads `Not checked: the Atlas dependency extractor
+  itself, which lives in another repository and was neither run nor read`.
+- `audit/rounds/fiat-447-...:7` reads `Not checked: ... live Atlas, Kronos, Fiat,
+  claim-comment, release-comment and GitHub publication behaviour`.
+- `audit/AUDIT.md`, risk id `current-main-loss`, names the Atlas only as a base
+  path that must survive a rewrite.
+- `audit/rounds/fiat-859-...:227`, finding `S5-R1-01`, severity low, is about a
+  packet naming two repositories, not about a launcher.
+- `audit/AUDIT_SYNOPSIS.md` lines 356 to 363 carry `[missing legacy field:
+  audit-schema]`, `[missing legacy field: covered]`, `[missing legacy field:
+  not-checked]` and `[missing legacy field: elenchus-verdict]` for the
+  fiat-434-era rounds. Those stay unknown.
+
+Nothing is carried forward from the audit history, because nothing in it judged
+this subject.
+
+### The Atlas, read at `ce866e3d7e8b489fcb8b70c608f7af72d9b7a673`
+
+`app/go/chatgpt/route.ts` and `app/go/claude/route.ts` each pick a random
+eligible job, put `fiatPrompt(job)` into a `q` parameter and return HTTP 307
+with `Cache-Control: no-store`. No job means HTTP 503. The Atlas `tests/`
+directory holds six files and none covers either route, so the guide's claim at
+line 117 that the two routes are "covered by the Atlas launcher tests" points at
+tests that do not exist.
+
+A live read confirmed the deployment answers: `GET /api/job` returned HTTP 200,
+`read_from: live`, `source_revision` equal to this run's base ref, 119 eligible
+jobs and a 1481-character `job.prompt`. `GET /go/claude` returned HTTP 307 to
+`https://claude.ai/new` with the prompt in `q`.
+
+### Outside both repositories
+
+- GitHub documents `ghapp://session/new` with `repo`, `pr`, `branch`, `prompt`
+  and `mode`, where `mode` takes `plan`, `interactive` or `autopilot`. The `plan`
+  value is a read-only mode the August record did not have. The Copilot app
+  reached general availability on 17 June 2026 and is offered on every Copilot
+  plan, including Copilot Free, or with a caller-supplied model key.
+- Cursor publishes no deep link. Its agent CLI takes `-p` for a prompt and
+  `--mode=ask` or `--plan` for read-only work.
+- Gemini CLI publishes no deep link. It takes `--prompt` or `-p` and
+  `--approval-mode plan`.
+- The Windsurf Cascade documentation URL now returns HTTP 307 to
+  `docs.devin.ai/desktop/cascade/cascade`, which documents Cascade inside Devin
+  Desktop under the Cognition and Devin brand. No prompt launcher is published.
+- Cline publishes no deep link. It takes `-p` or `--plan` and `--auto-approve
+  <boolean>`, and its positional-prompt form still defaults to act mode with
+  auto-approval on, so the hazard the August record named is unchanged.
+- `RooCodeInc/Roo-Code` reports `archived: true` with `pushed_at`
+  `2026-05-15T18:08:47Z`. The organisation's other repositories are
+  documentation, evaluation and JetBrains trees last pushed between June 2025
+  and May 2026. No active successor client was found.
+
+## 3. Constraints and non-goals
+
+Starting ref `8dc3aca54adeca49387a2bdfc174cf6e72d02a11` on `main`. Interpreter
+pinned by `.python-version`, standard-library `unittest`, root suite
+`python3 scripts/run_checks.py`. Atlas read at
+`ce866e3d7e8b489fcb8b70c608f7af72d9b7a673`. Host: darwin 25.5.0 on arm64.
+
+### What this host can and cannot do, per harness
+
+Each row was probed on 4 September 2026 by the commands named in
+`.hexaemeron/design/harness-evidence.json`. Client absence and authentication
+absence are recorded separately, because they are different findings.
+
+| Harness | Client here | Auth configured | Published prompt launcher | Runnable here |
+| --- | --- | --- | --- | --- |
+| GitHub Copilot | No. Absent from `PATH`; no desktop app in `/Applications`; `gh copilot --version` prints `Copilot CLI not installed` | No. `gh api user/copilot_seat` returns HTTP 404 for the active account; the organisation reports zero seats, `seat_management_setting: unconfigured` and `cli: unconfigured` | Yes, `ghapp://session/new` | No |
+| Cursor | No. `cursor` and `cursor-agent` absent from `PATH`; no app; no application-support directory | No. `~/.cursor/cli-config.json` holds settings keys only and no credential | No | No |
+| Gemini CLI | No. Absent from `PATH`; the global `node_modules` root holds only `@anthropic-ai` and `npm` | No. No `~/.config/gcloud`; no `GEMINI_*` or `GOOGLE_*` variable | No | No |
+| Windsurf | No. Absent from `PATH` and `/Applications`; no `~/.windsurf` or `~/.codeium` | Not applicable | No, and the product is now published as Cascade inside Devin Desktop | No |
+| Cline | No. Absent from `PATH`, from global `node_modules`, and from `~/.vscode/extensions` | No. No configuration directory, so `cline auth` has never run here | No | No |
+| Roo Code | Not applicable, the product is sunset | Not applicable | No | No |
+
+`~/.cursor`, `~/.gemini` and `~/.copilot` all exist with a modification date of
+24 August 2026 and hold settings and history but no client and no credential.
+They are residue of the filing's own probe run, and reading them as a present
+installation would be the error this table exists to prevent.
+
+The consequence is stated plainly: acceptance conditions 2, 3 and 4 ask for
+authenticated read-only client runs of five harnesses, and not one of the five
+can be run on this host without either an organisation policy change or a new
+account. The issue's own boundary forbids both. This run therefore delivers the
+record and the machinery, and records five named blockers instead of five
+passes.
+
+### Non-goals
+
+- No Atlas route is added, changed or tested in this run. `/go/copilot` is not
+  created. The missing route tests for `/go/chatgpt` and `/go/claude` are a
+  finding recorded against the other repository, not work done here.
+- No harness earns a launch button in this run. The badge block keeps the two
+  web routes it has.
+- No claim about whether Fiat checkpointing is finished is revisited. The
+  prompt's checkpoint sentence is read as bytes to preserve, not as a statement
+  to verify.
+- Codex and Claude Code are not re-probed. Their August result stands as
+  recorded, and the manifest carries it with its recorded date.
+
+### Always
+
+Both suites before a commit. The Imprimatur lint on every shipped document. A
+recorded measurement before any performance claim.
+
+### Ask first
+
+Adding a dependency. Enrolling any account in any harness plan, free or paid.
+Changing an organisation policy setting. Touching CI. Editing a byte of any file
+under `audit/`.
+
+### Never
+
+Store a harness credential, session token or model key anywhere in the tree, in
+the manifest, or in a probe log. Record a harness as `tested local route` or
+`Atlas launcher` without a recorded client run. Delete a failing test to green a
+suite. Claim a command ran when it did not.
+
+## 4. Design options
+
+Three constructions were drawn. The record at
+`.hexaemeron/design-evidence.json` selects one from checked gates; this prose
+explains what they are.
+
+**`hand-record`.** A maintainer writes the test record by hand and edits the
+three wording surfaces to agree with it. It is the cheapest construction to
+start and the only one that needs no new code. It trades away every guarantee
+that the surfaces still agree a month later, and it can only be completed by
+someone who can actually run all six clients.
+
+**`probe-manifest`, selected.** One probe script records, per harness, whether
+the client is present, its exact version when it is, whether an authentication
+method is configured, and what the client's current published contract offers.
+It writes one manifest. A renderer generates the README badge block, the guide
+table and the PDF harness page from that manifest, and a test fails when any
+surface drifts. It trades a build step and a schema for the property the issue
+actually wants: a roster that cannot outrun its evidence. Harnesses that cannot
+be run here are classified `manual route` and carry their exact blocker.
+
+**`contract-manifest`.** The same generated surfaces, but the manifest is
+maintained by hand from the published client contracts, with no machine probe.
+It is simpler than `probe-manifest` and keeps the single source. It cannot
+record a client version or an authentication state, because it never looks at
+the host, so it cannot satisfy acceptance condition 1.
+
+### How the record decided
+
+Three gates were resolved at selection, each computed by
+`python3 .hexaemeron/design/evaluate.py` from the recorded probe evidence and
+the declared constructions.
+
+| Candidate | `earned-class-only` | `per-harness-evidence` | `credential-free` | `hand-edit-sites` |
+| --- | --- | --- | --- | --- |
+| `hand-record` | pass | pass | **fail** | 3 |
+| `probe-manifest` | pass | pass | pass | 1 |
+| `contract-manifest` | pass | **fail** | pass | 1 |
+
+`hand-record` is removed because it cannot be completed with the credentials
+this host has: six harnesses need an authenticated client run and none has one.
+`contract-manifest` is removed because it emits only the launcher contract and
+never the client presence, version or authentication state that condition 1
+names. `probe-manifest` is the one surviving candidate, so `unique-frontier`
+holds.
+
+`hand-edit-sites` counts each candidate's declared wording surfaces. It is a
+count over a declaration in `.hexaemeron/design/candidates.json`, not a
+measurement of a built tree, and it is reported that way rather than as an
+observation. The three sites it counts for `hand-record` are the three that
+exist in the tree today.
+
+Three gates stay pending against later transitions. `roster-single-source` and
+`wording-regen-budget` are due at `step:4`, the step that makes the surfaces
+generated. `killed-probe-recovery` is due at `step:3`, the step that first
+writes the manifest. Each names its resolver and its future report path in the
+record.
+
+### The one question this study does not answer
+
+The Copilot desktop app is now offered on every Copilot plan, including Copilot
+Free, which costs nothing. The issue's boundary forbids "signing up for paid
+plans". Does that boundary also forbid enrolling the active account in Copilot
+Free, which would make the `ghapp://session/new` hand-off testable here?
+
+A yes leaves Copilot as `manual route` with its blocker recorded, which is what
+the selected design builds. A no adds one step that runs the deep link in
+`mode=plan` and can move Copilot to a tested class. The runbook is written for
+yes and says so; a no is an amendment, not a rewrite.
+
+## 5. Risk register seed
+
+The probe reads a host, shells out to client binaries, parses their output and
+writes a file that generates public prose. Every one of those is a place where a
+wrong answer becomes a published claim. The register below is what the audit
+loop enumerates; the ids are how a round cites a line.
+
+The two that matter most are `unearned-class` and `credential-leak`. The first
+is the issue's whole point: a roster that can say "tested" without a run is
+worse than no roster, because a contributor trusts it. The second is the
+boundary the issue draws in its own last paragraph, and a probe that prints a
+client's diagnostic output is exactly how a token reaches a log.
+
+```risk-register
+unearned-class | the classifier that turns probe output into a roster class | no input path can produce `tested local route` or `Atlas launcher` without a recorded client run, and a test asserts it
+credential-leak | the manifest, probe log and any captured client output | no token, key, cookie or session identifier reaches the manifest, the log or the tree, checked by a pattern test over both
+probe-subprocess | the argv of each spawned harness client | argv is a fixed list with no shell, the binary is resolved from PATH by exact name, and no probe input comes from the manifest
+absent-versus-unavailable | the per-harness record for a client that did not answer | absence from the host and a failed authentication are separate recorded fields and never collapse into one verdict
+stale-manifest | the manifest's recorded date against the surfaces it generated | the renderer refuses a manifest whose recorded host or date does not match the run that produced the surfaces
+partial-manifest-write | the manifest file during a probe that is killed | a killed probe leaves either the previous manifest or nothing, never a half-written file the renderer would accept
+network-absent | the launcher-contract field for a client whose documentation could not be read | an unreadable contract is recorded as unread with its reason, and never as absent
+roster-drift | the three generated wording surfaces against the manifest | the check mode fails when any surface differs from what the manifest renders
+atlas-claim | the guide sentence claiming Atlas launcher tests cover the two web routes | the sentence is corrected to what the Atlas repository actually holds, which is no route test
+pdf-nondeterminism | the generated PDF bytes across two runs of the builder | the harness page's text content is compared, not the whole PDF, so a timestamp does not fail the suite
+```
+
+## 6. Glossary seeds
+
+- **Hand-off.** The path from an Atlas job to a harness holding that job's
+  prompt, ending before any repository change.
+- **Atlas launcher.** A route under `/go/` that allocates a job and opens a
+  client with its prompt, proven by a recorded client run.
+- **Tested local route.** A local client path proven by a recorded read-only
+  client run against this repository.
+- **Manual route.** A path a person follows by hand: open the repository, read
+  `AGENTS.md`, paste the prompt. No launcher claim.
+- **Unsupported.** No active product to test.
+- **Manifest.** `docs/harness-classification.json`, the one record every roster
+  surface is generated from.
+- **Probe.** `scripts/probe_harnesses.py`, the re-runnable command that writes
+  the manifest from what the host actually shows.
+- **Blocker.** The exact named reason a harness could not reach a tested class,
+  recorded beside its classification.
+- **Residue.** A configuration directory left behind by a client that is no
+  longer installed. Not evidence of a present client.
+
+## 7. Sources
+
+- Issue #856, `wildcat-finance/skills`, read 4 September 2026, including its
+  26 August review header and its preserved original filing.
+- `wildcat-finance/skills` at `8dc3aca54adeca49387a2bdfc174cf6e72d02a11`:
+  `README.md` 313-324, `docs/how-to-help-shoggoth.md` 111-139 and 260,
+  `scripts/build_contributor_guide.py` 30-35 and 333-399, `AGENTS.md` 1-15 and
+  220-227, `.agents/skills/promise-machine/SKILL.md`,
+  `tests/test_marketplace_prose.py` 322-332.
+- Commits `b7fc2cb9` and `6c98a728` (pull request #528, API returns 404) and
+  `daa64e5f` (pull request #1003).
+- `audit/AUDIT.md`, `audit/AUDIT_SYNOPSIS.md`, and the 55 records under
+  `audit/rounds/`, with `audit_synopsis.py --check .` at exit zero.
+- `wildcat-finance/shoggoth-wave-atlas` at
+  `ce866e3d7e8b489fcb8b70c608f7af72d9b7a673`: `app/go/chatgpt/route.ts`,
+  `app/go/claude/route.ts`, `app/job.ts`, `app/api/job/route.ts`, `README.md`,
+  `tests/`, `.github/workflows/release-verification.yml` line 39.
+- Live Atlas at `https://shoggoth-wave-atlas.functi0nzer0.chatgpt.site`,
+  read 4 September 2026.
+- GitHub Copilot deep links,
+  `https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/github-copilot-app/open-with-deep-links`.
+- GitHub Changelog, Copilot app generally available, 17 June 2026, and
+  available to all, 7 July 2026.
+- Cursor CLI, `https://cursor.com/docs/cli/overview`.
+- Gemini CLI reference,
+  `https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/cli-reference.md`.
+- Cascade, `https://docs.windsurf.com/windsurf/cascade/cascade`, which returned
+  HTTP 307 to `https://docs.devin.ai/desktop/cascade/cascade`.
+- Cline CLI, `https://docs.cline.bot/usage/cli-overview`.
+- `https://github.com/RooCodeInc/Roo-Code`, and the `RooCodeInc` repository
+  listing.
+- `.hexaemeron/design/harness-evidence.json`, which records every probe command
+  and its result.
+
+## 8. Signals, and the questions behind them
+
+The probe is a command someone runs, so it has no unattended on-call life of its
+own. The manifest it writes does, because generated prose keeps being served
+long after the run that produced it. Two questions apply, and one does not.
+
+**"Is the roster the site is showing still true?"** The manifest carries the
+host, the date and the base ref of the run that wrote it. The renderer's
+`--check` mode is the signal: it exits non-zero when a surface no longer matches
+the manifest, and it is wired into the repository suite, so a drifted roster
+fails a normal test run rather than waiting for a reader to notice. Emitted by
+step 4.
+
+**"Why did this harness get the class it got?"** Every manifest entry carries
+the probe command, its observed result, and the blocker when there is one. A
+reader asking why Copilot is `manual route` gets the seat check and the
+organisation policy value, not an adjective. Emitted by steps 2 and 3.
+
+No alert, no metric series and no trace. Nothing here runs unattended, so there
+is nobody to page. [ephoros](../../plugins/hexaemeron/skills/ephoros/SKILL.md)
+owns what a signal must carry.
+
+## 9. Boundaries, per capability
+
+Three boundaries open, and each is a line in section 5 as well.
+
+**Spawning a harness client.** Worth taking because the issue's whole demand is
+an observed client rather than a documented one. Closed by a fixed argv list
+with no shell, an exact binary name resolved from `PATH`, no probe argument
+sourced from the manifest, and a bounded timeout on every spawn. Line
+`probe-subprocess`.
+
+**Handling whatever that client prints.** Worth taking because a version string
+is the only honest way to record a version. Closed by writing only fields the
+schema names, never raw client output, and by a pattern test over the manifest
+and the log for token, key, cookie and session shapes. Line `credential-leak`.
+
+**Reading a client's published contract over the network.** Worth taking
+because a launcher that no longer exists must not stay in the roster. Closed by
+recording an unread contract as unread with its reason, never as absent, and by
+never letting a fetched document decide a class on its own. Line
+`network-absent`.
+
+A fourth capability is deliberately not opened: the probe authenticates nothing
+and stores nothing. [phylax](../../plugins/hexaemeron/skills/phylax/SKILL.md)
+owns the boundary list and the controls.
+
+## 10. The budget, or its absence
+
+One budget, because the probe and the renderer both land in the repository
+suite and a slow check is a check people skip.
+
+The whole regeneration path completes inside 60 seconds on this host, measured
+by:
+
+```bash
+python3 .hexaemeron/design/time_wording_regen.py \
+  --report .hexaemeron/reports/probe-manifest-wording-regen-budget.json
+```
+
+That is the resolver named for the `wording-regen-budget` gate, which blocks
+`step:4`. The 60-second figure is a ceiling chosen against the existing
+`scripts/build_contributor_guide.py` run, not a measured baseline; the resolver
+produces the baseline at step 4 and the gate fails if the ceiling is wrong.
+
+No budget applies to the probe itself, because it is a command a person runs
+deliberately and its cost is dominated by client startup, which this repository
+does not control.
+[metron](../../plugins/hexaemeron/skills/metron/SKILL.md) owns what a budget
+carries and how it is checked.
+
+## 11. The fail-closed posture
+
+The probe stops the run when it cannot tell what it saw. An unrecognised client
+response, a spawn that times out, a schema violation, or a manifest write that
+cannot complete all end the command at a non-zero exit with the previous
+manifest untouched. It never falls back to a guessed class, and it never
+downgrades a harness silently: a harness it could not read keeps its recorded
+prior entry and gains an unread marker.
+
+The renderer fails closed the other way. `--check` refuses to pass when a
+surface differs from the manifest, when the manifest is missing, and when the
+manifest's recorded run does not match the surfaces it is being checked
+against.
+
+A fix for any failure here follows the guard convention: reproduce, reduce to
+the smallest case, fix the cause, and land a test that fails without the fix.
+The runner contract each step's `Tests` field names is the exact command Warden
+receives, with one `{report}` argument.
+[elenchus](../../plugins/hexaemeron/skills/elenchus/SKILL.md) owns the triage
+order and the guard rule.
+
+## 12. Decisions and their homes
+
+Three decisions here are expensive to reverse, because other things get written
+against them.
+
+**The manifest schema.** Once `docs/harness-classification.json` generates
+public prose and a suite binds to it, changing its field names is a change to
+three surfaces and a test at once. Record: a new ADR under `docs/adr/`.
+
+**The four classification names.** `Atlas launcher`, `tested local route`,
+`manual route` and `unsupported` become the vocabulary of the roster, the tests
+and every later harness discussion. Renaming one later rewrites history that
+readers have already seen. Record: the same ADR.
+
+**Reading acceptance condition 2 as "preserve `job.prompt` byte for byte", with
+the PR #479 clause treated as stale.** This one resolves a direct conflict
+between the issue and a live repository test, and a later reader who does not
+know it was decided will re-open it. Record: the same ADR, with the test lines
+cited.
+
+Not recorded: which harness got which class in this run. That belongs in the
+manifest, where it is regenerated, not in a decision record that would freeze
+it. [hypomnema](../../plugins/hexaemeron/skills/hypomnema/SKILL.md) owns which
+decisions earn a record and where each one lives.
+
+### Amendment -- 2026-09-04
+
+**What changed.** The study now carries the explicit bridge from its selected
+design to the standing record that holds it:
+
+```design-bridge
+schema | hypomnema-design-bridge/v1
+decision | probe-manifest
+record | docs/decisions/ADR-074-generate-the-harness-roster-from-one-probed-manifest.md
+```
+
+**Why.** Hypomnema study mode reports H008 against a shipped study whose chosen
+design reaches no standing record by an exact declared identifier. Step 1 wrote
+that record as ADR-074 and the prose names it, but nothing bound the two
+mechanically, so a reader had to take the join on trust. The bridge states it.
+
+**Steps touched.** Step 1.
+
+**Still holding.** Step 1: entry holds; exit holds. Step 2: entry holds; exit
+holds. Step 3: entry holds; exit holds. Step 4: entry holds; exit holds. Step 5:
+entry holds; exit holds.

--- a/docs/decisions/ADR-074-generate-the-harness-roster-from-one-probed-manifest.md
+++ b/docs/decisions/ADR-074-generate-the-harness-roster-from-one-probed-manifest.md
@@ -1,0 +1,139 @@
+# ADR-074: Generate the harness roster from one probed manifest
+
+## Status
+
+Accepted, 2026-09-04. Taken in the Fiat run for issue
+[#856](https://github.com/wildcat-finance/skills/issues/856), whose study and
+runbook are at [docs/atlas-harness-handoff/](../atlas-harness-handoff/study.md).
+The design record that selected the construction is
+`protasis-design-evidence/v1` at sha256
+`dc945d47bd56ee1ef71051fb86fd93d8a63242806bf9a8a41d1bbc5d193552fe`, candidate
+`probe-manifest`.
+
+## Context
+
+Three surfaces state which agent harnesses can pick up a Wildcat job and how:
+the badge block in `README.md`, the harness table in
+`docs/how-to-help-shoggoth.md`, and the harness page the PDF builder emits from
+`scripts/build_contributor_guide.py`. All three are written and edited by hand.
+Nothing holds them in agreement with each other, and nothing holds any of them
+to a run that actually happened. A contributor who reads that a harness is
+tested has no way to tell whether anyone ever tested it.
+
+Issue #856 asks for the remaining hand-offs to be tested before more launch
+buttons are added to the README. Probing this host answered that question in a
+way the issue did not anticipate: not one of the six clients is installed here,
+and not one is authenticated. Copilot has no seat and an unconfigured
+organisation policy; Cursor, Gemini CLI and Cline are absent from `PATH` and
+unauthenticated; Windsurf is absent and is now published as Cascade inside Devin
+Desktop; Roo Code is sunset and archived. The `~/.cursor`, `~/.gemini` and
+`~/.copilot` directories that do exist are residue of an earlier probe and hold
+no client and no credential.
+
+That turns the deliverable from six test results into a record that can carry
+five named blockers honestly, and machinery that keeps carrying them. Three
+constructions were drawn for it and graded against checked gates. `hand-record`
+failed `credential-free`, because completing it needs six authenticated client
+runs this host cannot perform. `contract-manifest` failed
+`per-harness-evidence`, because reading published client contracts never
+observes client presence, version or authentication state.
+
+Two of the decisions below are expensive to reverse once public prose is
+generated from them, which is why they are here rather than only in the study.
+The third resolves a direct conflict between the issue's own wording and a live
+test, and a later reader who does not know it was decided will reopen it.
+
+## Decision
+
+**One schema, one manifest, one generator.** The roster's single source is
+`docs/harness-classification.json`, validated by
+[`schemas/harness-classification-v1.json`](../../schemas/harness-classification-v1.json)
+under the identifier `harness-classification/v1`. A manifest carries a
+`recorded` block naming the host, the date and the base ref it was written
+against, and a `harnesses` array. Each harness entry carries `name`,
+`classification`, and the five observation fields `client_present`,
+`client_version`, `auth_configured`, `launcher_contract` and `blocker`, with
+optional `testable_here` and `probe`. Objects are closed: an undeclared field is
+refused rather than ignored. `client_version` may be null only where
+`client_present` is false, so an absent client cannot be recorded as a version
+nobody read.
+
+`client_present` and `auth_configured` are separate fields on purpose. A client
+that is missing and a client that is installed but unauthenticated are different
+facts, and a single verdict field would collapse them into one.
+
+**Four classification names, and no fifth.** A harness is exactly one of
+`Atlas launcher`, `tested local route`, `manual route` or `unsupported`. The
+first two are earned classes and require a recorded client run; the schema
+declares the four as a closed enumeration so an unknown name is refused rather
+than published. These four names become the vocabulary of the roster, the tests
+and every later harness discussion, so renaming one rewrites text readers have
+already seen.
+
+**Acceptance condition 2 means "preserve `job.prompt` byte for byte".** The
+condition asks the hand-off to retain a list of items including "the link to PR
+#479". That link was removed from the contributor prose by commit `daa64e5f`,
+and `tests/test_marketplace_prose.py` lines 331 and 332 now assert that
+`pull/479` and `PR #479` are absent from both `README.md` and
+`docs/how-to-help-shoggoth.md`. The issue and the suite cannot both be satisfied
+literally. The reading taken is that condition 2 requires the launcher to
+preserve `job.prompt` byte for byte, and that its enumerated items are checked
+against the prompt's current content rather than against the August wording. The
+current prompt carries the issue number and the checkpoint sentence and carries
+no reference to pull request 479, so the condition is met and the two test lines
+stand unchanged.
+
+Which harness got which class in this run is deliberately not recorded here. It
+belongs in the manifest, where it is regenerated from observation, not in a
+decision record that would freeze it.
+
+## Alternatives
+
+- **`hand-record`: write the test record by hand and edit the three surfaces to
+  agree.** The cheapest start and the only construction needing no new code.
+  Rejected on `credential-free`: it can only be completed by someone able to run
+  all six clients, and it gives away every guarantee that the surfaces still
+  agree a month later.
+- **`contract-manifest`: one hand-maintained manifest read from the published
+  client contracts, with no machine probe.** Keeps the single source and the
+  generated surfaces, and is simpler than a probe. Rejected on
+  `per-harness-evidence`: it never looks at the host, so it cannot record a
+  client version or an authentication state, and cannot satisfy acceptance
+  condition 1.
+- **Leave the three surfaces hand-edited and add a review checklist.** No new
+  code and no schema. Rejected because a checklist is not a check: the drift
+  this record exists to stop is exactly what review has already missed.
+- **A free-form classification string instead of a closed enumeration.**
+  Flexible, and no schema change when a new kind of hand-off appears. Rejected
+  because it admits `tested`, `Tested`, `Atlas Launcher` and anything else a
+  future writer reaches for, and the earned-class rule then has nothing to bind
+  to.
+- **Read acceptance condition 2 literally and restore the PR #479 link.**
+  Follows the issue's words. Rejected because it requires deleting or weakening
+  two passing assertions to satisfy a clause that a later, deliberate change
+  already superseded.
+- **Ask the issue author to amend condition 2 and wait.** Cleanest on paper.
+  Rejected as a blocker: the reading costs nothing to reverse in prose, and this
+  record makes it visible to whoever wants to argue with it.
+
+## Consequences
+
+The roster gains a build step and a schema. Publishing a harness change now
+means running the probe and regenerating three surfaces, rather than editing
+whichever one the writer was looking at. That is the cost bought deliberately:
+a roster that cannot outrun its evidence.
+
+Field names in `harness-classification/v1` are now load-bearing across the
+schema, the manifest, the renderer, three wording surfaces and the suite.
+Renaming one is a change to all of them at once, and needs a successor record
+rather than an edit.
+
+Five harnesses ship classified `manual route` or `unsupported` with a named
+blocker rather than as untested blanks. A reader learns what was tried and why
+it stopped, and any of the five can move to an earned class later by a probe run
+on a host that has the client, with no prose edit.
+
+The acceptance-condition-2 reading is recorded with the test lines it conflicts
+with. If a later reader decides the PR #479 clause should be honoured after all,
+the change is to those two assertions and to this record, in that order, and not
+a silent edit to either.

--- a/schemas/harness-classification-v1.json
+++ b/schemas/harness-classification-v1.json
@@ -1,0 +1,170 @@
+{
+  "$id": "https://wildcat.finance/schemas/harness-classification-v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "harness-classification/v1",
+  "description": "The one record every Atlas hand-off roster surface is generated from. Each harness entry carries what the host actually showed, so a class can never outrun the observation behind it. Pinned by docs/decisions/ADR-074-generate-the-harness-roster-from-one-probed-manifest.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "recorded",
+    "harnesses"
+  ],
+  "properties": {
+    "schema": {
+      "const": "harness-classification/v1"
+    },
+    "recorded": {
+      "$ref": "#/$defs/recorded"
+    },
+    "harnesses": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 64,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/harness"
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096
+    },
+    "recorded": {
+      "description": "The staleness signal. A renderer compares these against the run that produced the surfaces it is checking.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "host",
+        "date",
+        "base_ref"
+      ],
+      "properties": {
+        "host": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "date": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+        },
+        "base_ref": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        }
+      }
+    },
+    "classification": {
+      "description": "The four roster classes. Atlas launcher and tested local route are earned classes: neither may be recorded without a client run.",
+      "enum": [
+        "Atlas launcher",
+        "tested local route",
+        "manual route",
+        "unsupported"
+      ]
+    },
+    "probe": {
+      "description": "What the probe ran for this harness and what came back.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command",
+        "result"
+      ],
+      "properties": {
+        "command": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "result": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "harness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "classification",
+        "client_present",
+        "client_version",
+        "auth_configured",
+        "launcher_contract",
+        "blocker"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "classification": {
+          "$ref": "#/$defs/classification"
+        },
+        "client_present": {
+          "description": "Whether the client itself was found on this host. A left-behind configuration directory is residue and is not presence.",
+          "type": "boolean"
+        },
+        "client_version": {
+          "description": "The exact version the client reported. Null only where no client was present to report one.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 4096
+        },
+        "auth_configured": {
+          "description": "Whether an authentication method is configured here. Kept separate from client_present so absence and a failed authentication never collapse into one verdict.",
+          "type": "boolean"
+        },
+        "launcher_contract": {
+          "description": "What the client's current published contract offers, or the recorded reason it could not be read.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "blocker": {
+          "description": "The exact named reason this harness could not reach an earned class. Null only where nothing blocked it.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 4096
+        },
+        "testable_here": {
+          "description": "Whether an authenticated read-only client run was possible on this host.",
+          "type": "boolean"
+        },
+        "probe": {
+          "$ref": "#/$defs/probe"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "client_present"
+            ],
+            "properties": {
+              "client_present": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "client_version": {
+                "$ref": "#/$defs/nonEmptyString"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_harness_manifest.py
+++ b/tests/test_harness_manifest.py
@@ -1,0 +1,181 @@
+"""Scaffold checks for harness-classification/v1.
+
+The roster schema is the contract three generated wording surfaces will be
+rendered from, so these cases hold the two things that are expensive to reverse
+once prose exists: the four classification names, and the observation fields
+every harness entry has to carry.
+
+``jsonschema`` is a Lazarus dependency rather than a root one, so no case here
+may depend on it being installed. Each case asserts against the schema document
+itself, which always runs, and then asserts the same rule behaviourally when the
+library happens to be importable. A host without the library still checks the
+declared rule; it does not quietly skip.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "schemas/harness-classification-v1.json"
+SCHEMA_ID = "harness-classification/v1"
+
+CLASSIFICATIONS = (
+    "Atlas launcher",
+    "tested local route",
+    "manual route",
+    "unsupported",
+)
+
+OBSERVATION_FIELDS = (
+    "client_present",
+    "client_version",
+    "auth_configured",
+    "launcher_contract",
+    "blocker",
+)
+
+# The six harnesses issue #856 asks about. Named here so a missing-field case
+# removes a field from a realistic record rather than from a stub.
+HARNESSES = (
+    "GitHub Copilot",
+    "Cursor",
+    "Gemini CLI",
+    "Windsurf",
+    "Cline",
+    "Roo Code",
+)
+
+
+def load_schema():
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def validator():
+    """A Draft 2020-12 validator, or None where the library is absent."""
+    try:
+        import jsonschema
+    except ImportError:
+        return None
+    schema = load_schema()
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return jsonschema.Draft202012Validator(schema)
+
+
+def entry(name, **overrides):
+    record = {
+        "name": name,
+        "classification": "manual route",
+        "client_present": False,
+        "client_version": None,
+        "auth_configured": False,
+        "launcher_contract": "documented deep link, not exercised here",
+        "blocker": "absent from this host and unauthenticated",
+    }
+    record.update(overrides)
+    return record
+
+
+def manifest(*entries):
+    return {
+        "schema": SCHEMA_ID,
+        "recorded": {
+            "host": "darwin-arm64",
+            "date": "2026-09-04",
+            "base_ref": "8dc3aca54adeca49387a2bdfc174cf6e72d02a11",
+        },
+        "harnesses": list(entries) or [entry(name) for name in HARNESSES],
+    }
+
+
+class SchemaTests(unittest.TestCase):
+    def setUp(self):
+        self.schema = load_schema()
+        self.validator = validator()
+        self.harness = self.schema["$defs"]["harness"]
+
+    def assert_valid(self, document):
+        if self.validator is None:
+            return
+        self.assertEqual([e.message for e in self.validator.iter_errors(document)], [])
+
+    def assert_refused(self, document):
+        if self.validator is None:
+            return
+        self.assertNotEqual(list(self.validator.iter_errors(document)), [])
+
+    def test_the_schema_is_the_published_roster_contract(self):
+        self.assertEqual(self.schema["properties"]["schema"]["const"], SCHEMA_ID)
+        self.assertEqual(
+            self.schema["$id"],
+            "https://wildcat.finance/schemas/harness-classification-v1.json",
+        )
+        self.assert_valid(manifest())
+
+    def test_the_four_classification_names_are_exactly_these_four(self):
+        declared = self.schema["$defs"]["classification"]["enum"]
+        self.assertEqual(tuple(declared), CLASSIFICATIONS)
+
+    def test_each_classification_name_is_admitted(self):
+        for name in CLASSIFICATIONS:
+            with self.subTest(classification=name):
+                self.assert_valid(manifest(entry("Cursor", classification=name)))
+
+    def test_an_unknown_classification_name_is_refused(self):
+        declared = self.schema["$defs"]["classification"]
+        # A closed enum is what refuses the unknown name. A type keyword beside
+        # it would admit any string the enum forgot.
+        self.assertEqual(set(declared), {"enum", "description"})
+        for unknown in ("tested", "Atlas Launcher", "supported", ""):
+            with self.subTest(classification=unknown):
+                self.assertNotIn(unknown, declared["enum"])
+                self.assert_refused(
+                    manifest(entry("Cursor", classification=unknown))
+                )
+
+    def test_every_harness_entry_requires_the_five_observation_fields(self):
+        required = self.harness["required"]
+        for field in OBSERVATION_FIELDS:
+            with self.subTest(field=field):
+                self.assertIn(field, required)
+        self.assertFalse(self.harness["additionalProperties"])
+        document = manifest()
+        self.assertEqual(len(document["harnesses"]), len(HARNESSES))
+        self.assert_valid(document)
+
+    def test_a_harness_entry_missing_any_observation_field_is_refused(self):
+        for field in OBSERVATION_FIELDS:
+            with self.subTest(field=field):
+                record = entry("Cline")
+                del record[field]
+                self.assert_refused(manifest(record))
+
+    def test_a_null_client_version_is_admitted_when_the_client_is_absent(self):
+        self.assert_valid(
+            manifest(entry("Gemini CLI", client_present=False, client_version=None))
+        )
+
+    def test_a_null_client_version_is_refused_when_the_client_is_present(self):
+        conditional = self.harness["allOf"][0]
+        self.assertEqual(conditional["if"]["properties"]["client_present"]["const"], True)
+        self.assertIn("client_version", conditional["then"]["properties"])
+        self.assert_refused(
+            manifest(entry("Cursor", client_present=True, client_version=None))
+        )
+        self.assert_valid(
+            manifest(
+                entry(
+                    "Cursor",
+                    client_present=True,
+                    client_version="2026.8.1",
+                    classification="manual route",
+                )
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Step 1 of 5 on the hand-off run for issue #856, stacked on
`fiat/856-framework-13-test-the-remaining-atlas-hand-o`, which has no pull
request of its own yet. It ships four things: the classification schema, the
tests that hold it, the decision record behind it, and the committed copies of
the run's study and runbook. Nothing probes a host, no manifest is written, and
no README or contributor-guide wording moves. Those are steps 2 to 4.

## What changed

`schemas/harness-classification-v1.json` declares `harness-classification/v1`.
A manifest carries a `recorded` block naming the host, the date and the base ref
it was written against, and a `harnesses` array. Each entry carries `name`,
`classification` and five observation fields: `client_present`,
`client_version`, `auth_configured`, `launcher_contract` and `blocker`. Objects
are closed, so an undeclared field is refused rather than ignored, and
`client_version` may be null only where `client_present` is false.
`classification` is a closed enumeration of exactly four names: `Atlas
launcher`, `tested local route`, `manual route` and `unsupported`. The schema
fixes that vocabulary and refuses an unknown name. It does not enforce the
earned-class rule, which lands with step 2's classifier.

`tests/test_harness_manifest.py` holds eight cases. Each asserts against the
schema document itself, so a host without `jsonschema` still checks the declared
rule instead of skipping.

`docs/decisions/ADR-076-generate-the-harness-roster-from-one-probed-manifest.md`
records why the roster comes from one probed manifest, with the six alternatives
that lost. It also records the reading taken on acceptance condition 2: the
launcher must preserve `job.prompt` byte for byte, checked against the prompt's
current content rather than the August wording. `tests/test_marketplace_prose.py`
lines 331 and 332 assert that `pull/479` and `PR #479` are absent from both
`README.md` and `docs/how-to-help-shoggoth.md`, so the condition's literal
wording and the suite cannot both be satisfied.

`docs/atlas-harness-handoff/study.md` and `docs/atlas-harness-handoff/runbook.md`
are the committed copies of the controller-pinned originals. `cmp` reports both
byte-identical to their `.hexaemeron/` sources, which is this step's Exit
condition.

The rest of the eight-file diff is the audit trail and one generated counter.
This step's audit record and its synopsis land under `audit/rounds/`, and
`.horos/boundary.json` moves `files_walked` from 2492 to 2499 because seven
files arrived.

## Audit

Five rounds, 15 findings, closed `--no-further-leads`. Fixes are in `45d20fcb`
and `796d61fb`. The record is
`audit/rounds/fiat-856-framework-13-test-the-remaining-atlas-hand-o.md`.

Five items close accepted and unfixed. None is reachable from this branch.

| id | severity | what stands |
| --- | --- | --- |
| S1-R2-04 | medium | The study's `hypomnema-design-bridge/v1` block at line 524 names the ADR-074 path. `main` took ADR-074 through pull request #1181 mid-run, and ADR-075 is claimed by open pull request #1185, so this record became ADR-076. Study amendments are append-only, and Hypomnema refuses a study declaring more than one design bridge home, so the block can be neither repointed nor removed. `hypomnema --study` reports H008 against the shipped study permanently. ADR-076's closing section records the sequence and points the reader at the right file. |
| S1-R4-02 | low | A wrong quantity this audit wrote into its own append-only log: 52 for a count that is 54. |
| S1-R5-03 | low | The second wrong quantity in the same log: five for a count that was seven. |
| S1-R5-01 | low | In the final study amendment, a disclaimer that no quantity is restated, followed immediately by one. |
| S1-R5-02 | low | In the same amendment, a sentence true of its named files collectively but false of four of them individually. |

One divergence stands rather than resolves. The receipted runbook amendment at
`docs/atlas-harness-handoff/runbook.md:261` reads "ninety minutes later", and
ADR-076 corrects the interval to fifty-five minutes, measured from this record's
commit date to the merge. The amendment is append-only, so the two disagree in
the shipped tree.

## Proof

```
python3 scripts/run_checks.py --full
python3 tests/run_tests.py --elenchus-report <fresh path>
```

Last recorded: `run_checks.py --full` 28 of 28 checks, outcome green, exit 0.
`run_tests.py` 1140 of 1140, 0 failures, 0 errors, 0 skipped.

<!-- wildcat-origin: shoggoth -->
