### PR TITLE
Remove a duplicate audit log path test

### DIFF
--- a/plugins/hexaemeron/tests/test_audit_log_path.py
+++ b/plugins/hexaemeron/tests/test_audit_log_path.py
@@ -274,12 +274,6 @@ class AuditLogPathTests(HexctlCase):
         self.assertIn("config path is immutable", proc.stderr)
         self.assertEqual(self.log_path(), "audit/rounds/" + self.derived_name())
 
-    def test_only_the_log_path_leaf_may_move_the_record(self):
-        self.init()
-        moved = "plugins/hexaemeron/audit/rounds/" + self.derived_name()
-        self.run_ctl("config", "set", "audit.log_path", json.dumps(moved))
-        self.assertEqual(self.log_path(), moved)
-
     def test_a_branch_stored_as_the_wrong_type_answers_rather_than_raising(self):
         """Round 1 finding. The flattening runs a regex over the stored value."""
         self.init()


### PR DESCRIPTION
Removes one test, `test_only_the_log_path_leaf_may_move_the_record`, which is the same test as `test_an_override_may_move_the_directory` six methods above it.

## Evidence

The two are the same by construction: same class (`AuditLogPathTests`), same inherited `HexctlCase` fixture with no override, byte-identical normalised AST body, and identical covered-line sets — 1,503 lines each, zero symmetric difference.

Identical coverage is not on its own a reason to delete anything. A pair elsewhere in this same file has identical coverage and is **not** redundant: `test_a_branch_stored_as_the_wrong_type_answers_rather_than_raising` and `test_a_run_with_no_recorded_branch_keeps_the_older_freedom` each pin one disjunct of the guard at `hexctl.py:10740`, and flipping its `or` to `and` is killed by one and survived by the other. So this pair was checked the same way.

Differential mutation found nothing that separates them:

| | |
|---|---|
| Mutants tried | 198 |
| Killed by both | 109 |
| Killed by neither | 89 |
| Killed by exactly one | **0** |
| Run ended by | exhausting the available mutants, not the budget |

Operators were comparison flip, `and`/`or` swap, `True`/`False` swap, drop `not`, and `return None`. That set is not exhaustive, so this is strong evidence rather than proof — but it is the same standard under which the pair above was found *not* redundant.

## Which one was kept

The class docstring states the contract:

> An override may move the directory, because three plugins here keep their rounds under their own tree, but it may not take the name, because the name is what keeps two runs apart.

`test_an_override_may_move_the_directory` and `test_an_override_may_not_take_another_records_name` mirror those two clauses in order, so the kept test is the one the documentation names.

The removed test's name promises an "only" that its body never tests. That claim is asserted by `test_replacing_the_whole_audit_section_is_immutable` directly above it, which refuses a whole-section write with "config path is immutable" and checks the path is unchanged — complete without a positive counterpart, since the positive case is the kept test.

Neither name is referenced anywhere else in the repository.

## Verification

- `plugins/hexaemeron/tests/run_tests.py --jobs 4`: **2269/2269 passed**, 0 failures, 0 errors, 0 skipped, `exact_accounting: true`. The manifest count moves 2270 → 2269, exactly one test.
- `tests/run_tests.py`: **1167/1167 passed**.

## Related

The equivalent horos duplicate was already removed by #1187, which reached the same conclusion independently and kept the same member of that pair.
