### PR TITLE
fix(promise-machine): bind every digest and selector the coverage register records

### DIFF
--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -3904,7 +3904,7 @@
           "test_writer_refuses_bypass_and_never_writes_a_gap",
           "test_schema_and_runtime_document_the_same_closed_vocabulary"
         ],
-        "sha256": "431d2114d2b9f49a1a857dd03a2cba1957a39303048f61be9aae23d39650da0d"
+        "sha256": "4232ba03ac7cd735f0918785fda733884ab6083f3abbfbc6155b84a4d1349286"
       },
       {
         "path": "tests/test_run_observation_capture_inoculation.py",

--- a/tests/test_unique_identifiers.py
+++ b/tests/test_unique_identifiers.py
@@ -19,6 +19,7 @@ somebody found a check inconvenient.
 from __future__ import annotations
 
 import collections
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -74,6 +75,43 @@ def declared_promises(text):
 
 def coverage_document():
     return json.loads(COVERAGE.read_text(encoding="utf-8"))
+
+
+def records_with(document, field):
+    """Every object anywhere in the coverage file carrying `field`, with its location.
+
+    The walk is recursive and blind to the shape of what holds a record, on
+    purpose. Its predecessors read one level of named fields off each capability
+    entry and skipped anything a list held, so `run_observation_capture.tests` --
+    a list where the other capabilities use an object -- recorded a digest that
+    no check recomputed. `tests/test_run_observation_capture.py` then drifted
+    from its recorded bytes in 62a0cb87, which rebound nothing, and every check
+    went on reporting clean until an unrelated re-pin sweep read the file.
+
+    Reaching a record was conditional on two things beyond the record itself:
+    the entry above it carrying a `promise_id`, which `run_observation_binding`
+    does not, and the field holding it being an object rather than a list. A
+    walker that has to be taught each new container is the honour system with
+    extra steps, which is the failure the digest check below already names for
+    hand-rolled per-capability tests.
+
+    The location is returned as a dotted trail so a failure names the record
+    rather than only the file, because two entries can bind one path.
+    """
+    found = []
+
+    def walk(node, trail):
+        if isinstance(node, dict):
+            if field in node:
+                found.append((".".join(trail) or "<root>", node))
+            for name in sorted(node):
+                walk(node[name], trail + [name])
+        elif isinstance(node, list):
+            for index, item in enumerate(node):
+                walk(item, trail + [f"[{index}]"])
+
+    walk(document, [])
+    return found
 
 
 def bound_promise_ids(document):
@@ -163,46 +201,82 @@ class PromiseIdentifiers(unittest.TestCase):
         )
 
     def test_every_bound_capability_digest_matches_the_file_it_names(self):
-        """Recompute every capability digest, rather than trusting one per capability.
+        """Recompute every digest the register records, wherever it sits.
 
-        The digests in a capability entry were checked by a test written for that
-        one capability: `test_run_observation_coverage_binds_the_exact_release_surface`
+        The digests in a capability entry were once checked by a test written for
+        that one capability: `test_run_observation_coverage_binds_the_exact_release_surface`
         covers run-observation and nothing covered contributor-ranking, so its
         entry could name any digest at all and every check still reported clean.
         Enforcement that depends on somebody remembering to write the next
         hand-rolled test is the honour system with extra steps.
 
-        This recomputes them all, so a capability added later is bound by
-        construction.
-        """
-        import hashlib
+        Replacing that with a walk over named object fields under a `promise_id`
+        moved the same failure one level up rather than removing it. Nineteen of
+        the register's 126 digests fell outside those two conditions, and
+        seventeen were caught only because somebody had written the capability's
+        own test after all: nine by `assert_bound_paths` in
+        `tests/test_agent_instruction.py`, eight by
+        `test_run_observation_binding_coverage_binds_the_exact_release_surface`
+        in `tests/test_promise_machine_contract.py`.
 
+        The remaining two were `run_observation_capture.tests`, whose capability
+        test binds only its `reporter`. Zeroing both digests left the root suite
+        green at 166d3e21, and one of them was already stale. skills#1205.
+
+        `records_with` reaches a record by its own contents instead, so nothing
+        in this file records a digest that goes unchecked, and
+        `test_the_digest_walk_reaches_every_digest_the_register_records` is what
+        holds that true.
+        """
         checked, wrong = 0, []
-        for key, value in sorted(coverage_document().items()):
-            if not isinstance(value, dict) or "promise_id" not in value:
+        for trail, record in records_with(coverage_document(), "sha256"):
+            # Capability entries name their file `path` and the runtime bindings
+            # name it `source`. Both record a digest over whole file bytes, so
+            # both are recomputed the same way.
+            named, recorded = record.get("path") or record.get("source"), record["sha256"]
+            if not isinstance(named, str) or not isinstance(recorded, str):
+                wrong.append(f"{trail}: records a digest and names no file")
                 continue
