### PR TITLE
Anamnesis: give the declared-scope refusal the event it is said to leave

### DIFF
--- a/.horos/census.json
+++ b/.horos/census.json
@@ -8,7 +8,7 @@
     },
     {
       "boundary_bytes": 1485,
-      "bytes": 20185522,
+      "bytes": 20185975,
       "files": 1058,
       "suffix": ".md"
     },
@@ -26,7 +26,7 @@
     },
     {
       "boundary_bytes": 73,
-      "bytes": 12412914,
+      "bytes": 12416743,
       "files": 579,
       "suffix": ".py"
     },
@@ -189,6 +189,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 102174614,
+  "total_bytes": 102178896,
   "total_files": 2970
 }

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ command writes a report to a path that must not already exist.
 
 ### ANAMNESIS REBUILDS A PRESERVED AUDIT CORPUS
 
-<!-- front-door:demo skill="anamnesis" claim="anamnesis-corpus-demo" digest="eef87f229172adedd580df6932048f9530e89db7db335fe2a62abcc38cb9ce85" -->
+<!-- front-door:demo skill="anamnesis" claim="anamnesis-corpus-demo" digest="0a28ca71b97a7a2465ce65280679bb1cc43ec38e3f926b2ddbaa0980b76c62fa" -->
 [Anamnesis](./plugins/anamnesis) admits, curates and projects the pilot audit
 specimen from the producer's own bytes.
 

--- a/plugins/anamnesis/skills/anamnesis/DEMONSTRATION.md
+++ b/plugins/anamnesis/skills/anamnesis/DEMONSTRATION.md
@@ -2,7 +2,7 @@
 
 Contract: `plugins/hexaemeron/skills/DEMONSTRATIONS.md`
 
-- Current demonstration version: `anamnesis-demo-v0.2.0`
+- Current demonstration version: `anamnesis-demo-v0.3.0`
 - Demo frontier status: `open`
 - Demo frontier revision: `second-preserved-audit-corpus`
 - Current demonstration: The pilot specimen runs the whole admission-to-projection path over preserved bytes.
@@ -32,7 +32,7 @@ Contract: `plugins/hexaemeron/skills/DEMONSTRATIONS.md`
       "id": "program",
       "class": "repository",
       "path": "plugins/anamnesis/skills/anamnesis/scripts/anamnesis.py",
