### PR TITLE
front door: read each ledger where a claim binds it and refuse an unreadable one as FD39

### DIFF
--- a/.horos/census.json
+++ b/.horos/census.json
@@ -26,7 +26,7 @@
     },
     {
       "boundary_bytes": 73,
-      "bytes": 12344832,
+      "bytes": 12355975,
       "files": 574,
       "suffix": ".py"
     },
@@ -189,6 +189,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 101895017,
+  "total_bytes": 101906160,
   "total_files": 2913
 }

--- a/scripts/check_public_front_door.py
+++ b/scripts/check_public_front_door.py
@@ -104,6 +104,15 @@ page -- so the join is bounded rather than asserted. What a marked claim
 establishes is that the named ledger stands at the declared version, not that
 the sentence is about it.
 
+Each ledger is read the first time a claim binds to it, and never before. The
+sweep once resolved every governed ledger's version before it opened a page,
+so one `EVOLUTION.md` with no `- Current version:` row ended the whole run at
+exit 2 with no findings list, while an absent maintained page was one `FD01`
+beside every other page reporting normally. A ledger that cannot be read, or
+that reads cleanly and declares no current version row, is now `FD39` against
+each claim that needed it, the rest of the sweep reports as it would have, and
+a ledger no claim binds is never opened.
+
 What it does not do: it never grades free-form voice, which belongs to
 Imprimatur, Vulgate, Brevitas and human review. It does not decide whether a
 member-status sentence is true, only whether it still describes the version its
@@ -122,8 +131,8 @@ section heading quoted inside a fence is an example rather than the heading it
 imitates. Everything else still reads the fence, because the `COMMAND_RE` a
 card must display sits inside one.
 
-Exit 0 when the contract holds, 1 when a rule reports, 2 when an input cannot
-be read at all.
+Exit 0 when the contract holds, 1 when a rule reports, 2 when the topology or
+the demonstration records cannot be read at all.
 """
 
 from __future__ import annotations
@@ -525,6 +534,7 @@ REFUSALS = {
     "FD36": "generated-region claim is carried by the skill's own ledger",
     "FD37": "marked status prose names the version its marker declares",
     "FD38": "a marker that begins its line carries no prose on that line",
+    "FD39": "bound ledger is readable and declares its current version",
 }
 
 
@@ -591,13 +601,76 @@ def maintained_documents(topology) -> tuple[Maintained, ...]:
 def ledger_version(root: Path, directory: str) -> str:
     """The version one governed skill's own ledger currently records."""
 
-    text = read_document(root, f"{directory}/{LEDGER_NAME}")
+    return recorded_version(
+        read_document(root, f"{directory}/{LEDGER_NAME}"), directory
+    )
+
+
+def recorded_version(text: str, directory: str) -> str:
+    """The `- Current version:` row of one ledger, refusing one without it."""
+
     match = LEDGER_VERSION_RE.search(text)
     if match is None:
         raise FrontDoorError(
             f"{directory}/{LEDGER_NAME} declares no current version row"
         )
     return match.group("version")