-            for field, entry in sorted(value.items()):
-                if not isinstance(entry, dict):
-                    continue
-                path, recorded = entry.get("path"), entry.get("sha256")
-                if not path or not recorded:
-                    continue
-                target = REPOSITORY_ROOT / path
-                if not target.is_file():
-                    wrong.append(f"{key}.{field}: {path} is absent")
-                    continue
-                actual = hashlib.sha256(target.read_bytes()).hexdigest()
-                checked += 1
-                if actual != recorded:
-                    wrong.append(
-                        f"{key}.{field}: {path} is {actual[:12]} and the entry "
-                        f"records {recorded[:12]}"
-                    )
-        self.assertTrue(checked, "no capability digests were checked, so this proves nothing")
+            target = REPOSITORY_ROOT / named
+            if not target.is_file():
+                wrong.append(f"{trail}: {named} is absent")
+                continue
+            actual = hashlib.sha256(target.read_bytes()).hexdigest()
+            checked += 1
+            if actual != recorded:
+                wrong.append(
+                    f"{trail}: {named} is {actual[:12]} and the entry "
+                    f"records {recorded[:12]}"
+                )
+        self.assertTrue(checked, "no digests were checked, so this proves nothing")
         self.assertEqual(
             wrong, [],
-            "a capability entry records a digest that does not match the file it "
-            f"names, so the promise is bound to bytes that have changed: {wrong}",
+            "an entry records a digest that does not match the file it names, so "
+            "the promise is bound to bytes that have changed. Nothing regenerates "
+            "tests/promise_machine_coverage.json: recompute with `shasum -a 256 "
+            "<path>` and write the value into the matching sha256, as the last "
+            f"edit before you commit rather than the first: {wrong}",
+        )
+
+    def test_the_digest_walk_reaches_every_digest_the_register_records(self):
+        """The check above proves nothing about a record it does not reach.
+
+        That is not a hypothetical: reaching a record used to depend on the shape
+        of the field holding it, and the digest that went stale was one the walk
+        never visited, so its own count told it nothing was wrong.
+
+        The count here is lexical rather than structural, so it does not share a
+        traversal with the thing it is checking. A filter reinstated inside
+        `records_with` narrows that walk and fails here, instead of quietly
+        narrowing what the digest check covers.
+        """
+        recorded = COVERAGE.read_text(encoding="utf-8").count('"sha256"')
+        reached = len(records_with(coverage_document(), "sha256"))
+        self.assertEqual(
+            reached, recorded,
+            f"the digest walk reaches {reached} of the {recorded} digests "
+            "tests/promise_machine_coverage.json records, so the difference is "
+            "bound to bytes nothing recomputes",
         )
 
     def test_every_bound_capability_names_its_fixtures(self):
@@ -223,8 +297,6 @@ class PromiseIdentifiers(unittest.TestCase):
                     missing.append(f"{key}: {path} is absent")
                     continue
                 if isinstance(fixture, dict) and fixture.get("sha256"):
