### PR TITLE
Put titles in scope for the census and reuse the milestones we have

### DIFF
--- a/.horos/census.json
+++ b/.horos/census.json
@@ -8,7 +8,7 @@
     },
     {
       "boundary_bytes": 1485,
-      "bytes": 20190670,
+      "bytes": 20191936,
       "files": 1058,
       "suffix": ".md"
     },
@@ -26,7 +26,7 @@
     },
     {
       "boundary_bytes": 73,
-      "bytes": 12416743,
+      "bytes": 12419733,
       "files": 579,
       "suffix": ".py"
     },
@@ -189,6 +189,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 102183591,
+  "total_bytes": 102187847,
   "total_files": 2970
 }

--- a/.horos/census.json
+++ b/.horos/census.json
@@ -8,7 +8,7 @@
     },
     {
       "boundary_bytes": 1485,
-      "bytes": 20185975,
+      "bytes": 20190670,
       "files": 1058,
       "suffix": ".md"
     },
@@ -189,6 +189,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 102178896,
+  "total_bytes": 102183591,
   "total_files": 2970
 }

--- a/.horos/census.json
+++ b/.horos/census.json
@@ -26,7 +26,7 @@
     },
     {
       "boundary_bytes": 73,
-      "bytes": 12419733,
+      "bytes": 12428262,
       "files": 579,
       "suffix": ".py"
     },
@@ -189,6 +189,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 102187847,
+  "total_bytes": 102196376,
   "total_files": 2970
 }

--- a/docs/decisions/ADR-014-reallocate-the-live-wave-atlas-from-a-complete-census.md
+++ b/docs/decisions/ADR-014-reallocate-the-live-wave-atlas-from-a-complete-census.md
@@ -99,6 +99,88 @@ misstates what happened to the superseded alpha, beta, and Handover milestones.
 That correction needs its own amendment and a decision about whether closed
 issues should carry a Wave at all.
 
+## Amendment: Titles are in scope, and a refresh reuses the milestones it has (2026-09-08)
+
+The Context section lists titles among the surfaces outside the authorised
+mutation. That is wrong, and the maintainer corrected it on 2026-09-08. A title
+is where an issue declares its queue, so a census that may not touch titles
+cannot repair the one field the queue is read from.
+
+This amendment authorises two further mutations and withdraws one instruction.
+
+1. **An open issue's title may be edited to make it name its queue.** The four
+   forms are `{skill}-next: <summary>`, `{skill}-N: <summary>`,
+   `{skill}-wish: <summary>` and `framework-N: <summary>`, and
+   `hexctl issue-check` is the reader. The filed symptom carries over verbatim;
+   only the queue token and the separator are the census's to write.
+2. **A queue label may be corrected to the one the title's queue requires.**
+   The label set is mutually exclusive: `held-job` for `{skill}-next`, `wish`
+   for `{skill}-N`, `observation` for `framework-N`, and no queue label for
+   `{skill}-wish`. Every other label stays outside the mutation, as before.
+3. **Step 4's instruction to create fresh active milestones is withdrawn for a
+   refresh.** It reads "Create fresh active milestones instead of retitling the
+   prior beta milestones", which was right for the one-time move off the alpha
+   and beta queues and is wrong every time after: run repeatedly it grows the
+   milestone list rather than refreshing it, and Waves 19 to 22 were added that
+   way on 2026-09-06 on top of Wave 0 to 18, Δ, μ and Π. A refresh assigns into
+   the milestones that already exist. Creating a Wave now needs its own
+   decision.
+
+Filing prose outside the delimited status block is still never rewritten, and
+`framework-N` numbers are still assigned by hand, which is the defect recorded
+below rather than something this amendment fixes.
+
+### What was done under this amendment
+
+Read at `wildcat-finance/skills@f0ef9266` on 2026-09-08 across 269 open issues,
+with the filing contract as it landed in `0ad3e363` on 2026-09-05.
+
+- 70 titles took `: ` where an em or en dash stood between the queue token and
+  the summary. No summary changed and no numbered token moved.
+- 32 titles that carried no queue token were given one: 25 became
+  `framework-124` through `framework-148` with the `observation` label, and 7
+  became `{skill}-wish` under the skill whose code the filing names.
+- 4 `framework-N` numbers that named two open issues each were reassigned to
+  `framework-110` through `framework-123`, together with 10 observations that
+  had no number. `framework-64`, `-74`, `-76` and `-107` now resolve to one
+  issue. `framework-73` was left alone: its duplicate is closed and the four
+  citations in `plugins/dokimasia/docs/` pin the open issue by URL.
+- 7 queue labels were corrected, and #869's bare `elenchus-wish` title gained
+  the summary its body states.
+- 97 open issues that carried no Wave were assigned into 18 existing
+  milestones. The repository held 26 milestones before and after; none was
+  created, retitled or closed.
+- 6 status blocks were written recording what `main` had already answered, on
+  #882, #887, #901, #950, #1221 and #1300. The filing prose below each block
+  was read back and is unchanged.
+
+Contract-clean open issues went from 49 to 122 of 269.
+
+### What this amendment does not settle
+
+Two classes are left open on purpose, because each needs a decision this
+document cannot make on its own.
+
+The first is the `framework-N` body opening. The contract requires such a body
+to open with exactly "Protasis decides which skill or skills this observation
+upgrades. The filer is the wrong party to guess.", and 90 open bodies do not
+carry that sentence at all. Rule 3 above keeps filing prose unrewritten, so the
+contract currently refuses bodies it is not permitted to repair. Either the rule
+is prospective from `0ad3e363` and the reader should say so, or the sentence is
+insertable and this document must authorise that too.
+
+The second is the kickoff queue. 54 open issues are titled
+`kickoff/{skill}-{n}: <summary>` and every one was filed after the contract
+landed, so none of them is legacy drift. They cannot become `{skill}-next`,
+because that queue is one held job per skill ledger, and calling them
+`{skill}-N` would file frontier work as wishes. They are a fifth queue, and they
+now carry a `kickoff` label created for them on 2026-09-08. Registering that
+queue is a change to the contract in `hexctl`, not to this record.
+
+Nothing here assigns a `framework-N` number automatically, and nothing here
+checks that two issues do not share one. That gap is what produced the six
+collisions above.
+
 ## Alternatives
 
 - **Patch only the issues added since the previous census.** This would be