+
+
+class Ledgers:
+    """Every governed ledger, each read the first time a claim binds to it.
+
+    The sweep once resolved all of these before it opened a page, so one
+    ledger with no version row raised out of the whole run at exit 2 with no
+    findings list, on a tree where no page said anything about that skill.
+    Reading at the point of use gives the condition the shape of every other
+    declared one: `FD39` against the claim that needed the ledger, with the
+    rest of the sweep reporting as it would have.
+
+    Each ledger is opened at most once. The outcome is kept whether it was the
+    text or the error that stopped the read, so a ledger bound by several
+    claims is read once and an unreadable one is reported at each claim
+    without being opened again.
+    """
+
+    def __init__(self, root: Path, by_skill: dict[str, str]) -> None:
+        self.root = root
+        self.by_skill = by_skill
+        self._read: dict[str, str | FrontDoorError] = {}
+
+    def governed(self, skill: str) -> bool:
+        return skill in self.by_skill
+
+    def text(self, skill: str) -> str:
+        """The ledger as text, or the error that stopped its read."""
+
+        if skill not in self._read:
+            try:
+                self._read[skill] = read_document(
+                    self.root, f"{self.by_skill[skill]}/{LEDGER_NAME}"
+                )
+            except FrontDoorError as exc:
+                self._read[skill] = exc
+        outcome = self._read[skill]
+        if isinstance(outcome, FrontDoorError):
+            raise outcome
+        return outcome
+
+    def version(self, skill: str) -> str:
+        """The version the ledger currently records."""
+
+        return recorded_version(self.text(skill), self.by_skill[skill])
+
+    def carries(self, skill: str, display: str, offset: int) -> bool:
+        """Whether the ledger holds the sentence making the claim at `offset`.
+
+        Normalised the same way `claim_sentence` normalises the page, so the
+        two sides of the comparison differ only where the prose does.
+        """
+
+        return ledger_carries(
+            display, offset, flat(self.text(skill).replace("*", " "))
+        )
 
 
 def rendered(text: str) -> str:
@@ -794,6 +867,48 @@ def ledger_carries(display: str, offset: int, ledger: str) -> bool:
 
     sentence = claim_sentence(display, offset)
     return bool(sentence) and bool(ledger) and sentence in ledger
+
+
+def check_region_claim(
+    where: str,
+    kind: str,
+    claim: re.Match,
+    display: str,
+    entry: str | None,
+    ledgers: Ledgers | None,
+    findings: list[Finding],
+) -> None:
+    """Decide one claim inside a region that quotes the page's own ledger.
+
+    The region exempts the claim only when the entry skill's ledger carries
+    the sentence making it. The ledger is read here, at the first claim that
+    needs it, and not before; one that cannot be read shows nothing, so the
+    claim is refused against that ledger rather than against the sentence.
+    """
+
+    word = word_index(display, claim.start())
+    carried = False
+    if entry is not None and ledgers is not None and ledgers.governed(entry):
+        try:
+            carried = ledgers.carries(entry, display, claim.start())
+        except FrontDoorError as exc:
+            _finding(
+                findings,
+                "FD39",
+                f"{where}: the {kind} claim {claim.group(0)!r} at word {word} "
+                f"sits in a generated region quoting {entry}'s ledger, and "
+                f"{exc}; a ledger that cannot be read exempts nothing",
+            )
+            return
+    if carried:
+        return
+    _finding(
+        findings,
+        "FD36",
+        f"{where}: the {kind} claim {claim.group(0)!r} at word {word} sits in "
+        "a generated region and no sentence in this skill's own EVOLUTION.md "
+        "carries it, so the region exempts nothing here",
+    )
 
 
 def markers(text: str) -> list[Marker]:
@@ -1170,7 +1285,8 @@ def check_counts(
     findings: list[Finding],
     *,
     history: bool = False,
-    ledger: str = "",
+    entry: str | None = None,
+    ledgers: Ledgers | None = None,
 ) -> None:
     """Every current count claim names a derived quantity and agrees with it."""
 
