### PR TITLE
test(hexaemeron): name audit synopsis guards by behaviour

### DIFF
--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 2544
+    "files_walked": 2546
   },
   "entries": [
     {

--- a/plugins/hexaemeron/tests/test_audit_synopsis_recovery.py
+++ b/plugins/hexaemeron/tests/test_audit_synopsis_recovery.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Permanent composition guards for the issue 429 recovery."""
+"""Permanent composition guards for the audit-synopsis recovery."""
 
 from collections import Counter
 import hashlib
@@ -130,7 +130,7 @@ def sha256(path):
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-class Issue429RecoveryTests(unittest.TestCase):
+class AuditSynopsisRecoveryTests(unittest.TestCase):
     def composition_commit(self):
         matches = []
         for line in git("rev-list", "--parents", "HEAD", text=True).splitlines():
@@ -312,7 +312,7 @@ class Issue429RecoveryTests(unittest.TestCase):
 
 
 if PROOF_MODE:
-    class Issue429DisposableProofTests(unittest.TestCase):
+    class AuditSynopsisDisposableProofTests(unittest.TestCase):
         """Replay the release boundary with the checked-in runtime only."""
 
         OUTPUT_BYTES_MAX = 2 * 1024 * 1024
@@ -432,7 +432,7 @@ if PROOF_MODE:
         ):
             heading_schema = heading_schema or schema
             if heading_schema == "fiat-audit-round/v1":
-                heading = f"## issue 429 proof, step 1, round 1 -- {timestamp}"
+                heading = f"## audit synopsis proof, step 1, round 1 -- {timestamp}"
             else:
                 heading = f"## Step 1, round 1 -- {timestamp}"
             covered = covered or "; ".join(
@@ -481,7 +481,9 @@ if PROOF_MODE:
             controller_verified = []
             local_valid = hosted_valid = trailer_valid = reachable = 0
 
-            with tempfile.TemporaryDirectory(prefix="fiat-429-release-proof-") as raw:
+            with tempfile.TemporaryDirectory(
+                prefix="audit-synopsis-release-proof-"
+            ) as raw:
                 temporary_root = Path(raw)
                 repo = temporary_root / "repo"
                 self.run_bounded(
@@ -501,7 +503,7 @@ if PROOF_MODE:
                 )
 
                 worktree, step_branch = self.bootstrap_run(
-                    repo, "main", "issue 429 proof"
+                    repo, "main", "audit synopsis proof"
                 )
                 unsigned_message = (
                     "unsigned refusal fixture\n\n"
@@ -919,7 +921,7 @@ if PROOF_MODE:
                         self.assertEqual(row["v1"], 0)
 
                 specification = importlib.util.spec_from_file_location(
-                    "issue_429_checked_generator", GENERATOR
+                    "audit_synopsis_checked_generator", GENERATOR
                 )
                 renderer = importlib.util.module_from_spec(specification)
                 specification.loader.exec_module(renderer)
@@ -965,7 +967,7 @@ if PROOF_MODE:
                     cwd=repo,
                 )
                 trailer_worktree, trailer_branch = self.bootstrap_run(
-                    repo, "trailer-base", "issue 429 trailer proof"
+                    repo, "trailer-base", "audit synopsis trailer proof"
                 )
                 self.run_bounded(
                     ["git", "branch", trailer_branch, TRAILER_FIXTURE], cwd=repo

--- a/plugins/hexaemeron/tests/test_audit_synopsis_release.py
+++ b/plugins/hexaemeron/tests/test_audit_synopsis_release.py
@@ -1,4 +1,4 @@
-"""Keep issue 429's checked-in release evidence reproducible."""
+"""Keep the audit-synopsis release evidence reproducible."""
 
 import hashlib
 from pathlib import Path
@@ -19,7 +19,7 @@ PLUGIN_SUITE_JOBS = (
     (".github/workflows/lazarus.yml", "tests"),
     (".github/workflows/pandects.yml", "catalogue"),
 )
-ISSUE_429_RUNBOOK = (
+AUDIT_SYNOPSIS_RUNBOOK = (
     REPO_ROOT
     / "plugins"
     / "hexaemeron"
@@ -27,8 +27,8 @@ ISSUE_429_RUNBOOK = (
     / "audit-record-schema-timestamp-synopsis"
     / "runbook.md"
 )
-ISSUE_429_PROOF = ISSUE_429_RUNBOOK.with_name("proof.md")
-ISSUE_429_ELENCHUS_COMMAND = (
+AUDIT_SYNOPSIS_PROOF = AUDIT_SYNOPSIS_RUNBOOK.with_name("proof.md")
+AUDIT_SYNOPSIS_ELENCHUS_COMMAND = (
     "npx --yes --package=node@26.6.0 -- python3.12 "
     "plugins/hexaemeron/tests/run_tests.py --elenchus-report {report}"
 )
@@ -45,7 +45,7 @@ def workflow_job(path, job):
     return match.group(0)
 
 
-class Issue429ReleaseTests(unittest.TestCase):
+class AuditSynopsisReleaseTests(unittest.TestCase):
     def test_root_suite_jobs_need_no_repository_history(self):
         for relative, job in ROOT_SUITE_JOBS:
             with self.subTest(path=relative, job=job):
@@ -61,16 +61,16 @@ class Issue429ReleaseTests(unittest.TestCase):
                 self.assertNotIn("fetch-depth: 0", body)
 
     def test_runbook_exposes_the_elenchus_report_argument(self):
-        runbook = ISSUE_429_RUNBOOK.read_text(encoding="utf-8")
+        runbook = AUDIT_SYNOPSIS_RUNBOOK.read_text(encoding="utf-8")
         self.assertEqual(runbook.count("--elenchus-report {report}"), 4)
-        self.assertEqual(runbook.count(ISSUE_429_ELENCHUS_COMMAND), 4)
+        self.assertEqual(runbook.count(AUDIT_SYNOPSIS_ELENCHUS_COMMAND), 4)
         self.assertEqual(
-            shlex.split(ISSUE_429_ELENCHUS_COMMAND).count("{report}"), 1
+            shlex.split(AUDIT_SYNOPSIS_ELENCHUS_COMMAND).count("{report}"), 1
         )
 
     def test_proof_binds_the_current_runbook_and_corrected_gate(self):
-        runbook_digest = hashlib.sha256(ISSUE_429_RUNBOOK.read_bytes()).hexdigest()
-        proof = ISSUE_429_PROOF.read_text(encoding="utf-8")
+        runbook_digest = hashlib.sha256(AUDIT_SYNOPSIS_RUNBOOK.read_bytes()).hexdigest()
+        proof = AUDIT_SYNOPSIS_PROOF.read_text(encoding="utf-8")
         current_binding = (
             "| release runbook, "
             "`plugins/hexaemeron/docs/audit-record-schema-timestamp-synopsis/"

--- a/tests/test_repository_naming.py
+++ b/tests/test_repository_naming.py
@@ -1,0 +1,59 @@
+"""Repository names that must describe maintained behaviour."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import subprocess
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ISSUE_NUMBERED_TEST = re.compile(
+    r"(?:^|/)test_issue(?:_|-)?[0-9]+(?:[_.-]|$)"
+)
+
+
+def git_environment():
+    """Remove inherited Git routing so the query stays in this repository."""
+    environment = dict(os.environ)
+    for name in (
+        "GIT_DIR",
+        "GIT_INDEX_FILE",
+        "GIT_WORK_TREE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_NAMESPACE",
+        "GIT_PREFIX",
+        "GIT_INTERNAL_SUPER_PREFIX",
+    ):
+        environment.pop(name, None)
+    return environment
+
+
+class RepositoryNamingTests(unittest.TestCase):
+    def test_test_modules_are_named_for_behaviour_not_issue_numbers(self):
+        completed = subprocess.run(  # phylax: allow subprocess: fixed Git query
+            ["git", "-C", str(ROOT), "ls-files", "-z"],
+            check=True,
+            capture_output=True,
+            env=git_environment(),
+        )
+        paths = [os.fsdecode(path) for path in completed.stdout.split(b"\0") if path]
+        offenders = sorted(
+            path
+            for path in paths
+            if (ROOT / path).is_file() and ISSUE_NUMBERED_TEST.search(path)
+        )
+        self.assertEqual(
+            offenders,
+            [],
+            "test modules must name maintained behaviour, not the issue that "
+            f"introduced it: {offenders}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Rename `test_issue_429_release.py` and `test_issue_429_recovery.py` for the audit-synopsis behaviour they maintain.
- Rename their live classes, constants, and disposable fixture labels.
- Add `tests/test_repository_naming.py` to reject future `test_issue_<number>` module names.
- Refresh `.horos/boundary.json` for the added tracked test.

## Evidence

- Before the rename, the new guard failed twice and named both old module paths.
- `python3 -m unittest tests.test_repository_naming plugins.hexaemeron.tests.test_audit_synopsis_release plugins.hexaemeron.tests.test_audit_synopsis_recovery -v`: 14 passed.
- `python3 scripts/run_checks.py --base origin/main`: seven of eight mapped checks passed. `root-suite` fails because `AGENTS.md` links `docs/decisions/ADR-078-echo-fiat-required-as-a-filer-set-label.md`, which the portable package does not contain.
- The same package-closure test fails on detached `origin/main` at `5e2bb508d63a15b7103778ec5809fab7c8697fa9`; this branch changes neither `AGENTS.md` nor ADR-078.
- Elenchus reports `guarded`: its detached-parent report contains an assertion failure from the changed test set.
- Commit `8bceb4e37330f0b499cc515848b53173c87630c9` has a valid OpenPGP signature from `laurence@wildcat.finance`.

## Boundary

- Historical `fiat-429-*` paths, schemas, and receipted records are unchanged.
- This follows #1243. #892 is already closed, so this PR does not close it again.
- No Fiat run or controller state was changed, and no receipt is claimed.
