### PR TITLE
Define the digest an overlay run supplies to a suite promise

### DIFF
--- a/plugins/hexaemeron/skills/fiat/references/wildcat-overlays.md
+++ b/plugins/hexaemeron/skills/fiat/references/wildcat-overlays.md
@@ -46,6 +46,17 @@ Any accepted overlay replaces only the `entry` file the descriptor names, and
 the `references/` beside it. Nothing else about the phase changes: the same
 suite runs in the same order for the same reasons.
 
+## What an overlay run supplies to a suite promise
+
+`PROMISES.md` binds each vendored suite skill to the SHA-256 of its vendored
+bytes and names the digest-matched instruction as evidence. An accepted
+overlay replaces those bytes for one run, so for that run the digest-matched
+instruction is the accepted descriptor's `manifest_sha256`, verified as
+above. No other clause of the promise moves. The number of isolated role
+results it requires, its wait barrier, its raw outputs, its scope rules and
+every refusal bind the instruction the run actually read, whichever copy that
+is. An overlay does not relax any of them.
+
 ## When resolution fails
 
 A failed fetch, an unreadable descriptor, a rejected field, or a digest

--- a/plugins/hexaemeron/tests/test_fiat_skill.py
+++ b/plugins/hexaemeron/tests/test_fiat_skill.py
@@ -140,6 +140,20 @@ class FiatSkillContractTests(unittest.TestCase):
             overlays,
         )
 
+    def test_overlay_run_supplies_manifest_digest_to_suite_promise(self):
+        overlays = " ".join(self.overlays.split())
+        self.assertIn(
+            "the digest-matched instruction is the accepted descriptor's "
+            "`manifest_sha256`",
+            overlays,
+        )
+        self.assertIn("No other clause of the promise moves", overlays)
+        self.assertIn(
+            "bind the instruction the run actually read, whichever copy that is",
+            overlays,
+        )
+        self.assertIn("An overlay does not relax any of them", overlays)
+
     def test_overlay_resolution_failure_falls_back_without_reporting(self):
         overlays = " ".join(self.overlays.split())
         self.assertIn(


### PR DESCRIPTION
## What changed

`PROMISES.md` binds each vendored suite skill to the SHA-256 of its vendored
bytes and names the digest-matched instruction as evidence.
`wildcat-overlays.md` said an accepted overlay replaces those bytes for one
run, but not what digest evidence such a run supplies, nor that the promise's
other clauses still bind the instruction the run actually read. One paragraph
under `## What an overlay run supplies to a suite promise` states both: the
digest-matched instruction is the accepted descriptor's `manifest_sha256`,
verified as the reference already requires, and the role-result count, wait
barrier, raw outputs, scope rules and every refusal do not move.

`test_fiat_skill.py` pins the sentences beside the other overlay assertions.

## Checks

`test_fiat_skill`: 117 tests, OK. Root suite: 1337 tests, OK.
`promise_machine.py check`: clean, 18 plugins. `portable_promise_machine.py
check`: clean. Imprimatur clean on the reference; hypomnema clean over the
tree. Brevitas B022 at the reference's final paragraph predates this change
and is unchanged by it.
