### PR TITLE
Make the ADR number-collision check report-only

### DIFF
--- a/.horos/census.json
+++ b/.horos/census.json
@@ -26,7 +26,7 @@
     },
     {
       "boundary_bytes": 73,
-      "bytes": 13274233,
+      "bytes": 13275897,
       "files": 591,
       "suffix": ".py"
     },
@@ -189,6 +189,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 104934828,
+  "total_bytes": 104936492,
   "total_files": 3139
 }

--- a/tests/test_decision_records.py
+++ b/tests/test_decision_records.py
@@ -10,6 +10,10 @@ duplicate survived until 2026-08-24, when the licence record moved to 020. ADR-0
 nearly went the same way: one delivery held it while another landed it, and only a
 manual check caught the collision before both reached the default branch. There is
 no exception list below, because the state it would have described is fixed.
+
+One number per record in this tree is still enforced. The comparison against the
+default branch is report-only since 2026-09-12; that method's own docstring says
+why.
 """
 
 from __future__ import annotations
@@ -18,6 +22,7 @@ from pathlib import Path
 import os
 import re
 import subprocess
+import sys
 import unittest
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -110,6 +115,30 @@ class DecisionRecordNumbering(unittest.TestCase):
     def test_no_number_collides_with_one_already_on_the_default_branch(self):
         """The case a uniqueness check on this tree alone cannot catch.
 
+        Report-only since 2026-09-12. It prints the collision and passes. The
+        name is kept despite that, because ADR-076 and ten audit records cite
+        it by name and audit bytes are not swept.
+
+        It already had no bite in CI: `.github/workflows/repo.yml` checks out
+        at the default depth of 1, so no local ref for the default branch
+        exists and this skips. Every collision it has caught, it caught on a
+        contributor's machine.
+
+        There, failing on it costs more than it saves, because the fix is
+        always late. The file, its first heading and every citation of it move
+        together, after the number the branch was written against has been
+        taken by something that landed first. `docs/decisions/` carries 27
+        renames. The Probitas Midnight run is the worked example: its runbook
+        records the collision surviving four audit rounds unfixed, because the
+        smallest free number is only reliably knowable once no further step
+        will run.
+
+        The hazard is real and the detection stays. What changes is who
+        decides. The operator reads the report and either renumbers now or
+        lets it land and fixes it after. ADR-077's draft path removes the
+        hazard at source by not picking a number before merge; nothing in
+        `docs/decisions/drafts/` uses it yet.
+
         Two branches each add a record and each pick the same next number. Their
         filenames differ, so git merges both with no conflict and the duplicate
         only becomes visible once both have landed. Comparing against the default
@@ -146,12 +175,14 @@ class DecisionRecordNumbering(unittest.TestCase):
                         f"ADR-{number}: this branch adds {sorted(added)} while the "
                         f"default branch already has {sorted(theirs[number])}"
                     )
-        self.assertEqual(
-            collisions, [],
-            "a decision record on this branch reuses a number that is already taken "
-            "on the default branch. Renumber to the next free number and move every "
-            "reference with it: " + "; ".join(collisions),
-        )
+        if collisions:
+            print(
+                "decision-record number collision (report-only): a record on this "
+                "branch reuses a number already taken on the default branch. "
+                "Renumber to the next free number and move every reference with it, "
+                "or let it land and fix it after: " + "; ".join(collisions),
+                file=sys.stderr,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

`tests/test_decision_records.py` compared this branch's decision-record numbers
against the default branch and failed the suite on a collision. It now prints
the collision to stderr and passes.

One number per record within the tree is still enforced, as is the filename
convention and the filename-to-heading agreement. Only the cross-branch
comparison changes.

## Why this check

**It already had no bite in CI.** `.github/workflows/repo.yml` uses
`actions/checkout@v4` with no `fetch-depth`, so the checkout is depth 1, no
local ref for the default branch exists, and the check takes its own
`skipTest` branch. The `invariants` job that runs `unittest discover -s tests`
has never executed this comparison. The Probitas Midnight runbook records the
same finding independently: "the repository CI checks out at the default
shallow depth, so `tests/test_decision_records.py` finds no local
default-branch ref and skips".

**Where it does run, the fix is always late.** The number a branch was written
against gets taken by something that lands first, so the repair moves the file,
its first heading and every citation of it, at the end of a run.
`docs/decisions/` carries 27 renames. ADR-076 records being renumbered three
times in one delivery. The Probitas Midnight run recorded the collision as a
finding in step 3 audit round 3 and carried it through round 4 unfixed,
because the smallest free number is only reliably knowable once no further step
will run.

**The fix for the underlying hazard already exists and has no adopters.**
ADR-077 assigns numbers at merge, and Hypomnema v5.7.0 and v5.8.0 built the
draft path for it. Measured 2026-09-12: 86 numbered records in
`docs/decisions/`, 0 files in `docs/decisions/drafts/`, and the 2 legacy
`draft-*.md` at the root of `docs/decisions/`, a home H008 refuses.

So the check's only live effect was failing builds on contributors' machines,
for a hazard CI cannot see, with a fix that is cheaper applied after the fact
than before.

## Verification

Run on this branch rebased onto `main@1d131b98`.

| Check | Result |
|---|---|
| `python3 -m unittest tests.test_decision_records` | 5 tests, OK |
| Report path, forced with a real collision | Printed `ADR-001: this branch adds ['ADR-001-defang-probe.md'] while the default branch already has ['ADR-001-generate-install-local-promise-machine-copies.md']`, passed |
| `python3 -m unittest discover -s tests` | **2049 tests, OK**, 0 failures, 0 errors, 318.8s |
| `horos.py scan . --census --write` | re-pinned after the rebase |

The report path was proven by adding a probe record duplicating a number held
on `origin/main`, running the single method, and removing the probe. Under the
old assertion that case failed the suite.

## A note on the original verification

This branch was first written on 2026-09-12, when `main` was red: 30 tests
failing from a stale `PROMISE_MACHINE.md` corpus pin introduced by `49fc2caf`.
That red was not caused by this change — a clean detached snapshot of
`93b9d45d` failed the identical 30 — and it made the local commit gate
unpassable, so the first commit was made with `FIAT_SKIP_PRECOMMIT=1`.

That condition is over. #1538 closed COMPLETED on 2026-09-12, `48b6cf8c`
rebound the fixtures, and `repo.yml` on `main` has been green since. The
numbers above are from the rebased branch against a green `main`, not from that
period. The earlier state is recorded here rather than deleted, because the
commit it explains is still in this branch's history.

## Deliberately not done

**The method keeps its name.** `test_no_number_collides_with_one_already_on_the_default_branch`
no longer describes what it does, and is kept anyway: ADR-076 and ten audit
records under `audit/rounds/` cite it by name, and audit bytes are not swept.
The docstring leads with the report-only status and the reason for the name.

**ADR-076 is now partly stale and is not edited.** It says of this check "From
then on that test is the only thing between this file and a silent duplicate",
which stops being true here. That record is dated and describes the state
during its own delivery, and editing an accepted record's bytes is the friction
this change exists to reduce. Flagged rather than rewritten.

## Scope

One behaviour change, one census re-pin. No decision record added, so this
incurs none of the assignment machinery it is about.