-                    import hashlib
-
                     actual = hashlib.sha256(target.read_bytes()).hexdigest()
                     if actual != fixture["sha256"]:
                         missing.append(
@@ -234,21 +306,32 @@ class PromiseIdentifiers(unittest.TestCase):
         self.assertEqual(missing, [], f"fixtures named but absent: {missing}")
 
     def test_every_bound_capability_selector_exists_in_its_test_file(self):
-        """A selector naming no test binds the promise to nothing."""
+        """A selector naming no test binds the promise to nothing.
+
+        Read through the same walk as the digests, and for the same reason: this
+        read `value["tests"]` as an object under a `promise_id`, so two of the
+        register's nine selector lists were never opened. A bogus selector
+        planted in `run_observation_capture.tests[1]` left the root suite green
+        at 166d3e21. The eleven selectors those two lists name all resolve, but
+        nothing was checking that they did.
+
+        An absent file is a failure here rather than a skip. It was a `continue`
+        before, which reported a missing test file as a clean selector list.
+        """
         stray = []
-        for key, value in sorted(coverage_document().items()):
-            if not isinstance(value, dict) or "promise_id" not in value:
+        for trail, record in records_with(coverage_document(), "selectors"):
+            named = record.get("path")
+            if not isinstance(named, str):
+                stray.append(f"{trail}: records selectors and names no test file")
                 continue
-            tests = value.get("tests")
-            if not isinstance(tests, dict) or not tests.get("path"):
-                continue
-            target = REPOSITORY_ROOT / tests["path"]
+            target = REPOSITORY_ROOT / named
             if not target.is_file():
+                stray.append(f"{trail}: {named} is absent")
                 continue
             source = target.read_text(encoding="utf-8")
-            for selector in tests.get("selectors", []) or []:
+            for selector in record["selectors"] or []:
                 if f"def {selector}(" not in source:
-                    stray.append(f"{key}: {selector} is not defined in {tests['path']}")
+                    stray.append(f"{trail}: {selector} is not defined in {named}")
         self.assertEqual(stray, [], f"selectors naming no test: {stray}")
 
     def test_every_bound_capability_names_a_document_that_exists(self):


### PR DESCRIPTION
Closes #1205. Closes #1206.

## What was wrong

`tests/promise_machine_coverage.json` records **126** digests. The two generic
gates in `tests/test_unique_identifiers.py` reached a record through its
container rather than through the record itself, on two conditions a record had
to satisfy together:

```python
if not isinstance(value, dict) or "promise_id" not in value:
    continue
for field, entry in sorted(value.items()):
    if not isinstance(entry, dict):
        continue
```

Nineteen records satisfied neither. Seventeen were caught anyway, by a
hand-rolled test written for that one capability -- nine by `assert_bound_paths`
in `tests/test_agent_instruction.py`, eight by
`test_run_observation_binding_coverage_binds_the_exact_release_surface` in
`tests/test_promise_machine_contract.py`. That is the honour system the generic
gate exists to replace, and it left the last two uncovered:
`run_observation_capture.tests[0]` and `[1]`, whose own capability test binds
only its `reporter`.

**One of the two was already stale.** `41f074ba` bound
`tests/test_run_observation_capture.py` correctly on 2026-08-28. `62a0cb87`
deleted two unused imports from that file on 2026-09-03 and rebound nothing.
Nothing reported it. The current bytes are the intended ones, so the repair is a
rebind, not a revert.

The selector gate shares both conditions, so two of the register's nine selector
lists -- eleven selectors -- were never opened (#1206). It also `continue`d past
a bound test file that does not exist, reporting an absent file as a clean
selector list.

## Where each digest was actually checked, before this change

| Records | Count | Gated by |
| --- | --- | --- |
| Object-valued `{path,sha256}` under a `promise_id` | 24 | `test_every_bound_capability_digest_matches_the_file_it_names` |
| `fixtures[]` under a `promise_id` | 38 | `test_every_bound_capability_names_its_fixtures` |
| `runtime.*` `{source,sha256,bindings}` | 45 | `promise_machine.py coverage`, PM071 |
| `agent_instruction.documentation[]`, `.evidence[]` | 9 | `assert_bound_paths`, hand-rolled |
| `run_observation_binding.*` | 8 | `test_run_observation_binding_coverage_binds_the_exact_release_surface`, hand-rolled |
| `run_observation_capture.tests[]` | **2** | **nothing** |

`scripts/promise_machine.py coverage` was never a gate for these: it reads
`sha256` only under `runtime.*`, never the capability records. That is why it
reported clean throughout.

## What changed

`records_with(document, field)` walks the register recursively and reaches a
record by its own contents, not by its container's shape or its parent's keys.
Both gates read through it. The digest gate also accepts the runtime bindings'
`source`, so it recomputes all **126** recorded digests rather than the 62 it
reached -- all 45 runtime bindings were verified to match under a full-file hash
first, so this adds no exception and contradicts nothing PM071 already checks.
An absent bound file is now a selector failure rather than a skip.

`test_the_digest_walk_reaches_every_digest_the_register_records` counts
`"sha256"` **lexically** in the file and compares that with what the walk
reaches. It shares no traversal with the thing it checks, so a filter reinstated
inside `records_with` fails there rather than quietly covering less.

No exception list, per the module's own docstring: *"There is no exception list
anywhere in this module. One would grow every time somebody found a check
inconvenient."*

`run_observation_capture.tests[0]` is rebound to
`4232ba03ac7cd735f0918785fda733884ab6083f3abbfbc6155b84a4d1349286`.

## Evidence

Each mutation was run against the **pre-fix** code and the working tree restored
byte-identically afterwards.

| Mutation | Pre-fix | On this change |
| --- | --- | --- |
| Both `run_observation_capture.tests` digests zeroed, plus a bogus selector | root suite green, **1206 tests OK** | fails, naming the record, path, actual and recorded |
| Stale digest reinstated | digest gate passes | fails at `run_observation_capture.tests.[0]` |
| List filter reinstated inside `records_with` | n/a | digest gate **still reports OK**; the new count fails at **75 of 126** |
| `dead_code.tests.path` repointed at a missing file | selector gate passes | selector gate fails |

The third row is the point of the tripwire: a narrowed walk is exactly the
failure that reports clean, so the count is what catches it.

At exit, on `a7ba7400`:

- `python3 -m unittest discover -s tests` -- **1207 tests, OK**, exit 0
- `python3 scripts/promise_machine.py coverage` -- `clean: promises=95 coverage_rows=95 coverage_selected=95`
- `python3 -m unittest discover -s tests -p 'test_promise_machine*.py' -t .` -- 73 OK
- `python3 -m unittest discover -s tests -p 'test_run_observation_capture.py' -t .` -- 30 OK
- `lint-phylax`, `lint-ephoros` -- clean; `horos check .` -- boundary matches the tree
- `git diff --check` -- clean

## Not settled here

`assert_bound_paths` is now redundant for coverage but keeps a much better
failure message, naming the exact `shasum` command and warning against rebinding
before the last edit. It stays, per #1205's own closing note.

Two documents assert that `tests/test_unique_identifiers.py:165` "recomputes
every bound capability digest" -- `docs/dead-code-baseline-currency/runbook.md`
at lines 304 and 306. That was true for `dead_code`, whose `tests` is an object,
and false in general. Both are byte-pinned receipted records and are left
unedited; this change makes the sentence true rather than correcting it.

`docs/router-selection/study.md` line 256 makes the same generic claim in
looser terms and is likewise unedited.
