### PR TITLE
docs(agents): state the census regeneration duty beside the boundary's

### DIFF
--- a/.horos/census.json
+++ b/.horos/census.json
@@ -8,7 +8,7 @@
     },
     {
       "boundary_bytes": 1485,
-      "bytes": 20060826,
+      "bytes": 20061571,
       "files": 1051,
       "suffix": ".md"
     },
@@ -189,6 +189,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 101906160,
+  "total_bytes": 101906905,
   "total_files": 2913
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,3 +373,18 @@ boundary is regenerated:
 ```bash
 python3 plugins/horos/skills/horos/scripts/horos.py scan . --write
 ```
+
+`.horos/census.json` is the second generated artefact and moves for a
+different reason. The boundary lists classified sinks, so an ordinary source
+edit leaves it alone; the census counts bytes per filetype across every
+tracked file, so any change to any tracked file moves it. The root suite holds
+it to a fresh scan the same way, and a different flag rewrites it:
+
+```bash
+python3 plugins/horos/skills/horos/scripts/horos.py scan . --census --write
+```
+
+Run that before recording a green rather than after, and stage what it writes
+alongside the change. Every merge to `main` rewrites the census as well, so a
+branch left open across another merge conflicts on the byte counts: take
+`main`'s copy, run the command again, and stage the result.


### PR DESCRIPTION
Closes #1253.

`.horos/census.json` is written by `scan . --census --write` and, since `70d16f37` on 2026-09-05, held to a fresh scan by the root suite. `AGENTS.md` stated the boundary's regeneration duty and command under "Reading boundary" and said nothing about the census. That was the clause the filing left open: a currency check "with the regeneration duty stated where the boundary's is".

## What changed

One paragraph and one command block in `AGENTS.md`, after the boundary's, stating three things a contributor otherwise learns from a red suite:

- **The two artefacts move for different reasons.** The boundary lists classified sinks, 134 entries at `b716ca21`, so an ordinary source edit leaves it alone. The census counts bytes per filetype across every tracked file, 31 suffix rows over 2,913 files, so any tracked edit moves it.
- **The flag differs.** `scan . --census --write`, not the boundary's `scan . --write`.
- **When to run it.** Before recording a green rather than after, and again when a branch left open across another merge to `main` conflicts on the byte-count lines.

`.horos/census.json` is regenerated in this commit, as the new text instructs.

## Evidence

- Root suite through `.githooks/greenlight`: 1628 tests, OK, in 253 s; the commit carries the recorded green.
- `scripts/run_checks.py --base origin/main` on the committed tree: 9 selected checks passed (root-suite, dead-code-suite, dead-code-suppressions-check, demonstrations-suite, front-door-check, joined-front-door-suite, lint-ephoros, lint-hypomnema, lint-phylax), outcome green.
- `scripts/check_commit_identity.py` over the one-commit range with login `laurenceday`: passed, one human author.
- The tests that hold `AGENTS.md` and the two generated artefacts: 404 tests OK across `test_agent_instruction`, `test_shoggoth_identity`, `test_python_contract`, `test_portable_skills`, `test_marketplace_prose`, `test_boundary_currency` and `HorosCensusCurrencyTests`. `test_router_selection`: 12 OK.
- `hypomnema.py` over its linted set reports `clean`. `imprimatur.py AGENTS.md` exits 0, with signals only on pre-existing lines 19, 61, 77, 108, 142 and 148.
- The three sentences the router corpus quotes from `AGENTS.md` sit in "Marketplace boundaries" and are untouched, so no regrade is provoked.

## Where the two claims were measured

Both were observed on #1414 and are recorded on the issue:

- The census moves on any tracked-byte change. A diff touching two `.py` files moved `.py` `bytes` and `total_bytes` by 11,143 with no other delta, and reddened the root suite on `HorosCensusCurrencyTests` alone.
- It conflicts on every merge. That branch rebased four times across 2026-09-06 and 2026-09-07 while `main` moved 27, 65 and 13 commits, conflicting on those same two lines each time.

## Not in scope

- The `horos-v9.2.3` epoch row still quotes "1.83 MB across 261 files", the figure the filing showed no committed census reproduces. That row records what the maintainer decided on 2026-08-19 and is bound by its frontier digest, so it is not brought up to date. A dated measurement is evidence rather than a number to correct, which is the principle the front-door historical marker already states.
- Whether the census should be a live artefact or the filing's second shape, a dated capture, is not reopened. The currency check settled that as the first; this states its duty.