--- a/docs/decisions/ADR-014-reallocate-the-live-wave-atlas-from-a-complete-census.md
+++ b/docs/decisions/ADR-014-reallocate-the-live-wave-atlas-from-a-complete-census.md
@@ -154,22 +154,43 @@ with the filing contract as it landed in `0ad3e363` on 2026-09-05.
   #882, #887, #901, #950, #1221 and #1300. The filing prose below each block
   was read back and is unchanged.
 
-Contract-clean open issues went from 49 to 122 of 269.
+Contract-clean open issues went from 49 to 122 of the 269 open when the census
+was read. Four observations were then filed from what it found, and the reader
+change this amendment authorises clears the whole `framework-N` opening class,
+which takes the count to 208 of 273.
 
-### What this amendment does not settle
+What is left is 54 `kickoff/` titles, which need the fifth queue form named
+below, and 11 bodies missing a `Fiat-Required` line or a `carryover` block.
+Those 11 are body edits rule 3 still forbids, and unlike the opening they
+cannot be relaxed: `init` refuses on both, so the issue is unstartable rather
+than merely unchecked. They need their own decision.
 
-Two classes are left open on purpose, because each needs a decision this
-document cannot make on its own.
+### The `framework-N` body opening binds a candidate, not a filed issue
 
-The first is the `framework-N` body opening. The contract requires such a body
-to open with exactly "Protasis decides which skill or skills this observation
-upgrades. The filer is the wrong party to guess.", and 90 open bodies do not
-carry that sentence at all. Rule 3 above keeps filing prose unrewritten, so the
-contract currently refuses bodies it is not permitted to repair. Either the rule
-is prospective from `0ad3e363` and the reader should say so, or the sentence is
-insertable and this document must authorise that too.
+The contract requires such a body to open with exactly "Protasis decides which
+skill or skills this observation upgrades. The filer is the wrong party to
+guess.", and 90 open bodies do not carry that sentence at all. Rule 3 above
+keeps filing prose unrewritten, so the contract was refusing bodies it is not
+permitted to repair.
 
-The second is the kickoff queue. 54 open issues are titled
+The maintainer settled this on 2026-09-08: the rule is prospective, and it binds
+a candidate rather than an issue that is already filed. `issue-check --body`
+enforces the opening, because a candidate can still be edited before it is
+published. `issue-check --issue` does not, because that body is a filed record
+this document protects.
+
+Reading the rule this way rather than by filing date is what keeps the two
+readers agreeing. A date rule needs the issue's creation time, which only the
+REST path carries, so `--body` could not apply it at all; and it would still
+leave 13 filed bodies faulting on a sentence nothing may insert. The candidate
+reading needs no date, no exemption list and no edit to a filed body, and it
+refuses the next badly-formed filing exactly as before.
+
+Nothing here weakens the rule for new work. A `framework-N` issue filed after
+this is checked before it is published, which is the only moment the sentence
+can still be added.
+
+The kickoff queue is a separate matter. 54 open issues are titled
 `kickoff/{skill}-{n}: <summary>` and every one was filed after the contract
 landed, so none of them is legacy drift. They cannot become `{skill}-next`,
 because that queue is one held job per skill ledger, and calling them

