### PR TITLE
Horos: record the app-v2 marking on its default branch and ship the CI recipe

### DIFF
--- a/.horos/boundary.json
+++ b/.horos/boundary.json
@@ -6,7 +6,7 @@
     "bytes_lockfile": 254,
     "bytes_vendored": 94,
     "files_skipped_unreadable": 0,
-    "files_walked": 2962
+    "files_walked": 2966
   },
   "entries": [
     {

--- a/.horos/census.json
+++ b/.horos/census.json
@@ -8,8 +8,8 @@
     },
     {
       "boundary_bytes": 1485,
-      "bytes": 20185522,
-      "files": 1058,
+      "bytes": 20194199,
+      "files": 1060,
       "suffix": ".md"
     },
     {
@@ -20,13 +20,13 @@
     },
     {
       "boundary_bytes": 64487,
-      "bytes": 12866975,
-      "files": 901,
+      "bytes": 12872471,
+      "files": 903,
       "suffix": ".json"
     },
     {
       "boundary_bytes": 73,
-      "bytes": 12412914,
+      "bytes": 12416208,
       "files": 579,
       "suffix": ".py"
     },
@@ -189,6 +189,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 102174614,
-  "total_files": 2970
+  "total_bytes": 102192081,
+  "total_files": 2974
 }

--- a/plugins/horos/README.md
+++ b/plugins/horos/README.md
@@ -103,6 +103,13 @@ security review. Harnesses load those files at session start, so one paste
 makes the boundary effective for any instruction-following agent, with no
 install.
 
+A pasted boundary is only worth its last regeneration, so the adopting
+repository also needs `check` on every push. [The CI
+recipe](docs/adoption/ci.md) is the workflow for a repository that carries
+the boundary but not the skill: a pinned classifier, no install step, and
+a named cost, since any tracked file added or removed drifts the boundary
+until somebody commits a fresh one.
+
 ## WHERE IT IS HONEST ABOUT LIMITS
 
 Classification is fail-open. A file Horos cannot evidence stays readable, so

--- a/plugins/horos/docs/adoption/ci.md
+++ b/plugins/horos/docs/adoption/ci.md
@@ -1,0 +1,97 @@
+# Holding an adopted boundary current in CI
+
+A committed boundary goes stale the moment the tree it describes changes,
+and an agent that consults it does not know that. `horos check` re-derives
+the boundary and names every drifted path, so running it on every push is
+what makes the committed copy worth consulting.
+
+This is the workflow, written for a repository that has adopted a
+boundary and does not carry the skill. It was run against
+wildcat-app-v2 at `564a189bb9cdc9394b3fd4f444531a261ada99b3` with the
+artefacts regenerated, and reported `boundary matches the tree` at exit 0.
+
+```yaml
+name: horos
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: ['**']
+  push:
+    branches: ['**']
+    tags-ignore: ['**']
+
+permissions:
+  contents: read
+
+env:
+  HOROS_REPO: wildcat-finance/skills
+  HOROS_REF: 12cbe2e6ed95decd6d9d355740f2dbd052956abe
+  HOROS_SCRIPT: .horos-classifier/plugins/horos/skills/horos/scripts/horos.py
+
+jobs:
+  boundary:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v4
+
+      - name: Checkout the pinned Horos classifier
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.HOROS_REPO }}
+          ref: ${{ env.HOROS_REF }}
+          path: .horos-classifier
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Print tool versions
+        run: |
+          python3 --version
+          git -C .horos-classifier rev-parse HEAD
+
+      - name: Check the committed reading boundary
+        run: python3 "$HOROS_SCRIPT" check .
+```
+
+## What it needs
+
+**The pin.** `HOROS_REF` is a commit, not a branch. The classifier decides
+what counts as evidence, so an unpinned classifier turns an unrelated
+Horos change into a red build in somebody else's repository. `12cbe2e6`
+is `horos-v12.3.3`. Moving the pin is a deliberate commit, and the same
+commit regenerates the artefacts.
+
+**The checkout path.** The classifier lands inside the workspace at
+`.horos-classifier`, which is untracked there. `check` walks the
+git-tracked universe by default, so the checkout is invisible to the
+scan and needs no ignore rule.
+
+**Python and nothing else.** `horos.py` imports only the standard library
+and its own `languages` package, so there is no install step and no
+lockfile to keep current.
+
+**A green start.** `check` fails until the committed artefacts match the
+tree the workflow runs against. Regenerate both before the first run:
+
+```sh
+python3 horos.py scan . --write
+python3 horos.py scan . --census --write
+```
+
+## What it costs
+
+`counts.files_walked` is one of the compared fields, so adding or removing
+any tracked file drifts the boundary and reddens the check until the
+author commits a regenerated one. That is the gate working: a boundary
+that survived a file arriving is a boundary nobody can trust. On an
+active repository it is a real recurring cost, paid by whoever adds the
+file, and it is worth naming to the people who will pay it before the
+workflow lands.
+
+The check itself is cheap. Horos reads a bounded prefix of each file, and
+a whole-tree scan of a 17 MB repository takes tens of milliseconds.

