### PR TITLE
Trim BSD wc padding in the reinstatement runbook exits

### DIFF
--- a/.horos/census.json
+++ b/.horos/census.json
@@ -8,7 +8,7 @@
     },
     {
       "boundary_bytes": 1485,
-      "bytes": 21212965,
+      "bytes": 21213013,
       "files": 1084,
       "suffix": ".md"
     },
@@ -189,6 +189,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 105197513,
+  "total_bytes": 105197561,
   "total_files": 3177
 }

--- a/docs/wave-delta-reinstatement-runbook.md
+++ b/docs/wave-delta-reinstatement-runbook.md
@@ -166,7 +166,7 @@ python3 scripts/promise_machine.py coverage --check
 python3 -m unittest tests.test_decision_records tests.test_fiat_checkpoint_decision_record
 python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py docs/decisions
 python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/decisions/ADR-070-separate-the-checkpoint-protocol-from-its-authority-service.md docs/decisions/ADR-071-hold-checkpoint-authority-in-locked-storage-behind-replaceable-compute.md
-git diff --name-only HEAD~1..HEAD -- docs/decisions/ADR-029-separate-the-checkpoint-protocol-from-its-authority-service.md docs/decisions/ADR-030-use-s3-object-lock-behind-replaceable-digitalocean-compute.md | wc -l | grep -qx '0'
+git diff --name-only HEAD~1..HEAD -- docs/decisions/ADR-029-separate-the-checkpoint-protocol-from-its-authority-service.md docs/decisions/ADR-030-use-s3-object-lock-behind-replaceable-digitalocean-compute.md | wc -l | tr -d ' ' | grep -qx '0'
 ! git diff --name-only ff47f3070c8dce05c767b6c0dad65234c56870de..HEAD | grep -q '^plugins/'
 ```
 
@@ -215,7 +215,7 @@ python3 scripts/promise_machine.py coverage --check
 python3 -m unittest tests.test_decision_records tests.test_fiat_checkpoint_decision_record
 python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py docs/decisions
 python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/decisions/ADR-072-fence-external-fiat-transitions-on-signed-checkpoint-acceptance.md docs/decisions/ADR-073-model-checkpoint-lineage-as-an-explicitly-resolved-dag.md
-git diff --name-only HEAD~1..HEAD -- docs/decisions/ADR-031-fence-external-fiat-transitions-on-signed-checkpoint-acceptance.md docs/decisions/ADR-032-model-checkpoint-lineage-as-an-explicitly-resolved-dag.md | wc -l | grep -qx '0'
+git diff --name-only HEAD~1..HEAD -- docs/decisions/ADR-031-fence-external-fiat-transitions-on-signed-checkpoint-acceptance.md docs/decisions/ADR-032-model-checkpoint-lineage-as-an-explicitly-resolved-dag.md | wc -l | tr -d ' ' | grep -qx '0'
 ! git diff --name-only ff47f3070c8dce05c767b6c0dad65234c56870de..HEAD | grep -q '^plugins/'
 ```
 
@@ -264,7 +264,7 @@ python3 scripts/promise_machine.py coverage --check
 python3 -m unittest tests.test_decision_records tests.test_fiat_checkpoint_decision_record
 python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py --study docs/wave-delta-checkpoint-programme-study.md
 python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/wave-delta-checkpoint-programme-study.md docs/hexaemeron-checkpoint-programme-study.md