--- a/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
+++ b/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
@@ -101,7 +101,9 @@ FIAT_REQUIRED_LINE_RE = re.compile(
 FIAT_REQUIRED_VALUES = ("0", "1")
 ISSUE_BODY_BYTES_MAX = 262144
 ISSUE_TITLE_BYTES_MAX = 512
-ISSUE_QUEUE_LABELS = frozenset(("held-job", "wish", "observation"))
+ISSUE_QUEUE_LABELS = frozenset(
+    ("held-job", "wish", "observation", "kickoff")
+)
 FRAMEWORK_ISSUE_OPENING = (
     "Protasis decides which skill or skills this observation upgrades. "
     "The filer is the wrong party to guess."
@@ -112,6 +114,15 @@ FRAMEWORK_ISSUE_TITLE_RE = re.compile(
 SKILL_ISSUE_TITLE_RE = re.compile(
     r"^(?P<skill>[a-z0-9]+(?:-[a-z0-9]+)*)-"
     r"(?P<kind>next|wish|[1-9][0-9]*): (?P<summary>\S.*)$"
+)
+# The kickoff queue holds a skill's ordered future frontier jobs, many per
+# skill, which is why it is not `{skill}-next`: that queue is the one held job
+# a ledger carries. It keeps `held-job` for exactly that reason, so closing a
+# kickoff issue still increments the evolution counter, and adds `kickoff` to
+# say which of the two queues it sits in.
+KICKOFF_ISSUE_TITLE_RE = re.compile(
+    r"^kickoff/(?P<skill>[a-z0-9]+(?:-[a-z0-9]+)*)-"
+    r"(?P<number>[1-9][0-9]*): (?P<summary>\S.*)$"
 )
 
 # The status block ADR-014's amendment authorises: one span at the top of an open
@@ -4854,9 +4865,10 @@ def issue_queue_contract(
 ) -> tuple[dict, list[str]]:
     """The canonical queue selected by one publishable issue title.
 
-    The repository has four queues, not a free-form title convention. Queue
-    labels are checked as one mutually exclusive set while unrelated labels
-    remain allowed. A framework observation also carries the exact opening
+    The repository has five queues, not a free-form title convention. Queue
+    labels are checked as one set while unrelated labels remain allowed. Four
+    of the five take exactly one label, or none; the kickoff queue takes two,
+    because it is a `held-job` that also says which queue holds it. A framework observation also carries the exact opening
     that leaves ownership for Protasis to decide.
 
     That opening is asked of a candidate only. ADR-014's 2026-09-08 amendment
@@ -4878,9 +4890,14 @@ def issue_queue_contract(
     if _contains_nonprinting_character(title):
         faults.append(f"{label} title contains a control character")
     framework = FRAMEWORK_ISSUE_TITLE_RE.fullmatch(title)
-    skill = None if framework else SKILL_ISSUE_TITLE_RE.fullmatch(title)
+    kickoff = None if framework else KICKOFF_ISSUE_TITLE_RE.fullmatch(title)
+    skill = None if framework or kickoff else SKILL_ISSUE_TITLE_RE.fullmatch(title)
     if framework:
         queue, required_label, owner = "framework-N", "observation", "framework"
+    elif kickoff:
+        queue = "kickoff/{skill}-N"
+        required_label = ["held-job", "kickoff"]
+        owner = kickoff.group("skill")
     elif skill:
         owner = skill.group("skill")
         kind = skill.group("kind")
@@ -4893,12 +4910,18 @@ def issue_queue_contract(
     else:
         faults.append(
             f"{label} title is not one of `{{skill}}-next: <summary>`, "
-            f"`{{skill}}-N: <summary>`, `{{skill}}-wish: <summary>`, or "
+            f"`{{skill}}-N: <summary>`, `{{skill}}-wish: <summary>`, "
+            f"`kickoff/{{skill}}-N: <summary>`, or "
             "`framework-N: <summary>`"
         )
 
     queue_labels = sorted(set(labels) & ISSUE_QUEUE_LABELS)
-    expected = [] if required_label is None else [required_label]
+    if required_label is None:
+        expected = []
+    elif isinstance(required_label, str):
+        expected = [required_label]
+    else:
+        expected = sorted(required_label)
     if queue is not None and queue_labels != expected:
         actual = ", ".join(f"`{value}`" for value in queue_labels) or "none"
         wanted = ", ".join(f"`{value}`" for value in expected) or "no queue label"
@@ -4930,6 +4953,47 @@ def issue_queue_contract(
         "title": title,
         "labels": sorted(set(labels)),
     }, faults
+
+
+def framework_number_owners(
+    base_dir: str, repository: str, number: str, label: str,
+) -> list[int]:
+    """Every issue whose title already claims one `framework-N` number.
+
+    Read over the search endpoint rather than by listing issues: the question is
+    about one number, and a listing would page through the whole queue to answer
+    it. Search decides for itself how a title tokenises, so each hit is
+    confirmed locally against the same expression the contract uses, and a hit
+    that does not confirm is discarded rather than reported.
+
+    The number is a title token that nothing allocates, which is why this read
+    exists at all. Six numbers named two issues each on 2026-09-08, four of them
+    open against open. Issue #1476 records that and the allocation half this
+    check does not solve: two filers reading at the same moment can still pick
+    the same number, and this catches it at the filing rather than before.
+    """
+    query = f'repo:{repository} in:title "framework-{number}"'
+    path = "search/issues?q=" + urllib.parse.quote(query) + "&per_page=100"
+    payload = github_rest(base_dir, path, label)
+    items = payload.get("items")
+    if not isinstance(items, list):
+        github_unreachable(label, path, "returned items that are not an array")
+    owners = []
+    for index, item in enumerate(items, start=1):
+        if not isinstance(item, dict):
+            github_unreachable(
+                label, path, f"returned item {index} as something other than an object"
+            )
+        title = item.get("title")
+        owner = item.get("number")
+        if not isinstance(title, str) or not isinstance(owner, int):
+            github_unreachable(
+                label, path, f"returned item {index} without a text title and a number"
+            )
+        match = FRAMEWORK_ISSUE_TITLE_RE.fullmatch(title)
+        if match is not None and match.group("number") == number:
+            owners.append(owner)
+    return sorted(owners)
 
 
 def issue_label_names(payload: dict, label: str, path: str) -> list[str]:
@@ -5884,6 +5948,7 @@ def cmd_issue_check(args) -> None:
     """
     if bool(args.body) == bool(args.issue):
         die("issue-check needs exactly one of --body <path> or --issue <url>")
+    own_number = None
     if args.body:
         repository = target_repository_binding(args.dir)
         skills_contract = repository == "wildcat-finance/skills"
@@ -5912,6 +5977,7 @@ def cmd_issue_check(args) -> None:
         if identity is None:
             die(f"--issue {args.issue} is not a canonical GitHub issue URL")
         repository, number = identity
+        own_number = int(number)
         skills_contract = repository.casefold() == "wildcat-finance/skills"
         label = f"{repository}#{number}"
         payload = github_rest(
@@ -5935,6 +6001,23 @@ def cmd_issue_check(args) -> None:
             )
         else:
             record, faults = issue_contract_faults(text, label)
+    if skills_contract and record.get("queue") == "framework-N":
+        claimed = FRAMEWORK_ISSUE_TITLE_RE.fullmatch(record["title"])
+        taken = [
+            owner
+            for owner in framework_number_owners(
+                args.dir, repository, claimed.group("number"), label
+            )
+            if owner != own_number
+        ]
+        if taken:
+            held = ", ".join(f"#{owner}" for owner in taken)
+            faults.append(
+                f"{label} claims `framework-{claimed.group('number')}`, which "
+                f"{'issues' if len(taken) > 1 else 'issue'} {held} already "
+                f"carries. The number is a title token and nothing allocates "
+                f"it, so pick one no open or closed issue holds"
+            )
     for fault in faults:
         print(f"{label}: {fault}" if not fault.startswith(label) else fault,
               file=sys.stderr)

--- a/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
+++ b/plugins/hexaemeron/skills/fiat/scripts/hexctl.py
@@ -4849,7 +4849,8 @@ def issue_contract_faults(text: str, label: str) -> tuple[dict, list[str]]:
 
 
 def issue_queue_contract(
-    title: str, labels: list[str], text: str, label: str
+    title: str, labels: list[str], text: str, label: str,
+    candidate: bool = False,
 ) -> tuple[dict, list[str]]:
     """The canonical queue selected by one publishable issue title.
 
@@ -4857,6 +4858,14 @@ def issue_queue_contract(
     labels are checked as one mutually exclusive set while unrelated labels
     remain allowed. A framework observation also carries the exact opening
     that leaves ownership for Protasis to decide.
+
+    That opening is asked of a candidate only. ADR-014's 2026-09-08 amendment
+    settles it: rule 3 of the 2026-08-31 amendment keeps filing prose
+    unrewritten, so requiring the sentence of an issue that is already filed
+    refuses a body nothing is permitted to repair. A candidate can still be
+    edited before it is published, which is the only moment the sentence can be
+    added, so ``--body`` asks for it and ``--issue`` does not. Title, labels,
+    `Fiat-Required` and the carryover block are asked of both.
     """
     faults: list[str] = []
     queue = required_label = owner = None
@@ -4897,7 +4906,7 @@ def issue_queue_contract(
             f"{label} queue {queue} requires {wanted}; its queue labels are {actual}"
         )
 
-    if queue == "framework-N":
+    if queue == "framework-N" and candidate:
         lines = _unfenced_markdown_lines(text)
         span, _ = status_block_span(text, label)
         if span is not None:
@@ -4940,11 +4949,19 @@ def issue_label_names(payload: dict, label: str, path: str) -> list[str]:
 
 
 def issue_publication_contract_faults(
-    title: str, labels: list[str], text: str, label: str
+    title: str, labels: list[str], text: str, label: str,
+    candidate: bool = False,
 ) -> tuple[dict, list[str]]:
-    """The complete machine-checkable contract for a newly filed issue."""
+    """The complete machine-checkable contract for a newly filed issue.
+
+    ``candidate`` says whether these bytes can still be edited before they are
+    published. It is false by default, so every path that replays an issue
+    already on GitHub gets the reading ADR-014 protects.
+    """
     body_record, body_faults = issue_contract_faults(text, label)
-    queue_record, queue_faults = issue_queue_contract(title, labels, text, label)
+    queue_record, queue_faults = issue_queue_contract(
+        title, labels, text, label, candidate
+    )
     return {**queue_record, **body_record}, [*queue_faults, *body_faults]
 
 
@@ -5914,7 +5931,7 @@ def cmd_issue_check(args) -> None:
     if args.body:
         if skills_contract:
             record, faults = issue_publication_contract_faults(
-                args.title, args.label, text, label
+                args.title, args.label, text, label, candidate=True
             )
         else:
             record, faults = issue_contract_faults(text, label)

--- a/plugins/hexaemeron/tests/test_issue_filing_contract.py
+++ b/plugins/hexaemeron/tests/test_issue_filing_contract.py
@@ -411,9 +411,10 @@ class IssueQueueContractTests(unittest.TestCase):
     def setUpClass(cls):
         cls.hexctl = hexctl_module()
 
-    def check(self, title, labels=(), text=None):
+    def check(self, title, labels=(), text=None, candidate=True):
         return self.hexctl.issue_publication_contract_faults(
-            title, list(labels), body() if text is None else text, "candidate"
+            title, list(labels), body() if text is None else text, "candidate",
+            candidate=candidate,
         )
 
     def test_all_four_title_and_label_shapes_pass(self):
@@ -468,6 +469,48 @@ class IssueQueueContractTests(unittest.TestCase):
         )
         self.assertTrue(any("framework body must open" in fault
                             for fault in faults), faults)
+
+    def test_the_opening_is_asked_of_a_candidate_and_not_a_filed_issue(self):
+        """ADR-014's 2026-09-08 amendment makes the opening prospective.
+
+        Rule 3 of the 2026-08-31 amendment keeps filing prose unrewritten, so
+        asking a filed body for the sentence refuses a record nothing may
+        repair. A candidate can still be edited before publication, which is
+        the only moment the sentence can be added.
+        """
+        missing = body()
+        _, candidate_faults = self.check(
+            "framework-96: One", ["observation"], missing, candidate=True
+        )
+        self.assertTrue(any("framework body must open" in fault
+                            for fault in candidate_faults), candidate_faults)
+        _, filed_faults = self.check(
+            "framework-96: One", ["observation"], missing, candidate=False
+        )
+        self.assertEqual(filed_faults, [], filed_faults)
+
+    def test_a_filed_issue_still_owes_every_other_clause(self):
+        """Only the opening is relaxed. Title, labels and body stay checked."""
+        _, faults = self.check(
+            "framework-96: One", ["wish"], "Only prose.\n", candidate=False
+        )
+        self.assertTrue(any("observation" in fault for fault in faults), faults)
+        self.assertTrue(any("Fiat-Required" in fault for fault in faults), faults)
+        self.assertTrue(any("carryover" in fault for fault in faults), faults)
+        self.assertFalse(any("framework body must open" in fault
+                             for fault in faults), faults)
+
+    def test_the_publication_reader_defaults_to_the_filed_reading(self):
+        """Every REST replay path gets the reading ADR-014 protects.
+
+        `issue_publication_from_payload` and the integration replay call the
+        contract without naming a mode, so the default decides what they ask
+        of a record already on GitHub.
+        """
+        _, faults = self.hexctl.issue_publication_contract_faults(
+            "framework-96: One", ["observation"], body(), "filed"
+        )
+        self.assertEqual(faults, [], faults)
 
     def test_the_body_contract_is_part_of_the_same_result(self):
         _, faults = self.check("fiat-wish: One", [], "Only prose.\n")

--- a/plugins/hexaemeron/tests/test_issue_filing_contract.py
+++ b/plugins/hexaemeron/tests/test_issue_filing_contract.py
@@ -21,6 +21,7 @@ integration with its leftovers named in prose and disposed of nowhere.
 import json
 import os
 import subprocess
+import urllib.parse
 import unittest
 
 try:
@@ -417,11 +418,16 @@ class IssueQueueContractTests(unittest.TestCase):
             candidate=candidate,
         )
 
-    def test_all_four_title_and_label_shapes_pass(self):
+    def test_all_five_title_and_label_shapes_pass(self):
         cases = (
             ("fiat-next: Bind reused task names", ["held-job"], body()),
             ("fiat-13: Add a bounded report", ["wish"], body()),
             ("fiat-wish: Keep a later improvement", [], body()),
+            (
+                "kickoff/fiat-4: Take the next held entry",
+                ["held-job", "kickoff"],
+                body(),
+            ),
             (
                 "framework-96: Check prose quantities",
                 ["observation"],
@@ -448,6 +454,8 @@ class IssueQueueContractTests(unittest.TestCase):
             ("fiat-13: One", ["observation"], "wish"),
             ("fiat-wish: One", ["wish"], "no queue label"),
             ("framework-96: One", ["wish"], "observation"),
+            ("kickoff/fiat-4: One", ["held-job"], "`held-job`, `kickoff`"),
+            ("kickoff/fiat-4: One", ["kickoff"], "`held-job`, `kickoff`"),
         )
         for title, labels, expected in cases:
             text = body()
@@ -460,6 +468,39 @@ class IssueQueueContractTests(unittest.TestCase):
     def test_unrelated_labels_do_not_change_the_queue(self):
         _, faults = self.check(
             "fiat-wish: One", ["origin:ai", "only-pr-needed"]
+        )
+        self.assertEqual(faults, [], faults)
+
+    def test_the_kickoff_queue_keeps_held_job_and_adds_its_own_label(self):
+        """A kickoff issue is a held job that says which queue holds it.
+
+        It cannot be `{skill}-next`, because that queue is the one held job a
+        ledger carries and a skill has several kickoff entries. It cannot be
+        `{skill}-N` either, because that queue requires `wish` and would file
+        frontier work as an improvement, changing what closing it means.
+        """
+        record, faults = self.check(
+            "kickoff/alexandria-23: Component budget",
+            ["held-job", "kickoff", "origin:ai", "fiat-run-needed"],
+        )
+        self.assertEqual(faults, [], faults)
+        self.assertEqual(record["queue"], "kickoff/{skill}-N")
+        self.assertEqual(record["owner"], "alexandria")
+
+    def test_a_kickoff_title_needs_a_skill_and_a_number(self):
+        for title in ("kickoff/fiat: No number", "kickoff/Fiat-4: Wrong case",
+                      "kickoff/fiat-0: Zero", "kickoff/fiat-4:No space",
+                      "kickoff/: Nothing"):
+            with self.subTest(title=title):
+                _, faults = self.check(title, ["held-job", "kickoff"])
+                self.assertTrue(any("title is not one of" in fault
+                                    for fault in faults), faults)
+
+    def test_a_kickoff_body_is_not_asked_for_the_framework_opening(self):
+        """The opening belongs to the framework queue, not to every queue."""
+        _, faults = self.check(
+            "kickoff/fiat-4: One", ["held-job", "kickoff"], body(),
+            candidate=True,
         )
         self.assertEqual(faults, [], faults)
 
@@ -516,6 +557,73 @@ class IssueQueueContractTests(unittest.TestCase):
         _, faults = self.check("fiat-wish: One", [], "Only prose.\n")
         self.assertTrue(any("Fiat-Required" in fault for fault in faults), faults)
         self.assertTrue(any("carryover" in fault for fault in faults), faults)
+
+
+class FrameworkNumberCollisionTests(unittest.TestCase):
+    """The `framework-N` number is a title token that nothing allocates.
+
+    Six numbers named two issues each on 2026-09-08, four of them open against
+    open, because no allocator and no check existed. These cover the check;
+    #1476 records the allocation half it does not solve.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.hexctl = hexctl_module()
+
+    def owners(self, items, number="107"):
+        """Read the owners of one number from a stubbed search response."""
+        calls = []
+
+        def stub(base_dir, path, label):
+            calls.append(path)
+            return {"total_count": len(items), "items": items}
+
+        original = self.hexctl.github_rest
+        self.hexctl.github_rest = stub
+        try:
+            result = self.hexctl.framework_number_owners(
+                ".", "wildcat-finance/skills", number, "candidate"
+            )
+        finally:
+            self.hexctl.github_rest = original
+        return result, calls
+
+    def test_a_number_no_issue_holds_has_no_owner(self):
+        owners, calls = self.owners([])
+        self.assertEqual(owners, [])
+        self.assertEqual(len(calls), 1)
+        self.assertIn("search/issues", calls[0])
+        self.assertIn("framework-107", urllib.parse.unquote(calls[0]))
+
+    def test_every_confirmed_owner_is_reported_in_issue_order(self):
+        owners, _ = self.owners([
+            {"number": 1451, "title": "framework-107: no check walks audit/"},
+            {"number": 1436, "title": "framework-107: a conformance criterion"},
+        ])
+        self.assertEqual(owners, [1436, 1451])
+
+    def test_a_search_hit_the_title_expression_rejects_is_discarded(self):
+        """Search decides how a title tokenises; the contract decides what counts."""
+        owners, _ = self.owners([
+            {"number": 1, "title": "framework-1077: a longer number"},
+            {"number": 2, "title": "Mentions framework-107 in prose"},
+            {"number": 3, "title": "framework-107 no colon"},
+            {"number": 4, "title": "kickoff/framework-107: wrong queue"},
+            {"number": 5, "title": "framework-107: the only real one"},
+        ])
+        self.assertEqual(owners, [5])
+
+    def test_a_response_without_items_is_a_transport_refusal(self):
+        original = self.hexctl.github_rest
+        self.hexctl.github_rest = lambda base_dir, path, label: {"total_count": 0}
+        try:
+            with self.assertRaises(SystemExit):
+                self.hexctl.framework_number_owners(
+                    ".", "wildcat-finance/skills", "107", "candidate"
+                )
+        finally:
+            self.hexctl.github_rest = original
 
 
 class IssueCheckCommandTests(HexctlCase):

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -3928,7 +3928,7 @@
     "contract": "fiat-run-observation-binding/v1",
     "controller": {
       "path": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "8faac076c06f86e96156f0af52ca9beaef11dcc5a9e53bfd7e2e4af248a83f05"
+      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62"
     },
     "decision": {
       "path": "docs/decisions/ADR-024-bind-run-observation-prefixes-to-fiat-receipts.md",
@@ -4278,7 +4278,7 @@
         "transition": "deterministic export and single same-ledger restore joined to the canonical Authorises field",
         "unknowns": "outer transport, keys, remote publication, semantic truth of recorded claims and execution of the emitted directive"
       },
-      "sha256": "8faac076c06f86e96156f0af52ca9beaef11dcc5a9e53bfd7e2e4af248a83f05",
+      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "fiat-design-evidence": {
@@ -4292,7 +4292,7 @@
         "transition": "design lock, due step entry or integration entry joined to the canonical Authorises field",
         "unknowns": "criterion sufficiency, measurement validity, future pending results and environments outside the recorded evidence"
       },
-      "sha256": "8faac076c06f86e96156f0af52ca9beaef11dcc5a9e53bfd7e2e4af248a83f05",
+      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "fiat-final-integration": {
@@ -4306,7 +4306,7 @@
         "transition": "integration receipt and explicit user authority joined to the canonical Authorises field",
         "unknowns": "semantic correctness of each carryover disposition and any unrun external check"
       },
-      "sha256": "8faac076c06f86e96156f0af52ca9beaef11dcc5a9e53bfd7e2e4af248a83f05",
+      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "fiat-local-retirement": {
@@ -4320,7 +4320,7 @@
         "transition": "local archive, checkpoint-store preservation, active-state clearing and non-forced clean-worktree retirement joined to the canonical Authorises field",
         "unknowns": "underlying receipt truth, external copies and explicit forced Git adds"
       },
-      "sha256": "8faac076c06f86e96156f0af52ca9beaef11dcc5a9e53bfd7e2e4af248a83f05",
+      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "fiat-receipted-delivery": {
@@ -4334,7 +4334,7 @@
         "transition": "single next controller directive joined to the canonical Authorises field",
         "unknowns": "heterogeneous leaf values, unrun checks and receipt assertions not independently proved"
       },
-      "sha256": "8faac076c06f86e96156f0af52ca9beaef11dcc5a9e53bfd7e2e4af248a83f05",
+      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "fiat-run-observation-binding": {
@@ -4348,7 +4348,7 @@
         "transition": "non-authorising binding and explicit dependent verification joined to the canonical Authorises field",
         "unknowns": "event truth, completeness, unbound tail and unavailable observer states"
       },
-      "sha256": "8faac076c06f86e96156f0af52ca9beaef11dcc5a9e53bfd7e2e4af248a83f05",
+      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "fiat-runbook-amendment": {
@@ -4362,7 +4362,7 @@
         "transition": "canonical runbook replacement, receipt re-pin, exact source carriage and causally bound holding-or-blocked result joined to the canonical Authorises field",
         "unknowns": "semantic completeness, replacement correctness, future command success and truth of operator verdicts"
       },
-      "sha256": "8faac076c06f86e96156f0af52ca9beaef11dcc5a9e53bfd7e2e4af248a83f05",
+      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "fiat-study-amendment": {
@@ -4376,7 +4376,7 @@
         "transition": "canonical study replacement, receipt re-pin and holding-or-blocked result joined to the canonical Authorises field",
         "unknowns": "truth of the correction, correctness of holding verdicts and any unperformed runbook repair"
       },
-      "sha256": "8faac076c06f86e96156f0af52ca9beaef11dcc5a9e53bfd7e2e4af248a83f05",
+      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "fiat-version-resolution": {
@@ -4390,7 +4390,7 @@
         "transition": "newest current receipt carriage into the integration directive and the checked base-candidate merge request joined to the canonical Authorises field",
         "unknowns": "source-level compatibility, check sufficiency, label reservation and later GitHub base movement"
       },
-      "sha256": "8faac076c06f86e96156f0af52ca9beaef11dcc5a9e53bfd7e2e4af248a83f05",
+      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "hermes-baseline-promotion": {
@@ -4698,7 +4698,7 @@
         "transition": "verified decision assignment receipt carried to active sync and final integration joined to the canonical Authorises field",
         "unknowns": "decision-text correctness, publication, external merge enforcement and number reservation"
       },
-      "sha256": "8faac076c06f86e96156f0af52ca9beaef11dcc5a9e53bfd7e2e4af248a83f05",
+      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "hypomnema-decision-assignment": {

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -3928,7 +3928,7 @@
     "contract": "fiat-run-observation-binding/v1",
     "controller": {
       "path": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py",
-      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62"
+      "sha256": "58c5dce4bf614bd1f3225c04feefcf8a092e71d5d7e033b6983c9eedb9ffd7ac"
     },
     "decision": {
       "path": "docs/decisions/ADR-024-bind-run-observation-prefixes-to-fiat-receipts.md",
@@ -4278,7 +4278,7 @@
         "transition": "deterministic export and single same-ledger restore joined to the canonical Authorises field",
         "unknowns": "outer transport, keys, remote publication, semantic truth of recorded claims and execution of the emitted directive"
       },
-      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
+      "sha256": "58c5dce4bf614bd1f3225c04feefcf8a092e71d5d7e033b6983c9eedb9ffd7ac",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "fiat-design-evidence": {
@@ -4292,7 +4292,7 @@
         "transition": "design lock, due step entry or integration entry joined to the canonical Authorises field",
         "unknowns": "criterion sufficiency, measurement validity, future pending results and environments outside the recorded evidence"
       },
-      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
+      "sha256": "58c5dce4bf614bd1f3225c04feefcf8a092e71d5d7e033b6983c9eedb9ffd7ac",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "fiat-final-integration": {
@@ -4306,7 +4306,7 @@
         "transition": "integration receipt and explicit user authority joined to the canonical Authorises field",
         "unknowns": "semantic correctness of each carryover disposition and any unrun external check"
       },
-      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
+      "sha256": "58c5dce4bf614bd1f3225c04feefcf8a092e71d5d7e033b6983c9eedb9ffd7ac",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "fiat-local-retirement": {
@@ -4320,7 +4320,7 @@
         "transition": "local archive, checkpoint-store preservation, active-state clearing and non-forced clean-worktree retirement joined to the canonical Authorises field",
         "unknowns": "underlying receipt truth, external copies and explicit forced Git adds"
       },
-      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
+      "sha256": "58c5dce4bf614bd1f3225c04feefcf8a092e71d5d7e033b6983c9eedb9ffd7ac",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "fiat-receipted-delivery": {
@@ -4334,7 +4334,7 @@
         "transition": "single next controller directive joined to the canonical Authorises field",
         "unknowns": "heterogeneous leaf values, unrun checks and receipt assertions not independently proved"
       },
-      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
+      "sha256": "58c5dce4bf614bd1f3225c04feefcf8a092e71d5d7e033b6983c9eedb9ffd7ac",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "fiat-run-observation-binding": {
@@ -4348,7 +4348,7 @@
         "transition": "non-authorising binding and explicit dependent verification joined to the canonical Authorises field",
         "unknowns": "event truth, completeness, unbound tail and unavailable observer states"
       },
-      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
+      "sha256": "58c5dce4bf614bd1f3225c04feefcf8a092e71d5d7e033b6983c9eedb9ffd7ac",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "fiat-runbook-amendment": {
@@ -4362,7 +4362,7 @@
         "transition": "canonical runbook replacement, receipt re-pin, exact source carriage and causally bound holding-or-blocked result joined to the canonical Authorises field",
         "unknowns": "semantic completeness, replacement correctness, future command success and truth of operator verdicts"
       },
-      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
+      "sha256": "58c5dce4bf614bd1f3225c04feefcf8a092e71d5d7e033b6983c9eedb9ffd7ac",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "fiat-study-amendment": {
@@ -4376,7 +4376,7 @@
         "transition": "canonical study replacement, receipt re-pin and holding-or-blocked result joined to the canonical Authorises field",
         "unknowns": "truth of the correction, correctness of holding verdicts and any unperformed runbook repair"
       },
-      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
+      "sha256": "58c5dce4bf614bd1f3225c04feefcf8a092e71d5d7e033b6983c9eedb9ffd7ac",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "fiat-version-resolution": {
@@ -4390,7 +4390,7 @@
         "transition": "newest current receipt carriage into the integration directive and the checked base-candidate merge request joined to the canonical Authorises field",
         "unknowns": "source-level compatibility, check sufficiency, label reservation and later GitHub base movement"
       },
-      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
+      "sha256": "58c5dce4bf614bd1f3225c04feefcf8a092e71d5d7e033b6983c9eedb9ffd7ac",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "hermes-baseline-promotion": {
@@ -4698,7 +4698,7 @@
         "transition": "verified decision assignment receipt carried to active sync and final integration joined to the canonical Authorises field",
         "unknowns": "decision-text correctness, publication, external merge enforcement and number reservation"
       },
-      "sha256": "6a4777bd389847710ca05adf060917081f60f2000508751806dfc7e818f6dc62",
+      "sha256": "58c5dce4bf614bd1f3225c04feefcf8a092e71d5d7e033b6983c9eedb9ffd7ac",
       "source": "plugins/hexaemeron/skills/fiat/scripts/hexctl.py"
     },
     "hypomnema-decision-assignment": {


### PR DESCRIPTION
Amends ADR-014, records the census that ran under the amendment at
`wildcat-finance/skills@f0ef9266` on 2026-09-08 over all 269 open issues, and
carries the three contract changes the census asked for.

**Contract-clean open issues: 49 → 263 of 274.** The eleven that remain are the
one class still waiting on a decision, filed as
[#1479](https://github.com/wildcat-finance/skills/issues/1479).

Closes #1474, #1475, #1476.

## What the amendment changes

ADR-014's Context lists titles among the surfaces outside the authorised
mutation. A title is where an issue declares its queue, so a census that may
not touch titles cannot repair the one field the queue is read from. The
maintainer corrected that on 2026-09-08.

1. A title may be edited to make it name its queue. The filed symptom carries
   over verbatim; only the queue token and the separator change.
2. A queue label may be corrected to the one the title's queue requires.
3. Step 4's "Create fresh active milestones" is withdrawn for a refresh. It was
   right for the one-time move off the alpha and beta queues and wrong every
   time after: run repeatedly it grows the milestone list rather than
   refreshing it, and Waves 19 to 22 were added that way on 2026-09-06.

## Census results

Contract-clean open issues went from **49 to 122 of the 269** open when the census was read, and the reader change above takes it to **208 of 273**. Unmilestoned went
from **97 to 0**. The repository held **26 milestones before and after** —
none created, retitled or closed.

| Repair | Count |
| --- | --- |
| Titles given `: ` in place of a dash separator | 70 |
| Titles given a queue token they lacked | 32 |
| `framework-N` numbers reassigned or first assigned | 14 |
| Queue labels corrected | 7 |
| Open issues assigned into an existing Wave | 97 |
| Status blocks recording what `main` already answered | 6 |

Four `framework-N` numbers named two open issues each: `framework-64`, `-74`,
`-76` and `-107` now resolve to one issue. `framework-73` was left alone — its
duplicate is closed and the four citations in `plugins/dokimasia/docs/` pin the
open issue by URL.

## Obsolescence found against `origin/main`

No open issue is named as closed by any of the 710 merged pull requests. Of the
eleven citing a repo-rooted path absent from the tree, five are stale and each
now carries a status block:

- **#887** looks answered: `8bceb4e3` renamed both cited tests, and no schema
  names 429 outside the byte-pinned records under `audit/rounds/`.
- **#950**'s subject is gone: `task-admission` appears nowhere in the tree.
- **#901** cites `ADR-041-select-and-schedule-repository-checks-from-one-graph.md`,
  which is `ADR-045` on `main`.
- **#882** cites a test renamed to `tests/test_run_observation_inoculation.py`.
- **#1300**'s Goldfinch evidence went with `bcbeb995`.
- **#1221** is the opposite and now startable: `docs/decisions/drafts/` exists.

The filing prose below each block was read back and is unchanged.

## The `framework-N` opening, now settled

### The `framework-N` opening

**Prospective, and binding a candidate rather than a filed issue.** The
maintainer decided this on 2026-09-08, and both halves are in this pull request:
the amendment records the decision and `issue_queue_contract` implements it.
`issue-check --body` asks for the sentence, because a candidate can still be
edited before publication, which is the only moment it can be added.
`issue-check --issue` does not, because that body is a filed record rule 3
protects. The default is the filed reading, so `issue_publication_from_payload`
and the integration replay inherit it without naming a mode.

Reading it this way rather than by filing date is what keeps the two readers
agreeing: a date rule needs a creation time only the REST path carries, so
`--body` could not apply it at all, and it would still leave 13 filed bodies
faulting on a sentence nothing may insert.

Nothing is relaxed for new work, and nothing else is relaxed at all — title,
labels, `Fiat-Required` and the carryover block are still asked of both.
**Contract-clean open issues go from 122 to 208 of 273.** Closes #1474.

### The kickoff queue is a fifth title form

54 open issues are titled `kickoff/{skill}-{n}: <summary>`, all filed after the
contract landed. They cannot be `{skill}-next`, which is the one held job a
ledger carries, and `{skill}-N` requires `wish` and would file frontier work as
an improvement, changing what closing one means. The queue keeps `held-job` and
adds `kickoff`, making it the only queue that takes two labels. Clears 54.

### A taken `framework-N` number now refuses

`issue-check` reads the search endpoint for the number a candidate claims and
refuses one an open or closed issue already holds, confirming each hit locally
against the contract's own title expression so search's tokenising cannot widen
it. A filed issue does not collide with itself, and the pure contract function
stays offline — the read lives in the command.

It lands with no open issue violating it. The two open-against-closed pairs were
repaired by renumbering the **closed** member (#1057 → `framework-154`, #1098 →
`framework-155`), chosen over the open ones because
`plugins/dokimasia/docs/` cites `framework-73` at the open #1036. `framework-65`
stays as it is: both members are closed, and its two citations name different
issues under one number with one of them inside a byte-pinned audit record.
Allocation is untouched and stated as such on #1476.

## Left open on purpose

**Eleven bodies are unstartable**, carrying no `carryover` block and in five
cases no `Fiat-Required` line either. #1474's decision does not reach them: an
absent opening sentence leaves an issue unchecked but startable, while these two
absences make `init` refuse outright, so relaxing a reader cannot fix it — the
bytes have to arrive. Filed as
[#1479](https://github.com/wildcat-finance/skills/issues/1479).

**The kickoff queue.** 54 open issues are titled `kickoff/{skill}-{n}:` and every
one was filed after the contract landed. They cannot become `{skill}-next`, which
is one held job per skill ledger, and calling them `{skill}-N` would file
frontier work as wishes. They are a fifth queue, now carrying a `kickoff` label.
Registering it is a change to `hexctl`, not to this record.

## Checks

- `tests.test_decision_records` — 5 tests, OK
- `plugins.hexaemeron.tests.test_issue_filing_contract` — 76 tests, OK
- `tests.test_demonstrations.HorosCensusCurrencyTests` — OK after
  `horos.py scan . --census --write`
- `plugins.hexaemeron.tests.test_issue_filing_contract` — 86 tests, OK, including
  `test_the_opening_is_asked_of_a_candidate_and_not_a_filed_issue`,
  `test_a_filed_issue_still_owes_every_other_clause` and
  `test_the_publication_reader_defaults_to_the_filed_reading`, the kickoff-queue
  cases, and `FrameworkNumberCollisionTests`, which stubs the REST read so the
  check is covered without a network call
- `.githooks/greenlight` — root suite green, 1628 tests, exit 0

Each `hexctl.py` change moved its digest, which 11 entries in
`tests/promise_machine_coverage.json` record. Those were rebound by hand as the
last edit before the commit, which is what the `PM071` remedy asks for; no
result surface changed, so the field maps are untouched.

`adr-assignments` fails on this head and cannot pass. The workflow selects a pull
request from any `docs/decisions/ADR-NNN-*.md` path in the diff, including a plain
modification, then requires trailers matching an assignment composition it
reconstructs from a draft-to-numbered-file move. This amendment moves no draft and
assigns no number, so there is nothing for it to validate and no trailer set that
satisfies it. The check is not in the repository ruleset's required set, which holds
`invariants` alone, and `invariants` passes. Filed as
[#1477](https://github.com/wildcat-finance/skills/issues/1477) rather than worked
around with invented trailers.

## carryover

```carryover
kickoff-queue-title-form | filed | https://github.com/wildcat-finance/skills/issues/1475
framework-n-uniqueness-check | filed | https://github.com/wildcat-finance/skills/issues/1476
unstartable-bodies-missing-required-blocks | filed | https://github.com/wildcat-finance/skills/issues/1479
adr-assignment-gate-fires-on-amendment | filed | https://github.com/wildcat-finance/skills/issues/1477
wave-rescore-under-the-rubric | none | The 97 were placed by their skill's existing home Wave and by subject, which the amendment states; scoring them against ADR-014's 40/25/20/15 rubric is a separate pass nobody is waiting on.
```


