### PR TITLE
Stop the ADR gate reading an amendment as an assignment

### DIFF
--- a/.github/workflows/adr-assignments.yml
+++ b/.github/workflows/adr-assignments.yml
@@ -173,8 +173,20 @@ jobs:
           fi
           delta_bytes="$(wc -c <"$delta_file" | tr -d '[:space:]')"
           test "$delta_bytes" -le 262144 || refuse path-limit
+          # A record already numbered on the base is not an assignment. An
+          # in-place amendment to a merged decision moves no draft and takes no
+          # number, so counting its path would demand trailers describing a
+          # mapping that does not exist, and no author could satisfy them.
+          base_finals_file="$RUNNER_TEMP/adr-assignments-base-finals.z"
+          if ! safe_git --git-dir="$candidate_repository" ls-tree \
+            -r -z --name-only "$BASE_SHA" -- docs/decisions \
+            >"$base_finals_file"; then
+            refuse history-incomplete
+          fi
+          base_finals_bytes="$(wc -c <"$base_finals_file" | tr -d '[:space:]')"
+          test "$base_finals_bytes" -le 262144 || refuse path-limit
           finals_file="$RUNNER_TEMP/adr-assignments-finals.json"
-          if ! python3 - "$delta_file" "$finals_file" <<'PY'
+          if ! python3 - "$delta_file" "$finals_file" "$base_finals_file" <<'PY'
           import json
           from pathlib import Path
           import re
@@ -186,6 +198,10 @@ jobs:
               raise SystemExit(0)
           if raw[-1:] != b"\0":
               raise SystemExit(2)
+          base_raw = Path(sys.argv[3]).read_bytes()
+          if base_raw and base_raw[-1:] != b"\0":
+              raise SystemExit(2)
+          numbered_on_base = {path for path in base_raw.split(b"\0") if path}
           tokens = raw[:-1].split(b"\0")
           status_re = re.compile(br"[ACDMRTUXB][0-9]{0,3}")
           final_re = re.compile(
@@ -215,6 +231,8 @@ jobs:
               for path in final_candidates:
                   if final_re.fullmatch(path) is None:
                       raise SystemExit(2)
+                  if path in numbered_on_base:
+                      continue
                   finals.add(path.decode("ascii"))
           Path(sys.argv[2]).write_text(
               json.dumps(sorted(finals), separators=(",", ":")) + "\n",

--- a/.horos/census.json
+++ b/.horos/census.json
@@ -26,7 +26,7 @@
     },
     {
       "boundary_bytes": 73,
-      "bytes": 12416743,
+      "bytes": 12418049,
       "files": 579,
       "suffix": ".py"
     },
@@ -56,7 +56,7 @@
     },
     {
       "boundary_bytes": 0,
-      "bytes": 68069,
+      "bytes": 69127,
       "files": 14,
       "suffix": ".yml"
     },
@@ -189,6 +189,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 102178896,
+  "total_bytes": 102181260,
   "total_files": 2970
 }

--- a/tests/test_adr_assignment_workflow.py
+++ b/tests/test_adr_assignment_workflow.py
@@ -705,6 +705,32 @@ class WorkflowExecutionTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
         self.assertIn("mapping_count=0", output)
 
+    def test_amending_a_numbered_record_has_no_assignment(self):
+        """An in-place amendment assigns no number, so it demands no trailers.
+
+        The gate reads the diff to decide whether a candidate assigns a number.
+        A record already numbered on the base moves no draft and takes no
+        number, so a modification to one has no mapping to validate; counting it
+        would refuse `assignment-evidence` against trailers no author could
+        write. Issue #1477 records the amendment this refused.
+        """
+        existing = self.repo.source / "docs/decisions/ADR-060-existing.md"
+        write(
+            existing,
+            existing.read_text(encoding="utf-8")
+            + "\n## Amendment: correct one clause (2026-09-08)\n\n"
+            + "The decision stands; one clause was wrong.\n",
+        )
+        git(self.repo.source, "add", "docs/decisions/ADR-060-existing.md")
+        git(self.repo.source, "commit", "--quiet", "-m", "amend ADR-060")
+        candidate = git(self.repo.source, "rev-parse", "HEAD")
+        remote = self.repo.remote(candidate)
+        result, output, _summary = evaluate_workflow(
+            remote, base=self.repo.base, head=candidate
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("mapping_count=0", output)
+
     def test_preexisting_repository_symlink_is_a_fixed_refusal(self):
         write(self.repo.source / "README.md", "A repository change.\n")
         git(self.repo.source, "add", "README.md")


### PR DESCRIPTION
Closes #1477.

## What was wrong

`.github/workflows/adr-assignments.yml` picked a pull request as in scope from the diff alone:

```
diff-tree --no-commit-id --name-status -r -z "$BASE_SHA" "$HEAD_SHA" -- docs/decisions
```

Every path matching `docs/decisions/ADR-[0-9]{3}-<slug>.md` went into `finals` whatever its status letter, so a plain `M` counted the same as an `A`. With `final_count` above zero the job then reconstructed an assignment composition from a `docs/decisions/drafts/<slug>.md` to `docs/decisions/ADR-<n>-<slug>.md` move and required the head's trailers to match its mappings.

An in-place amendment moves no draft and takes no number. The reconstruction had nothing to build, so the job exited `refused (assignment-evidence)` and no trailer set could satisfy it.

## What changed

A path already numbered on the base is excluded before the count. `git ls-tree -r -z --name-only "$BASE_SHA" -- docs/decisions` supplies that set, bounded by the same 262144-byte limit the delta already uses, and refusing `history-incomplete` the same way if it cannot be read.

What still counts as an assignment:

- an addition, which is absent from the base;
- the destination of a draft-to-final rename, likewise absent;
- the destination of a final-to-final renumber, which is how `ADR-077` through `ADR-079` were corrected — the old path is excluded and the new one counts.

The path-shape refusal is untouched and still runs first, so a malformed decision path refuses before the exclusion is consulted.

## Why it mattered

Amending in place is the established way to correct a decision record: ADR-014 carries two amendment sections, one dated 2026-08-31 and one 2026-09-08. It is also the safer way, because a new numbered record has to pick a number and `ADR-024`, `ADR-050`, `ADR-076`, `ADR-077`, `ADR-078` and `ADR-079` all collided at authoring time — #888 and #1332 record that. The gate pushed an author away from the amendment and toward the collision.

The check is not in the repository ruleset's required set, which holds `invariants` alone, so a red result never blocked a merge. That is why this stayed invisible: the ten commits that amended a record on 2026-09-03 and 2026-09-04 have no `adr-assignments` result at all, and #1473 is the first to modify a numbered record with the workflow live on the pull request.

A check that cannot pass and does not block teaches a reader to ignore it.

## Checks

- `tests.test_adr_assignment_workflow` — 27 tests, OK, including the new `test_amending_a_numbered_record_has_no_assignment`.
- That test was run against the unfixed workflow and fails there with `AssertionError: 2 != 0`, the `assignment-evidence` refusal, so it fails without this change.
- `.githooks/greenlight` — root suite green, tree `ad53ea62` recorded.

```carryover
none | none | The trigger's over-reach is the complete scope; the number-collision defects it pushed authors toward are tracked on #1332 and #888.
```