-git diff --name-only ff47f3070c8dce05c767b6c0dad65234c56870de..HEAD -- docs/fiat-controller-checkpoint-study.md docs/fiat-controller-checkpoint-runbook.md | wc -l | grep -qx '0'
+git diff --name-only ff47f3070c8dce05c767b6c0dad65234c56870de..HEAD -- docs/fiat-controller-checkpoint-study.md docs/fiat-controller-checkpoint-runbook.md | wc -l | tr -d ' ' | grep -qx '0'
 ! git diff --name-only ff47f3070c8dce05c767b6c0dad65234c56870de..HEAD | grep -q '^plugins/'
 ```
 
@@ -313,7 +313,7 @@ python3 scripts/promise_machine.py coverage --check
 python3 -m unittest tests.test_decision_records tests.test_fiat_checkpoint_decision_record
 python3 plugins/hexaemeron/skills/protasis/scripts/protasis.py docs/wave-delta-checkpoint-programme-runbook.md
 python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py docs/wave-delta-checkpoint-programme-runbook.md docs/hexaemeron-checkpoint-programme-runbook.md
-git diff --name-only ff47f3070c8dce05c767b6c0dad65234c56870de..HEAD -- docs/fiat-controller-checkpoint-study.md docs/fiat-controller-checkpoint-runbook.md | wc -l | grep -qx '0'
+git diff --name-only ff47f3070c8dce05c767b6c0dad65234c56870de..HEAD -- docs/fiat-controller-checkpoint-study.md docs/fiat-controller-checkpoint-runbook.md | wc -l | tr -d ' ' | grep -qx '0'
 ! git diff --name-only ff47f3070c8dce05c767b6c0dad65234c56870de..HEAD | grep -q '^plugins/'
 ```
 


### PR DESCRIPTION
`docs/wave-delta-reinstatement-runbook.md` carries this check in the Exit field
of steps 2, 3, 4 and 5, at lines 169, 218, 267 and 316:

```
git diff --name-only <range> -- <two paths> | wc -l | grep -qx '0'
```

BSD `wc -l` right-pads its count to eight columns. `od -c` on the empty case
gives seven spaces, `0`, newline, so the anchored `grep -qx '0'` never matches
and the check cannot exit zero on macOS, which is where the run that wrote it
executed.

## What changed

Each of the four pipes through `tr -d ' '` before the match:

```
git diff --name-only <range> -- <two paths> | wc -l | tr -d ' ' | grep -qx '0'
```

That is the form `docs/remove-the-beginner-primer/runbook.md:159` already uses,
so the repository now spells the idiom one way.

Nothing else in the runbook moves. The prose at line 173 names the check as
`git diff --name-only … | wc -l`, which stays accurate.

`.horos/census.json` is rebound in the same commit: `.md` bytes and
`total_bytes` each rise 48, the four twelve-byte insertions.
`test_demonstrations.HorosCensusCurrencyTests` fails without it.

## Proof

Each of the four lines, run verbatim as it now appears, against the empty diff
it asserts — and the same four with ` | tr -d ' '` removed:

| line | before | after |
| --- | --- | --- |
| 169 | exit 1 | exit 0 |
| 218 | exit 1 | exit 0 |
| 267 | exit 1 | exit 0 |
| 316 | exit 1 | exit 0 |

```bash
python3 plugins/horos/skills/horos/scripts/horos.py check .      # boundary matches the tree
python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py docs/wave-delta-reinstatement-runbook.md   # clean
python3 -m unittest discover -s plugins/horos/tests              # 262 tests, OK
python3 -m unittest tests.test_demonstrations.HorosCensusCurrencyTests   # OK
```

## Suite state

`python3 -m unittest discover -s tests` on this branch: 1,853 tests, 19
failures and 11 errors. A clean detached snapshot of `b9cafd19` returns the same
1,853 tests, 19 failures and 11 errors, and the two failure sets are equal —
`comm` over the sorted sets reports nothing on either side. Those 30 are the
default branch's own, reported at #1538.

The commit gate was skipped with `FIAT_SKIP_PRECOMMIT=1`, the path its refusal
names. `.githooks/greenlight` records a green on suite exit zero alone, and no
tree can reach that while the default branch is red.

The subject of the check held throughout the #859 run: zero files differed for
ADR-029 through ADR-032 across the delivery, verified with the trimmed form at
every step that owed it. Recorded as finding S2-R1-03 in
`audit/rounds/fiat-859-reinstate-the-wave-delta-distributed-checkpo.md`.

Closes #1176



## The red `invariants` check

`invariants` fails on this pull request: 1,853 tests, 19 failures, 11 errors,
7 skipped. The same job on the other pull request opened alongside this one
reports the same 30, and both sets are byte-identical to the set a clean
detached snapshot of `b9cafd19` produces locally — `diff` over the sorted names
reports nothing.

The first cause is `PROMISE_MACHINE.md is off its manifest digest`, which
`tests/fixtures/agent-instruction-v1/manifest.json` pins; the payload case is
`27036319 not less than 26214400`. Those are #1538 and #1467, and neither is
reachable from this change.