--- a/plugins/horos/docs/evidence/wildcat-app-v2-ci-gate.md
+++ b/plugins/horos/docs/evidence/wildcat-app-v2-ci-gate.md
@@ -1,0 +1,115 @@
+# Evidence bundle: the TypeScript marking on its default branch
+
+The three-repository marking left wildcat-app-v2 with an open pull
+request and said so. This bundle records where that pull request went,
+what the default branch carries now, and what `horos check` says about
+it under the classifier as it ships today. Captured 2026-09-08 against
+`horos-v12.3.3`.
+
+## Where the marking landed
+
+[wildcat-app-v2#360](https://github.com/wildcat-finance/wildcat-app-v2/pull/360)
+merged into `develop` on 2026-08-19 as
+`b15b9e459648ba9be92f90e61eecdbda9875e3fc`, carrying `.gitattributes`,
+the three `.horos` artefacts and the AGENTS.md stanza. It reached the
+default branch `main` on 2026-08-20 inside
+`01191ed39f06b4445f79fd00ab470fcc70d2d8e8`, an aggregation of `develop`.
+Nothing was merged again to establish this; the two commits were read
+back from the repository.
+
+At `main` today, `564a189bb9cdc9394b3fd4f444531a261ada99b3`:
+
+- [.horos/boundary.json](./wildcat-app-v2.boundary.main.json): schema 2,
+  tracked universe, 13 hard entries binding 13,407,206 bytes
+- `.horos/candidates.json`: schema 2, 117 advisory candidates
+- `.horos/census.json`: 1,123 files, 17,089,542 bytes across 23 filetypes
+- `AGENTS.md`: the adoption stanza, byte for byte the text `scan --write`
+  prints today
+
+The boundary committed on `main` is not the copy this repository froze at
+marking time. [wildcat-app-v2.boundary.v2.json](./wildcat-app-v2.boundary.v2.json)
+records the scan of `9b8b6d5d6db06428c5b539f267623277b65315cd` at 1,041
+files walked; the pull request was regenerated against a later `develop`
+before it merged, so `main` carries 1,051 and a lockfile 18 bytes larger.
+Both are the same 13 entries.
+
+## What the check says
+
+`horos check .` under `horos-v12.3.3`, each commit read at a clean tree:
+
+| Commit | Drifted paths | Exit |
+| --- | --- | --- |
+| `b15b9e45` merge of #360 | 1 | 1 |
+| `01191ed3` aggregation to `main` | 2 | 1 |
+| `564a189b` `main` today | 2 | 1 |
+
+Two causes, and only two:
+
+1. `prisma/migrations/migration_lock.toml` carries the evidence string
+   `marker 'do not edit' in the first 4096 bytes`. Since `horos-v10.3.3`
+   a marker binds only on a comment-led line, so the classifier now
+   writes `marker 'do not edit' on a comment-led line in the first 4096
+   bytes` for the same file. The entry is otherwise identical. This is
+   the classifier moving, not the tree.
+2. `counts.files_walked` reads 1,051 against a rescan's 1,053. Two
+   tracked files arrived after the boundary was written. This is the tree
+   moving, and it is the drift the gate exists to name.
+
+At the merge commit the first cause is the whole difference: `counts` and
+every entry matched. The marking was current for the tree it described on
+the day it landed.
+
+The rescan is committed beside the boundary as
+[wildcat-app-v2.boundary.main-rescan.json](./wildcat-app-v2.boundary.main-rescan.json),
+so the two causes are checkable here rather than only reproducible there.
+
+## The gate that is not there
+
+`main` runs `commitlint.yml`, `release-please.yml` and `vercel-purge.yml`.
+None of them calls `horos check`, so nothing in that repository notices
+either drift. A boundary an agent consults without checking is only worth
+what its last regeneration was worth.
+
+The workflow that closes it is in
+[the CI recipe](../adoption/ci.md), which was run against
+`564a189b` with the artefacts regenerated: `boundary matches the tree`,
+exit 0. It is not committed in wildcat-app-v2, and this run opened no
+pull request there.
+
+## Stale-boundary rejection
+
+The gate was made to fail on purpose, twice, at `564a189b` with the
+boundary freshly regenerated and green:
+
+- a new tracked file carrying a generation marker: exit 1, two drifted
+  paths, `src/__horos_stale_demo.ts: evidenced by the tree but missing
+  from the boundary` beside the `counts` move from 1,054 to 1,055
+- one byte changed by hand in a committed entry: exit 1, one drifted
+  path, `package-lock.json: entry changed`
+
+Both restore to exit 0 by regenerating. Neither can be silenced by
+editing the boundary, because the boundary is the thing being compared.
+
+## What this does not establish
+
+That the gate runs in wildcat-app-v2. No workflow was committed there, no
+CI run exists on any of the three commits, and the issue's default-branch
+condition is unmet. The check results above were produced locally against
+clean checkouts of the public repository, and they are evidence about
+those exact trees under that exact classifier version, not about a run
+GitHub performed.
+
+## Machine-readable capture lines
+
+The consistency test parses these against the two committed boundary
+documents.
+
+<!-- cigate:commit 564a189bb9cdc9394b3fd4f444531a261ada99b3 -->
+<!-- cigate:merge_commit b15b9e459648ba9be92f90e61eecdbda9875e3fc -->
+<!-- cigate:aggregation_commit 01191ed39f06b4445f79fd00ab470fcc70d2d8e8 -->
+<!-- cigate:entries 13 -->
+<!-- cigate:hard_bytes 13407206 -->
+<!-- cigate:committed_files_walked 1051 -->
+<!-- cigate:rescan_files_walked 1053 -->
+<!-- cigate:drifted_paths 2 -->
+<!-- cigate:candidates 117 -->

--- a/plugins/horos/docs/evidence/wildcat-app-v2.boundary.main-rescan.json
+++ b/plugins/horos/docs/evidence/wildcat-app-v2.boundary.main-rescan.json
@@ -1,0 +1,106 @@
+{
+  "counts": {
+    "bytes_binary": 2495808,
+    "bytes_generated": 9015991,
+    "bytes_lockfile": 1895407,
+    "files_skipped_unreadable": 0,
+    "files_walked": 1053
+  },
+  "entries": [
+    {
+      "bytes": 1895407,
+      "category": "lockfile",
+      "evidence": "lockfile name package-lock.json",
+      "grade": "hard",
+      "path": "package-lock.json"
+    },
+    {
+      "bytes": 126,
+      "category": "generated",
+      "evidence": "marker 'do not edit' on a comment-led line in the first 4096 bytes",
+      "grade": "hard",
+      "path": "prisma/migrations/migration_lock.toml"
+    },
+    {
+      "bytes": 3434,
+      "category": "binary",
+      "evidence": "file signature png",
+      "grade": "hard",
+      "path": "src/assets/icons/avatarmob_icon.png"
+    },
+    {
+      "bytes": 2785,
+      "category": "binary",
+      "evidence": "file signature png",
+      "grade": "hard",
+      "path": "src/assets/icons/fire_icon.png"
+    },
+    {
+      "bytes": 1299338,
+      "category": "binary",
+      "evidence": "file signature riff",
+      "grade": "hard",
+      "path": "src/assets/pictures/background.webp"
+    },
+    {
+      "bytes": 10410,
+      "category": "binary",
+      "evidence": "file signature riff",
+      "grade": "hard",
+      "path": "src/assets/pictures/bannerBG.webp"
+    },
+    {
+      "bytes": 167999,
+      "category": "binary",
+      "evidence": "file signature png",
+      "grade": "hard",
+      "path": "src/assets/pictures/banner_bg.png"
+    },
+    {
+      "bytes": 6478,
+      "category": "binary",
+      "evidence": "file signature riff",
+      "grade": "hard",
+      "path": "src/assets/pictures/ethereum-icon.webp"
+    },
+    {
+      "bytes": 94370,
+      "category": "binary",
+      "evidence": "file signature riff",
+      "grade": "hard",
+      "path": "src/assets/pictures/login_page.webp"
+    },
+    {
+      "bytes": 899778,
+      "category": "binary",
+      "evidence": "file signature riff",
+      "grade": "hard",
+      "path": "src/assets/pictures/overviewBG.webp"
+    },
+    {
+      "bytes": 11216,
+      "category": "binary",
+      "evidence": "file signature png",
+      "grade": "hard",
+      "path": "src/assets/pictures/plasma-icon.png"
+    },
+    {
+      "bytes": 1448802,
+      "category": "generated",
+      "evidence": "linguist-generated for 'src/config/elfs-by-country.json' in .gitattributes",
+      "grade": "hard",
+      "path": "src/config/elfs-by-country.json"
+    },
+    {
+      "bytes": 7567063,
+      "category": "generated",
+      "evidence": "directory name storybook-static corroborated by sample: 6 of 8 files minified, binary or generated",
+      "files": 72,
+      "grade": "hard",
+      "path": "storybook-static/"
+    }
+  ],
+  "schema": 2,
+  "tool": "horos",
+  "universe": "tracked"
+}

--- a/plugins/horos/docs/evidence/wildcat-app-v2.boundary.main.json
+++ b/plugins/horos/docs/evidence/wildcat-app-v2.boundary.main.json
@@ -1,0 +1,106 @@
+{
+  "counts": {
+    "bytes_binary": 2495808,
+    "bytes_generated": 9015991,
+    "bytes_lockfile": 1895407,
+    "files_skipped_unreadable": 0,
+    "files_walked": 1051
+  },
+  "entries": [
+    {
+      "bytes": 1895407,
+      "category": "lockfile",
+      "evidence": "lockfile name package-lock.json",
+      "grade": "hard",
+      "path": "package-lock.json"
+    },
+    {
+      "bytes": 126,
+      "category": "generated",
+      "evidence": "marker 'do not edit' in the first 4096 bytes",
+      "grade": "hard",
+      "path": "prisma/migrations/migration_lock.toml"
+    },
+    {
+      "bytes": 3434,
+      "category": "binary",
+      "evidence": "file signature png",
+      "grade": "hard",
+      "path": "src/assets/icons/avatarmob_icon.png"
+    },
+    {
+      "bytes": 2785,
+      "category": "binary",
+      "evidence": "file signature png",
+      "grade": "hard",
+      "path": "src/assets/icons/fire_icon.png"
+    },
+    {
+      "bytes": 1299338,
+      "category": "binary",
+      "evidence": "file signature riff",
+      "grade": "hard",
+      "path": "src/assets/pictures/background.webp"
+    },
+    {
+      "bytes": 10410,
+      "category": "binary",
+      "evidence": "file signature riff",
+      "grade": "hard",
+      "path": "src/assets/pictures/bannerBG.webp"
+    },
+    {
+      "bytes": 167999,
+      "category": "binary",
+      "evidence": "file signature png",
+      "grade": "hard",
+      "path": "src/assets/pictures/banner_bg.png"
+    },
+    {
+      "bytes": 6478,
+      "category": "binary",
+      "evidence": "file signature riff",
+      "grade": "hard",
+      "path": "src/assets/pictures/ethereum-icon.webp"
+    },
+    {
+      "bytes": 94370,
+      "category": "binary",
+      "evidence": "file signature riff",
+      "grade": "hard",
+      "path": "src/assets/pictures/login_page.webp"
+    },
+    {
+      "bytes": 899778,
+      "category": "binary",
+      "evidence": "file signature riff",
+      "grade": "hard",
+      "path": "src/assets/pictures/overviewBG.webp"
+    },
+    {
+      "bytes": 11216,
+      "category": "binary",
+      "evidence": "file signature png",
+      "grade": "hard",
+      "path": "src/assets/pictures/plasma-icon.png"
+    },
+    {
+      "bytes": 1448802,
+      "category": "generated",
+      "evidence": "linguist-generated for 'src/config/elfs-by-country.json' in .gitattributes",
+      "grade": "hard",
+      "path": "src/config/elfs-by-country.json"
+    },
+    {
+      "bytes": 7567063,
+      "category": "generated",
+      "evidence": "directory name storybook-static corroborated by sample: 6 of 8 files minified, binary or generated",
+      "files": 72,
+      "grade": "hard",
+      "path": "storybook-static/"
+    }
+  ],
+  "schema": 2,
+  "tool": "horos",
+  "universe": "tracked"
+}

--- a/plugins/horos/tests/test_evidence.py
+++ b/plugins/horos/tests/test_evidence.py
@@ -3,9 +3,15 @@
 from pathlib import Path
 import json
 import re
+import sys
 import unittest
 
 PLUGIN = Path(__file__).resolve().parents[1]
+
+sys.path.insert(0, str(PLUGIN / "skills" / "horos" / "scripts"))  # noqa: E402  (locates horos.py)
+
+import horos  # noqa: E402
+
 EVIDENCE = PLUGIN / "docs" / "evidence"
 BUNDLE = EVIDENCE / "wildcat-app-v2.md"
 BOUNDARY = EVIDENCE / "wildcat-app-v2.boundary.json"
@@ -25,6 +31,10 @@ RESULTS_7 = EVIDENCE / "v2-protocol-outline.results.json"
 BUNDLE_9 = EVIDENCE / "skills-markdown-outline.md"
 RESULTS_9 = EVIDENCE / "skills-markdown-outline.results.json"
 BUNDLE_8 = EVIDENCE / "three-repository-marking.md"
+BUNDLE_10 = EVIDENCE / "wildcat-app-v2-ci-gate.md"
+CI_GATE_COMMITTED = EVIDENCE / "wildcat-app-v2.boundary.main.json"
+CI_GATE_RESCAN = EVIDENCE / "wildcat-app-v2.boundary.main-rescan.json"
+CI_RECIPE = PLUGIN / "docs" / "adoption" / "ci.md"
 MARKING_V2P = EVIDENCE / "v2-protocol.boundary.json"
 MARKING_APP = EVIDENCE / "wildcat-app-v2.boundary.v2.json"
 # Frozen beside the other two marked repositories. Reading this repository's
@@ -295,6 +305,71 @@ class SecondCaptureTests(unittest.TestCase):
         )
         share = 100 * int(second["classified_bytes"]) / int(second["total_bytes"])
         self.assertAlmostEqual(share, 83.3, places=1)