@@ -1321,15 +1437,8 @@ def check_counts(
         if claim.start() in marked or inside(spans, claim.start(), COUNT_RULE):
             continue
         if ledger_backed(spans, claim.start()):
-            if ledger_carries(display, claim.start(), ledger):
-                continue
-            _finding(
-                findings,
-                "FD36",
-                f"{where}: the count claim {claim.group(0)!r} at word "
-                f"{word_index(display, claim.start())} sits in a generated "
-                "region and no sentence in this skill's own EVOLUTION.md "
-                "carries it, so the region exempts nothing here",
+            check_region_claim(
+                where, "count", claim, display, entry, ledgers, findings
             )
             continue
         _finding(
@@ -1345,14 +1454,13 @@ def check_status(
     where: str,
     text: str,
     display: str,
-    versions: dict[str, str],
+    ledgers: Ledgers,
     spans: Sequence[tuple[int, int, frozenset[str], bool]],
     findings: list[Finding],
     *,
     plugin: str | None = None,
     by_plugin: dict[str, str] | None = None,
     entry: str | None = None,
-    ledger: str = "",
 ) -> None:
     """Every member-status claim names the ledger version it describes.
 
@@ -1399,8 +1507,7 @@ def check_status(
         covered.update(region[0] + start for start in claims)
         skill = marker.attributes["skill"]
         declared = marker.attributes["version"]
-        current = versions.get(skill)
-        if current is None:
+        if not ledgers.governed(skill):
             _finding(
                 findings,
                 "FD32",
@@ -1460,6 +1567,20 @@ def check_status(
                 "names and for no other",
             )
             continue
+        # The ledger is read here, at the comparison that needs it, and not
+        # before. The three rules above are decided from the page alone, so a
+        # ledger that cannot be read refuses this marker and hides nothing else.
+        try:
+            current = ledgers.version(skill)
+        except FrontDoorError as exc:
+            _finding(
+                findings,
+                "FD39",
+                f"{where}: the status marker at word "
+                f"{word_index(display, marker.start)} binds {skill!r}, and "
+                f"{exc}, so nothing decides whether {declared} is current",
+            )
+            continue
         if declared != current:
             _finding(
                 findings,
@@ -1473,15 +1594,8 @@ def check_status(
         if claim.start() in covered or inside(spans, claim.start(), STATUS_RULE):
             continue
         if ledger_backed(spans, claim.start()):
-            if ledger_carries(display, claim.start(), ledger):
-                continue
-            _finding(
-                findings,
-                "FD36",
-                f"{where}: the member-status claim {claim.group(0)!r} at word "
-                f"{word_index(display, claim.start())} sits in a generated "
-                "region and no sentence in this skill's own EVOLUTION.md "
-                "carries it, so the region exempts nothing here",
+            check_region_claim(
+                where, "member-status", claim, display, entry, ledgers, findings
             )
             continue
         _finding(
@@ -1717,9 +1831,10 @@ def check(root: Path) -> tuple[list[Finding], list[dict]]:
     by_plugin = {
         skill: directory.split("/")[1] for skill, directory in by_skill.items()
     }
-    versions = {
-        skill: ledger_version(root, directory) for skill, directory in by_skill.items()
-    }
+    # No ledger is read here. Each is opened by the first claim that binds to
+    # it, so a ledger no page describes is never read, and one that cannot be
+    # read is a refusal against that claim rather than the end of the sweep.
+    ledgers = Ledgers(root, by_skill)
     # The entry skill one landing page is about, and the ledger its generated
     # region quotes. A landing block is the skill's own frontier prose copied
     # out of `EVOLUTION.md`, so the ledger is what decides whether a claim
@@ -1727,15 +1842,6 @@ def check(root: Path) -> tuple[list[Finding], list[dict]]:
     entries = {
         directory.split("/")[1]: directory.rsplit("/", 1)[-1]
         for directory in topology.canonical
-    }
-    # Normalised the same way `claim_sentence` normalises the page, so the two
-    # sides of the comparison differ only where the prose does.
-    ledgers = {
-        plugin: flat(
-            read_document(root, f"{by_skill[skill]}/{LEDGER_NAME}").replace("*", " ")
-        )
-        for plugin, skill in entries.items()
-        if skill in by_skill
     }
     counts = topology.counts()
 
@@ -1760,20 +1866,20 @@ def check(root: Path) -> tuple[list[Finding], list[dict]]:
                 spans,
                 findings,
                 history=item.carries(HISTORY_RULE),
-                ledger=ledgers.get(owner or "", ""),
+                entry=entries.get(owner or ""),
+                ledgers=ledgers,
             )
         if item.carries(STATUS_RULE):
             check_status(
                 item.relative,
                 text,
                 display,
-                versions,
+                ledgers,
                 spans,
                 findings,
                 plugin=owner,
                 by_plugin=by_plugin,
                 entry=entries.get(owner or ""),
-                ledger=ledgers.get(owner or "", ""),
             )
         if item.carries(FRONT_DOOR_RULE):
             records = demonstrations.load_records(root)

--- a/tests/test_public_front_door.py
+++ b/tests/test_public_front_door.py
@@ -37,8 +37,9 @@ import re
 import sys
 import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))  # noqa: E402  (locates the checker)
@@ -88,6 +89,10 @@ LEDGER_FRONTIER = (
     "The seed release holds 41 findings from three skills chosen by hand, "
     "and the compile path has not shipped."
 )
+# The ledger the planted lantern page binds, and one no planted page binds.
+LANTERN_LEDGER = "plugins/lantern/skills/lantern/EVOLUTION.md"
+HOLLOW = "hollow"
+HOLLOW_LEDGER = f"plugins/{HOLLOW}/skills/{HOLLOW}/EVOLUTION.md"
 
 
 def write(path: Path, body: str) -> str:
@@ -344,7 +349,9 @@ def install(root: Path, records: dict[str, dict], overrides: dict[str, str]) -> 
     """Write every swept document, with the named ones replaced.
 
     `clean.md` is the default front door, so a specimen for another page is
-    checked against a repository that holds its contract everywhere else.
+    checked against a repository that holds its contract everywhere else. An
+    override may also name a file that is not a swept page, such as a ledger,
+    and is written the same way.
     """
 
     pages = {front_door.FRONT_DOOR: read_specimen("clean"), **COMPANIONS, **overrides}
@@ -641,6 +648,14 @@ PROVOCATIONS = {
             "This version rebuilds the held specimen and claims nothing beyond it.",
             "{{stale:lantern}} has not shipped the rebuild path.",
         )
+    },
+    # The ledger a page binds, not the page. A ledger that reads cleanly and
+    # records no version row was an exit rather than a refusal, so nothing
+    # here could provoke it. The planted frontier row stays so the generated
+    # region still finds its sentence and this remains one break.
+    "FD39": lambda: {
+        LANTERN_LEDGER: "# LEDGER\n\n- Frontier status: `open`\n"
+        f"- Current frontier: {LEDGER_FRONTIER}\n"
     },
 }
 
@@ -1234,6 +1249,39 @@ def phase_host_codes(landing: str) -> list[str]:
     return [finding.code for finding in findings]
 
 
+def plant_unbound_member(root: Path) -> None:
+    """Add one governed plugin whose landing page says nothing about its version.
+
+    Every member `plant` writes binds its own ledger from its landing page, so
+    a case about a ledger nothing binds needs a member the sweep can read
+    without ever opening the ledger behind it.
+    """
+
+    record_for(root, {"id": HOLLOW, "status": "mixed"})
+    write(
+        root / "plugins" / HOLLOW / "README.md",
+        f"# {HOLLOW.upper()}\n\n## WHAT IT IS\n\nA member whose page states "
+        "nothing about what its current release does.\n",
+    )
+    for manifest, entry in (
+        (
+            ".claude-plugin/marketplace.json",
+            {"name": HOLLOW, "source": f"./plugins/{HOLLOW}"},
+        ),
+        (
+            ".agents/plugins/marketplace.json",
+            {
+                "name": HOLLOW,
+                "source": {"source": "local", "path": f"./plugins/{HOLLOW}"},
+            },
+        ),
+    ):
+        path = root / manifest
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["plugins"].append(entry)
+        write(path, json.dumps(payload, indent=2) + "\n")
+
+
 @unittest.skipIf(front_door is None, "Step 4 checker is absent on the entry parent")
 class StepFiveAuditRoundTwoTests(unittest.TestCase):
     """The partial fixes round one left, and the two rules it wrote.
@@ -1453,6 +1501,108 @@ class StepFiveAuditRoundTwoTests(unittest.TestCase):
         self.assertTrue(
             sentence_case,
             "no pinned sentence-case heading occurs in PROMISE_MACHINE.md",
+        )
+
+
+@unittest.skipIf(front_door is None, "Step 4 checker is absent on the entry parent")
+class LedgerReadAtPointOfUseTests(unittest.TestCase):
+    """A ledger is read by the claim that binds it, and refused there.
+
+    `check()` once resolved every governed ledger's version before it opened a
+    page, so one `EVOLUTION.md` with no `- Current version:` row raised out of
+    the whole sweep at exit 2 with no findings list, even on a tree where no
+    page said anything about that skill, while an absent maintained page was
+    one `FD01` beside every other page reporting normally. Issue #1313 records
+    the asymmetry; these cases hold the repair.
+    """
+
+    def malformed(self) -> dict[str, str]:
+        """lantern's ledger with its version row removed and nothing else."""
+
+        return PROVOCATIONS["FD39"]()
+
+    def test_a_ledger_without_a_version_row_is_refused_at_the_claim_that_binds_it(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            records = plant(root)
+            install(root, records, self.malformed())
+            findings, events = front_door.check(root)
+        self.assertEqual([finding.code for finding in findings], ["FD39"])
+        message = str(findings[0])
+        self.assertIn("plugins/lantern/README.md", message)
+        self.assertIn(LANTERN_LEDGER, message)
+        self.assertIn(LEDGER_VERSION.format(plugin="lantern"), message)
+        # The rest of the sweep reported as it would have: the front door's
+        # cards were still checked and still bind every real-data record.
+        self.assertEqual(
+            len(events), sum(member["status"] == "real-data" for member in MEMBERS)
+        )
+
+    def test_an_unreadable_ledger_is_refused_at_every_claim_that_needed_it(self):
+        """Three claims on lantern's page need its ledger; each is refused once.
+
+        The status marker needs the version, and the count and status claims
+        quoted into the generated region need the text. A ledger that is not
+        UTF-8 passes discovery, which opens it and decodes nothing, and fails
+        at the checker's own read.
+        """
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            records = plant(root)
+            install(root, records, {})
+            (root / LANTERN_LEDGER).write_bytes(b"# LEDGER\n\n\xff\xfe\n")
+            findings, _ = front_door.check(root)
+        self.assertEqual([finding.code for finding in findings], ["FD39"] * 3)
+        for finding in findings:
+            with self.subTest(finding=str(finding)):
+                self.assertIn(LANTERN_LEDGER, str(finding))
+                self.assertIn("not UTF-8", str(finding))
+
+    def test_a_ledger_no_claim_binds_is_never_opened(self):
+        """Nothing describes hollow, so its ledger is not read, whatever it holds."""
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            records = plant(root)
+            plant_unbound_member(root)
+            install(root, records, {})
+            write(root / HOLLOW_LEDGER, "# LEDGER\n\n- Frontier status: `open`\n")
+            opened: list[str] = []
+            original = front_door.read_document
+
+            def recording(root_: Path, relative: str) -> str:
+                opened.append(relative)
+                return original(root_, relative)
+
+            with mock.patch.object(front_door, "read_document", recording):
+                findings, _ = front_door.check(root)
+        self.assertEqual(findings, [])
+        self.assertNotIn(HOLLOW_LEDGER, opened)
+        # Three claims on lantern's page bind its ledger; it was opened once.
+        self.assertEqual(opened.count(LANTERN_LEDGER), 1)
+
+    def test_a_rule_decided_from_the_page_alone_reports_before_the_ledger_is_read(self):
+        """FD37 needs no ledger, so a ledger with no version row hides nothing."""
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            records = plant(root)
+            install(root, records, {**PROVOCATIONS["FD37"](), **self.malformed()})
+            findings, _ = front_door.check(root)
+        self.assertEqual([finding.code for finding in findings], ["FD37"])
+
+    def test_main_reports_a_malformed_ledger_as_a_finding_at_exit_one(self):
+        """The symptom the issue records was exit 2 with no findings list."""
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            records = plant(root)
+            install(root, records, self.malformed())
+            out, err = io.StringIO(), io.StringIO()
+            with redirect_stdout(out), redirect_stderr(err):
+                code = front_door.main(["--root", str(root)])
+        self.assertEqual(code, 1)
+        self.assertIn("FD39", err.getvalue())
+        self.assertRegex(
+            err.getvalue(),
+            r"maintained surface: 1 finding\(s\) across \d+ document\(s\)",
         )
 
 


### PR DESCRIPTION
Closes #1313.

`scripts/check_public_front_door.py` resolved `ledger_version` for all 27 governed skills before it opened any page. A governed `EVOLUTION.md` with no `- Current version:` row therefore raised out of the whole sweep at exit 2 with no findings list, even when no maintained page said anything about that skill, while an absent maintained document was one `FD01` beside 26 pages reporting normally.

## What changed

- Each ledger is now read the first time a claim binds to it, through a `Ledgers` object that opens each ledger at most once and keeps the outcome, text or error.
- A ledger that cannot be read, or reads cleanly and declares no `- Current version:` row, is reported as `FD39` (`bound ledger is readable and declares its current version`) against the claim that needed it: the status marker at its `FD33` comparison, or the count or member-status claim inside a generated region at its `FD36` comparison. `FD32`, `FD35` and `FD37` are decided from the page alone and still report when the ledger is broken.
- A ledger no claim binds is never opened.
- Exit 2 remains for the topology reader and the demonstration records. The module docstring states the new shape and the narrowed exit contract.
- `ledger_version(root, directory)` keeps its signature; `tests/test_public_front_door.py` still reads every live ledger through it.
- `.horos/census.json` regenerated with `horos.py scan . --census --write`: the only delta is `.py` bytes and `total_bytes`, both up by 11,143, which is the growth of the two edited files. `HorosCensusCurrencyTests` was the one red test on the first root-suite run, is green on a clean HEAD, and names this command.

## Evidence

- `tests.test_public_front_door` and `tests.test_joined_front_door`: 83 tests, OK (65 + 13 before; 5 new cases in `LedgerReadAtPointOfUseTests` and the `FD39` provocation).
- The same test module replayed against the parent commit's checker: 7 red (`failures=2, errors=5`): the 5 new cases and the two inventory cases that hold `PROVOCATIONS` to `REFUSALS`.
- `python3 scripts/check_public_front_door.py --root .`: `27 document(s) hold the contract, with 4 checked card(s) on README.md`, exit 0.
- New cases: a version-less ledger yields exactly `["FD39"]` naming the page, the ledger path and the declared version, with the front door's cards still checked; a non-UTF-8 ledger yields `FD39` three times, once per claim that needed it; a version-less ledger no page binds yields no finding and is never opened, and a ledger bound by three claims is opened once; `FD37` still reports on a page whose ledger has no version row; `main` returns 1 with `FD39` and the findings summary on stderr.
- Root suite through `.githooks/greenlight`: 1628 tests, OK, in 198 s; the commit carries the recorded green.
- `scripts/run_checks.py --base origin/main` on the committed tree: 9 selected checks passed (root-suite, dead-code-suite, dead-code-suppressions-check, demonstrations-suite, front-door-check, joined-front-door-suite, lint-ephoros, lint-hypomnema, lint-phylax), outcome green.
- `scripts/check_commit_identity.py` over the one-commit range with login `laurenceday`: passed, one human author.

## If `.horos/census.json` conflicts at merge

Every merge to `main` regenerates the census, so this branch conflicts on the two byte-count lines (`.py` `bytes` and `total_bytes`) whenever `main` has moved since its last rebase; it did so twice on 2026-09-06 and 2026-09-07 (27 and 65 commits behind). Take `main`'s copy, then run `python3 plugins/horos/skills/horos/scripts/horos.py scan . --census --write` and stage the result; the delta is those two lines, up by 11,143.

## Not in scope

- `audit/rounds/fiat-shoggoth-front-door-derived.md` records `S5-R1-06` as accepted on the reasoning this PR reverses. Audit records are byte-pinned and stay as written; the issue and this PR are the record of the reversal.
- Whether every live ledger carries a version row is still held by `test_skill_metadata_matches_current_ledger_version` in `tests/test_evolution_contract.py`, which iterates every governed skill and fails on a missing row. The front-door checker no longer duplicates that check for ledgers no page binds.