-      "sha256": "d1f5d8afea9dbf909af9cb814901f35e479763b0f65abbd51646f365a99eae80"
+      "sha256": "5cdee6bad6d18f836103404a00f5bfda312bce11b295590c42dcb94d3867d8d7"
     }
   ],
   "commands": [
@@ -55,7 +55,7 @@ Contract: `plugins/hexaemeron/skills/DEMONSTRATIONS.md`
     "run: line \"4. Synkrisis cohort cohort:41d640fb168049d5: 41 included against 41 findings; 0 exclusion(s), 144 unknown(s)\""
   ],
   "frontier": {
-    "version": "anamnesis-demo-v0.2.0",
+    "version": "anamnesis-demo-v0.3.0",
     "status": "open",
     "revision": "second-preserved-audit-corpus",
     "sha256": "04859403f738c0e6c358e794307f9db5abecd53f5ec8ec2dd7a2863886086374",
@@ -71,3 +71,4 @@ Contract: `plugins/hexaemeron/skills/DEMONSTRATIONS.md`
 | --- | --- | --- | --- | --- | --- |
 | `anamnesis-demo-v0.1.0` | baseline | `second-preserved-audit-corpus` | `04859403f738c0e6c358e794307f9db5abecd53f5ec8ec2dd7a2863886086374` | `adr/govern-real-data-demonstrations-separately` | The demonstration lane starts here. Status `real-data` is decided by the material inputs above, not by the prose. |
 | `anamnesis-demo-v0.2.0` | generation | `second-preserved-audit-corpus` | `04859403f738c0e6c358e794307f9db5abecd53f5ec8ec2dd7a2863886086374` | `adr/declared-corpus-scope`, [test_s8_scope.py](../../tests/test_s8_scope.py) | The pilot was re-released under a declared corpus scope and the record re-pinned to the new program digest and release id without moving the demo frontier. |
+| `anamnesis-demo-v0.3.0` | generation | `second-preserved-audit-corpus` | `04859403f738c0e6c358e794307f9db5abecd53f5ec8ec2dd7a2863886086374` | `issue/1465`, [test_s8_scope.py](../../tests/test_s8_scope.py) | `verify` takes an optional event sink, so the declared-scope refusal leaves the durable event an operator is told to read. The record is re-pinned to the new program digest; the release id, the observations and the demo frontier are unmoved. |

--- a/plugins/anamnesis/skills/anamnesis/scripts/anamnesis.py
+++ b/plugins/anamnesis/skills/anamnesis/scripts/anamnesis.py
@@ -1068,8 +1068,13 @@ def check_manifest_shape(manifest):
     return manifest
 
 
-def verify_release(out):
-    """Recompute every component digest from the bytes on disk."""
+def verify_release(out, events=None):
+    """Recompute every component digest from the bytes on disk.
+
+    `events` is optional. A caller that wants the declared-scope refusal on a
+    durable stream supplies a sink; a caller that does not gets the identical
+    refusal with nothing written.
+    """
     manifest_path = os.path.join(out, "manifest.json")
     raw = read_bounded(manifest_path, MAX_POLICY_BYTES, "release manifest")
     try:
@@ -1144,17 +1149,28 @@ def verify_release(out):
         raise Refusal("A119", "manifest counts differ from the released components")
     # Both sides of this comparison are inside the release, so a release says
     # for itself whether it holds exactly the sources its scope declares.
-    scope = manifest["policy"].get("scope")
-    if not isinstance(scope, dict) or not isinstance(scope.get("sources"), list):
-        raise Refusal("A077", "manifest policy declares no scope sources")
-    declared = set(scope["sources"])
-    listed = {source["id"] for source in manifest["sources"]}
-    if declared != listed:
-        raise Refusal(
-            "A077",
-            f"manifest sources {sorted(listed)} differ from the declared scope "
-            f"sources {sorted(declared)}",
-        )
+    #
+    # This is the one check the declared scope owns, and an operator asking why
+    # a release was refused is told to read that answer off the event stream, so
+    # it runs inside the recorded span. The refusals above it belong to release
+    # integrity and are raised before the policy bytes that key a correlation id
+    # have been recomputed, so they stay outside it.
+    with refusals_recorded(
+        events if events is not None else Events(),
+        policy.get("version"),
+        hashlib.sha256(bodies["policy.json"]).hexdigest(),
+    ):
+        scope = manifest["policy"].get("scope")
+        if not isinstance(scope, dict) or not isinstance(scope.get("sources"), list):
+            raise Refusal("A077", "manifest policy declares no scope sources")
+        declared = set(scope["sources"])
+        listed = {source["id"] for source in manifest["sources"]}
+        if declared != listed:
+            raise Refusal(
+                "A077",
+                f"manifest sources {sorted(listed)} differ from the declared scope "
+                f"sources {sorted(declared)}",
+            )
     return manifest, checked_bodies
 
 
@@ -1554,7 +1570,7 @@ def cmd_release(args):
 
 
 def cmd_verify(args):
-    manifest, _ = verify_release(args.release)
+    manifest, _ = verify_release(args.release, Events(args.events))
     print(
         f"verified {manifest['release_id']}: "
         f"{len(manifest['components'])} component(s), "
@@ -1768,6 +1784,7 @@ def build_parser():
     verify = sub.add_parser(
         "verify", help="recompute every component digest in a release")
     verify.add_argument("--release", required=True)
+    verify.add_argument("--events", default=None)
     verify.set_defaults(handler=cmd_verify)
 
     measure = sub.add_parser(

--- a/plugins/anamnesis/tests/test_s8_scope.py
+++ b/plugins/anamnesis/tests/test_s8_scope.py
@@ -173,6 +173,61 @@ class ScopeRefusals(PilotFixture):
                 refusal = self.refusal(lambda: anamnesis.verify_release(out))
                 self.assertEqual(refusal.code, "A077")
 
+    def test_the_scope_refusal_emits_its_rule_policy_and_correlation_id(self):
+        """The signal an operator is told to read: verify takes a sink, so the
+        one refusal the declared scope owns leaves a durable event rather than
+        only an exit code."""
+        policy = copy.deepcopy(self.policy)
+        policy["scope"]["sources"] = policy["scope"]["sources"][:-1]
+        out = str(self.scratch / "scope-refusal-emits")
+        anamnesis.build_release(out, policy, self.sources, self.graph)
+        events = anamnesis.Events()
+        self.refusal(lambda: anamnesis.verify_release(out, events))
+        refused = [e for e in events.emitted if e["event"] == "anamnesis.source.refused"]
+        self.assertEqual(len(refused), 1)
+        event = refused[0]
+        self.assertEqual(event["rule"], "A077")
+        self.assertEqual(event["policy_version"], policy["version"])
+        self.assertIsNone(event["record"])
+        self.assertEqual(len(event["correlation_id"]), 16)
+        self.assertIn("differ from the declared scope", event["reason"])
+
+    def test_the_scope_refusal_is_identical_without_a_sink(self):
+        """The sink is optional and adds nothing to the refusal itself."""
+        policy = copy.deepcopy(self.policy)
+        policy["scope"]["sources"] = policy["scope"]["sources"][:-1]
+        out = str(self.scratch / "scope-refusal-sinkless")
+        anamnesis.build_release(out, policy, self.sources, self.graph)
+        sunk = anamnesis.Events()
+        with_sink = self.refusal(lambda: anamnesis.verify_release(out, sunk))
+        without = self.refusal(lambda: anamnesis.verify_release(out))
+        self.assertEqual((without.code, without.message), (with_sink.code, with_sink.message))
+
+    def test_verify_writes_the_scope_refusal_to_a_named_stream(self):
+        """The command threads the sink, so an operator gets the event on disk."""
+        policy = copy.deepcopy(self.policy)
+        policy["scope"]["sources"] = policy["scope"]["sources"][:-1]
+        out = str(self.scratch / "scope-refusal-stream")
+        anamnesis.build_release(out, policy, self.sources, self.graph)
+        stream = self.scratch / "events.jsonl"
+        run = subprocess.run(
+            [sys.executable, str(SCRIPT), "verify", "--release", out,
+             "--events", str(stream)],
+            capture_output=True, text=True, cwd=str(WORKTREE),
+        )
+        self.assertEqual(run.returncode, 1)
+        lines = stream.read_text(encoding="utf-8").strip().splitlines()
+        self.assertEqual(len(lines), 1)
+        event = json.loads(lines[0])
+        self.assertEqual(event["event"], "anamnesis.source.refused")
+        self.assertEqual(event["rule"], "A077")
+
+    def test_a_verified_release_emits_nothing(self):
+        """No refusal, no event: the sink is for refusals alone."""
+        events = anamnesis.Events()
+        anamnesis.verify_release(str(RELEASE), events)
+        self.assertEqual(events.emitted, [])
+
 
 class ScopeInTheReleaseId(PilotFixture):
     def test_a_one_byte_change_to_any_scope_field_changes_the_release_id(self):


### PR DESCRIPTION
Closes #1465.

## What was wrong

The corpus-scope study says of `A073`, `A074`, `A075`, `A076` and `A077` that they "are raised inside the `refusals_recorded` boundary and so emit `anamnesis.source.refused` with the rule, the record, the policy version and the correlation id". That held for four of them. `A077` is raised in `verify_release`, which took no events sink, so a release whose manifest sources differed from its declared scope refused and recorded nothing. The study is receipted and immutable, so the code moves to meet it.

## What changed

`verify_release(out, events=None)` takes an optional sink. `cmd_verify` supplies one from a new `verify --events` flag.

The recorded span covers the declared-scope check alone. The refusals above it — `A103`, `A104`, `A105`, `A117`, `A118`, `A119`, `A123` — are release-integrity checks the study makes no signal claim about, and `A101`, `A102` and `A108` are raised before the policy bytes that key a correlation id have been recomputed. A code comment states that boundary.

The correlation id is keyed from the released `policy.json` digest recomputed from verified bytes, and the policy version from the released policy the manifest has already been proved to match (`A117`). The refusal itself is byte-identical with or without a sink.

## Tests

Four in `plugins/anamnesis/tests/test_s8_scope.py`:

1. the emitted event carries rule `A077`, the policy version, a `null` record and a 16-character correlation id;
2. the refusal code and message are identical with and without a sink;
3. `verify --release ... --events ...` exits 1 and writes exactly one JSONL event;
4. a release that verifies emits nothing.

## Re-pins

The program bytes moved, so:

- `DEMONSTRATION.md` re-pins the `program` source digest and records the generation at `anamnesis-demo-v0.3.0`; the release id, the observations and the demo frontier are unmoved.
- `README.md` re-pins the front-door demo card digest.
- `.horos/census.json` is rescanned.

## Evidence

`python3 scripts/run_checks.py --base origin/main` — green, ten checks:

| Check | Result |
| --- | --- |
| anamnesis-suite | passed |
| dead-code-suite | passed |
| dead-code-suppressions-check | passed |
| demonstrations-suite | passed |
| front-door-check | passed |
| joined-front-door-suite | passed |
| lint-ephoros | passed |
| lint-hypomnema | passed |
| lint-phylax | passed |
| root-suite | passed (1628 tests) |

No study, no runbook and no audit loop: the issue records `Fiat-Required: 0`.

## Not established

The other seven refusals in `verify_release` still emit nothing. That is deliberate and unchanged, and no document claims otherwise.