+
+
+class CiGateBundleTests(unittest.TestCase):
+    """The default-branch capture and its drift claim stay checkable here.
+
+    The bundle's whole point is that two named causes, and only two, separate
+    the boundary wildcat-app-v2 committed from a rescan of the same tree. That
+    claim is reproducible in that repository and nowhere else, so both
+    documents are frozen beside the prose and the drift is recomputed with the
+    shipped comparison rather than restated.
+    """
+
+    def setUp(self):
+        self.lines = capture_lines(BUNDLE_10, "cigate")
+        self.committed = json.loads(CI_GATE_COMMITTED.read_text(encoding="utf-8"))
+        self.rescan = json.loads(CI_GATE_RESCAN.read_text(encoding="utf-8"))
+
+    def test_the_quoted_figures_equal_the_committed_boundary(self):
+        self.assertEqual(self.committed["schema"], 2)
+        self.assertEqual(self.committed["universe"], "tracked")
+        self.assertEqual(int(self.lines["entries"]), len(self.committed["entries"]))
+        self.assertEqual(
+            int(self.lines["hard_bytes"]),
+            sum(entry["bytes"] for entry in self.committed["entries"]),
+        )
+        self.assertEqual(
+            int(self.lines["committed_files_walked"]),
+            self.committed["counts"]["files_walked"],
+        )
+        self.assertTrue(
+            all(entry["grade"] == "hard" for entry in self.committed["entries"])
+        )
+
+    def test_the_rescan_carries_the_same_entries_at_a_moved_count(self):
+        self.assertEqual(
+            int(self.lines["rescan_files_walked"]),
+            self.rescan["counts"]["files_walked"],
+        )
+        self.assertEqual(len(self.rescan["entries"]), len(self.committed["entries"]))
+        self.assertEqual(
+            sum(entry["bytes"] for entry in self.rescan["entries"]),
+            sum(entry["bytes"] for entry in self.committed["entries"]),
+        )
+
+    def test_exactly_the_two_recorded_causes_drift(self):
+        drifted = horos.diff_boundary_documents(self.committed, self.rescan)
+        self.assertEqual(len(drifted), int(self.lines["drifted_paths"]))
+        paths = [path for path, _ in drifted]
+        self.assertEqual(
+            sorted(paths),
+            sorted([".horos/boundary.json#counts", "prisma/migrations/migration_lock.toml"]),
+        )
+        reasons = dict(drifted)
+        self.assertIn("field changed", reasons[".horos/boundary.json#counts"])
+        self.assertIn(
+            "on a comment-led line",
+            reasons["prisma/migrations/migration_lock.toml"],
+        )
+
+    def test_the_recipe_pins_a_commit_and_runs_the_check(self):
+        recipe = CI_RECIPE.read_text(encoding="utf-8")
+        pins = re.findall(r"HOROS_REF: ([0-9a-f]{40})\b", recipe)
+        self.assertEqual(len(pins), 1)
+        self.assertIn('"$HOROS_SCRIPT" check .', recipe)
+        self.assertIn("docs/adoption/ci.md", (PLUGIN / "README.md").read_text(encoding="utf-8"))
 
 
 class OutlineResultsShapeTests(unittest.TestCase):


