### PR TITLE
Number the five standing decision drafts and unjam the allocator

### DIFF
--- a/.horos/census.json
+++ b/.horos/census.json
@@ -8,7 +8,7 @@
     },
     {
       "boundary_bytes": 1485,
-      "bytes": 19189658,
+      "bytes": 19189644,
       "files": 1021,
       "suffix": ".md"
     },
@@ -189,6 +189,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 100019474,
+  "total_bytes": 100019460,
   "total_files": 2776
 }

--- a/docs/decisions/ADR-081-declare-a-held-jobs-inputs-in-the-ledger.md
+++ b/docs/decisions/ADR-081-declare-a-held-jobs-inputs-in-the-ledger.md
@@ -1,4 +1,4 @@
-# Decision: Declare a held job's required inputs in the ledger
+# ADR-081: Declare a held job's required inputs in the ledger
 
 Stable identity: `adr/declare-a-held-jobs-inputs-in-the-ledger`.
 

--- a/docs/decisions/ADR-082-derive-topology-counts-from-the-tree.md
+++ b/docs/decisions/ADR-082-derive-topology-counts-from-the-tree.md
@@ -1,4 +1,4 @@
-# Decision: Derive topology counts from the tree
+# ADR-082: Derive topology counts from the tree
 
 ## Status
 

--- a/docs/decisions/ADR-083-emit-the-fixed-and-guarded-result-as-a-closed-record.md
+++ b/docs/decisions/ADR-083-emit-the-fixed-and-guarded-result-as-a-closed-record.md
@@ -1,9 +1,9 @@
-# Decision: Emit the fixed-and-guarded result as a closed record
+# ADR-083: Emit the fixed-and-guarded result as a closed record
 
 ## Status
 
 Proposed, 2026-09-05. Numberless under
-[ADR-077](../ADR-077-assign-adr-numbers-at-merge-not-at-authoring.md), which
+[ADR-077](ADR-077-assign-adr-numbers-at-merge-not-at-authoring.md), which
 assigns the number at merge.
 
 ## Context
@@ -11,7 +11,7 @@ assigns the number at merge.
 Elenchus reproduces a failure, localises it to a mechanism, repairs the
 mechanism and leaves a guard, then hands the result back as prose. The
 `elenchus-fixed-and-guarded` Promise in
-[the skill file](../../../plugins/hexaemeron/skills/elenchus/SKILL.md) already
+[the skill file](../../plugins/hexaemeron/skills/elenchus/SKILL.md) already
 names every part of that claim, and the skill already holds every part in order
 to make it. Nothing survives the run in a form another program can read.
 
@@ -23,7 +23,7 @@ next wants to count recurrences, unless the reason is written down where the
 shape is.
 
 Both are settled here rather than in
-[the study](../../elenchus-fixed-and-guarded-record/study.md), because a study
+[the study](../elenchus-fixed-and-guarded-record/study.md), because a study
 is read once and a record is read whenever somebody meets the schema.
 
 ## Decision

--- a/docs/decisions/ADR-084-govern-real-data-demonstrations-separately.md
+++ b/docs/decisions/ADR-084-govern-real-data-demonstrations-separately.md
@@ -1,4 +1,4 @@
-# Decision: Govern real-data demonstrations separately
+# ADR-084: Govern real-data demonstrations separately
 
 ## Status
 

--- a/docs/decisions/ADR-085-keep-the-root-readme-as-a-front-door.md
+++ b/docs/decisions/ADR-085-keep-the-root-readme-as-a-front-door.md
@@ -1,4 +1,4 @@
-# Decision: Keep the root README as a front door
+# ADR-085: Keep the root README as a front door
 
 ## Status
 


### PR DESCRIPTION
`decision_assignments.py:593` refuses `base-draft` for any assignment base
carrying a file under `docs/decisions/drafts/`. The check sits in
`build_report`, so `plan` and the read-only verifier refuse alike. Five drafts
stand on `main`, which means no run can allocate a number, including a run that
would clear them.

The count is rising. Two stood when this change was first prepared, and three
more merged within the hour.

## What this does

Numbers all five, using the allocator's own transform.
`decision_assignments.transformed` produced the bytes: the drafts sorted,
numbered from the highest record on `main`, and only the first line rewritten
from `# Decision:` to `# ADR-NNN:`. Everything after that first newline is
byte-identical, which the function asserts and which this change re-checked.

```
declare-a-held-jobs-inputs-in-the-ledger              -> ADR-081
derive-topology-counts-from-the-tree                  -> ADR-082
emit-the-fixed-and-guarded-result-as-a-closed-record  -> ADR-083
govern-real-data-demonstrations-separately            -> ADR-084
keep-the-root-readme-as-a-front-door                  -> ADR-085
```

With this commit as the base, a draft on top of it plans cleanly to `ADR-086`,
one mapping, `outcome: planned`. That is the check this change exists to
restore.

## Two things that had to come with it

Three relative links in ADR-083 are re-based by one level. A draft sits one
directory below a record, so a relative link in it breaks on the move, and
`transformed` cannot repair one: it rewrites the first line and requires every
byte after it to be unchanged. The allocator would have produced the same three
broken links and `lint-hypomnema` refuses them. That is a property of the
drafts convention rather than of this record, and it is on #1332.

`.horos/census.json` is regenerated, because the census describes the tree the
ledgers ship with and five paths moved.

## The advisory status

`adr-assignments` will report red on this head. The delta adds numbered records
without the `ADR-Assignment-Base` and `ADR-Assignment` trailers, only the
allocator produces those, and the allocator refuses the base. The two rules
close on each other, which is the jam.

The status is advisory rather than blocking: `main` carries no branch
protection and its one ruleset stands at `evaluate`. ADR-077 anticipated this
in its own consequences, saying the repository proves the mechanism locally
until a separately authorised ruleset activation makes the status required.

This clears the state. It does not close the cause, which is that `hexctl done
sync-run` treats `--decision-assignments` as opt-in and never reads the drafts
directory, while `adr-assignments` builds its `finals` set only from
`docs/decisions/ADR-NNN-*.md` and so passes a draft-only delta without asking
for anything. #1332 carries both gaps.

Refs #1332

<!-- wildcat-origin: shoggoth -->
