### PR TITLE
fix(fiat): name hexctl.py in stale-digest failures

### DIFF
--- a/plugins/hexaemeron/tests/test_issue_429_recovery.py
+++ b/plugins/hexaemeron/tests/test_issue_429_recovery.py
@@ -45,9 +45,6 @@ PRODUCT_CONTROLLER_SHA256 = (
 RECOVERY_GENERATOR_SHA256 = (
     "2972258d0c363bee0cc7e97668da96bcbb5ea19421fc278eefdae60ddcde9d75"
 )
-INTEGRATED_CONTROLLER_SHA256 = (
-    "6ab044d4a15e3bf44d5fe41f4644e87fa2419d6fb7761aae2b8fd6030b022ba1"
-)
 PROOF_SHA256 = "badb5f3eeffe9927453e43b8d3dbdcfbda87773e5b9ce1cbb7973cc44796bafb"
 PRODUCT_SUFFIX = (
     ROOT
@@ -281,20 +278,36 @@ class Issue429RecoveryTests(unittest.TestCase):
                 encoding="utf-8"
             )
         )
-        digests = [coverage["run_observation_binding"]["controller"]["sha256"]]
-        for promise in (
-            "fiat-design-evidence",
-            "fiat-final-integration",
-            "fiat-local-retirement",
-            "fiat-receipted-delivery",
-            "fiat-study-amendment",
-            "fiat-runbook-amendment",
-            "fiat-run-observation-binding",
-        ):
-            digests.append(coverage["runtime"][promise]["sha256"])
-        self.assertEqual(sha256(CONTROLLER), INTEGRATED_CONTROLLER_SHA256)
+        controller_path = CONTROLLER.relative_to(ROOT).as_posix()
+        observation = coverage["run_observation_binding"]["controller"]
         self.assertEqual(
-            digests, [INTEGRATED_CONTROLLER_SHA256] * len(digests)
+            observation.get("path"),
+            controller_path,
+            "run_observation_binding.controller must name " + controller_path,
+        )
+        bindings = [("run_observation_binding.controller", observation)]
+        bindings.extend(
+            (f"runtime.{name}", binding)
+            for name, binding in sorted(coverage["runtime"].items())
+            if binding.get("source") == controller_path
+        )
+        self.assertGreater(
+            len(bindings),
+            1,
+            "tests/promise_machine_coverage.json has no runtime binding for "
+            + controller_path,
+        )
+        actual = sha256(CONTROLLER)
+        stale = [
+            f"{trail} records {binding.get('sha256')!r}"
+            for trail, binding in bindings
+            if binding.get("sha256") != actual
+        ]
+        self.assertEqual(
+            stale,
+            [],
+            f"{controller_path} is {actual}; update every matching sha256 in "
+            f"tests/promise_machine_coverage.json: {stale}",
         )
 
 

--- a/scripts/promise_machine.py
+++ b/scripts/promise_machine.py
@@ -1695,7 +1695,8 @@ def check_coverage(root: Path, inventory: Inventory, selected_groups: set[str]):
                                 "PM071",
                                 "drift",
                                 binding_path,
-                                f"runtime binding source digest is {actual}; inventory records {digest}",
+                                f"runtime binding source {source!r} digest is {actual}; "
+                                f"inventory records {digest}",
                                 "review the changed result surface and update its field map and digest together",
                                 promise_id=promise_id,
                             )

--- a/tests/test_promise_machine_contract.py
+++ b/tests/test_promise_machine_contract.py
@@ -1348,7 +1348,11 @@ class PromiseCoverageTests(unittest.TestCase):
             )
         report = json.loads(completed.stdout)
         self.assertEqual(completed.returncode, 1)
-        self.assertIn("PM071", [item["code"] for item in report["findings"]])
+        drift = [
+            item for item in report["findings"] if item["code"] == "PM071"
+        ]
+        self.assertEqual(len(drift), 1)
+        self.assertIn("tests/evidence.py", drift[0]["message"])
 
     def test_runtime_binding_source_read_is_bounded(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
Closes #892.

## What was wrong

A change to `plugins/hexaemeron/skills/fiat/scripts/hexctl.py` would leave 11
digest records stale: one run-observation record and ten runtime bindings.
PM071 identified each JSON binding but omitted the file that changed.

The issue 429 recovery guard also kept `INTEGRATED_CONTROLLER_SHA256` as a
second current digest. It checked only eight of the 11 records and failed with
a bare hash comparison, so a controller edit looked like a separate failure
and required another re-pin.

Current `main` already has a generic digest walker that names all 11 records.
That left the Promise Machine command and recovery guard to fix here.

## What changed

- PM071 now includes the runtime binding's `source` path in every drift
  finding.
- The recovery guard derives the expected digest from `hexctl.py`, finds every
  matching runtime binding, and includes the run-observation controller.
- A stale recovery check now names `hexctl.py` and each affected JSON trail.
  The separate `INTEGRATED_CONTROLLER_SHA256` constant is gone.

## Evidence

- The strengthened PM071 regression test failed twice on the unfixed checker:
  its finding did not contain `tests/evidence.py`.
- After a temporary one-line controller change, PM071 produced ten drift
  findings that each named
  `plugins/hexaemeron/skills/fiat/scripts/hexctl.py`; the recovery guard named
  the same path and all 11 JSON trails. The temporary change was removed.
- `python3 -m unittest` over the three focused guards passed, 3/3.
- `python3 scripts/promise_machine.py coverage --check` reported clean at
  98/98/98.
- `python3 scripts/portable_promise_machine.py sync` followed by `check`
  passed for the ignored generated runtime.
- `python3 scripts/run_checks.py --base origin/main` passed all eight selected
  checks: root, Hexaemeron, Imprimatur, both dead-code checks, and the Phylax,
  Ephoros, and Hypomnema lints.
- Elenchus classified commit `38ccfa3013bb0f1f7a0e2f0959e87c7b4b19cad4` as
  `guarded`: the changed tests produced an assertion failure on its parent,
  with no runner error.
- `git verify-commit 38ccfa3013bb0f1f7a0e2f0959e87c7b4b19cad4`
  passed for `B83B60AE16F5DD1A`.

## Boundary

No controller behaviour or coverage-manifest bytes changed. No live Fiat state
was created or modified, and no Fiat receipt was written. The mapped test suite
invoked `hexctl.py` only inside disposable fixtures.