### PR DESCRIPTION
Filed against [#1357](https://github.com/wildcat-finance/skills/issues/1357), which asks for the TypeScript marking landed in its target repository with a CI job running `horos check` on every push. The issue declares `Fiat-Required: 0`, so no controller run was started; Horos's ledger is `mature` at `horos-v12.3.3`, so no version moves here either. This is ordinary target delivery, recorded in the repository that owns the tool.

**It does not close #1357.** The reason is in the last section.

## What was found

`wildcat-app-v2` already carries three of the four things the issue names, and it has since August:

- [wildcat-app-v2#360](https://github.com/wildcat-finance/wildcat-app-v2/pull/360) merged into `develop` on 2026-08-19 as `b15b9e459648ba9be92f90e61eecdbda9875e3fc`, and reached the default branch `main` on 2026-08-20 inside `01191ed39f06b4445f79fd00ab470fcc70d2d8e8`.
- At `main` today, `564a189bb9cdc9394b3fd4f444531a261ada99b3`: `.horos/boundary.json` at schema 2 with 13 hard entries binding 13,407,206 bytes, `.horos/candidates.json` with 117 candidates, `.horos/census.json` at 1,123 files and 17,089,542 bytes, and the AGENTS.md stanza byte for byte as `scan --write` prints it today.
- The workflows there are `commitlint.yml`, `release-please.yml` and `vercel-purge.yml`. **None of them runs `horos check`.**

`horos check .` against that default branch exits 1 on two drifted paths, and there are exactly two causes. The `horos-v10.3.3` comment-led marker rule rewrote one evidence string on `prisma/migrations/migration_lock.toml`; and `counts.files_walked` reads 1,051 against a rescan's 1,053, because two tracked files arrived after the boundary was written. At the merge commit the first cause is the whole difference: the marking was current for the tree it described on the day it landed.

## What this lands

- `plugins/horos/docs/evidence/wildcat-app-v2-ci-gate.md`, the bundle recording the above, with both boundary documents frozen beside it (`wildcat-app-v2.boundary.main.json`, the copy the default branch carries, and `wildcat-app-v2.boundary.main-rescan.json`, a rescan of the same tree). The drift claim is recomputed by `horos.diff_boundary_documents` in the test rather than restated in prose.
- `plugins/horos/docs/adoption/ci.md`, the workflow that closes the gap, with its classifier pin, its untracked checkout path, and its recurring cost named. It was run against `main` with the artefacts regenerated: `boundary matches the tree`, exit 0.
- Four cases in `plugins/horos/tests/test_evidence.py` binding the bundle's figures, the rescan, the two drift causes and the recipe's pin.
- One paragraph in `plugins/horos/README.md` pointing the adoption section at the recipe.
- Regenerated `.horos/boundary.json` and `.horos/census.json` for the files this branch adds.

## Evidence

- `plugins/horos/tests/test_evidence.py`: 29 tests, OK.
- `.githooks/greenlight`: **1,627 of 1,628.** The one failure is `test_python_contract.PythonRuntimeContractTests::test_current_runtime_prose_points_to_the_pin`, and every path it names sits under `.claude/worktrees/` in other sessions' checkouts. None comes from this diff, those directories are untracked and absent on CI, and clearing them is not this branch's to do. The commit was made with the gate's own `FIAT_SKIP_PRECOMMIT=1` escape for that reason.
- `imprimatur`: 100.0/100, zero defects, on both new documents and the README.
- `horos check .` on this tree: `boundary matches the tree`, exit 0.

The stale-boundary rejection the issue asks for was demonstrated twice against `main` with the boundary freshly regenerated and green: a new tracked file carrying a generation marker gave exit 1 on two drifted paths, and one byte changed by hand in a committed entry gave exit 1 on one. Both are recorded in the bundle.

## What it does not establish

That the gate runs in `wildcat-app-v2`. **Nothing was pushed there and no pull request was opened there.** The check results were produced locally against clean checkouts of the public repository, so they are evidence about those exact trees under that exact classifier version, not about a run GitHub performed.

## Why #1357 stays open

Its done-condition is the pull request merged and the CI check green on the default branch of `wildcat-app-v2`. The marking half is merged and was verified here; the CI half is not, and landing it needs two decisions that are not mine:

1. **Which base.** `main` is protected, takes pull requests only from `develop` and `release-please`, and requires review plus two Snyk checks. `develop` is the route #360 used, and reaches `main` on the next aggregation.
2. **Whether the cost is accepted.** `counts.files_walked` is a compared field, so the gate reddens any app-v2 pull request that adds or removes a tracked file until its author commits a regenerated boundary. On an active frontend repository that is a real recurring tax, and the people who would pay it should agree to it before the workflow lands.

The workflow is written, validated and quoted in the recipe, so both decisions are one commit away from being acted on.

```carryover
horos-ci-in-app-v2 | none | the CI job belongs in wildcat-app-v2, not here; #1357 stays open and holds it, with the two decisions above named in its next comment
```
