### PR TITLE
Say what a per-worktree hooksPath override does and how to clear it

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -23,6 +23,45 @@ the execution is nobody's checkout, and `scripts/run_checks.py` sets the
 second for the snapshot it runs the suite from, so neither the checked runner
 nor a hosted runner tells you whether your clone is activated.
 
+## When a worktree runs another tree's hooks
+
+A linked worktree can carry a `core.hooksPath` of its own, and git reads that
+ahead of the shared value whenever `extensions.worktreeConfig` is true. Tooling
+outside this repository writes one, an absolute path to the main checkout:
+
+```
+[core]
+	hooksPath = /Users/<user>/Projects/wildcat-skills/.githooks
+```
+
+The tracked relative value never applies there, so git runs another directory's
+`pre-commit` against this worktree's staged tree and `ActivationTests` fails.
+Running the activation command above from inside such a worktree does not
+repair it: that writes the shared config, which was already correct, and leaves
+the override where it is.
+
+Clear it in the worktree that carries it:
+
+```
+git config --worktree --unset core.hooksPath
+```
+
+The repair does not hold by itself. On 6 September 2026 four worktrees of one
+clone were unset together; the one whose session was active had the absolute
+value written back twenty-three seconds later, and the other three stayed
+repaired. A second unset on that worktree was still intact ninety seconds on,
+with its `config.worktree` untouched. So the override arrives at a discrete
+moment rather than continuously, and what evidence there is points at worktree
+creation or session start. Read it again when work resumes in a worktree rather
+than once:
+
+```
+git config core.hooksPath
+```
+
+That prints `.githooks` in a worktree that will run its own copy. Which tool
+writes the override is not established here.
+
 ## Skip it for one commit
 
 ```

--- a/.horos/census.json
+++ b/.horos/census.json
@@ -8,7 +8,7 @@
     },
     {
       "boundary_bytes": 1485,
-      "bytes": 21212965,
+      "bytes": 21214470,
       "files": 1084,
       "suffix": ".md"
     },
@@ -189,6 +189,6 @@
   ],
   "schema": 1,
   "tool": "horos",
-  "total_bytes": 105197513,
+  "total_bytes": 105199018,
   "total_files": 3177
 }


### PR DESCRIPTION
`tests.test_commit_gate.ActivationTests.test_this_checkout_has_the_gate_activated`
refuses a `core.hooksPath` that resolves anywhere but the tracked `.githooks`
of the tree being committed. A linked worktree can carry its own value, which
git reads ahead of the shared one when `extensions.worktreeConfig` is true, and
tooling outside this repository writes an absolute path to the main checkout
there. Git then runs another directory's `pre-commit` against the worktree's
staged tree, and the activation case fails while the shared value is correct
throughout.

Nothing in the repository said so, and the activation command does not repair
it: run from inside such a worktree, `git config core.hooksPath .githooks`
writes the shared config and leaves the override in place.

## What changed

`.githooks/README.md` gains one section between **Turn it on** and **Skip it
for one commit**. It names the condition, the `config.worktree` mechanism that
produces it, the repair:

```
git config --worktree --unset core.hooksPath
```

and why the activation command is not that repair.

It also records what #1336's comment added and the filing did not: **the repair
is not durable.** Of four worktrees unset together on 6 September 2026, the one
whose session was active had the absolute value written back twenty-three
seconds later; the other three stayed repaired, and a second unset on that
worktree was intact ninety seconds on with its `config.worktree` untouched. The
override therefore arrives at a discrete moment, and what evidence exists points
at worktree creation or session start. The section tells a reader to re-read
`git config core.hooksPath` when work resumes in a worktree rather than assume
one unset holds.

Which tool writes the override is not established, and the section says that
rather than guessing.

## Proof

This branch was written in a worktree that carried the override. Before:

```
worktree:  /Users/<user>/Projects/wildcat-skills/.githooks
effective: /Users/<user>/Projects/wildcat-skills/.githooks
```

After `git config --worktree --unset core.hooksPath`:

```
shared:    .githooks
worktree:  (unset)
effective: .githooks   ->  <this worktree>/.githooks
```

```bash
python3 -m unittest tests.test_commit_gate          # 52 tests, OK
python3 plugins/hexaemeron/skills/imprimatur/scripts/imprimatur.py .githooks/README.md   # score 100.0/100, 0 defects
python3 plugins/hexaemeron/skills/hypomnema/scripts/hypomnema.py .githooks/README.md     # clean
python3 plugins/horos/skills/horos/scripts/horos.py check .   # boundary matches the tree
```

`.horos/census.json` is rebound in the same commit for the added bytes;
`test_demonstrations.HorosCensusCurrencyTests` fails without it.

## Suite state

`python3 -m unittest discover -s tests`: 1,853 tests, 19 failures and 11 errors.
A clean detached snapshot of `b9cafd19` returns the same counts, and `comm` over
the two sorted failure sets reports nothing on either side. Those 30 are the
default branch's own, reported at #1538.

The commit gate was skipped with `FIAT_SKIP_PRECOMMIT=1`, the path its refusal
names, because `.githooks/greenlight` records a green on suite exit zero alone
and no tree reaches that while the default branch is red.

This adds prose only. The assertion that made the condition visible is unchanged.

Closes #1336



## The red `invariants` check

`invariants` fails on this pull request: 1,853 tests, 19 failures, 11 errors,
7 skipped. The same job on the other pull request opened alongside this one
reports the same 30, and both sets are byte-identical to the set a clean
detached snapshot of `b9cafd19` produces locally — `diff` over the sorted names
reports nothing.

The first cause is `PROMISE_MACHINE.md is off its manifest digest`, which
`tests/fixtures/agent-instruction-v1/manifest.json` pins; the payload case is
`27036319 not less than 26214400`. Those are #1538 and #1467, and neither is
reachable from this change.