### PR TITLE
Give the fake adapter a budget a loaded machine can meet

### DIFF
--- a/.horos/census.json
+++ b/.horos/census.json
@@ -26,7 +26,7 @@
     },
     {
       "boundary_bytes": 73,
-      "bytes": 12420821,
+      "bytes": 12423496,
       "files": 579,
       "suffix": ".py"
     },
@@ -189,6 +189,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 102185196,
+  "total_bytes": 102187871,
   "total_files": 2970
 }

--- a/tests/promise_machine_coverage.json
+++ b/tests/promise_machine_coverage.json
@@ -122,7 +122,7 @@
     ],
     "tests": {
       "path": "tests/test_agent_instruction.py",
-      "sha256": "5dcd25863c25a5a203e61577319351cb50108f4109c141cb9f24060c5ea90164",
+      "sha256": "fa266a0fb9b2bd366984c81262918ec2e84347eca090c70e49872c459a68d139",
       "selectors": [
         "test_root_promise_has_complete_exact_field_inventory",
         "test_specialised_coverage_binds_promise_and_contract",

--- a/tests/test_agent_instruction.py
+++ b/tests/test_agent_instruction.py
@@ -2088,6 +2088,18 @@ class MutationTests(RefusalAssertions, unittest.TestCase):
         self.assertRefusal("WAI-E-MUTATION.EXPECTED", AI._validate_mutations, record, fixture_id, model, AI.canonical_json_bytes(model), 1)
 
 
+# The fake adapter's `sleep` mode blocks for this long, and only
+# `test_fake_timeout_refuses` runs it. Its own budget below is shorter, so the
+# deadline expires whether the machine is idle or loaded; load can only delay
+# the answer further, never bring it forward.
+FAKE_ADAPTER_SLEEP_SECONDS = 2
+# The budget every other adapter case runs under. It has to clear the time a
+# child process needs to start and answer on a machine running other suites,
+# not the time that takes when nothing else is happening. See issue 1175.
+FAKE_ADAPTER_ANSWER_BUDGET_SECONDS = "120"
+# What `test_fake_timeout_refuses` narrows to, kept below the sleep above.
+FAKE_ADAPTER_TIMEOUT_BUDGET_SECONDS = "1"
+
 FAKE_ADAPTER_SOURCE = r'''import json
 import os
 import sys
@@ -2106,7 +2118,7 @@ if command == "environment":
 
 mode = sys.argv[2]
 if mode == "sleep":
-    time.sleep(2)
+    time.sleep(__SLEEP_SECONDS__)
 if mode == "stdout-cap":
     sys.stdout.write("x" * 128)
     raise SystemExit(0)
@@ -2170,7 +2182,10 @@ class AdapterFixtureTests(RefusalAssertions):
         self.temporary = tempfile.TemporaryDirectory()
         self.root = Path(self.temporary.name)
         self.fake = self.root / "fake-runtime.py"
-        self.fake.write_text(f"#!{sys.executable}\n" + FAKE_ADAPTER_SOURCE, encoding="utf-8")
+        source = FAKE_ADAPTER_SOURCE.replace(
+            "__SLEEP_SECONDS__", str(FAKE_ADAPTER_SLEEP_SECONDS)
+        )
+        self.fake.write_text(f"#!{sys.executable}\n" + source, encoding="utf-8")
         self.fake.chmod(0o700)
 
     def tearDown(self):
@@ -2251,7 +2266,15 @@ class AdapterFixtureTests(RefusalAssertions):
                 "repository_instruction_paths": [],
                 "tool_definition_ids": [],
             },
-            "timeout_seconds": "2",
+            # Generous on purpose. Every test but `test_fake_timeout_refuses`
+            # wants the fake adapter to answer, and this budget is a wall-clock
+            # deadline on a child process inside a parallel suite. At the two
+            # seconds this held until issue 1175, a loaded machine spent the
+            # whole budget before the child could answer, so cases asserting
+            # some other refusal saw WAI-E-ADAPTER.TIMEOUT instead and the root
+            # suite's verdict depended on what else was running. Only the
+            # timeout case narrows it, and it does so locally.
+            "timeout_seconds": FAKE_ADAPTER_ANSWER_BUDGET_SECONDS,
             "max_stdout_bytes": "4096",
             "max_stderr_bytes": "4096",
             "context_window": "1024",
@@ -2555,9 +2578,35 @@ class MeasurementTests(AdapterFixtureTests, unittest.TestCase):
             path="$.fake",
         )
 
+    def test_answering_cases_are_not_racing_the_timeout_budget(self):
+        """Issue 1175: the shared budget is a deadline, not an expectation.
+
+        Every case but the one below wants an answer, so its budget has to
+        clear what a child process needs on a loaded machine. Two seconds did
+        not, and the cases that lost the race reported WAI-E-ADAPTER.TIMEOUT in
+        place of the refusal they asserted. Nothing here measures how long the
+        adapter takes; it fixes the margins that made the suite's verdict
+        depend on the machine.
+        """
+        answer = int(self.profile()["timeout_seconds"])
+        timeout = int(FAKE_ADAPTER_TIMEOUT_BUDGET_SECONDS)
+        self.assertGreaterEqual(
+            answer,
+            60,
+            "the answering budget is back within racing distance of a loaded "
+            "child process; see issue 1175",
+        )
+        self.assertLess(
+            timeout,
+            FAKE_ADAPTER_SLEEP_SECONDS,
+            "the timeout case can no longer expire, so it would stop proving "
+            "that the deadline fires",
+        )
+        self.assertLessEqual(answer, 600, "the adapter refuses a budget above 600")
+
     def test_fake_timeout_refuses(self):
         profile = self.profile(mode="sleep")
-        profile["timeout_seconds"] = "1"
+        profile["timeout_seconds"] = FAKE_ADAPTER_TIMEOUT_BUDGET_SECONDS
         self.assertRefusal(
             "WAI-E-ADAPTER.TIMEOUT",
             AI._ollama_generate,


### PR DESCRIPTION
`tests/test_agent_instruction.py` gave every fake-adapter case one two-second
wall-clock deadline. Only `test_fake_timeout_refuses` wants that deadline to
fire. On a machine running other suites the child process spent the whole
budget before answering, so cases asserting some other refusal saw
`WAI-E-ADAPTER.TIMEOUT` instead, and `python3 -m unittest discover -s tests`
returned a different verdict depending on what else was running.

Issue #1175 recorded seven such reds across five steps of one run, each green
when the module was re-run alone.

## What changed

The answering budget is now 120 seconds, named
`FAKE_ADAPTER_ANSWER_BUDGET_SECONDS`. The fake adapter's sleep and the timeout
case's own budget become `FAKE_ADAPTER_SLEEP_SECONDS` and
`FAKE_ADAPTER_TIMEOUT_BUDGET_SECONDS` beside it, so the margin that has to hold
in each direction is visible rather than implied by two literals three hundred
lines apart. Load can only delay an answer, never bring one forward, so the
timeout case still expires deterministically at one second against a two-second
sleep.

Nothing here measures how long the adapter takes. `_run_bounded` in
`scripts/agent_instruction.py` is unchanged, and so is the refusal it raises:
the deadline is the fail-closed boundary for feeding an external program, and
it belongs there. Only the fixture's margins move.

`test_answering_cases_are_not_racing_the_timeout_budget` fails if the answering
budget returns to racing distance, if the timeout case can no longer expire, or
if the budget exceeds the adapter's own 600-second cap.

`tests/promise_machine_coverage.json` binds this test file by digest and
nothing regenerates it, so its `sha256` is rebound in the same commit.

## Proof

```bash
python3 -m unittest tests.test_agent_instruction
```

`Ran 330 tests`, OK.

The guard is not vacuous: setting `FAKE_ADAPTER_ANSWER_BUDGET_SECONDS` back to
`"2"` fails `test_answering_cases_are_not_racing_the_timeout_budget`, and
restoring it returns the file to digest
`fa266a0fb9b2bd366984c81262918ec2e84347eca090c70e49872c459a68d139`.

`.githooks/greenlight` recorded tree `ad816f60b50d568074bfdd61cf85c98ec29c1f52`
after the root suite passed. `phylax`, `ephoros` and `hypomnema` each exit 0,
and `git diff --check` is clean.

## What this does not fix

The flake is gone from the fixture, not from the class of problem: any other
test that asserts an outcome within a short wall-clock window remains
load-sensitive. This change did not audit for those.

Closes #1175

<!-- wildcat-origin: shoggoth -->
